### PR TITLE
Improve UI with toggleable narrow chat view

### DIFF
--- a/webui/css/messages.css
+++ b/webui/css/messages.css
@@ -6,6 +6,9 @@
   flex-direction: column;
   flex-grow: 1;
   width: 100%;
+  max-width: 50rem; /* limit width to maintain a readable line-length */
+  margin-left: auto; /* center */
+  margin-right: auto; /* center */
   overflow-y: scroll;
   overflow-x: hidden;
   scroll-behavior: auto !important; /* avoid infinite scrolling! */

--- a/webui/index.css
+++ b/webui/index.css
@@ -906,6 +906,8 @@ h4 {
   max-width: 50rem; /* limit width to maintain a readable line-length */
   margin-left: auto; /* center */
   margin-right: auto; /* center */
+  -webkit-transition: all 0.3s ease;
+  transition: all 0.3s ease;
 }
 
 #input-section {

--- a/webui/index.css
+++ b/webui/index.css
@@ -901,6 +901,13 @@ h4 {
 }
 
 /* Input section layout */
+#input-section-container {
+  width: 100%;
+  max-width: 50rem; /* limit width to maintain a readable line-length */
+  margin-left: auto; /* center */
+  margin-right: auto; /* center */
+}
+
 #input-section {
   display: flex;
   flex-direction: column;

--- a/webui/index.html
+++ b/webui/index.html
@@ -295,6 +295,14 @@
                                     <span class="slider"></span>
                                 </label>
                             </li>
+                            <li x-data="{ narrowChat: localStorage.getItem('narrowChat') != 'false' }"
+                                x-init="$watch('narrowChat', val => toggleNarrowChat(val))">
+                                <span>Narrow chat</span>
+                                <label class="switch">
+                                    <input type="checkbox" x-model="narrowChat">
+                                    <span class="slider"></span>
+                                </label>
+                            </li>
                             <li x-data="{ speech: localStorage.getItem('speech') == 'true' }"
                                 x-init="$watch('speech', val => toggleSpeech(val))">
                                 <span class="switch-label">Speech</span>

--- a/webui/index.html
+++ b/webui/index.html
@@ -371,157 +371,158 @@
                 <button class="toast__copy" style="display: none;">Copy</button>
                 <button class="toast__close">Close</button>
             </div>
-            <div id="progress-bar-box">
-                <h4 id="progress-bar-h">
-                    <span id="progress-bar-i">|></span><span id="progress-bar"></span>
-                </h4>
-                <h4 id="progress-bar-stop-speech" x-data x-cloak x-show="$store.speech.isSpeaking">
-                    <span id="stop-speech" @click="$store.speech.stop()" style="cursor: pointer">Stop Speech</span>
-                </h4>
-            </div>
-            <div id="input-section" x-data="{
-                paused: false
-            }">
-
-                <!-- Attachment Preview section -->
-                <div>
-                    <x-component path="/chat/attachments/inputPreview.html" />
+            <div id="input-section-container">
+                <div id="progress-bar-box">
+                    <h4 id="progress-bar-h">
+                        <span id="progress-bar-i">|></span><span id="progress-bar"></span>
+                    </h4>
+                    <h4 id="progress-bar-stop-speech" x-data x-cloak x-show="$store.speech.isSpeaking">
+                        <span id="stop-speech" @click="$store.speech.stop()" style="cursor: pointer">Stop Speech</span>
+                    </h4>
                 </div>
+                <div id="input-section" x-data="{
+                    paused: false
+                }">
 
-                <!-- Top row with input and buttons -->
-                <div class="input-row">
-                    <!-- Attachment icon with tooltip -->
-                    <div class="attachment-wrapper" x-data="{ showTooltip: false }">
-                        <label for="file-input" class="attachment-icon" @mouseover="showTooltip = true"
-                            @mouseleave="showTooltip = false">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
-                                fill="currentColor">
-                                <path
-                                    d="M16.5 6v11.5c0 2.21-1.79 4-4 4s-4-1.79-4-4V5c0-1.38 1.12-2.5 2.5-2.5s2.5 1.12 2.5 2.5v10.5c0 .55-.45 1-1 1s-1-.45-1-1V6H10v9.5c0 1.38 1.12 2.5 2.5 2.5s2.5-1.12 2.5-2.5V5c0-2.21-1.79-4-4-4S7 2.79 7 5v12.5c0 3.04 2.46 5.5 5.5 5.5s5.5-2.46 5.5-5.5V6h-1.5z" />
-                            </svg>
-                        </label>
-                        <input type="file" id="file-input" accept="*" multiple style="display: none" @change="$store.chatAttachments.handleFileUpload($event)">
+                    <!-- Attachment Preview section -->
+                    <div>
+                        <x-component path="/chat/attachments/inputPreview.html" />
+                    </div>
 
-                        <div x-show="showTooltip" class="tooltip">
-                            Add attachments to the message
+                    <!-- Top row with input and buttons -->
+                    <div class="input-row">
+                        <!-- Attachment icon with tooltip -->
+                        <div class="attachment-wrapper" x-data="{ showTooltip: false }">
+                            <label for="file-input" class="attachment-icon" @mouseover="showTooltip = true"
+                                @mouseleave="showTooltip = false">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+                                    fill="currentColor">
+                                    <path
+                                        d="M16.5 6v11.5c0 2.21-1.79 4-4 4s-4-1.79-4-4V5c0-1.38 1.12-2.5 2.5-2.5s2.5 1.12 2.5 2.5v10.5c0 .55-.45 1-1 1s-1-.45-1-1V6H10v9.5c0 1.38 1.12 2.5 2.5 2.5s2.5-1.12 2.5-2.5V5c0-2.21-1.79-4-4-4S7 2.79 7 5v12.5c0 3.04 2.46 5.5 5.5 5.5s5.5-2.46 5.5-5.5V6h-1.5z" />
+                                </svg>
+                            </label>
+                            <input type="file" id="file-input" accept="*" multiple style="display: none" @change="$store.chatAttachments.handleFileUpload($event)">
+
+                            <div x-show="showTooltip" class="tooltip">
+                                Add attachments to the message
+                            </div>
+                        </div>
+
+                        <!-- Container for textarea and button -->
+                        <div id="chat-input-container" style="position: relative;">
+                            <textarea id="chat-input" placeholder="Type your message here..." rows="1"></textarea>
+
+                            <!-- Expand button inside the textarea container -->
+                            <button id="expand-button" @click="$store.fullScreenInputModal.openModal()" aria-label="Expand input">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
+                                </svg>
+                            </button>
+                        </div>
+
+                        <div id="chat-buttons-wrapper">
+
+                            <!-- Send button -->
+                            <button class="chat-button" id="send-button" aria-label="Send message">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                                    <path d="M25 20 L75 50 L25 80" fill="none" stroke="currentColor" stroke-width="15">
+                                    </path>
+                                </svg>
+                            </button>
+
+                            <!-- Microphone button -->
+                            <button class="chat-button mic-inactive" id="microphone-button"
+                                aria-label="Start/Stop recording"
+                                @click="$store.speech.handleMicrophoneClick()"
+                                x-effect="$store.speech.updateMicrophoneButtonUI()">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 18" fill="currentColor">
+                                    <path
+                                        d="m8,12c1.66,0,3-1.34,3-3V3c0-1.66-1.34-3-3-3s-3,1.34-3,3v6c0,1.66,1.34,3,3,3Zm-1,1.9c-2.7-.4-4.8-2.6-5-5.4H0c.2,3.8,3.1,6.9,7,7.5v2h2v-2c3.9-.6,6.8-3.7,7-7.5h-2c-.2,2.8-2.3,5-5,5.4h-2Z" />
+                                </svg>
+
+                            </button>
+
                         </div>
                     </div>
 
-                    <!-- Container for textarea and button -->
-                    <div id="chat-input-container" style="position: relative;">
-                        <textarea id="chat-input" placeholder="Type your message here..." rows="1"></textarea>
+                    <!-- Bottom row with text buttons -->
+                    <div class="text-buttons-row">
 
-                        <!-- Expand button inside the textarea container -->
-                        <button id="expand-button" @click="$store.fullScreenInputModal.openModal()" aria-label="Expand input">
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
+                        <button class="text-button" @click="pauseAgent(!paused)">
+                            <!-- Dynamic path that switches between pause and play icons -->
+                            <template x-if="!paused">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"
+                                    stroke-width="1.5" stroke="currentColor" width="14" height="14">
+                                    <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"></path>
+                                </svg>
+                            </template>
+                            <template x-if="paused">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"
+                                    stroke-width="1.8" stroke="currentColor" width="14" height="14">
+                                    <path d="M8 5v14l11-7z"></path>
+                                </svg>
+                            </template>
                             </svg>
+                            <span x-text="paused ? 'Resume Agent' : 'Pause Agent'"></span>
                         </button>
-                    </div>
 
-                    <div id="chat-buttons-wrapper">
-
-                        <!-- Send button -->
-                        <button class="chat-button" id="send-button" aria-label="Send message">
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-                                <path d="M25 20 L75 50 L25 80" fill="none" stroke="currentColor" stroke-width="15">
+                        <button class="text-button" @click="loadKnowledge()"><svg xmlns="http://www.w3.org/2000/svg"
+                                fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round"
+                                    d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5">
                                 </path>
                             </svg>
+                            <p>Import knowledge</p>
                         </button>
-
-                        <!-- Microphone button -->
-                        <button class="chat-button mic-inactive" id="microphone-button"
-                            aria-label="Start/Stop recording"
-                            @click="$store.speech.handleMicrophoneClick()"
-                            x-effect="$store.speech.updateMicrophoneButtonUI()">
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 18" fill="currentColor">
+                        <button class="text-button" id="work_dir_browser" @click="fileBrowserModalProxy.openModal()">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 123.37 92.59">
                                 <path
-                                    d="m8,12c1.66,0,3-1.34,3-3V3c0-1.66-1.34-3-3-3s-3,1.34-3,3v6c0,1.66,1.34,3,3,3Zm-1,1.9c-2.7-.4-4.8-2.6-5-5.4H0c.2,3.8,3.1,6.9,7,7.5v2h2v-2c3.9-.6,6.8-3.7,7-7.5h-2c-.2,2.8-2.3,5-5,5.4h-2Z" />
+                                    d="m5.72,11.5l-3.93,8.73h119.77s-3.96-8.73-3.96-8.73h-60.03c-1.59,0-2.88-1.29-2.88-2.88V1.75H13.72v6.87c0,1.59-1.29,2.88-2.88,2.88h-5.12Z"
+                                    fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="7"></path>
+                                <path
+                                    d="m6.38,20.23H1.75l7.03,67.03c.11,1.07.55,2.02,1.2,2.69.55.55,1.28.89,2.11.89h97.1c.82,0,1.51-.33,2.05-.87.68-.68,1.13-1.67,1.28-2.79l9.1-66.94H6.38Z"
+                                    fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="8"></path>
                             </svg>
-
+                            <p>Files</p>
                         </button>
 
+                        <button class="text-button" id="history_inspect" @click="globalThis.openHistoryModal()">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="5 10 85 85">
+                                <path fill="currentColor"
+                                    d="m59.572,57.949c-.41,0-.826-.105-1.207-.325l-9.574-5.528c-.749-.432-1.21-1.231-1.21-2.095v-14.923c0-1.336,1.083-2.419,2.419-2.419s2.419,1.083,2.419,2.419v13.526l8.364,4.829c1.157.668,1.554,2.148.886,3.305-.448.776-1.261,1.21-2.097,1.21Zm30.427-7.947c0,10.684-4.161,20.728-11.716,28.283-6.593,6.59-15.325,10.69-24.59,11.544-1.223.113-2.448.169-3.669.169-7.492,0-14.878-2.102-21.22-6.068l-15.356,5.733c-.888.331-1.887.114-2.557-.556s-.887-1.669-.556-2.557l5.733-15.351c-4.613-7.377-6.704-16.165-5.899-24.891.854-9.266,4.954-17.998,11.544-24.588,7.555-7.555,17.6-11.716,28.285-11.716s20.73,4.161,28.285,11.716c7.555,7.555,11.716,17.599,11.716,28.283Zm-15.137-24.861c-13.71-13.71-36.018-13.71-49.728,0-11.846,11.846-13.682,30.526-4.365,44.417.434.647.53,1.464.257,2.194l-4.303,11.523,11.528-4.304c.274-.102.561-.153.846-.153.474,0,.944.139,1.348.41,13.888,9.315,32.568,7.479,44.417-4.365,13.707-13.708,13.706-36.014,0-49.723Zm-24.861-4.13c-15.989,0-28.996,13.006-28.996,28.992s13.008,28.992,28.996,28.992c1.336,0,2.419-1.083,2.419-2.419s-1.083-2.419-2.419-2.419c-13.32,0-24.157-10.835-24.157-24.153s10.837-24.153,24.157-24.153,24.153,10.835,24.153,24.153c0,1.336,1.083,2.419,2.419,2.419s2.419-1.083,2.419-2.419c0-15.986-13.006-28.992-28.992-28.992Zm25.041,33.531c-1.294.347-2.057,1.673-1.71,2.963.343,1.289,1.669,2.057,2.963,1.71,1.289-.343,2.053-1.669,1.71-2.963-.347-1.289-1.673-2.057-2.963-1.71Zm-2.03,6.328c-1.335,0-2.419,1.084-2.419,2.419s1.084,2.419,2.419,2.419,2.419-1.084,2.419-2.419-1.084-2.419-2.419-2.419Zm-3.598,5.587c-1.289-.347-2.615.416-2.963,1.71-.343,1.289.421,2.615,1.71,2.963,1.294.347,2.62-.421,2.963-1.71.347-1.294-.416-2.62-1.71-2.963Zm-4.919,4.462c-1.157-.667-2.638-.27-3.306.887-.667,1.157-.27,2.638.887,3.305,1.157.668,2.638.27,3.306-.887.667-1.157.27-2.638-.887-3.306Zm-9.327,3.04c-.946.946-.946,2.478,0,3.42.942.946,2.473.946,3.42,0,.946-.942.946-2.473,0-3.42-.946-.946-2.478-.946-3.42,0Z">
+                                </path>
+                            </svg>
+                            <p>History</p>
+                        </button>
+
+                        <button class="text-button" id="ctx_window" @click="globalThis.openCtxWindowModal()">
+                            <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="17 15 70 70" fill="currentColor">
+                                <path
+                                    d="m63 25c1.1016 0 2-0.89844 2-2s-0.89844-2-2-2h-26c-1.1016 0-2 0.89844-2 2s0.89844 2 2 2z">
+                                </path>
+                                <path
+                                    d="m63 79c1.1016 0 2-0.89844 2-2s-0.89844-2-2-2h-26c-1.1016 0-2 0.89844-2 2s0.89844 2 2 2z">
+                                </path>
+                                <path
+                                    d="m68 39h-36c-6.0703 0-11 4.9297-11 11s4.9297 11 11 11h36c6.0703 0 11-4.9297 11-11s-4.9297-11-11-11zm0 18h-36c-3.8594 0-7-3.1406-7-7s3.1406-7 7-7h36c3.8594 0 7 3.1406 7 7s-3.1406 7-7 7z">
+                                </path>
+                            </svg>
+                            <p>Context</p>
+                        </button>
+
+                        <button class="text-button" id="nudges_window" @click="nudge()">
+                            <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 49 58"
+                                fill="currentColor">
+                                <path
+                                    d="m11.97,16.32c-.46,0-.91-.25-1.15-.68-.9-1.63-1.36-3.34-1.36-5.1C9.45,4.73,14.18,0,20,0s10.55,4.73,10.55,10.55c0,.87-.13,1.75-.41,2.76-.19.7-.9,1.13-1.62.93-.7-.19-1.12-.92-.93-1.62.21-.79.31-1.44.31-2.07,0-4.36-3.55-7.91-7.91-7.91s-7.91,3.55-7.91,7.91c0,1.3.35,2.59,1.03,3.82.36.64.13,1.44-.51,1.79-.21.11-.42.17-.64.17Z"
+                                    stroke-width="0.5" stroke="currentColor" />
+                                <path
+                                    d="m34.5,58h-6.18c-3.17,0-6.15-1.23-8.39-3.47L1.16,35.75c-1.54-1.54-1.54-4.05,0-5.59,2.4-2.4,6.27-2.68,8.99-.64l4.58,3.44V10.55c0-2.91,2.36-5.27,5.27-5.27s5.27,2.36,5.27,5.27v8.62c.78-.45,1.68-.71,2.64-.71,2.3,0,4.26,1.48,4.98,3.53.84-.56,1.85-.89,2.93-.89,2.3,0,4.26,1.48,4.98,3.53.84-.56,1.85-.89,2.93-.89,2.91,0,5.27,2.36,5.27,5.27v14.5c0,8-6.51,14.5-14.5,14.5ZM6.03,30.79c-1.1,0-2.19.42-3.01,1.23-.51.51-.51,1.35,0,1.86l18.77,18.78c1.74,1.74,4.06,2.7,6.53,2.7h6.18c6.54,0,11.86-5.32,11.86-11.86v-14.5c0-1.45-1.18-2.64-2.64-2.64s-2.64,1.18-2.64,2.64v1.32c0,.73-.59,1.32-1.32,1.32s-1.32-.59-1.32-1.32v-3.95c0-1.45-1.18-2.64-2.64-2.64s-2.64,1.18-2.64,2.64v3.95c0,.73-.59,1.32-1.32,1.32s-1.32-.59-1.32-1.32v-6.59c0-1.45-1.18-2.64-2.64-2.64s-2.64,1.18-2.64,2.64v6.59c0,.73-.59,1.32-1.32,1.32s-1.32-.59-1.32-1.32V10.55c0-1.45-1.18-2.64-2.64-2.64s-2.64,1.18-2.64,2.64v25.05c0,.5-.28.95-.73,1.18s-.98.18-1.38-.12l-6.69-5.02c-.75-.56-1.65-.84-2.54-.84Z"
+                                    stroke-width="0.5" stroke="currentColor" />
+                            </svg>
+                            <p>Nudge</p>
+                        </button>
                     </div>
-                </div>
-
-                <!-- Bottom row with text buttons -->
-                <div class="text-buttons-row">
-
-                    <button class="text-button" @click="pauseAgent(!paused)">
-                        <!-- Dynamic path that switches between pause and play icons -->
-                        <template x-if="!paused">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"
-                                stroke-width="1.5" stroke="currentColor" width="14" height="14">
-                                <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"></path>
-                            </svg>
-                        </template>
-                        <template x-if="paused">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"
-                                stroke-width="1.8" stroke="currentColor" width="14" height="14">
-                                <path d="M8 5v14l11-7z"></path>
-                            </svg>
-                        </template>
-                        </svg>
-                        <span x-text="paused ? 'Resume Agent' : 'Pause Agent'"></span>
-                    </button>
-
-                    <button class="text-button" @click="loadKnowledge()"><svg xmlns="http://www.w3.org/2000/svg"
-                            fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round"
-                                d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5">
-                            </path>
-                        </svg>
-                        <p>Import knowledge</p>
-                    </button>
-                    <button class="text-button" id="work_dir_browser" @click="fileBrowserModalProxy.openModal()">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 123.37 92.59">
-                            <path
-                                d="m5.72,11.5l-3.93,8.73h119.77s-3.96-8.73-3.96-8.73h-60.03c-1.59,0-2.88-1.29-2.88-2.88V1.75H13.72v6.87c0,1.59-1.29,2.88-2.88,2.88h-5.12Z"
-                                fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="7"></path>
-                            <path
-                                d="m6.38,20.23H1.75l7.03,67.03c.11,1.07.55,2.02,1.2,2.69.55.55,1.28.89,2.11.89h97.1c.82,0,1.51-.33,2.05-.87.68-.68,1.13-1.67,1.28-2.79l9.1-66.94H6.38Z"
-                                fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="8"></path>
-                        </svg>
-                        <p>Files</p>
-                    </button>
-
-                    <button class="text-button" id="history_inspect" @click="globalThis.openHistoryModal()">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="5 10 85 85">
-                            <path fill="currentColor"
-                                d="m59.572,57.949c-.41,0-.826-.105-1.207-.325l-9.574-5.528c-.749-.432-1.21-1.231-1.21-2.095v-14.923c0-1.336,1.083-2.419,2.419-2.419s2.419,1.083,2.419,2.419v13.526l8.364,4.829c1.157.668,1.554,2.148.886,3.305-.448.776-1.261,1.21-2.097,1.21Zm30.427-7.947c0,10.684-4.161,20.728-11.716,28.283-6.593,6.59-15.325,10.69-24.59,11.544-1.223.113-2.448.169-3.669.169-7.492,0-14.878-2.102-21.22-6.068l-15.356,5.733c-.888.331-1.887.114-2.557-.556s-.887-1.669-.556-2.557l5.733-15.351c-4.613-7.377-6.704-16.165-5.899-24.891.854-9.266,4.954-17.998,11.544-24.588,7.555-7.555,17.6-11.716,28.285-11.716s20.73,4.161,28.285,11.716c7.555,7.555,11.716,17.599,11.716,28.283Zm-15.137-24.861c-13.71-13.71-36.018-13.71-49.728,0-11.846,11.846-13.682,30.526-4.365,44.417.434.647.53,1.464.257,2.194l-4.303,11.523,11.528-4.304c.274-.102.561-.153.846-.153.474,0,.944.139,1.348.41,13.888,9.315,32.568,7.479,44.417-4.365,13.707-13.708,13.706-36.014,0-49.723Zm-24.861-4.13c-15.989,0-28.996,13.006-28.996,28.992s13.008,28.992,28.996,28.992c1.336,0,2.419-1.083,2.419-2.419s-1.083-2.419-2.419-2.419c-13.32,0-24.157-10.835-24.157-24.153s10.837-24.153,24.157-24.153,24.153,10.835,24.153,24.153c0,1.336,1.083,2.419,2.419,2.419s2.419-1.083,2.419-2.419c0-15.986-13.006-28.992-28.992-28.992Zm25.041,33.531c-1.294.347-2.057,1.673-1.71,2.963.343,1.289,1.669,2.057,2.963,1.71,1.289-.343,2.053-1.669,1.71-2.963-.347-1.289-1.673-2.057-2.963-1.71Zm-2.03,6.328c-1.335,0-2.419,1.084-2.419,2.419s1.084,2.419,2.419,2.419,2.419-1.084,2.419-2.419-1.084-2.419-2.419-2.419Zm-3.598,5.587c-1.289-.347-2.615.416-2.963,1.71-.343,1.289.421,2.615,1.71,2.963,1.294.347,2.62-.421,2.963-1.71.347-1.294-.416-2.62-1.71-2.963Zm-4.919,4.462c-1.157-.667-2.638-.27-3.306.887-.667,1.157-.27,2.638.887,3.305,1.157.668,2.638.27,3.306-.887.667-1.157.27-2.638-.887-3.306Zm-9.327,3.04c-.946.946-.946,2.478,0,3.42.942.946,2.473.946,3.42,0,.946-.942.946-2.473,0-3.42-.946-.946-2.478-.946-3.42,0Z">
-                            </path>
-                        </svg>
-                        <p>History</p>
-                    </button>
-
-                    <button class="text-button" id="ctx_window" @click="globalThis.openCtxWindowModal()">
-                        <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="17 15 70 70" fill="currentColor">
-                            <path
-                                d="m63 25c1.1016 0 2-0.89844 2-2s-0.89844-2-2-2h-26c-1.1016 0-2 0.89844-2 2s0.89844 2 2 2z">
-                            </path>
-                            <path
-                                d="m63 79c1.1016 0 2-0.89844 2-2s-0.89844-2-2-2h-26c-1.1016 0-2 0.89844-2 2s0.89844 2 2 2z">
-                            </path>
-                            <path
-                                d="m68 39h-36c-6.0703 0-11 4.9297-11 11s4.9297 11 11 11h36c6.0703 0 11-4.9297 11-11s-4.9297-11-11-11zm0 18h-36c-3.8594 0-7-3.1406-7-7s3.1406-7 7-7h36c3.8594 0 7 3.1406 7 7s-3.1406 7-7 7z">
-                            </path>
-                        </svg>
-                        <p>Context</p>
-                    </button>
-
-                    <button class="text-button" id="nudges_window" @click="nudge()">
-                        <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 49 58"
-                            fill="currentColor">
-                            <path
-                                d="m11.97,16.32c-.46,0-.91-.25-1.15-.68-.9-1.63-1.36-3.34-1.36-5.1C9.45,4.73,14.18,0,20,0s10.55,4.73,10.55,10.55c0,.87-.13,1.75-.41,2.76-.19.7-.9,1.13-1.62.93-.7-.19-1.12-.92-.93-1.62.21-.79.31-1.44.31-2.07,0-4.36-3.55-7.91-7.91-7.91s-7.91,3.55-7.91,7.91c0,1.3.35,2.59,1.03,3.82.36.64.13,1.44-.51,1.79-.21.11-.42.17-.64.17Z"
-                                stroke-width="0.5" stroke="currentColor" />
-                            <path
-                                d="m34.5,58h-6.18c-3.17,0-6.15-1.23-8.39-3.47L1.16,35.75c-1.54-1.54-1.54-4.05,0-5.59,2.4-2.4,6.27-2.68,8.99-.64l4.58,3.44V10.55c0-2.91,2.36-5.27,5.27-5.27s5.27,2.36,5.27,5.27v8.62c.78-.45,1.68-.71,2.64-.71,2.3,0,4.26,1.48,4.98,3.53.84-.56,1.85-.89,2.93-.89,2.3,0,4.26,1.48,4.98,3.53.84-.56,1.85-.89,2.93-.89,2.91,0,5.27,2.36,5.27,5.27v14.5c0,8-6.51,14.5-14.5,14.5ZM6.03,30.79c-1.1,0-2.19.42-3.01,1.23-.51.51-.51,1.35,0,1.86l18.77,18.78c1.74,1.74,4.06,2.7,6.53,2.7h6.18c6.54,0,11.86-5.32,11.86-11.86v-14.5c0-1.45-1.18-2.64-2.64-2.64s-2.64,1.18-2.64,2.64v1.32c0,.73-.59,1.32-1.32,1.32s-1.32-.59-1.32-1.32v-3.95c0-1.45-1.18-2.64-2.64-2.64s-2.64,1.18-2.64,2.64v3.95c0,.73-.59,1.32-1.32,1.32s-1.32-.59-1.32-1.32v-6.59c0-1.45-1.18-2.64-2.64-2.64s-2.64,1.18-2.64,2.64v6.59c0,.73-.59,1.32-1.32,1.32s-1.32-.59-1.32-1.32V10.55c0-1.45-1.18-2.64-2.64-2.64s-2.64,1.18-2.64,2.64v25.05c0,.5-.28.95-.73,1.18s-.98.18-1.38-.12l-6.69-5.02c-.75-.56-1.65-.84-2.54-.84Z"
-                                stroke-width="0.5" stroke="currentColor" />
-                        </svg>
-                        <p>Nudge</p>
-                    </button>
-
                 </div>
             </div>
         </div>

--- a/webui/index.js
+++ b/webui/index.js
@@ -799,6 +799,21 @@ globalThis.toggleUtils = async function (showUtils) {
   );
 };
 
+globalThis.toggleNarrowChat = function (isNarrow) {
+  css.toggleCssProperty(
+    "#input-section-container",
+    "max-width",
+    isNarrow ? "50rem" : "100%"
+  );
+  css.toggleCssProperty(
+    "#chat-history",
+    "max-width",
+    isNarrow ? "50rem" : "100%"
+  );
+  console.log("Narrow chat:", isNarrow);
+  localStorage.setItem("narrowChat", isNarrow);
+};
+
 globalThis.toggleDarkMode = function (isDark) {
   if (isDark) {
     document.body.classList.remove("light-mode");
@@ -871,6 +886,9 @@ globalThis.restart = async function () {
 document.addEventListener("DOMContentLoaded", () => {
   const isDarkMode = localStorage.getItem("darkMode") !== "false";
   toggleDarkMode(isDarkMode);
+
+  const isNarrowChat = localStorage.getItem("narrowChat") !== "false";
+  toggleNarrowChat(isNarrowChat);
 });
 
 globalThis.loadChats = async function () {


### PR DESCRIPTION
This PR adjusts the UI to limit the right panel / chat history container’s max-width to improve readability. It is enabled by default but can be toggled off by clicking the toggle in the preferences.

![vivaldi_20250830211039_x](https://github.com/user-attachments/assets/30750b2b-0f20-462c-8944-a04e4fe7c6ce)
