### PR TITLE
Read file refactor + Fix include path errors

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -506,7 +506,7 @@ class Agent:
         ):  # if agent has custom folder, use it and use default as backup
             prompt_dir = files.get_abs_path("agents", self.config.profile, "prompts")
             backup_dir.append(files.get_abs_path("prompts"))
-        prompt = files.read_file(
+        prompt = files.read_prompt_file(
             files.get_abs_path(prompt_dir, file), _backup_dirs=backup_dir, **kwargs
         )
         prompt = files.remove_code_fences(prompt)

--- a/prompts/agent.system.tool.call_sub.py
+++ b/prompts/agent.system.tool.call_sub.py
@@ -13,7 +13,7 @@ class CallSubordinate(VariablesPlugin):
         agent_subdirs = files.get_subdirectories("agents", exclude=["_example"])
         for agent_subdir in agent_subdirs:
             try:
-                context = files.read_file(
+                context = files.read_prompt_file(
                     files.get_abs_path("agents", agent_subdir, "_context.md")
                 )
                 profiles.append({"name": agent_subdir, "context": context})

--- a/prompts/agent.system.tools.py
+++ b/prompts/agent.system.tools.py
@@ -22,7 +22,7 @@ class CallSubordinate(VariablesPlugin):
         tools = []
         for prompt_file in prompt_files:
             try:
-                tool = files.read_file(prompt_file)
+                tool = files.read_prompt_file(prompt_file)
                 tools.append(tool)
             except Exception as e:
                 PrintStyle().error(f"Error loading tool '{prompt_file}': {e}")

--- a/python/extensions/system_prompt/_20_behaviour_prompt.py
+++ b/python/extensions/system_prompt/_20_behaviour_prompt.py
@@ -16,7 +16,7 @@ def get_custom_rules_file(agent: Agent):
 def read_rules(agent: Agent):
     rules_file = get_custom_rules_file(agent)
     if files.exists(rules_file):
-        rules = files.read_file(rules_file)
+        rules = files.read_prompt_file(rules_file)
         return agent.read_prompt("agent.system.behaviour.md", rules=rules)
     else:
         rules = agent.read_prompt("agent.system.behaviour_default.md")

--- a/python/helpers/files.py
+++ b/python/helpers/files.py
@@ -221,6 +221,9 @@ def process_includes(_content, _base_path, _backup_dirs, **kwargs):
 
     def replace_include(match):
         include_path = match.group(1)
+        # if the path is absolute, do not process it
+        if os.path.isabs(include_path):
+            return match.group(0)
         # First attempt to resolve the include relative to the base path
         full_include_path = find_file_in_dirs(
             os.path.join(_base_path, include_path), _backup_dirs

--- a/python/helpers/files.py
+++ b/python/helpers/files.py
@@ -73,7 +73,17 @@ from python.helpers.strings import sanitize_string
 
 
 def parse_file(_relative_path, _backup_dirs=None, _encoding="utf-8", **kwargs):
-    content = read_file(_relative_path, _backup_dirs, _encoding)
+    if _backup_dirs is None:
+        _backup_dirs = []
+
+    # Try to get the absolute path for the file from the original directory or backup directories
+    absolute_path = find_file_in_dirs(_relative_path, _backup_dirs)
+
+    # Read the file content
+    with open(absolute_path, "r", encoding=_encoding) as f:
+        # content = remove_code_fences(f.read())
+        content = f.read()
+    
     is_json = is_full_json_template(content)
     content = remove_code_fences(content)
     variables = load_plugin_variables(_relative_path, _backup_dirs) or {}  # type: ignore
@@ -85,10 +95,15 @@ def parse_file(_relative_path, _backup_dirs=None, _encoding="utf-8", **kwargs):
         return obj
     else:
         content = replace_placeholders_text(content, **variables)
+        # Process include statements
+        content = process_includes(
+            # here we use kwargs, the plugin variables are not inherited
+            content, os.path.dirname(_relative_path), _backup_dirs, **kwargs
+        )
         return content
 
 
-def read_file(_relative_path, _backup_dirs=None, _encoding="utf-8", **kwargs):
+def read_prompt_file(_relative_path, _backup_dirs=None, _encoding="utf-8", **kwargs):
     if _backup_dirs is None:
         _backup_dirs = []
 
@@ -113,6 +128,18 @@ def read_file(_relative_path, _backup_dirs=None, _encoding="utf-8", **kwargs):
     )
 
     return content
+
+
+def read_file(_relative_path, _backup_dirs=None, _encoding="utf-8"):
+    if _backup_dirs is None:
+        _backup_dirs = []
+
+    # Try to get the absolute path for the file from the original directory or backup directories
+    absolute_path = find_file_in_dirs(_relative_path, _backup_dirs)
+
+    # Read the file content
+    with open(absolute_path, "r", encoding=_encoding) as f:
+        return f.read()
 
 
 def read_file_bin(_relative_path, _backup_dirs=None):
@@ -200,7 +227,7 @@ def process_includes(_content, _base_path, _backup_dirs, **kwargs):
         )
 
         # Recursively read the included file content, keeping the original base path
-        included_content = read_file(full_include_path, _backup_dirs, **kwargs)
+        included_content = read_prompt_file(full_include_path, _backup_dirs, **kwargs)
         return included_content
 
     # Replace all includes with the file content
@@ -219,6 +246,9 @@ def find_file_in_dirs(file_path, backup_dirs):
 
     # Loop through the backup directories
     for backup_dir in backup_dirs:
+        # backup path should be os.path.join(backup_dir, file_path) but that can lead to problems
+        # with absolute paths in file_path. So we use basename.
+        # This means that we don't support include paths like "subdir/something.md" from backups
         backup_path = os.path.join(backup_dir, os.path.basename(file_path))
         if os.path.isfile(get_abs_path(backup_path)):
             return get_abs_path(backup_path)

--- a/python/tools/behaviour_adjustment.py
+++ b/python/tools/behaviour_adjustment.py
@@ -58,7 +58,7 @@ def get_custom_rules_file(agent: Agent):
 def read_rules(agent: Agent):
     rules_file = get_custom_rules_file(agent)
     if files.exists(rules_file):
-        rules = files.read_file(rules_file)
+        rules = files.read_prompt_file(rules_file)
         return agent.read_prompt("agent.system.behaviour.md", rules=rules)
     else:
         rules = agent.read_prompt("agent.system.behaviour_default.md")

--- a/run_ui.py
+++ b/run_ui.py
@@ -157,8 +157,10 @@ async def serve_index():
             "version": "unknown",
             "commit_time": "unknown",
         }
-    return files.read_file(
+    return files.read_prompt_file(
         "./webui/index.html",
+        _backup_dirs=[],
+        _encoding="utf-8",
         version_no=gitinfo["version"],
         version_time=gitinfo["commit_time"],
     )


### PR DESCRIPTION
- Refactored `read_file` to `read_prompt_file` for better clarity and introduced a new, simpler `read_file` for basic file operations.
- Fixed a bug where `{{ include '/absolute/path' }}` in memories or behavior rules would cause an error during processing. The system now correctly ignores these absolute-path includes, leaving them for the agent to handle.