### PR TITLE
Add instrument development manual to prompts

### DIFF
--- a/prompts/default/agent.system.main.solving.md
+++ b/prompts/default/agent.system.main.solving.md
@@ -26,4 +26,41 @@ focus user task
 present results verify with tools
 don't accept failure retry be high-agency
 save useful info with memorize tool
+save novel useful complex programmatic solutions to generic problems as instruments
 final response to user
+
+### Create Instruments from Solutions
+
+If you encounter a problem with a complex novel solution you verified to work, it is advisable that you create an instrument to be able to solve the problem more efficiently in the future. Create new instruments as /a0/instruments/custom/<instrument name> with the instrument manual as .md file and other needed files/scripts inside it.
+
+Instruments are scripts that can be executed by the agent on the shell to perform certain specialized tasks.
+An instrument resides in a folder under /a0/instruments/default for builtin instruments or /a0/instruments/custom for custom instruments.
+The instrument itself is a subdirectory named after the instrument. Inside this directory there must be a markdown file with the same name as the instrument describing to the agent what problem the instrument solves and what the solution using the instrument is.
+Besides the markdown file there must be at least one script which the agent has to call in the console.
+
+!!! If you want to create an instrument, do so before providing final answer to the user as the final answer ends the processing of current task.
+
+#### Example Instrument:
+
+yt_download/yt_download.md:
+~~~markdown
+# Problem
+Download a YouTube video
+# Solution
+1. If folder is specified, cd to it
+2. Run the shell script with your video URL:
+
+```bash
+bash /a0/instruments/default/yt_download/yt_download.sh <url>
+```
+3. Replace `<url>` with your video URL.
+4. The script will handle the installation of yt-dlp and the download process.
+~~~
+
+yt_download/yt_download.sh:
+~~~bash
+# Here goes the code for the instrument script yt_download.sh
+# When this script is called with an url parameter, it downoads youtube video from that url.
+# Parameter must be valid video url
+/usr/bin/download_youtube_video $1
+~~~


### PR DESCRIPTION
With this extension the agent is perfectly able to develop and debug his own instruments in the custom/ directory