### PR TITLE
Add GitHub Copilot provider and update installation docs

### DIFF
--- a/conf/model_providers.yaml
+++ b/conf/model_providers.yaml
@@ -30,6 +30,13 @@ chat:
   deepseek:
     name: DeepSeek
     litellm_provider: deepseek
+  github_copilot:
+    name: GitHub Copilot
+    litellm_provider: github_copilot
+    kwargs:
+      extra_headers:
+          "Editor-Version": "vscode/1.85.1"
+          "Copilot-Integration-Id": "vscode-chat"
   google:
     name: Google
     litellm_provider: gemini

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -186,6 +186,14 @@ Agent Zero provides a comprehensive settings interface to customize various aspe
 - Configure API keys for various service providers directly within the Web UI
 - Click `Save` to confirm your settings
 
+> [!CAUTION]
+> **GitHub Copilot Provider:** When using the GitHub Copilot provider, after selecting the model and entering your first prompt, the OAuth login procedure will begin. You'll find the authentication code and link in the output logs. Complete the authentication process by following the provided link and entering the code, then you may continue using Agent Zero.
+
+> [!NOTE]
+> **GitHub Copilot Limitations:** GitHub Copilot models typically have smaller rate limits and context windows compared to models hosted by other providers like OpenAI, Anthropic, or Azure. Consider this when working with large conversations or high-frequency requests.
+
+
+
 ### Authentication
 - **UI Login:** Set username for web interface access
 - **UI Password:** Configure password for web interface security


### PR DESCRIPTION
This pull request adds support for GitHub Copilot as a model provider and updates the documentation to guide users through authentication and highlight limitations. The most important changes are:

**Model Provider Integration:**

* Added a new `github_copilot` provider configuration in `model_providers.yaml`, including custom headers for integration headers via VS Code specifications.

**Documentation Updates:**

* Updated `docs/installation.md` to include instructions for GitHub Copilot OAuth authentication, explaining how users can complete the login process via a link and code found in the output logs.
* Added a note about GitHub Copilot's rate limits and context window limitations compared to other providers, helping users set expectations when choosing this provider.