### PR TITLE
added missing coma

### DIFF
--- a/initialize.py
+++ b/initialize.py
@@ -47,7 +47,7 @@ def initialize():
         code_exec_docker_enabled = True,
         # code_exec_docker_name = "agent-zero-exe",
         # code_exec_docker_image = "frdel/agent-zero-exe:latest",
-        # code_exec_docker_ports = { "22/tcp": 50022 }
+        # code_exec_docker_ports = { "22/tcp": 50022 },
         # code_exec_docker_volumes = { 
             # files.get_abs_path("work_dir"): {"bind": "/root", "mode": "rw"},
             # files.get_abs_path("instruments"): {"bind": "/instruments", "mode": "rw"},


### PR DESCRIPTION
Line #50 in initialize.py is missing a coma

 # code_exec_docker_ports = { "22/tcp": 50022 },

