### PR TITLE
Implement additional MCP client for each agent profile

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -688,13 +688,16 @@ class Agent:
 
             tool = None  # Initialize tool to None
 
-            # Try getting tool from MCP first
+            # Try getting tool from MCP first (profile-specific, then default)
             try:
                 import python.helpers.mcp_handler as mcp_helper
 
-                mcp_tool_candidate = mcp_helper.MCPConfig.get_instance().get_tool(
-                    self, tool_name
-                )
+                profile = (getattr(self.config, "profile", None) or "default").strip()
+                # profile-specific first
+                mcp_tool_candidate = mcp_helper.MCPConfig.get_instance(profile).get_tool(self, tool_name)
+                if not mcp_tool_candidate and profile != "default":
+                    # fallback to default if not found
+                    mcp_tool_candidate = mcp_helper.MCPConfig.get_instance("default").get_tool(self, tool_name)
                 if mcp_tool_candidate:
                     tool = mcp_tool_candidate
             except ImportError:

--- a/python/api/list_agent_profiles.py
+++ b/python/api/list_agent_profiles.py
@@ -1,0 +1,13 @@
+from python.helpers.api import ApiHandler, Request, Response
+from typing import Any
+from python.helpers import files
+
+
+class ListAgentProfiles(ApiHandler):
+    async def process(self, input: dict[Any, Any], request: Request) -> dict[str, Any] | Response:
+        try:
+            profiles = [p for p in files.get_subdirectories("agents") if p != "_example"]
+            profiles.sort()
+            return {"success": True, "profiles": profiles}
+        except Exception as e:
+            return {"success": False, "error": str(e)}

--- a/python/api/mcp_profile_get_config.py
+++ b/python/api/mcp_profile_get_config.py
@@ -1,0 +1,22 @@
+from python.helpers.api import ApiHandler, Request, Response
+from typing import Any
+from python.helpers import files
+
+DEFAULT_CONFIG = '{\n    "mcpServers": {}\n}'
+
+
+class McpProfileGetConfig(ApiHandler):
+    async def process(self, input: dict[Any, Any], request: Request) -> dict[str, Any] | Response:
+        try:
+            profile = (input.get("profile") or "default").strip()
+            if profile == "default":
+                # Read from settings hidden field is handled client-side; provide it for symmetry if needed later
+                return {"success": True, "mcp_servers": DEFAULT_CONFIG}
+            rel_path = f"agents/{profile}/mcp.json"
+            if files.exists(rel_path):
+                content = files.read_file(rel_path)
+            else:
+                content = DEFAULT_CONFIG
+            return {"success": True, "mcp_servers": content}
+        except Exception as e:
+            return {"success": False, "error": str(e)}

--- a/python/api/mcp_server_get_detail.py
+++ b/python/api/mcp_server_get_detail.py
@@ -6,12 +6,12 @@ from python.helpers.mcp_handler import MCPConfig
 
 class McpServerGetDetail(ApiHandler):
     async def process(self, input: dict[Any, Any], request: Request) -> dict[Any, Any] | Response:
-        
         # try:
-            server_name = input.get("server_name")
-            if not server_name:
-                return {"success": False, "error": "Missing server_name"}
-            detail = MCPConfig.get_instance().get_server_detail(server_name)
-            return {"success": True, "detail": detail}
+        server_name = input.get("server_name")
+        if not server_name:
+            return {"success": False, "error": "Missing server_name"}
+        profile = (input.get("profile") or "default").strip()
+        detail = MCPConfig.get_instance(profile).get_server_detail(server_name)
+        return {"success": True, "detail": detail}
         # except Exception as e:
         #     return {"success": False, "error": str(e)}

--- a/python/api/mcp_server_get_log.py
+++ b/python/api/mcp_server_get_log.py
@@ -6,12 +6,12 @@ from python.helpers.mcp_handler import MCPConfig
 
 class McpServerGetLog(ApiHandler):
     async def process(self, input: dict[Any, Any], request: Request) -> dict[Any, Any] | Response:
-        
         # try:
-            server_name = input.get("server_name")
-            if not server_name:
-                return {"success": False, "error": "Missing server_name"}
-            log = MCPConfig.get_instance().get_server_log(server_name)
-            return {"success": True, "log": log}
+        server_name = input.get("server_name")
+        if not server_name:
+            return {"success": False, "error": "Missing server_name"}
+        profile = (input.get("profile") or "default").strip()
+        log = MCPConfig.get_instance(profile).get_server_log(server_name)
+        return {"success": True, "log": log}
         # except Exception as e:
         #     return {"success": False, "error": str(e)}

--- a/python/api/mcp_servers_apply.py
+++ b/python/api/mcp_servers_apply.py
@@ -5,20 +5,32 @@ from typing import Any
 
 from python.helpers.mcp_handler import MCPConfig
 from python.helpers.settings import set_settings_delta
+from python.helpers import files
 
 
 class McpServersApply(ApiHandler):
     async def process(self, input: dict[Any, Any], request: Request) -> dict[Any, Any] | Response:
         mcp_servers = input["mcp_servers"]
+        profile = (input.get("profile") or "default").strip()
         try:
-            # MCPConfig.update(mcp_servers) # done in settings automatically
-            set_settings_delta({"mcp_servers": "[]"}) # to force reinitialization
-            set_settings_delta({"mcp_servers": mcp_servers})
+            if profile == "default":
+                # Global config via settings flow
+                set_settings_delta({"mcp_servers": "[]"})  # to force reinitialization
+                set_settings_delta({"mcp_servers": mcp_servers})
 
-            time.sleep(1) # wait at least a second
-            # MCPConfig.wait_for_lock() # wait until config lock is released
-            status = MCPConfig.get_instance().get_servers_status()
-            return {"success": True, "status": status}
+                time.sleep(1)  # wait at least a second
+                status = MCPConfig.get_instance("default").get_servers_status()
+                return {"success": True, "status": status}
+            else:
+                # Per-agent profile: persist to agents/<profile>/mcp.json
+                rel_path = files.deabsolute_path(files.get_abs_path("agents", profile, "mcp.json"))
+                files.write_file(rel_path, mcp_servers)
+
+                # Update MCP multiton for this profile
+                MCPConfig.update(mcp_servers, profile=profile)
+                time.sleep(0.2)
+                status = MCPConfig.get_instance(profile).get_servers_status()
+                return {"success": True, "status": status}
 
         except Exception as e:
             return {"success": False, "error": str(e)}

--- a/python/api/mcp_servers_status.py
+++ b/python/api/mcp_servers_status.py
@@ -5,11 +5,11 @@ from typing import Any
 from python.helpers.mcp_handler import MCPConfig
 
 
-class McpServersStatuss(ApiHandler):
+class McpServersStatus(ApiHandler):
     async def process(self, input: dict[Any, Any], request: Request) -> dict[Any, Any] | Response:
-        
         # try:
-            status = MCPConfig.get_instance().get_servers_status()
-            return {"success": True, "status": status}
+        profile = (input.get("profile") or "default").strip()
+        status = MCPConfig.get_instance(profile).get_servers_status()
+        return {"success": True, "status": status}
         # except Exception as e:
         #     return {"success": False, "error": str(e)}

--- a/python/extensions/system_prompt/_10_system_prompt.py
+++ b/python/extensions/system_prompt/_10_system_prompt.py
@@ -30,12 +30,12 @@ def get_tools_prompt(agent: Agent):
 
 
 def get_mcp_tools_prompt(agent: Agent):
-    mcp_config = MCPConfig.get_instance()
+    profile = (getattr(agent.config, "profile", None) or "default").strip()
+    mcp_config = MCPConfig.get_instance(profile)
     if mcp_config.servers:
         pre_progress = agent.context.log.progress
-        agent.context.log.set_progress("Collecting MCP tools") # MCP might be initializing, better inform via progress bar
-        tools = MCPConfig.get_instance().get_tools_prompt()
-        agent.context.log.set_progress(pre_progress) # return original progress
+        agent.context.log.set_progress("Collecting MCP tools")  # MCP might be initializing, better inform via progress bar
+        tools = mcp_config.get_tools_prompt()
+        agent.context.log.set_progress(pre_progress)  # return original progress
         return tools
     return ""
-        

--- a/python/helpers/mcp_handler.py
+++ b/python/helpers/mcp_handler.py
@@ -23,6 +23,7 @@ from datetime import timedelta
 import json
 from python.helpers import errors
 from python.helpers import settings
+from python.helpers import files
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
@@ -79,9 +80,10 @@ def _is_streaming_http_type(server_type: str) -> bool:
 
 
 def initialize_mcp(mcp_servers_config: str):
-    if not MCPConfig.get_instance().is_initialized():
+    # Ensure default/global MCP is initialized
+    if not MCPConfig.get_instance("default").is_initialized():
         try:
-            MCPConfig.update(mcp_servers_config)
+            MCPConfig.update(mcp_servers_config, profile="default")
         except Exception as e:
             from agent import AgentContext
 
@@ -95,6 +97,29 @@ def initialize_mcp(mcp_servers_config: str):
                 background_color="black", font_color="red", padding=True
             ).print(f"Failed to update MCP settings: {e}")
 
+    # Eagerly initialize all agent profile MCP configs (create empty when missing)
+    try:
+        profiles = [p for p in files.get_subdirectories("agents") if p != "_example"]
+        for profile in profiles:
+            # Avoid re-initializing if already loaded
+            if not MCPConfig.get_instance(profile).is_initialized():
+                try:
+                    has_cfg = files.exists("agents", profile, "mcp.json")
+                    cfg = files.read_file(f"agents/{profile}/mcp.json") if has_cfg else settings.get_default_settings()["mcp_servers"]
+                    MCPConfig.update(cfg, profile=profile)
+                    PrintStyle(font_color="green").print(
+                        f"Initialized MCP for profile '{profile}'"
+                    )
+                except Exception as e:
+                    PrintStyle(
+                        background_color="#AA4455", font_color="white", padding=True
+                    ).print(f"Failed to initialize MCP for profile '{profile}': {e}")
+    except Exception as e:
+        # Non-fatal: just log
+        PrintStyle(
+            background_color="#AA4455", font_color="white", padding=True
+        ).print(f"MCP eager profile initialization error: {e}")
+
 
 class MCPTool(Tool):
     """MCP Tool wrapper"""
@@ -102,9 +127,14 @@ class MCPTool(Tool):
     async def execute(self, **kwargs: Any):
         error = ""
         try:
-            response: CallToolResult = await MCPConfig.get_instance().call_tool(
-                self.name, kwargs
-            )
+            # Prefer agent-specific MCP config if available, fallback to default
+            profile = getattr(self.agent.config, "profile", None) or "default"
+            response: CallToolResult
+            config_for_profile = MCPConfig.get_instance(profile)
+            if config_for_profile.has_tool(self.name):
+                response = await config_for_profile.call_tool(self.name, kwargs)
+            else:
+                response = await MCPConfig.get_instance("default").call_tool(self.name, kwargs)
             message = "\n\n".join(
                 [item.text for item in response.content if item.type == "text"]
             )
@@ -218,7 +248,7 @@ class MCPServerRemote(BaseModel):
     tool_timeout: int = Field(default=0)
     disabled: bool = Field(default=False)
 
-    __lock: ClassVar[threading.Lock] = PrivateAttr(default=threading.Lock())
+    __lock: ClassVar[threading.RLock] = PrivateAttr(default=threading.RLock())
     __client: Optional["MCPClientRemote"] = PrivateAttr(default=None)
 
     def __init__(self, config: dict[str, Any]):
@@ -295,7 +325,7 @@ class MCPServerLocal(BaseModel):
     tool_timeout: int = Field(default=0)
     disabled: bool = Field(default=False)
 
-    __lock: ClassVar[threading.Lock] = PrivateAttr(default=threading.Lock())
+    __lock: ClassVar[threading.RLock] = PrivateAttr(default=threading.RLock())
     __client: Optional["MCPClientLocal"] = PrivateAttr(default=None)
 
     def __init__(self, config: dict[str, Any]):
@@ -368,16 +398,23 @@ MCPServer = Annotated[
 class MCPConfig(BaseModel):
     servers: list[MCPServer] = Field(default_factory=list)
     disconnected_servers: list[dict[str, Any]] = Field(default_factory=list)
-    __lock: ClassVar[threading.Lock] = PrivateAttr(default=threading.Lock())
-    __instance: ClassVar[Any] = PrivateAttr(default=None)
-    __initialized: ClassVar[bool] = PrivateAttr(default=False)
+    __lock: ClassVar[threading.RLock] = PrivateAttr(default=threading.RLock())
+    # Multiton registry keyed by profile id ("default" for global config)
+    __instances: ClassVar[dict[str, "MCPConfig"]] = PrivateAttr(default={})
+    __initialized: ClassVar[dict[str, bool]] = PrivateAttr(default={})
+    _profile: str = PrivateAttr(default="default")
 
     @classmethod
-    def get_instance(cls) -> "MCPConfig":
-        # with cls.__lock:
-        if cls.__instance is None:
-            cls.__instance = cls(servers_list=[])
-        return cls.__instance
+    def get_instance(cls, profile: str = "default") -> "MCPConfig":
+        key = (profile or "default").strip()
+        with cls.__lock:
+            inst = cls.__instances.get(key)
+            if inst is None:
+                inst = cls(servers_list=[])
+                cls.__instances[key] = inst
+                cls.__initialized.setdefault(key, False)
+                inst._profile = key
+            return inst
 
     @classmethod
     def wait_for_lock(cls):
@@ -385,100 +422,48 @@ class MCPConfig(BaseModel):
             return
 
     @classmethod
-    def update(cls, config_str: str) -> Any:
-        with cls.__lock:
-            servers_data: List[Dict[str, Any]] = []  # Default to empty list
-
-            if (
-                config_str and config_str.strip()
-            ):  # Only parse if non-empty and not just whitespace
-                try:
-                    # Try with standard json.loads first, as it should handle escaped strings correctly
-                    parsed_value = dirty_json.try_parse(config_str)
-                    normalized = cls.normalize_config(parsed_value)
-
-                    if isinstance(normalized, list):
-                        valid_servers = []
-                        for item in normalized:
-                            if isinstance(item, dict):
-                                valid_servers.append(item)
-                            else:
-                                PrintStyle(
-                                    background_color="yellow",
-                                    font_color="black",
-                                    padding=True,
-                                ).print(
-                                    f"Warning: MCP config item (from json.loads) was not a dictionary and was ignored: {item}"
-                                )
-                        servers_data = valid_servers
-                    else:
-                        PrintStyle(
-                            background_color="red", font_color="white", padding=True
-                        ).print(
-                            f"Error: Parsed MCP config (from json.loads) top-level structure is not a list. Config string was: '{config_str}'"
-                        )
-                        # servers_data remains empty
-                except (
-                    Exception
-                ) as e_json:  # Catch json.JSONDecodeError specifically if possible, or general Exception
-                    PrintStyle.error(
-                        f"Error parsing MCP config string: {e_json}. Config string was: '{config_str}'"
+    def update(cls, config_str: str, profile: str = "default") -> Any:
+        key = (profile or "default").strip()
+        # Parse and build servers list outside the lock
+        servers_data: List[Dict[str, Any]] = []
+        if config_str and config_str.strip():
+            try:
+                parsed_value = dirty_json.try_parse(config_str)
+                normalized = cls.normalize_config(parsed_value)
+                if isinstance(normalized, list):
+                    valid_servers = []
+                    for item in normalized:
+                        if isinstance(item, dict):
+                            valid_servers.append(item)
+                        else:
+                            PrintStyle(
+                                background_color="yellow",
+                                font_color="black",
+                                padding=True,
+                            ).print(
+                                f"Warning: MCP config item (from json.loads) was not a dictionary and was ignored: {item}"
+                            )
+                    servers_data = valid_servers
+                else:
+                    PrintStyle(
+                        background_color="red", font_color="white", padding=True
+                    ).print(
+                        f"Error: Parsed MCP config (from json.loads) top-level structure is not a list. Config string was: '{config_str}'"
                     )
+            except Exception as e_json:
+                PrintStyle.error(
+                    f"Error parsing MCP config string: {e_json}. Config string was: '{config_str}'"
+                )
 
-                    # # Fallback to DirtyJson or log error if standard json.loads fails
-                    # PrintStyle(background_color="orange", font_color="black", padding=True).print(
-                    #     f"Standard json.loads failed for MCP config: {e_json}. Attempting DirtyJson as fallback."
-                    # )
-                    # try:
-                    #     parsed_value = DirtyJson.parse_string(config_str)
-                    #     if isinstance(parsed_value, list):
-                    #         valid_servers = []
-                    #         for item in parsed_value:
-                    #             if isinstance(item, dict):
-                    #                 valid_servers.append(item)
-                    #             else:
-                    #                 PrintStyle(background_color="yellow", font_color="black", padding=True).print(
-                    #                     f"Warning: MCP config item (from DirtyJson) was not a dictionary and was ignored: {item}"
-                    #                 )
-                    #         servers_data = valid_servers
-                    #     else:
-                    #         PrintStyle(background_color="red", font_color="white", padding=True).print(
-                    #             f"Error: Parsed MCP config (from DirtyJson) top-level structure is not a list. Config string was: '{config_str}'"
-                    #         )
-                    #         # servers_data remains empty
-                    # except Exception as e_dirty:
-                    #     PrintStyle(background_color="red", font_color="white", padding=True).print(
-                    #         f"Error parsing MCP config string with DirtyJson as well: {e_dirty}. Config string was: '{config_str}'"
-                    #     )
-                    #     # servers_data remains empty, allowing graceful degradation
+        # Construct new instance OUTSIDE the class lock to avoid long-held locks during server init
+        new_instance = cls(servers_list=servers_data)
+        new_instance._profile = key
 
-            # Initialize/update the singleton instance with the (potentially empty) list of server data
-            instance = cls.get_instance()
-            # Directly update the servers attribute of the existing instance or re-initialize carefully
-            # For simplicity and to ensure __init__ logic runs if needed for setup:
-            new_instance_data = {
-                "servers": servers_data
-            }  # Prepare data for re-initialization or update
-
-            # Option 1: Re-initialize the existing instance (if __init__ is idempotent for other fields)
-            instance.__init__(servers_list=servers_data)
-
-            # Option 2: Or, if __init__ has side effects we don't want to repeat,
-            # and 'servers' is the primary thing 'update' changes:
-            # instance.servers = [] # Clear existing servers first
-            # for server_item_data in servers_data:
-            #     try:
-            #         if server_item_data.get("url", None):
-            #             instance.servers.append(MCPServerRemote(server_item_data))
-            #         else:
-            #             instance.servers.append(MCPServerLocal(server_item_data))
-            #     except Exception as e_init:
-            #         PrintStyle(background_color="grey", font_color="red", padding=True).print(
-            #             f"MCPConfig.update: Failed to create MCPServer from item '{server_item_data.get('name', 'Unknown')}': {e_init}"
-            #         )
-
-            cls.__initialized = True
-            return instance
+        # Swap instance under lock
+        with cls.__lock:
+            cls.__instances[key] = new_instance
+            cls.__initialized[key] = True
+            return new_instance
 
     @classmethod
     def normalize_config(cls, servers: Any):
@@ -677,7 +662,12 @@ class MCPConfig(BaseModel):
     def is_initialized(self) -> bool:
         """Check if the client is initialized"""
         with self.__lock:
-            return self.__initialized
+            # Determine this instance's key by reverse lookup
+            for key, inst in self.__class__.__instances.items():
+                if inst is self:
+                    return self.__class__.__initialized.get(key, False)
+            # Fallback to False
+            return False
 
     def get_tools(self) -> List[dict[str, dict[str, Any]]]:
         """Get all tools from all servers"""
@@ -698,49 +688,57 @@ class MCPConfig(BaseModel):
             pass
 
         prompt = '## "Remote (MCP Server) Agent Tools" available:\n\n'
-        server_names = []
-        for server in self.servers:
-            if not server_name or server.name == server_name:
-                server_names.append(server.name)
+        included: set[tuple[str, str]] = set()
+        servers_to_render: list[tuple[str, MCPServer, list[dict[str, Any]]]] = []
 
-        if server_name and server_name not in server_names:
+        # Helper to collect from a config instance
+        def collect_from_config(cfg: "MCPConfig"):
+            for srv in cfg.servers:
+                if server_name and srv.name != server_name:
+                    continue
+                try:
+                    tools = srv.get_tools()
+                except Exception:
+                    tools = []
+                servers_to_render.append((srv.name, srv, tools))
+
+        # Private/profile instance first
+        collect_from_config(self)
+        # Then default instance (skip duplicates)
+        default_cfg = self.__class__.get_instance("default")
+        if default_cfg is not self:
+            collect_from_config(default_cfg)
+
+        # Render servers, ensuring duplicates are skipped at tool level
+        for srv_name, srv, tools in servers_to_render:
+            # If server filter was specified and nothing matches, ValueError after loop
+            prompt += f"### {srv_name}\n"
+            prompt += f"{srv.description}\n"
+            for tool in tools:
+                key = (srv_name, tool["name"])
+                if key in included:
+                    continue
+                included.add(key)
+                prompt += (
+                    f"\n### {srv_name}.{tool['name']}:\n"
+                    f"{tool['description']}\n\n"
+                )
+                input_schema = (
+                    json.dumps(tool["input_schema"]) if tool.get("input_schema") else ""
+                )
+                prompt += f"#### Input schema for tool_args:\n{input_schema}\n\n"
+                prompt += (
+                    f"#### Usage:\n"
+                    f"{{\n"
+                    f"    \"thoughts\": [\"...\"],\n"
+                    f"    \"tool_name\": \"{srv_name}.{tool['name']}\",\n"
+                    f"    \"tool_args\": !follow schema above\n"
+                    f"}}\n"
+                )
+
+        # If a specific server was requested but none matched, raise
+        if server_name and all(srv_name != server_name for srv_name, _, _ in servers_to_render):
             raise ValueError(f"Server {server_name} not found")
-
-        for server in self.servers:
-            if server.name in server_names:
-                server_name = server.name
-                prompt += f"### {server_name}\n"
-                prompt += f"{server.description}\n"
-                tools = server.get_tools()
-
-                for tool in tools:
-                    prompt += (
-                        f"\n### {server_name}.{tool['name']}:\n"
-                        f"{tool['description']}\n\n"
-                        # f"#### Categories:\n"
-                        # f"* kind: MCP Server Tool\n"
-                        # f'* server: "{server_name}" ({server.description})\n\n'
-                        # f"#### Arguments:\n"
-                    )
-
-                    input_schema = (
-                        json.dumps(tool["input_schema"]) if tool["input_schema"] else ""
-                    )
-
-                    prompt += f"#### Input schema for tool_args:\n{input_schema}\n"
-
-                    prompt += "\n"
-
-                    prompt += (
-                        f"#### Usage:\n"
-                        f"{{\n"
-                        # f'    "observations": ["..."],\n' # TODO: this should be a prompt file with placeholders
-                        f'    "thoughts": ["..."],\n'
-                        # f'    "reflection": ["..."],\n' # TODO: this should be a prompt file with placeholders
-                        f"    \"tool_name\": \"{server_name}.{tool['name']}\",\n"
-                        f'    "tool_args": !follow schema above\n'
-                        f"}}\n"
-                    )
 
         return prompt
 
@@ -752,13 +750,19 @@ class MCPConfig(BaseModel):
         with self.__lock:
             for server in self.servers:
                 if server.name == server_name_part:
-                    return server.has_tool(tool_name_part)
-            return False
+                    if server.has_tool(tool_name_part):
+                        return True
+        # Fallback to default profile if this is not default
+        default_cfg = self.__class__.get_instance("default")
+        if default_cfg is not self:
+            return default_cfg.has_tool(tool_name)
+        return False
 
     def get_tool(self, agent: Any, tool_name: str) -> MCPTool | None:
-        if not self.has_tool(tool_name):
-            return None
-        return MCPTool(agent=agent, name=tool_name, method=None, args={}, message="", loop_data=None)
+        if self.has_tool(tool_name):
+            return MCPTool(agent=agent, name=tool_name, method=None, args={}, message="", loop_data=None)
+        # not found anywhere
+        return None
 
     async def call_tool(
         self, tool_name: str, input_data: Dict[str, Any]
@@ -771,7 +775,11 @@ class MCPConfig(BaseModel):
             for server in self.servers:
                 if server.name == server_name_part and server.has_tool(tool_name_part):
                     return await server.call_tool(tool_name_part, input_data)
-            raise ValueError(f"Tool {tool_name} not found")
+        # fallback to default profile
+        default_cfg = self.__class__.get_instance("default")
+        if default_cfg is not self:
+            return await default_cfg.call_tool(tool_name, input_data)
+        raise ValueError(f"Tool {tool_name} not found")
 
 
 T = TypeVar("T")
@@ -782,7 +790,7 @@ class MCPClientBase(ABC):
     # tools: List[dict[str, Any]] # Defined in __init__
     # No self.session, self.exit_stack, self.stdio, self.write as persistent instance fields
 
-    __lock: ClassVar[threading.Lock] = threading.Lock()
+    __lock: ClassVar[threading.RLock] = threading.RLock()
 
     def __init__(self, server: Union[MCPServerLocal, MCPServerRemote]):
         self.server = server

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -99,7 +99,7 @@ class Settings(TypedDict):
     mcp_server_token: str
 
     a2a_server_enabled: bool
-    
+
 
 
 class PartialSettings(Settings, total=False):
@@ -1436,9 +1436,9 @@ def _apply_settings(previous: Settings | None):
                     type="info", content="Updating MCP settings...", temp=True
                 )
 
-                mcp_config = MCPConfig.get_instance()
+                mcp_config = MCPConfig.get_instance("default")
                 try:
-                    MCPConfig.update(mcp_servers)
+                    MCPConfig.update(mcp_servers, profile="default")
                 except Exception as e:
                     AgentContext.log_to_all(
                         type="error",

--- a/webui/components/settings/mcp/client/mcp-servers.html
+++ b/webui/components/settings/mcp/client/mcp-servers.html
@@ -21,6 +21,13 @@
                     <button class="btn slim primary" :disabled="$store.mcpServersStore.loading"
                         style="margin-left: 0.5em;" @click="$store.mcpServersStore.applyNow()">Apply now</button>
                 </h3>
+                <div class="profile-select-row">
+                    <label>Profile:</label>
+                    <select id="mcp-profiles-select"
+                            x-model="$store.mcpServersStore.selectedProfile"
+                            @change="$store.mcpServersStore.onProfileChange($event.target.value)">
+                    </select>
+                </div>
                 <div id="mcp-servers-config-json"></div>
 
                 <h3 id="mcp-servers-status">Servers status (refreshing automatically)</h3>
@@ -33,8 +40,8 @@
                                 <!-- Status indicator -->
                                 <div class="status-dot" x-data="{ connected: server.connected }">
                                     <svg viewBox="0 0 16 16" width="12" height="12">
-                                        <circle cx="8" cy="8" r="6" x-bind:fill="server.connected 
-                                                ? (server.error ? '#e40138' : (server.tool_count > 0 ? '#00c340' : '#e40138')) 
+                                        <circle cx="8" cy="8" r="6" x-bind:fill="server.connected
+                                                ? (server.error ? '#e40138' : (server.tool_count > 0 ? '#00c340' : '#e40138'))
                                                 : 'none'" x-bind:opacity="server.connected ? 1 : 0" />
                                         <circle cx="8" cy="8" r="6" fill="none" stroke="#e40138" stroke-width="2"
                                             x-bind:opacity="server.connected ? 0 : 1" />
@@ -80,6 +87,12 @@
         margin-top: 2rem;
         margin-bottom: 2rem;
     }
+        .profile-select-row {
+            display: flex;
+            align-items: center;
+            gap: 0.5em;
+            margin-bottom: 0.6em;
+        }
         #mcp-servers-config-json {
             width: 100%;
             height: 40em;


### PR DESCRIPTION
In additon to the default MCP config now every agent profile can bring it's own MCP config which gets initialized and managed separately only for this profile. This way agent profiles can now bring their own set of MCP servers private to them.