### PR TITLE
fix: synchronize job loop with development instance

### DIFF
--- a/python/helpers/job_loop.py
+++ b/python/helpers/job_loop.py
@@ -1,16 +1,37 @@
 import asyncio
+from datetime import datetime
+import time
 from python.helpers.task_scheduler import TaskScheduler
 from python.helpers.print_style import PrintStyle
 from python.helpers import errors
+from python.helpers import runtime
+
+
+SLEEP_TIME = 60
+
+keep_running = True
+pause_time = 0
 
 
 async def run_loop():
+    global pause_time, keep_running
+
     while True:
-        try:
-            await scheduler_tick()
-        except Exception as e:
-            PrintStyle().error(errors.format_error(e))
-        await asyncio.sleep(60) # TODO! - if we lower it under 1min, it can run a 5min job multiple times in it's target minute
+        if runtime.is_development():
+            # Signal to container that the job loop should be paused
+            # if we are runing a development instance to avoid duble-running the jobs
+            try:
+                await runtime.call_development_function(pause_loop)
+            except Exception as e:
+                PrintStyle().error("Failed to pause job loop by development instance: " + errors.error_text(e))
+        if not keep_running and (time.time() - pause_time) > (SLEEP_TIME * 2):
+            resume_loop()
+        if keep_running:
+            try:
+                await scheduler_tick()
+            except Exception as e:
+                PrintStyle().error(errors.format_error(e))
+        await asyncio.sleep(SLEEP_TIME)  # TODO! - if we lower it under 1min, it can run a 5min job multiple times in it's target minute
 
 
 async def scheduler_tick():
@@ -18,3 +39,15 @@ async def scheduler_tick():
     scheduler = TaskScheduler.get()
     # Run the scheduler tick
     await scheduler.tick()
+
+
+def pause_loop():
+    global keep_running, pause_time
+    keep_running = False
+    pause_time = time.time()
+
+
+def resume_loop():
+    global keep_running, pause_time
+    keep_running = True
+    pause_time = 0


### PR DESCRIPTION
This PR makes sure that if a development instance connects to a docker container, the container pauses the job_loop to not run the tasks twice.