### PR TITLE
fix: use async versions of faiss methods in memory helper

### DIFF
--- a/python/helpers/memory.py
+++ b/python/helpers/memory.py
@@ -326,7 +326,7 @@ class Memory:
                 # fnd = self.db.get(where={"id": {"$in": document_ids}})
                 # if fnd["ids"]: self.db.delete(ids=fnd["ids"])
                 # tot += len(fnd["ids"])
-                self.db.delete(ids=document_ids)
+                await self.db.adelete(ids=document_ids)
                 tot += len(document_ids)
 
             # If fewer than K document IDs, break the loop
@@ -339,7 +339,7 @@ class Memory:
 
     async def delete_documents_by_ids(self, ids: list[str]):
         # aget_by_ids is not yet implemented in faiss, need to do a workaround
-        rem_docs = self.db.get_by_ids(ids)  # existing docs to remove (prevents error)
+        rem_docs = await self.db.aget_by_ids(ids)  # existing docs to remove (prevents error)
         if rem_docs:
             rem_ids = [doc.metadata["id"] for doc in rem_docs]  # ids to remove
             await self.db.adelete(ids=rem_ids)
@@ -370,7 +370,7 @@ class Memory:
                 model_config=self.agent.config.embeddings_model, input=docs_txt
             )
 
-            self.db.add_documents(documents=docs, ids=ids)
+            await self.db.aadd_documents(documents=docs, ids=ids)
             self._save_db()  # persist
         return ids
 


### PR DESCRIPTION
This might make the memory a little more responsive and non-blocking as I noticed sometimes solution and memory operations were going for very long before continueing