### PR TITLE
Fix: Prevent auto-send when pressing Enter with a non-English input m…

### DIFF
--- a/webui/index.js
+++ b/webui/index.js
@@ -188,7 +188,7 @@ function toastFetchError(text, error) {
 globalThis.toastFetchError = toastFetchError;
 
 chatInput.addEventListener("keydown", (e) => {
-  if (e.key === "Enter" && !e.shiftKey) {
+  if (e.key === "Enter" && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {
     e.preventDefault();
     sendMessage();
   }


### PR DESCRIPTION
This fix addresses an issue where pressing Enter while using a non-English input method (e.g., Chinese IME) would unintentionally send the message. With this update, typing in English under a non-English input method now respects the expected user behavior and prevents accidental auto-send.