### PR TITLE
Patch to allow the anthropic sonnet 4 and opus 4 models to work.

### DIFF
--- a/python/helpers/anthropic_patch.py
+++ b/python/helpers/anthropic_patch.py
@@ -1,0 +1,37 @@
+"""
+Monkey patch for langchain-anthropic 0.3.3 to fix the NoneType + int error
+in _create_usage_metadata function.
+"""
+
+def patch_anthropic():
+    try:
+        from langchain_anthropic.chat_models import _create_usage_metadata
+        import langchain_anthropic.chat_models as chat_models
+        
+        # Store the original function
+        original_create_usage_metadata = _create_usage_metadata
+        
+        # Create a patched version
+        def patched_create_usage_metadata(anthropic_usage):
+            if anthropic_usage is None:
+                return None
+            
+            # Safely get attributes with defaults
+            input_tokens = getattr(anthropic_usage, "input_tokens", None) or 0
+            output_tokens = getattr(anthropic_usage, "output_tokens", None) or 0
+            
+            return {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "total_tokens": input_tokens + output_tokens
+            }
+        
+        # Replace the function
+        chat_models._create_usage_metadata = patched_create_usage_metadata
+        print("Successfully patched langchain-anthropic usage metadata handling")
+        
+    except Exception as e:
+        print(f"Failed to patch langchain-anthropic: {e}")
+
+# Auto-patch on import
+patch_anthropic()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansio==0.0.1
 beautifulsoup4==4.12.3
-browser-use==0.1.40
+browser-use==0.2.3
 docker==7.1.0
 duckduckgo-search==6.1.12
 faiss-cpu==1.8.0.post1


### PR DESCRIPTION
I created this patch to address errors I was getting when using the anthropic models.  I was getting errors like this:

    File "/opt/venv/lib/python3.11/site-packages/langchain_core/runnables/base.py", line 3387, in _atransform
      async for output in final_pipeline:
    File "/opt/venv/lib/python3.11/site-packages/langchain_core/runnables/base.py", line 1472, in atransform
      async for output in self.astream(final, config, **kwargs):
    File "/opt/venv/lib/python3.11/site-packages/langchain_core/language_models/chat_models.py", line 512, in
  astream
      async for chunk in self._astream(
    File "/opt/venv/lib/python3.11/site-packages/langchain_anthropic/chat_models.py", line 750, in _astream
      msg = _make_message_chunk_from_anthropic_event(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/venv/lib/python3.11/site-packages/langchain_anthropic/chat_models.py", line 1335, in
  _make_message_chunk_from_anthropic_event
      usage_metadata = _create_usage_metadata(event.usage)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/venv/lib/python3.11/site-packages/langchain_anthropic/chat_models.py", line 1363, in
  _create_usage_metadata
      getattr(anthropic_usage, "input_tokens", 0)
  TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'


  TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'