### PR TITLE
feat: Add support for extra HTTP headers in Browser Agent

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -221,6 +221,7 @@ class AgentConfig:
     profile: str = ""
     memory_subdir: str = ""
     knowledge_subdirs: list[str] = field(default_factory=lambda: ["default", "custom"])
+    browser_http_headers: dict[str, str] = field(default_factory=dict)  # Custom HTTP headers for browser requests
     code_exec_ssh_enabled: bool = True
     code_exec_ssh_addr: str = "localhost"
     code_exec_ssh_port: int = 55022

--- a/initialize.py
+++ b/initialize.py
@@ -79,6 +79,7 @@ def initialize_agent():
         memory_subdir=current_settings["agent_memory_subdir"],
         knowledge_subdirs=[current_settings["agent_knowledge_subdir"], "default"],
         mcp_servers=current_settings["mcp_servers"],
+        browser_http_headers=current_settings["browser_http_headers"],
         # code_exec params get initialized in _set_runtime_config
         # additional = {},
     )

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -52,6 +52,7 @@ class Settings(TypedDict):
     browser_model_rl_input: int
     browser_model_rl_output: int
     browser_model_kwargs: dict[str, str]
+    browser_http_headers: dict[str, str]
 
     agent_profile: str
     agent_memory_subdir: str
@@ -500,6 +501,16 @@ def convert_out(settings: Settings) -> SettingsOutput:
             "description": "Any other parameters supported by <a href='https://docs.litellm.ai/docs/set_keys' target='_blank'>LiteLLM</a>. Format is KEY=VALUE on individual lines, just like .env file.",
             "type": "textarea",
             "value": _dict_to_env(settings["browser_model_kwargs"]),
+        }
+    )
+
+    browser_model_fields.append(
+        {
+            "id": "browser_http_headers",
+            "title": "HTTP Headers",
+            "description": "HTTP headers to include with all browser requests. Format is KEY=VALUE on individual lines, just like .env file. Example: Authorization=Bearer token123",
+            "type": "textarea",
+            "value": _dict_to_env(settings.get("browser_http_headers", {})),
         }
     )
 
@@ -1213,7 +1224,14 @@ def convert_in(settings: dict) -> Settings:
                 )
 
                 if not should_skip:
-                    if field["id"].endswith("_kwargs"):
+                    # Special handling for browser_http_headers
+                    if field["id"] == "browser_http_headers":
+                        headers_dict = _env_to_dict(field["value"])
+                        # Validate headers before saving
+                        validated_headers = _validate_http_headers(headers_dict)
+                        current[field["id"]] = validated_headers
+                        PrintStyle().info(f"Set browser_http_headers: {validated_headers}")
+                    elif field["id"].endswith("_kwargs"):
                         current[field["id"]] = _env_to_dict(field["value"])
                     elif field["id"].startswith("api_key_"):
                         current["api_keys"][field["id"]] = field["value"]
@@ -1365,6 +1383,7 @@ def get_default_settings() -> Settings:
         browser_model_rl_input=0,
         browser_model_rl_output=0,
         browser_model_kwargs={"temperature": "0"},
+        browser_http_headers={},
         memory_recall_enabled=True,
         memory_recall_delayed=False,
         memory_recall_interval=3,
@@ -1536,6 +1555,45 @@ def _dict_to_env(data_dict):
             value = f'"{value}"'
         lines.append(f"{key}={value}")
     return "\n".join(lines)
+
+
+def _validate_http_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Validate and sanitize HTTP headers for browser requests"""
+    valid_headers = {}
+    
+    # Headers that should not be set manually as they're controlled by the browser
+    dangerous_headers = {
+        'host', 'content-length', 'connection', 'upgrade', 'expect',
+        'transfer-encoding', 'te', 'trailer', 'proxy-connection'
+    }
+    
+    for key, value in headers.items():
+        # Remove any leading/trailing whitespace
+        key = key.strip()
+        value = value.strip()
+        
+        # Skip empty keys or values
+        if not key or not value:
+            continue
+            
+        # Check for dangerous headers
+        if key.lower() in dangerous_headers:
+            PrintStyle().warning(f"Skipping potentially dangerous header: {key}")
+            continue
+            
+        # Basic header name validation (RFC 7230)
+        if not re.match(r'^[!#$%&\'*+\-.0-9A-Z^_`a-z|~]+$', key):
+            PrintStyle().warning(f"Invalid header name format: {key}")
+            continue
+            
+        # Header value validation - remove control characters except tab
+        cleaned_value = re.sub(r'[\x00-\x08\x0A-\x1F\x7F]', '', value)
+        if cleaned_value != value:
+            PrintStyle().warning(f"Cleaned invalid characters from header value: {key}")
+            
+        valid_headers[key] = cleaned_value
+    
+    return valid_headers
 
 
 def set_root_password(password: str):

--- a/python/tools/browser_agent.py
+++ b/python/tools/browser_agent.py
@@ -39,7 +39,18 @@ class State:
 
         # for some reason we need to provide exact path to headless shell, otherwise it looks for headed browser
         pw_binary = ensure_playwright_binary()
-
+        
+        # Prepare HTTP headers with error handling
+        try:
+            http_headers = self.agent.config.browser_http_headers or {}
+            if http_headers:
+                PrintStyle().info(f"Using HTTP headers: {list(http_headers.keys())}")
+            else:
+                PrintStyle().info("No custom HTTP headers configured")
+        except Exception as e:
+            PrintStyle().warning(f"Error processing HTTP headers, using defaults: {e}")
+            http_headers = {}
+        
         self.browser_session = browser_use.BrowserSession(
             browser_profile=browser_use.BrowserProfile(
                 headless=True,
@@ -64,6 +75,7 @@ class State:
                     / "profiles"
                     / f"agent_{self.agent.context.id}"
                 ),
+                extra_http_headers=http_headers,
             )
         )
 


### PR DESCRIPTION
- Add browser_http_headers field to AgentConfig for custom HTTP headers
- Implement UI settings field with textarea input for header configuration
- Add validation function to sanitize and validate HTTP headers
- Integrate headers into browser session initialization with error handling
- Support KEY=VALUE format in settings UI for easy header configuration
- Add safety checks to prevent dangerous headers that could break browser functionality

Resolves #657