### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@
 [Documentation](./docs/README.md) •
 [Usage](./docs/usage.md)
 
+<!-- Keep these links. Translations will automatically update with the README. -->
+[Deutsch](https://www.readme-i18n.com/frdel/agent-zero?lang=de) | 
+[Español](https://www.readme-i18n.com/frdel/agent-zero?lang=es) | 
+[français](https://www.readme-i18n.com/frdel/agent-zero?lang=fr) | 
+[日本語](https://www.readme-i18n.com/frdel/agent-zero?lang=ja) | 
+[한국어](https://www.readme-i18n.com/frdel/agent-zero?lang=ko) | 
+[Português](https://www.readme-i18n.com/frdel/agent-zero?lang=pt) | 
+[Русский](https://www.readme-i18n.com/frdel/agent-zero?lang=ru) | 
+[中文](https://www.readme-i18n.com/frdel/agent-zero?lang=zh)
 </div>
 
 


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.

The updated can be previewed in my forked repository: https://github.com/dowithless/agent-zero/tree/patch-1