### PR TITLE
Do not crash if runtime parameter is not set in code exec

### DIFF
--- a/python/tools/code_execution_tool.py
+++ b/python/tools/code_execution_tool.py
@@ -71,7 +71,7 @@ class CodeExecution(Tool):
 
     def get_heading(self, text: str = ""):
         if not text:
-            text = f"{self.name} - {self.args['runtime']}"
+            text = f"{self.name} - {self.args['runtime'] if 'runtime' in self.args else 'unknown'}"
         text = truncate_text_string(text, 60)
         session = self.args.get("session", None)
         session_text = f"[{session}] " if session or session == 0 else ""


### PR DESCRIPTION
If the agent does not set the runtime, the parameter is not set. In that case do not crash.