### PR TITLE
fix timezone not found on windows

### DIFF
--- a/run_ui.py
+++ b/run_ui.py
@@ -22,7 +22,8 @@ from python.helpers.print_style import PrintStyle
 # Set the new timezone to 'UTC'
 os.environ["TZ"] = "UTC"
 # Apply the timezone change
-time.tzset()
+if hasattr(time, 'tzset'):
+    time.tzset()
 
 # initialize the internal Flask server
 webapp = Flask("app", static_folder=get_abs_path("./webui"), static_url_path="/")


### PR DESCRIPTION
Windows does not have time.tzset() fix it on windows.