### PR TITLE
feat: Manage Model Groups

### DIFF
--- a/python/api/model_group_create.py
+++ b/python/api/model_group_create.py
@@ -1,0 +1,21 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers import model_groups
+
+
+class ModelGroupCreate(ApiHandler):
+    @classmethod
+    def requires_auth(cls) -> bool:
+        return True
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["POST"]
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        name = input.get('name')
+        chat = input.get('chat')
+        util = input.get('util')
+        if not name:
+            return Response(response='{"error":"name required"}', status=400, mimetype='application/json')
+        data = model_groups.create_group(name, chat or {}, util or {})
+        return {"status": "ok", "data": data}

--- a/python/api/model_group_delete.py
+++ b/python/api/model_group_delete.py
@@ -1,0 +1,19 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers import model_groups
+
+
+class ModelGroupDelete(ApiHandler):
+    @classmethod
+    def requires_auth(cls) -> bool:
+        return True
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["POST"]
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        name = input.get('name')
+        if not name:
+            return Response(response='{"error":"name required"}', status=400, mimetype='application/json')
+        data = model_groups.delete_group(name)
+        return {"status": "ok", "data": data}

--- a/python/api/model_group_select.py
+++ b/python/api/model_group_select.py
@@ -1,0 +1,92 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers import model_groups, settings as settings_helper
+import json
+
+
+class ModelGroupSelect(ApiHandler):
+    @classmethod
+    def requires_auth(cls) -> bool:
+        return True
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["POST"]
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        grp = input.get('group')
+        if not grp:
+            return Response(response='{"error":"group field required"}', status=400, mimetype='application/json')
+
+        g = model_groups.get_group(grp)
+        if not g:
+            return Response(response='{"error":"group not found"}', status=404, mimetype='application/json')
+
+        # map group to settings delta
+        delta = {}
+        chat = g.get('chat', {})
+        util = g.get('util', {})
+
+        # Attempt to fill missing api_base from pool entries if needed
+        try:
+            mg_all = model_groups.get_all()
+            chat_pool = mg_all.get('chat_models', [])
+            util_pool = mg_all.get('utility_models', [])
+        except Exception:
+            chat_pool = []
+            util_pool = []
+
+        def find_api_base(pool, provider, name):
+            if not provider or not name:
+                return ''
+            p_low = (provider or '').lower()
+            n_low = (name or '').lower()
+            for m in pool:
+                try:
+                    if (m.get('provider') or '').lower() == p_low and (m.get('name') or '').lower() == n_low:
+                        return m.get('api_base', '') or ''
+                except Exception:
+                    continue
+            return ''
+
+        if chat:
+            chat_provider = chat.get('provider', '')
+            chat_name = chat.get('name', '')
+            chat_api = chat.get('api_base', '') or find_api_base(chat_pool, chat_provider, chat_name)
+            delta['chat_model_provider'] = chat_provider
+            delta['chat_model_name'] = chat_name
+            delta['chat_model_api_base'] = chat_api
+            delta['chat_model_kwargs'] = chat.get('kwargs', {})
+        if util:
+            util_provider = util.get('provider', '')
+            util_name = util.get('name', '')
+            util_api = util.get('api_base', '') or find_api_base(util_pool, util_provider, util_name)
+            delta['util_model_provider'] = util_provider
+            delta['util_model_name'] = util_name
+            delta['util_model_api_base'] = util_api
+            delta['util_model_kwargs'] = util.get('kwargs', {})
+
+        # apply settings runtime and capture errors
+        applied = False
+        error_msg = None
+        try:
+            settings_helper.set_settings_delta(delta, apply=True)
+            applied = True
+        except Exception as e:
+            error_msg = str(e)
+
+        # mark active group in model_groups persistence (non-fatal)
+        try:
+            model_groups.set_active(grp)
+        except Exception:
+            # ignore persistence failures
+            pass
+
+        result = {"status": "ok" if applied else "error", "applied": applied, "active": grp}
+        if error_msg:
+            result["error"] = error_msg
+
+        if not applied:
+            return Response(response=json.dumps(result), status=500, mimetype='application/json')
+
+        return result
+

--- a/python/api/model_group_update.py
+++ b/python/api/model_group_update.py
@@ -1,0 +1,45 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers import model_groups
+
+
+class ModelGroupUpdate(ApiHandler):
+    @classmethod
+    def requires_auth(cls) -> bool:
+        return True
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["POST"]
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        name = input.get('name')
+        new_name = input.get('new_name')
+        chat = input.get('chat')
+        util = input.get('util')
+        if not name:
+            return Response(response='{"error":"name required"}', status=400, mimetype='application/json')
+        try:
+            # if renaming requested, perform rename first (validate conflicts)
+            if new_name and new_name != name:
+                try:
+                    model_groups.rename_group(name, new_name)
+                except KeyError as e:
+                    # rename failed: either original not found or new name exists
+                    return Response(response=json_response({'error': str(e)}), status=409, mimetype='application/json')
+                name_to_use = new_name
+            else:
+                name_to_use = name
+
+            # perform update (chat/util may be omitted)
+            data = model_groups.update_group(name_to_use, chat if chat is not None else None, util if util is not None else None)
+        except KeyError:
+            return Response(response='{"error":"group not found"}', status=404, mimetype='application/json')
+        return {"status": "ok", "data": data}
+
+
+def json_response(obj: dict) -> str:
+    try:
+        import json as _json
+        return _json.dumps(obj)
+    except Exception:
+        return '{"error":"unknown"}'

--- a/python/api/model_groups_list.py
+++ b/python/api/model_groups_list.py
@@ -1,0 +1,13 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers import model_groups
+
+
+class ModelGroupsList(ApiHandler):
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["GET"]
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        data = model_groups.get_all()
+        return data
+

--- a/python/api/model_groups_manage.py
+++ b/python/api/model_groups_manage.py
@@ -1,0 +1,51 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers import model_groups
+
+
+class ModelGroupsManage(ApiHandler):
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["POST"]
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        action = input.get('action')
+        if not action:
+            return Response(response='{"error":"action required"}', status=400, mimetype='application/json')
+
+        try:
+            if action == 'create_group':
+                name = str(input.get('name') or '')
+                chat = input.get('chat') or {}
+                util = input.get('util') or {}
+                data = model_groups.create_group(name, chat, util)
+                return data
+            if action == 'update_group':
+                name = str(input.get('name') or '')
+                chat = input.get('chat') if 'chat' in input else None
+                util = input.get('util') if 'util' in input else None
+                data = model_groups.update_group(name, chat, util)
+                return data
+            if action == 'delete_group':
+                name = str(input.get('name') or '')
+                data = model_groups.delete_group(name)
+                return data
+            if action == 'add_model':
+                mtype = str(input.get('type') or '')
+                provider = str(input.get('provider') or '')
+                name = str(input.get('model') or '')
+                api_base = str(input.get('api_base') or '')
+                kwargs = input.get('kwargs', {}) or {}
+                data = model_groups.add_model_to_pool(mtype, provider, name, api_base, kwargs)
+                return data
+            if action == 'remove_model':
+                mtype = str(input.get('type') or '')
+                provider = str(input.get('provider') or '')
+                name = str(input.get('model') or '')
+                data = model_groups.remove_model_from_pool(mtype, provider, name)
+                return data
+        except KeyError:
+            return Response(response='{"error":"not found"}', status=404, mimetype='application/json')
+        except Exception as e:
+            return Response(response=f'{{"error":"{str(e)}"}}', status=500, mimetype='application/json')
+
+        return Response(response='{"error":"unknown action"}', status=400, mimetype='application/json')

--- a/python/api/model_groups_regenerate.py
+++ b/python/api/model_groups_regenerate.py
@@ -1,0 +1,54 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers import model_groups, settings as settings_helper
+
+
+class ModelGroupsRegenerate(ApiHandler):
+    @classmethod
+    def requires_auth(cls) -> bool:
+        return True
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["POST"]
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        force = bool(input.get('force'))
+        # load existing model_groups and current settings
+        mg = model_groups.get_all()
+        s = settings_helper.get_settings()
+
+        # Helper: check if group/default chat/util match current settings
+        def _is_default_matching_settings(mg_obj, settings_obj):
+            try:
+                groups = mg_obj.get('groups', {})
+                default_name = mg_obj.get('default')
+                if not default_name or default_name not in groups:
+                    return False
+                g = groups[default_name]
+                chat = g.get('chat', {}) or {}
+                util = g.get('util', {}) or {}
+                # compare provider and name
+                if (chat.get('provider') or '') != (settings_obj.get('chat_model_provider') or ''):
+                    return False
+                if (chat.get('name') or '') != (settings_obj.get('chat_model_name') or ''):
+                    return False
+                if (util.get('provider') or '') != (settings_obj.get('util_model_provider') or ''):
+                    return False
+                if (util.get('name') or '') != (settings_obj.get('util_model_name') or ''):
+                    return False
+                return True
+            except Exception:
+                return False
+
+        if force:
+            data = model_groups.create_default_from_settings()
+            return {"status": "ok", "data": data}
+
+        # If default missing or not matching current settings or default's chat/util empty -> regenerate
+        default_missing = not (mg.get('groups') and mg.get('default'))
+        default_mismatch = not _is_default_matching_settings(mg, s)
+        if default_missing or default_mismatch:
+            data = model_groups.create_default_from_settings()
+            return {"status": "ok", "data": data, "reason": "regenerated"}
+
+        return {"status": "skipped", "reason": "default up-to-date"}

--- a/python/api/model_pool_add.py
+++ b/python/api/model_pool_add.py
@@ -1,0 +1,30 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers import model_groups
+
+
+class ModelPoolAdd(ApiHandler):
+    @classmethod
+    def requires_auth(cls) -> bool:
+        return True
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["POST"]
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        model_type = input.get('type')
+        provider = input.get('provider')
+        name = input.get('name')
+        api_base = input.get('api_base', '')
+        kwargs = input.get('kwargs', {})
+        if not model_type:
+            return Response(response='{"error":"type required"}', status=400, mimetype='application/json')
+        model_type = model_type.lower()
+        if model_type == 'util':
+            model_type = 'utility'
+        if model_type not in ('chat', 'utility'):
+            return Response(response='{"error":"type must be chat or utility"}', status=400, mimetype='application/json')
+        if not provider or not name:
+            return Response(response='{"error":"provider and name required"}', status=400, mimetype='application/json')
+        data = model_groups.add_model_to_pool(model_type, provider, name, api_base, kwargs)
+        return {"status": "ok", "data": data}

--- a/python/api/model_pool_remove.py
+++ b/python/api/model_pool_remove.py
@@ -1,0 +1,26 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers import model_groups
+
+
+class ModelPoolRemove(ApiHandler):
+    @classmethod
+    def requires_auth(cls) -> bool:
+        return True
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["POST"]
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        model_type = input.get('type')
+        provider = input.get('provider')
+        name = input.get('name')
+        if not model_type or not provider or not name:
+            return Response(response='{"error":"type/provider/name required"}', status=400, mimetype='application/json')
+        model_type = model_type.lower()
+        if model_type == 'util':
+            model_type = 'utility'
+        if model_type not in ('chat', 'utility'):
+            return Response(response='{"error":"type must be chat or utility"}', status=400, mimetype='application/json')
+        data = model_groups.remove_model_from_pool(model_type, provider, name)
+        return {"status": "ok", "data": data}

--- a/python/api/model_providers_list.py
+++ b/python/api/model_providers_list.py
@@ -1,0 +1,16 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers import providers
+
+
+class ModelProvidersList(ApiHandler):
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["GET"]
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        try:
+            chat = providers.get_providers('chat')
+            embedding = providers.get_providers('embedding')
+            return {'chat': chat, 'embedding': embedding}
+        except Exception as e:
+            return Response(response=f'{{"error":"{str(e)}"}}', status=500, mimetype='application/json')

--- a/python/helpers/model_groups.py
+++ b/python/helpers/model_groups.py
@@ -1,0 +1,280 @@
+import json
+from typing import Any, Dict
+from python.helpers import files
+from python.helpers import settings as settings_helper
+
+
+MODEL_GROUPS_PATH = files.get_abs_path('tmp/model_groups.json')
+
+
+def _read() -> Dict[str, Any]:
+    try:
+        with open(MODEL_GROUPS_PATH, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        return {}
+
+
+def _write(obj: Dict[str, Any]):
+    # ensure dir
+    files.make_dirs('tmp/model_groups.json')
+    with open(MODEL_GROUPS_PATH, 'w', encoding='utf-8') as f:
+        json.dump(obj, f, indent=2, ensure_ascii=False)
+
+
+def get_all() -> Dict[str, Any]:
+    data = _read()
+    # If file missing/empty OR groups key missing OR groups mapping empty,
+    # regenerate defaults from settings to ensure callers always get a
+    # sensible model_groups object.
+    if not data or 'groups' not in data or not data.get('groups'):
+        ensure_exists()
+        data = _read()
+    return data
+
+
+def set_active(name: str) -> Dict[str, Any]:
+    data = get_all()
+    data['active'] = name
+    _write(data)
+    return data
+
+
+def get_active() -> str | None:
+    data = get_all()
+    return data.get('active')
+
+
+def list_groups() -> Dict[str, Dict[str, Any]]:
+    data = get_all()
+    return data.get('groups', {})
+
+
+def get_group(name: str) -> Dict[str, Any] | None:
+    groups = list_groups()
+    return groups.get(name)
+
+
+def create_default_from_settings():
+    # Merge default group and pool entries from current settings into existing model_groups
+    # Try to use settings_helper, but fall back to loading the raw settings file
+    # if that call fails (robust for environments where importing settings
+    # triggers heavy dependencies).
+    try:
+        s = settings_helper.get_settings()
+        if not s:
+            raise Exception('empty settings from helper')
+    except Exception:
+        try:
+            # direct read of tmp/settings.json as fallback
+            settings_path = files.get_abs_path('tmp/settings.json')
+            with open(settings_path, 'r', encoding='utf-8') as sf:
+                s = json.load(sf)
+        except Exception:
+            # give up with empty defaults
+            s = {}
+
+    # read existing content without triggering ensure_exists recursion
+    existing = _read() or {}
+
+    groups = existing.get('groups', {})
+
+    default_group = {
+        'chat': {
+            'provider': s.get('chat_model_provider', ''),
+            'name': s.get('chat_model_name', ''),
+            'api_base': s.get('chat_model_api_base', ''),
+            'kwargs': s.get('chat_model_kwargs', {}),
+        },
+        'util': {
+            'provider': s.get('util_model_provider', ''),
+            'name': s.get('util_model_name', ''),
+            'api_base': s.get('util_model_api_base', ''),
+            'kwargs': s.get('util_model_kwargs', {}),
+        },
+    }
+
+    # set default group if missing or empty
+    default_name = existing.get('default', 'default')
+    # Use default_name to check existence (previous check mistakenly looked for the
+    # literal 'default' key in groups). Also ensure we create a default when the
+    # groups mapping is empty.
+    if default_name not in groups or not groups.get(default_name):
+        groups.setdefault(default_name, default_group)
+    else:
+        # if default exists but has empty chat/util, fill from settings
+        dg = groups.get(default_name, {})
+        if not (dg.get('chat', {}) or {}).get('name'):
+            dg['chat'] = default_group['chat']
+        if not (dg.get('util', {}) or {}).get('name'):
+            dg['util'] = default_group['util']
+        groups[default_name] = dg
+
+    # ensure chat_models and utility_models exist and include current settings entries
+    chat_models = existing.get('chat_models', [])
+    util_models = existing.get('utility_models', [])
+
+    def _ensure_in_list(lst, provider, name, api_base='', kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        for m in lst:
+            if (m.get('provider') or '').lower() == (provider or '').lower() and (m.get('name') or '') == (name or ''):
+                # update api_base/kwargs if missing
+                if api_base and not m.get('api_base'):
+                    m['api_base'] = api_base
+                if kwargs and not m.get('kwargs'):
+                    m['kwargs'] = kwargs
+                return lst
+        lst.append({'provider': provider or '', 'name': name or '', 'api_base': api_base or '', 'kwargs': kwargs or {}})
+        return lst
+
+    chat_models = _ensure_in_list(chat_models, s.get('chat_model_provider', ''), s.get('chat_model_name', ''), s.get('chat_model_api_base', ''), s.get('chat_model_kwargs', {}))
+    util_models = _ensure_in_list(util_models, s.get('util_model_provider', ''), s.get('util_model_name', ''), s.get('util_model_api_base', ''), s.get('util_model_kwargs', {}))
+
+    out = existing.copy()
+    out['default'] = default_name
+    out['groups'] = groups
+    out['chat_models'] = chat_models
+    out['utility_models'] = util_models
+
+    _write(out)
+    return out
+
+
+def ensure_exists():
+    data = _read()
+    # If file missing/empty OR 'groups' key missing OR groups mapping is empty,
+    # regenerate defaults from current Settings so UI always has a sensible
+    # default group when settings indicate models are configured.
+    if not data or 'groups' not in data or not data.get('groups'):
+        return create_default_from_settings()
+    return data
+
+
+# Ensure file exists on import
+ensure_exists()
+
+
+def _model_in_list(lst: list[dict], provider: str, name: str) -> bool:
+    for m in lst:
+        if (m.get('provider') or '').lower() == (provider or '').lower() and (m.get('name') or '') == (name or ''):
+            return True
+    return False
+
+
+def add_model_to_pool(model_type: str, provider: str, name: str, api_base: str = '', kwargs: dict | None = None) -> Dict[str, Any]:
+    data = get_all()
+    if kwargs is None:
+        kwargs = {}
+    key = 'chat_models' if model_type == 'chat' else 'utility_models'
+    lst = data.get(key, [])
+    if not _model_in_list(lst, provider, name):
+        lst.append({'provider': provider, 'name': name, 'api_base': api_base, 'kwargs': kwargs})
+        data[key] = lst
+        _write(data)
+    return data
+
+
+def remove_model_from_pool(model_type: str, provider: str, name: str) -> Dict[str, Any]:
+    data = get_all()
+    key = 'chat_models' if model_type == 'chat' else 'utility_models'
+    lst = data.get(key, [])
+    new_lst = [m for m in lst if not ((m.get('provider') or '').lower() == (provider or '').lower() and (m.get('name') or '') == (name or ''))]
+    data[key] = new_lst
+    _write(data)
+    return data
+
+
+def create_group(name: str, chat: dict, util: dict) -> Dict[str, Any]:
+    data = get_all()
+    groups = data.get('groups', {})
+    # normalize chat/util to dicts if they come as strings like 'provider:name'
+    def _normalize_ref(r):
+        if not r:
+            return {}
+        if isinstance(r, str):
+            parts = r.split(':')
+            return {'provider': parts[0] if len(parts) > 0 else '', 'name': parts[1] if len(parts) > 1 else '', 'api_base': parts[2] if len(parts) > 2 else '', 'kwargs': {}}
+        # assume dict-like
+        return r
+
+    chat_obj = _normalize_ref(chat)
+    util_obj = _normalize_ref(util)
+
+    groups[name] = {'chat': chat_obj or {}, 'util': util_obj or {}}
+    data['groups'] = groups
+    # If there is no active group currently set, make this newly created group active
+    # so the UX of creating+activating a group works reliably without an extra step.
+    if not data.get('active'):
+        data['active'] = name
+    # ensure models are in pool
+    if chat_obj:
+        add_model_to_pool('chat', chat_obj.get('provider', ''), chat_obj.get('name', ''), chat_obj.get('api_base', ''), chat_obj.get('kwargs'))
+    if util_obj:
+        add_model_to_pool('utility', util_obj.get('provider', ''), util_obj.get('name', ''), util_obj.get('api_base', ''), util_obj.get('kwargs'))
+    _write(data)
+    return data
+
+
+def update_group(name: str, chat: dict | None = None, util: dict | None = None) -> Dict[str, Any]:
+    data = get_all()
+    groups = data.get('groups', {})
+    if name not in groups:
+        raise KeyError('group not found')
+    def _normalize_ref(r):
+        if not r:
+            return {}
+        if isinstance(r, str):
+            parts = r.split(':')
+            return {'provider': parts[0] if len(parts) > 0 else '', 'name': parts[1] if len(parts) > 1 else '', 'api_base': parts[2] if len(parts) > 2 else '', 'kwargs': {}}
+        return r
+
+    if chat is not None:
+        chat_obj = _normalize_ref(chat)
+        groups[name]['chat'] = chat_obj
+        add_model_to_pool('chat', chat_obj.get('provider', ''), chat_obj.get('name', ''), chat_obj.get('api_base', ''), chat_obj.get('kwargs'))
+    if util is not None:
+        util_obj = _normalize_ref(util)
+        groups[name]['util'] = util_obj
+        add_model_to_pool('utility', util_obj.get('provider', ''), util_obj.get('name', ''), util_obj.get('api_base', ''), util_obj.get('kwargs'))
+    data['groups'] = groups
+    _write(data)
+    return data
+
+
+def rename_group(old_name: str, new_name: str) -> Dict[str, Any]:
+    data = get_all()
+    groups = data.get('groups', {})
+    if old_name not in groups:
+        raise KeyError('group not found')
+    if new_name in groups and new_name != old_name:
+        raise KeyError('new name already exists')
+    # perform rename
+    groups[new_name] = groups.pop(old_name)
+    # update default if it pointed to old_name
+    if data.get('default') == old_name:
+        data['default'] = new_name
+    # update active if it pointed to old_name
+    if data.get('active') == old_name:
+        data['active'] = new_name
+    data['groups'] = groups
+    _write(data)
+    return data
+
+
+def delete_group(name: str) -> Dict[str, Any]:
+    data = get_all()
+    groups = data.get('groups', {})
+    if name in groups:
+        del groups[name]
+        data['groups'] = groups
+        # If the deleted group was active, clear active or pick a fallback
+        if data.get('active') == name:
+            data.pop('active', None)
+        _write(data)
+        # If no groups left, regenerate defaults from current settings
+        if not data.get('groups'):
+            return create_default_from_settings()
+    return data

--- a/webui/components/settings/model-groups/model-groups.html
+++ b/webui/components/settings/model-groups/model-groups.html
@@ -1,0 +1,74 @@
+<template id="tmpl-model-groups">
+  <template x-teleport="body">
+    <div id="modelGroupsModal" class="modal-overlay" x-cloak x-show="$store.modelGroups.isOpen" 
+         @click.self="window.closeModelGroupsModal()" 
+         @keydown.escape.window="$store.modelGroups.isOpen && window.closeModelGroupsModal()" 
+         x-transition x-data="{}" data-legacy-overlay="true">
+      <div class="modal-container modal-small" id="modelGroupsContainer" 
+           @click.stop>
+      <div class="modal-header">
+        <h2>Manage Model Groups</h2>
+        <button class="modal-close" onclick="window.closeModelGroupsModal()">&times;</button>
+      </div>
+      <div class="modal-content">
+        <div class="mg-column">
+          <div class="mg-section">
+            <div class="mg-section-title">Create / Edit Model Group</div>
+            <div class="mg-help">Give the group a descriptive name and pick chat + utility model refs.</div>
+            <div class="mg-form">
+              <div class="mg-inline-row">
+                <input id="mg-new-name" class="mg-control mg-input-native" placeholder="Group name" />
+                <select id="mg-chat-ref" class="mg-control mg-input-native"><option value="">(none)</option></select>
+                <select id="mg-util-ref" class="mg-control mg-input-native"><option value="">(none)</option></select>
+                <div class="mg-actions">
+                  <button id="mg-create-btn" class="mg-btn-native">Create</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="mg-section mg-section-list">
+            <div class="mg-section-title">Model Groups</div>
+            <div id="model-groups-list" class="mg-list"></div>
+          </div>
+        </div>
+
+        <div class="mg-column" style="margin-top:12px;">
+          <div class="mg-section">
+            <div class="mg-section-title">New Pool Entry</div>
+            <div class="mg-help">Add a model to the pool so groups can reference it (api_base optional).</div>
+            <div class="mg-form">
+              <div class="mg-inline-row">
+                <select id="mg-pool-type" class="mg-control mg-input-native">
+                  <option value="chat">Chat Model</option>
+                  <option value="utility">Utility Model</option>
+                </select>
+                <select id="mg-pool-provider" class="mg-control mg-input-native">
+                  <option value="">(select provider)</option>
+                </select>
+                <input id="mg-pool-provider-fallback" class="mg-control mg-input-native" placeholder="provider" style="display:none;" />
+                <input id="mg-pool-name" class="mg-control mg-input-native" placeholder="name" />
+                <input id="mg-pool-api" class="mg-control mg-input-native" placeholder="api_base (optional)" />
+                <div class="mg-actions">
+                  <button id="mg-pool-add-btn" class="mg-btn-native">Add to Pool</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="mg-section mg-section-list">
+            <div class="mg-section-title">Pool Entries</div>
+            <div id="model-groups-pool" class="mg-list"></div>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <div id="buttons-container">
+          <button class="btn btn-ok" onclick="window.closeModelGroupsModal()">Save</button>
+          <button class="btn btn-cancel" onclick="window.closeModelGroupsModal()">Cancel</button>
+        </div>
+      </div>
+      </div>
+    </div>
+  </template>
+</template>

--- a/webui/components/settings/model-groups/model-groups.js
+++ b/webui/components/settings/model-groups/model-groups.js
@@ -1,0 +1,735 @@
+// Minimal script extracted for Manage Model Groups modal
+// This file contains the functions that directly manipulate the modal DOM
+// and wire the buttons. It calls into existing global helpers like
+// `listModelGroups`, `callJsonApi`, `fetchApi`, and dispatches
+// `model-groups-changed` where appropriate.
+
+(function () {
+  // Define logDebug function if not available
+  function logDebug(message, error) {
+    if (window.DEBUG || window.console) {
+      console.log('[Model Groups Debug]', message, error || '');
+    }
+  }
+  // NOTE: legacy hook wiring removed. Previously there was a helper to wire legacy
+  // open/close hooks when the template was injected; that logic has been removed
+  // to centralize all open/close behavior in this module.
+
+  // Expose refresh helper so other modules can trigger a reload and event
+  window.refreshAndDispatchModelGroups = async function () {
+    try {
+      const latest = await listModelGroups();
+      document.dispatchEvent(new CustomEvent('model-groups-changed', { detail: latest }));
+    } catch (e) {
+      try { logDebug('Failed to listModelGroups during refreshAndDispatchModelGroups', e); } catch (err) { /* ignore */ }
+    }
+  };
+
+  // Insert template into DOM when script loads if placeholder exists
+  function insertTemplateIfNeeded() {
+    try {
+      const placeholder = document.querySelector('[data-mg-placeholder]');
+      if (!placeholder) return;
+      // avoid double-insert
+      if (document.getElementById('modelGroupsModal')) return;
+
+      const tpl = document.getElementById('tmpl-model-groups');
+      if (!tpl) {
+        // Try to fetch the component file and inject it
+        fetch('components/settings/model-groups/model-groups.html', {credentials: 'same-origin'})
+          .then(r => {
+            if (!r.ok) throw new Error('Failed to fetch model-groups template');
+            return r.text();
+          })
+          .then(html => {
+            // create a temporary container to parse
+            const tmp = document.createElement('div');
+            tmp.innerHTML = html;
+            // If the fetched html contains a <template id="tmpl-model-groups">, use it
+            const fetchedTpl = tmp.querySelector('#tmpl-model-groups');
+            if (fetchedTpl) {
+              const clone = fetchedTpl.content.cloneNode(true);
+              placeholder.parentNode.insertBefore(clone, placeholder.nextSibling);
+            } else {
+              // fallback: insert raw html
+              placeholder.parentNode.insertAdjacentHTML('afterend', html);
+            }
+          })
+          .catch(e => {
+            console.error('Failed to load model-groups component', e);
+          });
+        return;
+      }
+      const clone = tpl.content.cloneNode(true);
+      // Insert directly before placeholder to keep DOM order predictable
+      placeholder.parentNode.insertBefore(clone, placeholder.nextSibling);
+
+      // If Alpine is present and `settingsModalProxy` exposes modelGroupsOpen, ensure
+      // the inserted overlay is not displayed until Alpine sets it.
+  // Let Alpine control visibility (x-show/x-cloak) — do not force display here
+  const overlay = document.getElementById('modelGroupsModal');
+
+    } catch (e) {
+      console.error('Failed to insert Model Groups template', e);
+    }
+  }
+
+  // Provide an initialization function that resolves when the template is present.
+  // Uses MutationObserver to avoid polling and to be robust across insertion timing.
+  window.initModelGroupsComponent = function () {
+    return new Promise((resolve) => {
+      try {
+        insertTemplateIfNeeded();
+      } catch (e) {
+        console.error('initModelGroupsComponent: insertTemplateIfNeeded failed', e);
+      }
+
+      // If already present, resolve immediately
+      let overlay = document.getElementById('modelGroupsModal');
+      if (overlay) {
+        return resolve();
+      }
+
+      // Observe the document body for additions of the template element
+      const observer = new MutationObserver((mutations, obs) => {
+        for (const m of mutations) {
+          for (const node of Array.from(m.addedNodes || [])) {
+            try {
+              if (node && node.querySelector && node.querySelector('#modelGroupsModal')) {
+                obs.disconnect();
+                return resolve();
+              }
+              // If the added node itself is the overlay
+              if (node && node.id === 'modelGroupsModal') {
+                obs.disconnect();
+                return resolve();
+              }
+            } catch (e) {
+              // ignore individual node errors
+            }
+          }
+        }
+      });
+
+      try {
+        observer.observe(document.documentElement || document.body, { childList: true, subtree: true });
+        // As a non-polling fallback, resolve after a timeout to avoid leaving the
+        // promise pending indefinitely in environments where MutationObserver may fail.
+        // This is a single timeout (not polling).
+        setTimeout(() => {
+          try { observer.disconnect(); } catch (e) { /* ignore */ }
+          return resolve();
+        }, 10000);
+      } catch (e) {
+        // If observe itself throws, fall back to resolving after a short timeout.
+        setTimeout(() => { return resolve(); }, 10000);
+      }
+    });
+  };
+
+  // Implement open/close here so other modules can simply call the globals.
+  // These functions will control Alpine state if present, and ensure population occurs.
+  window.openModelGroupsModal = async function () {
+  try { if (window.DEBUG && console && typeof console.debug === 'function') console.debug('openModelGroupsModal invoked'); } catch (e) {}
+    try {
+      await window.initModelGroupsComponent();
+    } catch (e) {
+      logDebug('openModelGroupsModal: init failed', e);
+    }
+
+    // Use Alpine store to control modal visibility
+    try {
+      if (window.Alpine && window.Alpine.store) {
+        const modelGroupsStore = window.Alpine.store('modelGroups');
+        if (modelGroupsStore) {
+          modelGroupsStore.open();
+        }
+      } else {
+        // Fallback for when Alpine is not available
+        const overlay = document.getElementById('modelGroupsModal');
+        if (overlay) {
+          overlay.style.display = 'block';
+          overlay.setAttribute('x-show', 'true');
+        } else {
+          logDebug('openModelGroupsModal: no Alpine store or overlay found');
+        }
+      }
+    } catch (e) {
+      logDebug('openModelGroupsModal: error toggling Alpine state', e);
+    }
+
+    // populate the modal content
+    try {
+      if (typeof window.populateModelGroupsModal === 'function') await window.populateModelGroupsModal();
+    } catch (e) { logDebug('populateModelGroupsModal failed on open', e); }
+  };
+
+  window.closeModelGroupsModal = function () {
+  try { if (window.DEBUG && console && typeof console.debug === 'function') console.debug('closeModelGroupsModal invoked'); } catch (e) {}
+    try {
+      if (window.Alpine && window.Alpine.store) {
+        const modelGroupsStore = window.Alpine.store('modelGroups');
+        if (modelGroupsStore) {
+          modelGroupsStore.close();
+        }
+      } else {
+        // Fallback for when Alpine is not available
+        const overlay = document.getElementById('modelGroupsModal');
+        if (overlay) {
+          overlay.style.display = 'none';
+          overlay.setAttribute('x-show', 'false');
+        }
+      }
+    } catch (e) {
+      logDebug('closeModelGroupsModal: error toggling state', e);
+    }
+    // No extra cleanup required here; UI will hide via Alpine. If needed, dispatch an event.
+  };
+
+  // Populate the modal: fetch providers and groups, render lists and wire buttons
+  window.populateModelGroupsModal = async function () {
+    // Ensure template is injected
+    try {
+      if (typeof window.initModelGroupsComponent === 'function') await window.initModelGroupsComponent();
+      else insertTemplateIfNeeded();
+    } catch (e) {
+      // fallback short-wait
+      insertTemplateIfNeeded();
+    }
+
+    let overlay = document.getElementById('modelGroupsModal');
+    for (let i = 0; i < 10 && !overlay; i++) {
+      // small wait
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise(r => setTimeout(r, 40));
+      overlay = document.getElementById('modelGroupsModal');
+    }
+    if (!overlay) {
+      console.error('populateModelGroupsModal: modelGroupsModal not found');
+      return;
+    }
+
+    // fetch provider list
+    let providerData = null;
+    try {
+      const resp = await fetchApi(`/model_providers_list`, { method: 'GET', credentials: 'same-origin' });
+      if (resp.ok) providerData = await resp.json();
+    } catch (e) {
+      logDebug('Failed to load provider list', e);
+      providerData = null;
+    }
+
+    // fetch groups and pools
+    try {
+      const data = await listModelGroups();
+      const el = document.getElementById('model-groups-list');
+      if (!el) {
+        console.error('populateModelGroupsModal: model-groups-list element missing');
+        return;
+      }
+      el.innerHTML = '';
+
+      function formatRef(r) {
+        if (!r) return '(empty)';
+        if (typeof r === 'string') {
+          const s = r.trim();
+          if (s.startsWith('{') || s.startsWith('[')) {
+            try { return formatRef(JSON.parse(s)); } catch (e) { /* fallthrough */ }
+          }
+          return s;
+        }
+        try {
+          const provider = r.provider || '';
+          const name = r.name || '';
+          if (!provider && !name) return '(empty)';
+          return provider + ':' + name;
+        } catch (e) { return String(r); }
+      }
+
+      if (data) {
+        // populate chat/util selects
+        const chatSelect = document.getElementById('mg-chat-ref');
+        const utilSelect = document.getElementById('mg-util-ref');
+        if (chatSelect) {
+          chatSelect.innerHTML = '<option value="">(none)</option>';
+          for (const m of (data.chat_models || [])) {
+            const opt = document.createElement('option');
+            opt.value = (m.provider || '') + ':' + (m.name || '');
+            opt.textContent = (m.provider || '') + ':' + (m.name || '') + (m.api_base ? ' @ ' + m.api_base : '');
+            chatSelect.appendChild(opt);
+          }
+        }
+        if (utilSelect) {
+          utilSelect.innerHTML = '<option value="">(none)</option>';
+          for (const m of (data.utility_models || [])) {
+            const opt = document.createElement('option');
+            opt.value = (m.provider || '') + ':' + (m.name || '');
+            opt.textContent = (m.provider || '') + ':' + (m.name || '') + (m.api_base ? ' @ ' + m.api_base : '');
+            utilSelect.appendChild(opt);
+          }
+        }
+
+        // provider select
+        const providerSelect = document.getElementById('mg-pool-provider');
+        const providerFallbackInput = document.getElementById('mg-pool-provider-fallback');
+        if (providerData && providerSelect) {
+          providerSelect.style.display = '';
+          if (providerFallbackInput) providerFallbackInput.style.display = 'none';
+          providerSelect.innerHTML = '<option value="">(select provider)</option>';
+          const seen = new Set();
+          const addOpts = (list) => {
+            if (!list) return;
+            for (const p of list) {
+              const val = (p.value || p.id || '').toLowerCase();
+              const label = p.label || p.name || val;
+              if (!val || seen.has(val)) continue; seen.add(val);
+              const opt = document.createElement('option'); opt.value = val; opt.textContent = label; providerSelect.appendChild(opt);
+            }
+          };
+          addOpts(providerData.chat || []);
+          addOpts(providerData.embedding || []);
+        } else {
+          if (providerSelect) providerSelect.style.display = 'none';
+          if (providerFallbackInput) providerFallbackInput.style.display = '';
+        }
+
+        // render pool lists
+        const poolEl = document.getElementById('model-groups-pool');
+        if (poolEl) {
+          poolEl.innerHTML = '';
+          const chatModels = data.chat_models || [];
+          const utilModels = data.utility_models || [];
+
+          function makePoolTable(title, list, type) {
+            if (!list || list.length === 0) return;
+            const h = document.createElement('div'); h.textContent = title; h.style.marginBottom = '6px'; poolEl.appendChild(h);
+            const table = document.createElement('table'); table.className = 'mg-pool-table';
+            const thead = document.createElement('thead'); const headRow = document.createElement('tr');
+            ['Provider', 'Name', 'API Base', 'Actions'].forEach(htext => { const th = document.createElement('th'); th.textContent = htext; headRow.appendChild(th); });
+            thead.appendChild(headRow); table.appendChild(thead);
+            const tbody = document.createElement('tbody');
+            for (const m of list) {
+              const tr = document.createElement('tr'); const provTd = document.createElement('td'); provTd.textContent = m.provider || '';
+              const nameTd = document.createElement('td'); nameTd.textContent = m.name || '';
+              const apiTd = document.createElement('td'); apiTd.textContent = m.api_base || '';
+              const actionsTd = document.createElement('td'); actionsTd.style.whiteSpace = 'nowrap';
+
+              const edit = document.createElement('button'); edit.className = 'btn btn-secondary'; edit.textContent = 'Edit'; edit.style.marginRight = '6px';
+              edit.onclick = () => {
+                document.getElementById('mg-pool-type').value = (type === 'chat' ? 'chat' : 'util');
+                const providerSelectEl = document.getElementById('mg-pool-provider');
+                const providerFallbackEl = document.getElementById('mg-pool-provider-fallback');
+                if (providerSelectEl && providerSelectEl.style.display !== 'none') providerSelectEl.value = (m.provider || '').toLowerCase();
+                else if (providerFallbackEl) providerFallbackEl.value = m.provider || '';
+                document.getElementById('mg-pool-name').value = m.name || '';
+                document.getElementById('mg-pool-api').value = m.api_base || '';
+                const poolAddBtn = document.getElementById('mg-pool-add-btn'); poolAddBtn.textContent = 'Update Pool';
+                poolAddBtn.onclick = async () => {
+                  let t = document.getElementById('mg-pool-type').value.trim();
+                  let provider = '';
+                  const providerSelectEl2 = document.getElementById('mg-pool-provider');
+                  const providerFallbackEl2 = document.getElementById('mg-pool-provider-fallback');
+                  if (providerSelectEl2 && providerSelectEl2.style.display !== 'none') provider = providerSelectEl2.value.trim();
+                  else if (providerFallbackEl2) provider = providerFallbackEl2.value.trim();
+                  const name = document.getElementById('mg-pool-name').value.trim();
+                  const api_base = document.getElementById('mg-pool-api').value.trim();
+                  if (!t || !provider || !name) return alert('type/provider/name required');
+                  if (t.toLowerCase() === 'util') t = 'utility';
+                  await callJsonApi('/model_pool_remove', { type: (type === 'chat' ? 'chat' : 'utility'), provider: m.provider, name: m.name });
+                  await callJsonApi('/model_pool_add', { type: t, provider, name, api_base, kwargs: {} });
+                  showToast('Updated pool entry', 'success');
+                  poolAddBtn.textContent = 'Add to Pool'; poolAddBtn.onclick = null;
+                  refreshAndDispatchModelGroups(); window.openModelGroupsModal();
+                };
+              };
+
+              const del = document.createElement('button'); del.className = 'btn btn-danger'; del.textContent = 'Delete';
+              del.onclick = async () => { if (!confirm('Remove ' + (m.provider || '') + ':' + (m.name || '') + ' from pool?')) return; await callJsonApi('/model_pool_remove', { type: (type === 'chat' ? 'chat' : 'utility'), provider: m.provider, name: m.name }); showToast('Removed from pool', 'success'); refreshAndDispatchModelGroups(); window.openModelGroupsModal(); };
+
+              actionsTd.appendChild(edit); actionsTd.appendChild(del);
+              tr.appendChild(provTd); tr.appendChild(nameTd); tr.appendChild(apiTd); tr.appendChild(actionsTd);
+              tbody.appendChild(tr);
+            }
+            table.appendChild(tbody); poolEl.appendChild(table);
+          }
+
+          makePoolTable('Chat models:', chatModels, 'chat');
+          makePoolTable('Utility models:', utilModels, 'util');
+        }
+
+        // helper findModelInPool
+        function findModelInPool(list, provider, name) {
+          if (!list || !provider || !name) return null;
+          const providerLower = (provider || '').toLowerCase();
+          const nameLower = (name || '').toLowerCase();
+          return list.find(m => (m.provider || '').toLowerCase() === providerLower && ((m.name || '').toLowerCase() === nameLower));
+        }
+
+        // render groups table
+        if (data.groups) {
+          const table = document.createElement('table'); table.className = 'mg-groups-table';
+          const thead = document.createElement('thead'); const headRow = document.createElement('tr');
+          ['Name', 'Chat', 'Utility', 'Actions'].forEach(h => { const th = document.createElement('th'); th.textContent = h; headRow.appendChild(th); });
+          thead.appendChild(headRow); table.appendChild(thead);
+          const tbody = document.createElement('tbody');
+
+          for (const [name, g] of Object.entries(data.groups)) {
+            const tr = document.createElement('tr'); tr.dataset.groupName = name;
+            const nameTd = document.createElement('td'); nameTd.textContent = name;
+            const chatTd = document.createElement('td'); chatTd.textContent = formatRef(g.chat);
+            const utilTd = document.createElement('td'); utilTd.textContent = formatRef(g.util);
+            const actionsTd = document.createElement('td'); actionsTd.className = 'mg-actions'; actionsTd.style.whiteSpace = 'nowrap';
+
+            const selBtn = document.createElement('button'); selBtn.className = 'btn btn-ok'; selBtn.textContent = 'Select';
+            selBtn.onclick = async () => {
+              const resp = await selectModelGroup(name);
+              showToast('Selected model group: ' + name, 'success');
+              try {
+                const settingsComp = document.getElementById('settingsModal');
+                if (settingsComp && window.Alpine && typeof Alpine.$data === 'function') {
+                  const sdata = Alpine.$data(settingsComp);
+
+                  // Support both older proxy shape (`settings`) and newer component shape (`settingsData`)
+                  const settingsObj = (sdata && (sdata.settingsData || sdata.settings)) ? (sdata.settingsData || sdata.settings) : null;
+                  if (sdata && settingsObj) {
+                    function findField(id) { for (const sec of settingsObj.sections || []) { for (const f of sec.fields || []) { if (f.id === id) return f; } } return null; }
+                    const mgPayload = await listModelGroups(); const groupsObj = mgPayload.groups || {}; const chatModelsPool = mgPayload.chat_models || []; const utilModelsPool = mgPayload.utility_models || [];
+                    const grpObj = groupsObj[name] || {}; const chat = Object.assign({}, grpObj.chat || {}); const util = Object.assign({}, grpObj.util || {});
+                    if ((!chat.api_base || chat.api_base === '') && chat.provider && chat.name) { const found = findModelInPool(chatModelsPool, chat.provider, chat.name); if (found && found.api_base) chat.api_base = found.api_base; }
+                    if ((!util.api_base || util.api_base === '') && util.provider && util.name) { const found = findModelInPool(utilModelsPool, util.provider, util.name); if (found && found.api_base) util.api_base = found.api_base; }
+                    const chatIds = ['chat_model_provider', 'chat_model_name', 'chat_model_api_base', 'chat_model_kwargs'];
+                    const utilIds = ['util_model_provider', 'util_model_name', 'util_model_api_base', 'util_model_kwargs'];
+                    function fieldDomValue(id) { const el = document.querySelector(`[name="${id}"]`) || document.getElementById(id); if (!el) return null; return el.value; }
+                    let modified = false;
+                    for (const id of [...chatIds, ...utilIds]) { const f = findField(id); if (!f) continue; const baseline = f.value ?? ''; const domv = fieldDomValue(id); if (domv !== null && String(domv) !== String(baseline)) { modified = true; break; } }
+                    if (modified) { if (!confirm('Settings 页面中 Chat/Utility 有未保存更改，是否用选定的模型组覆盖这些字段？')) { window.openModelGroupsModal(); return; } }
+                    function setField(id, val) {
+                      const f = findField(id);
+                      if (f) f.value = val ?? '';
+                      // keep both shapes in sync if present on proxy
+                      try { if (sdata.settingsData) sdata.settingsData = sdata.settingsData; if (sdata.settings) sdata.settings = sdata.settings; } catch (e) { /* ignore */ }
+                      const el = document.querySelector(`[name="${id}"]`) || document.getElementById(id);
+                      if (el) { el.value = val ?? ''; try { el.dispatchEvent(new Event('input', { bubbles: true })); el.dispatchEvent(new Event('change', { bubbles: true })); } catch (e) { } }
+                      try {
+                        const modalEl = document.getElementById('settingsModal');
+                        if (modalEl) {
+                          const modalData = Alpine.$data(modalEl);
+                          if (modalData) {
+                            if (typeof modalData.$nextTick === 'function') {
+                              modalData.$nextTick(() => { if (typeof modalData.updateFilteredSections === 'function') { modalData.updateFilteredSections(); } });
+                            } else {
+                              if (typeof modalData.updateFilteredSections === 'function') modalData.updateFilteredSections();
+                            }
+                          }
+                        }
+                      } catch (e) { logDebug('Failed to trigger Alpine refresh after setField', e); }
+                    }
+                    setField('chat_model_provider', chat.provider || ''); setField('chat_model_name', chat.name || ''); setField('chat_model_api_base', chat.api_base || ''); setField('chat_model_kwargs', JSON.stringify(chat.kwargs || {}));
+                    setField('util_model_provider', util.provider || ''); setField('util_model_name', util.name || ''); setField('util_model_api_base', util.api_base || ''); setField('util_model_kwargs', JSON.stringify(util.kwargs || {}));
+
+                    // Attempt to refresh via component API if available, otherwise try backend fetch fallback
+                    try {
+                      const modalEl = document.getElementById('settingsModal');
+                      if (modalEl && !modified) {
+                        const modalData = Alpine.$data(modalEl);
+                        if (modalData && typeof modalData.fetchSettings === 'function') {
+                          await modalData.fetchSettings();
+                          if (typeof modalData.updateFilteredSections === 'function') modalData.updateFilteredSections();
+                        } else {
+                          // fallback: try to fetch settings from server and update the proxy object
+                          try {
+                            let resp = null;
+                            try {
+                              resp = await fetchApi('/api/settings_get', { method: 'GET' });
+                            } catch (e) { resp = null; }
+                            if (!resp || !resp.ok) {
+                              try { resp = await fetchApi('/settings_get', { method: 'GET' }); } catch (e) { resp = null; }
+                            }
+                            if (resp && resp.ok) {
+                              const data = await resp.json();
+                              if (data && data.settings) {
+                                // Merge server settings into the existing proxy object instead
+                                // of replacing it completely. This preserves UI-only
+                                // properties (like the modal's buttons) that are added
+                                // locally and would otherwise disappear.
+                                const serverSettings = data.settings || {};
+                                try {
+                                  if (sdata.settingsData) {
+                                    const preservedButtons = sdata.settingsData.buttons;
+                                    sdata.settingsData = Object.assign({}, serverSettings);
+                                    if (preservedButtons && !sdata.settingsData.buttons) sdata.settingsData.buttons = preservedButtons;
+                                  }
+                                  if (sdata.settings) {
+                                    const preservedButtons2 = sdata.settings.buttons;
+                                    sdata.settings = Object.assign({}, serverSettings);
+                                    if (preservedButtons2 && !sdata.settings.buttons) sdata.settings.buttons = preservedButtons2;
+                                  }
+                                } catch (e) {
+                                  // If merge fails for any reason, fall back to assignment
+                                  try { if (sdata.settingsData) sdata.settingsData = serverSettings; if (sdata.settings) sdata.settings = serverSettings; } catch (ee) { /* ignore */ }
+                                }
+                                if (typeof sdata.updateFilteredSections === 'function') sdata.updateFilteredSections();
+                              }
+                            }
+                          } catch (e) { logDebug('Failed to refresh settings modal after select via fallback fetch', e); }
+                        }
+                      }
+                    } catch (e) { logDebug('Failed to refresh settings modal after group select', e); }
+                  }
+                }
+              } catch (e) { logDebug('Failed to sync settings modal fields after select', e); }
+              // Notify other components by fetching latest settings and dispatching event
+              try {
+                let respSettings = null;
+                try { respSettings = await fetchApi('/api/settings_get', { method: 'GET' }); } catch (e) { respSettings = null; }
+                if (!respSettings || !respSettings.ok) {
+                  try { respSettings = await fetchApi('/settings_get', { method: 'GET' }); } catch (e) { respSettings = null; }
+                }
+                if (respSettings && respSettings.ok) {
+                  const data = await respSettings.json();
+                  try { document.dispatchEvent(new CustomEvent('settings-updated', { detail: data.settings })); } catch (e) { logDebug('Failed to dispatch settings-updated', e); }
+                }
+              } catch (e) { logDebug('Failed to fetch/dispatch settings after model group select', e); }
+              refreshAndDispatchModelGroups(); window.openModelGroupsModal();
+            };
+
+            const delBtn = document.createElement('button'); delBtn.className = 'btn btn-danger'; delBtn.textContent = 'Delete'; delBtn.onclick = async () => { if (!confirm('Delete group ' + name + '?')) return; await callJsonApi('/model_group_delete', { name }); showToast('Deleted group: ' + name, 'success'); refreshAndDispatchModelGroups(); window.openModelGroupsModal(); };
+
+            const editBtn = document.createElement('button'); editBtn.className = 'btn btn-secondary'; editBtn.textContent = 'Edit'; editBtn.style.marginRight = '6px';
+            editBtn.onclick = () => {
+              document.getElementById('mg-new-name').value = name;
+              document.getElementById('mg-chat-ref').value = formatRef(g.chat) === '(empty)' ? '' : formatRef(g.chat);
+              document.getElementById('mg-util-ref').value = formatRef(g.util) === '(empty)' ? '' : formatRef(g.util);
+              const createBtn = document.getElementById('mg-create-btn'); createBtn.textContent = 'Update';
+              createBtn.onclick = async () => {
+                const chatRef = document.getElementById('mg-chat-ref').value.trim(); const utilRef = document.getElementById('mg-util-ref').value.trim(); const newName = document.getElementById('mg-new-name').value.trim();
+                function parseRef(ref) { if (!ref) return {}; if (typeof ref === 'string' && ref.includes(':')) { const parts = ref.split(':'); return { provider: parts[0] || '', name: parts[1] || '', api_base: parts[2] || '', kwargs: {} }; } return { provider: '', name: ref, api_base: '', kwargs: {} }; }
+                const chat = parseRef(chatRef); const util = parseRef(utilRef);
+                try { await callJsonApi('/model_group_update', { name, new_name: newName, chat, util }); showToast('Updated group ' + name, 'success'); } catch (err) { console.error('Failed to update group', err); showToast('Failed to update group: ' + err.message, 'error'); return; }
+                refreshAndDispatchModelGroups(); createBtn.textContent = 'Create'; createBtn.onclick = null; window.openModelGroupsModal();
+              };
+            };
+
+            const activeName = data.active || data.active_group || null; if (activeName && activeName === name) tr.classList.add('selected');
+            actionsTd.appendChild(selBtn); actionsTd.appendChild(editBtn); actionsTd.appendChild(delBtn);
+            tr.appendChild(nameTd); tr.appendChild(chatTd); tr.appendChild(utilTd); tr.appendChild(actionsTd); tbody.appendChild(tr);
+          }
+
+          table.appendChild(tbody); el.appendChild(table);
+        } else {
+          el.innerHTML = '<i>No groups found</i>';
+        }
+      }
+    } catch (e) {
+      console.error('Failed to list model groups', e);
+      showToast('Failed to list model groups: ' + e.message, 'error');
+    }
+
+    // wire create button
+    const createBtn = document.getElementById('mg-create-btn');
+    if (createBtn) {
+      createBtn.onclick = async () => {
+        const name = document.getElementById('mg-new-name').value.trim();
+        const chatRef = document.getElementById('mg-chat-ref').value.trim();
+        const utilRef = document.getElementById('mg-util-ref').value.trim();
+        if (!name) return alert('Name required');
+        function parseRef(ref) { if (!ref) return {}; if (typeof ref === 'string' && ref.includes(':')) { const parts = ref.split(':'); return { provider: parts[0] || '', name: parts[1] || '', api_base: parts[2] || '', kwargs: {} }; } return { provider: '', name: ref, api_base: '', kwargs: {} }; }
+        const chat = parseRef(chatRef); const util = parseRef(utilRef);
+        try { await callJsonApi('/model_group_create', { name, chat, util }); showToast('Created group ' + name, 'success'); } catch (err) { console.error('Failed to create group', err); showToast('Failed to create group: ' + err.message, 'error'); return; }
+        refreshAndDispatchModelGroups(); window.openModelGroupsModal();
+      };
+    }
+
+    // wire pool add button
+    const poolAddBtn = document.getElementById('mg-pool-add-btn');
+    if (poolAddBtn) {
+      poolAddBtn.onclick = async () => {
+        let type = document.getElementById('mg-pool-type').value.trim();
+        const provider = document.getElementById('mg-pool-provider').value.trim();
+        const name = document.getElementById('mg-pool-name').value.trim();
+        const api_base = document.getElementById('mg-pool-api').value.trim();
+        if (!type || !provider || !name) return alert('type/provider/name required');
+        type = type.toLowerCase(); if (type === 'util') type = 'utility'; if (type !== 'chat' && type !== 'utility') return alert('type must be chat or utility');
+        await callJsonApi('/model_pool_add', { type, provider, name, api_base, kwargs: {} }); showToast('Added model to pool', 'success'); window.openModelGroupsModal();
+      };
+    }
+
+  };
+
+  // Auto init on load
+  document.addEventListener('DOMContentLoaded', () => {
+    insertTemplateIfNeeded();
+    try {
+      if (typeof window.initQuickModelGroupSelector === 'function') window.initQuickModelGroupSelector();
+    } catch (e) { /* ignore */ }
+  });
+})();
+
+// Quick Model Groups selector logic (migrated here from settings.js)
+window.initQuickModelGroupSelector = function () {
+  const toggle = document.getElementById('quick-mg-toggle');
+  const panel = document.getElementById('quick-mg-panel');
+  const listEl = document.getElementById('quick-mg-list');
+  const search = document.getElementById('quick-mg-search');
+  if (!toggle || !panel || !listEl || !search) return;
+
+  let cached = null;
+  let focusedIndex = -1;
+
+  async function fetchAndRender() {
+    try {
+      const data = await listModelGroups();
+      cached = data;
+      renderList(data);
+      try {
+        if (panel && panel.style.display === 'block') {
+          requestAnimationFrame(() => {
+            try { positionPanel(); } catch (e) { /* ignore */ }
+          });
+        }
+      } catch (e) { /* ignore */ }
+    } catch (e) {
+      logDebug('Failed to load model groups for quick selector', e);
+      listEl.innerHTML = '<li><i>Failed to load</i></li>';
+    }
+  }
+
+  function formatRef(r) {
+    if (!r) return '(empty)';
+    if (typeof r === 'string') return r;
+    try { return (r.provider || '') + ':' + (r.name || ''); } catch (e) { return String(r); }
+  }
+
+  function renderList(data) {
+    listEl.innerHTML = '';
+    if (!data || !data.groups) return listEl.innerHTML = '<li><i>No groups</i></li>';
+    const q = (search.value || '').trim().toLowerCase();
+    const activeName = data.active || data.active_group || null;
+    let idx = 0;
+    for (const [name, g] of Object.entries(data.groups)) {
+      if (q && !name.toLowerCase().includes(q)) continue;
+      const li = document.createElement('li');
+      li.dataset.index = String(idx);
+      const title = document.createElement('span');
+      title.className = 'mg-name';
+      title.textContent = name;
+      li.appendChild(title);
+
+      if (activeName && activeName === name) {
+        li.classList.add('selected');
+      }
+
+      li.onclick = async () => {
+        try {
+          await selectModelGroup(name);
+          showToast('Selected ' + name, 'success');
+          try { if (cached) cached.active = name; } catch (e) { /* ignore */ }
+        } catch (err) { logDebug(err); }
+        hidePanel();
+      };
+      li.onmouseover = () => {
+        try {
+          const prev = listEl.querySelector('li.focused');
+          if (prev) prev.classList.remove('focused');
+        } catch (e) {}
+        li.classList.add('focused');
+        focusedIndex = parseInt(li.dataset.index || '-1');
+      };
+      li.onmouseleave = () => { try { li.classList.remove('focused'); } catch (e) {} };
+      idx += 1;
+      listEl.appendChild(li);
+    }
+  }
+
+  function positionPanel() {
+    if (!panel || !toggle) return;
+    const rect = toggle.getBoundingClientRect();
+    const prevDisplay = panel.style.display;
+    if (panel.style.display === 'none' || !panel.style.display) panel.style.display = 'block';
+    const pr = panel.getBoundingClientRect();
+    let left = rect.left;
+    let top = rect.bottom + 6;
+    if (left + pr.width > window.innerWidth - 8) {
+      left = Math.max(8, window.innerWidth - pr.width - 8);
+    }
+    if (top + pr.height > window.innerHeight - 8) {
+      top = rect.top - pr.height - 6;
+      if (top < 8) top = 8;
+    }
+    panel.style.left = left + 'px';
+    panel.style.top = top + 'px';
+    if (prevDisplay === 'none') panel.style.display = 'none';
+  }
+
+  function onModelGroupsChanged(e) {
+    try {
+      const payload = (e && e.detail) ? e.detail : null;
+      if (payload) {
+        cached = payload;
+      } else {
+        fetchAndRender();
+        return;
+      }
+      try { renderList(cached); } catch (err) { /* ignore */ }
+      try { if (panel && panel.style.display === 'block') positionPanel(); } catch (err) { /* ignore */ }
+    } catch (err) { logDebug('onModelGroupsChanged handler failed', err); }
+  }
+  document.addEventListener('model-groups-changed', onModelGroupsChanged);
+
+  function showPanel() {
+    if (panel.style.display === 'block') return;
+    if (!cached) fetchAndRender(); else renderList(cached);
+    if (panel.parentElement !== document.body) {
+      panel._mg_orig_parent = panel.parentElement;
+      panel._mg_next_sibling = panel.nextElementSibling;
+      document.body.appendChild(panel);
+      panel.style.position = 'fixed';
+    }
+    panel.style.display = 'block'; panel.setAttribute('aria-hidden', 'false');
+    try { const s = panel.querySelector('#quick-mg-search'); if (s) s.focus(); } catch (e) {}
+    positionPanel(); window.addEventListener('resize', positionPanel); window.addEventListener('scroll', positionPanel, true);
+    try {
+      if (cached && cached.groups) {
+        const active = cached.active || cached.active_group || null;
+        if (active) {
+          const items = Array.from(listEl.querySelectorAll('li'));
+          for (let i = 0; i < items.length; i++) {
+            const txt = (items[i].textContent || '').trim();
+            if (txt === active) { focusedIndex = i; items[i].classList.add('focused'); items[i].scrollIntoView({ block: 'nearest' }); break; }
+          }
+        } else { focusedIndex = -1; }
+      }
+    } catch (e) { focusedIndex = -1; }
+
+    panel._mg_keydown = function (e) {
+      const items = Array.from(listEl.querySelectorAll('li'));
+      if (!items || items.length === 0) return;
+      if (e.key === 'ArrowDown') { e.preventDefault(); if (focusedIndex < items.length - 1) focusedIndex += 1; else focusedIndex = 0; items.forEach(it => it.classList.remove('focused')); const cur = items[focusedIndex]; if (cur) { cur.classList.add('focused'); cur.scrollIntoView({ block: 'nearest' }); } }
+      else if (e.key === 'ArrowUp') { e.preventDefault(); if (focusedIndex > 0) focusedIndex -= 1; else focusedIndex = items.length - 1; items.forEach(it => it.classList.remove('focused')); const cur = items[focusedIndex]; if (cur) { cur.classList.add('focused'); cur.scrollIntoView({ block: 'nearest' }); } }
+      else if (e.key === 'Enter') { e.preventDefault(); if (focusedIndex >= 0 && focusedIndex < items.length) { const name = (items[focusedIndex].textContent || '').trim(); if (name) items[focusedIndex].click(); } }
+    };
+    window.addEventListener('keydown', panel._mg_keydown);
+    document.addEventListener('click', outsideClick); window.addEventListener('keydown', escHandler);
+  }
+
+  function hidePanel() {
+    if (panel.style.display === 'none') return;
+    panel.style.display = 'none'; panel.setAttribute('aria-hidden', 'true'); document.removeEventListener('click', outsideClick); window.removeEventListener('keydown', escHandler);
+    try { window.removeEventListener('resize', positionPanel); window.removeEventListener('scroll', positionPanel, true); } catch (e) {}
+    try { if (panel._mg_keydown) { window.removeEventListener('keydown', panel._mg_keydown); delete panel._mg_keydown; } } catch (e) { logDebug('Failed to cleanup quick panel keydown handler', e); }
+    if (panel._mg_orig_parent) {
+      try { if (panel._mg_next_sibling) panel._mg_orig_parent.insertBefore(panel, panel._mg_next_sibling); else panel._mg_orig_parent.appendChild(panel); } catch (e) { console.warn('Could not restore quick panel to original parent', e); }
+      delete panel._mg_orig_parent; delete panel._mg_next_sibling; panel.style.position = ''; panel.style.left = ''; panel.style.top = ''; }
+  }
+
+  function togglePanel() { if (panel.style.display === 'block') hidePanel(); else showPanel(); }
+  function outsideClick(e) { const p = panel; if (!p) return; if (!p.contains(e.target) && e.target !== toggle) hidePanel(); }
+  function escHandler(e) { if (e.key === 'Escape' || e.key === 'Esc') hidePanel(); }
+  toggle.onclick = (e) => { e.stopPropagation(); togglePanel(); };
+  search.oninput = () => { if (cached) renderList(cached); };
+};
+
+
+// Signal for runtime debugging that the model-groups module initialized
+try { console.debug && console.debug('model-groups.js initialized: open/close functions registered'); } catch (e) {}
+

--- a/webui/css/model-groups.css
+++ b/webui/css/model-groups.css
@@ -1,0 +1,1084 @@
+/* Base layout styles */
+.mg-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: nowrap;
+}
+
+.mg-control {
+  height: 34px;
+  padding: 6px 8px;
+  width: 200px;
+  box-sizing: border-box;
+  border-radius: 4px;
+}
+
+.mg-action {
+  height: 34px;
+  padding: 6px 12px;
+}
+
+.mg-manage-row {
+  display: contents;
+  gap: 8px;
+  align-items: center;
+}
+
+/* Modal grid layout */
+.mg-modal-grid {
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  gap: var(--spacing-lg);
+  align-items: start;
+}
+
+.mg-column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.mg-section {
+  background: var(--color-panel);
+  border: 1px solid var(--color-border);
+  padding: var(--spacing-md);
+  border-radius: var(--spacing-sm);
+}
+
+.mg-section-title {
+  font-size: 1.25rem;
+  font-weight: bold;
+  color: var(--color-primary);
+  margin-bottom: 0.5rem;
+}
+
+.mg-help {
+  color: var(--color-text);
+  margin-bottom: 1rem;
+}
+
+/* Form styles */
+.mg-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.mg-input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.mg-actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  justify-content: flex-start;
+  margin-top: var(--spacing-xs);
+}
+
+.mg-actions button {
+  margin-left: 0;
+}
+
+/* List styles */
+.mg-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 320px;
+  overflow: auto;
+  padding-top: 6px;
+}
+
+.mg-list .mg-card {
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  background: var(--color-background);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  transition: all 0.15s ease;
+}
+
+.mg-list .mg-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+  border-color: rgba(100, 150, 255, 0.45);
+}
+
+.mg-list .mg-card.selected {
+  background: linear-gradient(90deg, rgba(100, 150, 255, 0.06), rgba(100, 150, 255, 0.02));
+  border-color: rgba(100, 150, 255, 0.7);
+  box-shadow: 0 10px 30px rgba(100, 150, 255, 0.08);
+}
+
+.mg-list .mg-card .mg-card-body {
+  flex: 1;
+}
+
+/* Row layout styles */
+.mg-row-wrap {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.mg-inline-row {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+  width: 100%;
+}
+
+.mg-inline-row .mg-control {
+  flex: 1 1 auto;
+  min-width: 120px;
+}
+
+.mg-inline-row .mg-actions {
+  flex: 0 0 auto;
+  margin-left: var(--spacing-xs);
+}
+
+/* Native-style inputs and buttons */
+.mg-input-native {
+  background-color: var(--color-input);
+  border: 1px solid var(--color-border);
+  border-radius: var(--spacing-xs);
+  color: var(--color-text);
+  font-family: var(--font-family-main);
+  font-size: var(--font-size-smaller);
+  padding: var(--spacing-sm) 0.75rem;
+  transition: all var(--transition-speed);
+  outline: none;
+  line-height: 1.4;
+  min-height: 2.3rem;
+}
+
+/* Select element specific adjustments */
+select.mg-input-native {
+  padding: 8px 0.75rem;
+  line-height: 1.4;
+  height: auto;
+  min-height: 2.4rem;
+}
+
+/* Ensure select option text is not clipped */
+select.mg-input-native option {
+  padding: 4px 8px;
+  line-height: 1.4;
+}
+
+.mg-input-native:focus {
+  background-color: var(--color-input-focus);
+  border-color: rgba(155, 155, 155, 0.5);
+  outline: 0.05rem solid rgba(155, 155, 155, 0.5);
+}
+
+.mg-input-native::placeholder {
+  color: var(--color-text);
+  opacity: 0.6;
+}
+
+.mg-btn-native {
+  background-color: var(--color-background);
+  border: 0.1rem solid var(--color-border);
+  border-radius: var(--spacing-xs);
+  color: var(--color-text);
+  cursor: pointer;
+  font-family: var(--font-family-main);
+  font-size: var(--font-size-small);
+  opacity: 0.8;
+  padding: var(--spacing-sm) 0.75rem;
+  transition: all var(--transition-speed), transform 0.1s ease-in-out;
+  min-height: 2.3rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+}
+
+/* Smaller button sizes for table cells to fit */
+.mg-pool-table .mg-btn-native,
+.mg-groups-table .mg-btn-native {
+  min-height: 1.8rem;
+  padding: 4px 8px;
+  font-size: var(--font-size-small);
+}
+
+.mg-btn-native:hover {
+  background-color: var(--color-secondary);
+  opacity: 1;
+}
+
+.mg-btn-native:active {
+  opacity: 0.5;
+}
+
+/* Model groups table styles */
+.mg-groups-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 8px;
+  font-size: var(--font-size-smaller);
+  table-layout: fixed;
+}
+
+.mg-groups-table thead th {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text);
+  font-weight: 600;
+  font-size: var(--font-size-smaller);
+}
+
+/* Unified column width allocation */
+.mg-groups-table thead th:nth-child(1) {
+  width: 22%;
+}
+
+.mg-groups-table thead th:nth-child(2) {
+  width: 28%;
+}
+
+.mg-groups-table thead th:nth-child(3) {
+  width: 28%;
+}
+
+.mg-groups-table thead th:nth-child(4) {
+  width: 22%;
+}
+
+.mg-groups-table tbody td {
+  padding: 8px 10px;
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.03);
+  vertical-align: middle;
+  word-wrap: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mg-groups-table tbody tr {
+  transition: background-color var(--transition-speed) ease;
+}
+
+.mg-groups-table tbody tr:hover {
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.mg-groups-table tbody tr.selected {
+  background: linear-gradient(90deg, rgba(115, 122, 129, 0.06), rgba(115, 122, 129, 0.02));
+  border-left: 4px solid var(--color-primary);
+}
+
+/* Pool table title styles */
+.mg-pool-title {
+  font-weight: 600;
+  font-size: var(--font-size-smaller);
+  color: var(--color-text);
+  margin-bottom: var(--spacing-xs);
+  margin-top: var(--spacing-sm);
+}
+
+.mg-pool-title:first-child {
+  margin-top: 0;
+}
+
+/* Pool table styles */
+.mg-pool-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 16px;
+  table-layout: fixed;
+  /* Fixed table layout to ensure consistent column widths */
+}
+
+.mg-pool-table thead th {
+  text-align: left;
+  padding: 8px 10px;
+  font-weight: 600;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text);
+  font-size: var(--font-size-smaller);
+}
+
+.mg-pool-table thead th:nth-child(1) {
+  width: 22%;
+}
+
+.mg-pool-table thead th:nth-child(2) {
+  width: 28%;
+}
+
+.mg-pool-table thead th:nth-child(3) {
+  width: 28%;
+}
+
+.mg-pool-table thead th:nth-child(4) {
+  width: 22%;
+}
+
+.mg-pool-table tbody td {
+  padding: 8px 10px;
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.03);
+  vertical-align: middle;
+  word-wrap: break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mg-pool-table tbody tr {
+  transition: background-color 0.15s ease;
+}
+
+.mg-pool-table tbody tr:hover {
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+/* Unified table button styles */
+.mg-pool-table .btn,
+.mg-groups-table .btn {
+  background-color: var(--color-background);
+  border: 0.1rem solid var(--color-border);
+  border-radius: var(--spacing-xs);
+  color: var(--color-text);
+  cursor: pointer;
+  font-family: var(--font-family-main);
+  font-size: var(--font-size-small);
+  opacity: 0.8;
+  padding: 4px 8px;
+  margin-left: 4px;
+  transition: all var(--transition-speed);
+  min-height: 1.8rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+}
+
+/* Ensure button containers have enough space */
+.mg-pool-table td:last-child,
+.mg-groups-table td:last-child {
+  white-space: nowrap;
+}
+
+.mg-pool-table .btn:hover,
+.mg-groups-table .btn:hover {
+  background-color: var(--color-secondary);
+  opacity: 1;
+}
+
+.mg-pool-table .btn:active,
+.mg-groups-table .btn:active {
+  opacity: 0.5;
+}
+
+/* Delete button special style */
+.mg-btn-native.btn-delete,
+.mg-pool-table .btn.btn-delete,
+.mg-groups-table .btn.btn-delete {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.mg-btn-native.btn-delete:hover,
+.mg-pool-table .btn.btn-delete:hover,
+.mg-groups-table .btn.btn-delete:hover {
+  background-color: var(--color-accent);
+  color: var(--color-text);
+  opacity: 1;
+}
+
+/* Quick model groups panel styles */
+.quick-mg-container {
+  position: relative;
+  display: inline-block;
+}
+
+/* quick-mg-toggle button styles */
+#quick-mg-toggle {
+  background-color: var(--color-background);
+  border-radius: var(--spacing-xs);
+  color: var(--color-text);
+  cursor: pointer;
+  font-family: var(--font-family-main);
+  font-size: var(--font-size-small);
+  opacity: 0.8;
+  padding: 0.5rem 1rem;
+  transition: all var(--transition-speed);
+  min-height: 2.3rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+}
+
+#quick-mg-toggle:hover {
+  background-color: var(--color-secondary);
+  opacity: 1;
+}
+
+#quick-mg-toggle:active {
+  opacity: 0.5;
+}
+
+#quick-mg-toggle:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.quick-mg-container .mg-btn-native {
+  padding: 6px 10px;
+  font-size: var(--font-size-small);
+  min-width: auto;
+  height: auto;
+  min-height: auto;
+}
+
+.quick-mg-panel {
+  position: absolute;
+  top: 36px;
+  left: 0;
+  width: 300px;
+  max-height: 360px;
+  background: var(--color-panel);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  border-radius: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  z-index: 1200;
+  overflow: auto;
+  transition: opacity var(--transition-speed) ease, transform var(--transition-speed) ease;
+}
+
+.quick-mg-panel[aria-hidden="true"] {
+  opacity: 0;
+  transform: translateY(-4px);
+  pointer-events: none;
+}
+
+.quick-mg-search {
+  width: 100%;
+  padding: var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--spacing-xs);
+  background: var(--color-input);
+  color: var(--color-text);
+  font-family: var(--font-family-main);
+  font-size: var(--font-size-smaller);
+  transition: all var(--transition-speed);
+}
+
+.quick-mg-search:focus {
+  outline: 0.05rem solid rgba(155, 155, 155, 0.5);
+  background-color: var(--color-input-focus);
+  border-color: rgba(155, 155, 155, 0.5);
+}
+
+.quick-mg-search::placeholder {
+  color: var(--color-text);
+  opacity: 0.6;
+}
+
+.quick-mg-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.quick-mg-list li {
+  padding: 8px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  display: block;
+}
+
+.quick-mg-list li:hover {
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.quick-mg-list li.focused {
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.quick-mg-list li.selected {
+  background: linear-gradient(90deg, rgba(115, 122, 129, 0.06), rgba(115, 122, 129, 0.02));
+  border-left: 4px solid #737a81;
+}
+
+.quick-mg-list .mg-name {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 2px;
+}
+
+.quick-mg-list .mg-ref {
+  font-size: 0.9rem;
+  color: #737a81;
+  margin-left: 8px;
+}
+
+.quick-mg-list .mg-refs {
+  font-size: 0.8rem;
+  color: #737a81;
+  opacity: 0.8;
+}
+
+/* Place input-right controls (expand button + quick model groups) inside the chat input */
+#chat-input-container .input-right-controls {
+  position: absolute;
+  /* vertically center the control group within the input */
+  top: 50%;
+  right: 8px;
+  /* small upward nudge to visually center against the input's padding/border */
+  transform: translateY(calc(-50% - 2px));
+  height: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  pointer-events: auto;
+}
+
+/* Override the default absolute expand-button so it participates in the inline controls layout */
+#chat-input-container .input-right-controls #expand-button {
+  position: relative;
+  top: 0;
+  right: 0;
+  margin: 0;
+  padding: 6px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  z-index: 1300;
+  opacity: 0.6;
+}
+
+/* Slightly increase visibility on hover */
+#chat-input-container .input-right-controls #expand-button:hover {
+  opacity: 0.9;
+}
+
+/* Ensure the quick model toggle is vertically centered and doesn't collapse */
+#chat-input-container .input-right-controls .quick-mg-container {
+  display: inline-flex;
+  align-items: center;
+  /* let the toggle size itself naturally so it vertically centers with flex alignment */
+  height: auto;
+}
+
+/* Ensure the toggle button content is centered (fix visual baseline offsets) */
+#chat-input-container .input-right-controls #quick-mg-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  padding-top: 0.36rem;
+  padding-bottom: 0.36rem;
+}
+
+@media (max-width: 768px) {
+  #chat-input-container .input-right-controls {
+    transform: translateY(calc(-50% - 1px));
+  }
+}
+
+/* Align the quick-mg-panel to the right edge of the toggle and keep it below the input */
+.quick-mg-panel {
+  left: auto;
+  right: 0;
+  top: calc(100% + 6px);
+  z-index: 1200;
+}
+
+/* Prevent chat text from being hidden under the right-side controls */
+#chat-input {
+  padding-right: 180px;
+}
+
+/* Responsive: make the reserved padding smaller on narrow screens */
+@media (max-width: 768px) {
+  #chat-input {
+    padding-right: 120px;
+  }
+  #chat-input-container .input-right-controls {
+    right: 6px;
+    gap: 6px;
+  }
+  .quick-mg-panel {
+    right: -6px;
+    width: 260px;
+  }
+}
+
+@media (max-width: 480px) {
+  #chat-input {
+    padding-right: 100px;
+  }
+  #chat-input-container .input-right-controls {
+    gap: 4px;
+  }
+  .quick-mg-panel {
+    width: 95vw;
+    left: 0;
+    right: 0;
+  }
+}
+
+/* Light mode text colors */
+.light-mode .quick-mg-list .mg-ref,
+.light-mode .quick-mg-list .mg-refs {
+  color: #384653;
+}
+
+/* Model Groups modal styles */
+#modelGroupsModal {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+#modelGroupsModal[x-cloak] {
+  display: none !important;
+}
+
+/* Modal container size adjustments */
+.modal-container.modal-small {
+  width: 1100px;
+  max-width: 95vw;
+}
+
+/* Alpine.js transition classes */
+.x-transition-enter {
+  opacity: 0;
+  transform: scale(0.95);
+}
+
+.x-transition-enter-active {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.x-transition-enter-to {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.x-transition-leave {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.x-transition-leave-active {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.x-transition-leave-to {
+  opacity: 0;
+  transform: scale(0.95);
+}
+
+/* Loading state styles */
+.loading {
+  opacity: 0.6;
+  pointer-events: none;
+  position: relative;
+}
+
+.loading::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  margin: -8px 0 0 -8px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Responsive design */
+
+@media (max-width: 1024px) {
+  .mg-modal-grid {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-md);
+  }
+
+  .mg-column+.mg-column {
+    order: 2;
+  }
+
+  /* Adjust table column widths */
+  .mg-groups-table thead th:nth-child(1),
+  .mg-pool-table thead th:nth-child(1) {
+    width: 20%;
+  }
+
+  .mg-groups-table thead th:nth-child(2),
+  .mg-pool-table thead th:nth-child(2) {
+    width: 25%;
+  }
+
+  .mg-groups-table thead th:nth-child(3),
+  .mg-pool-table thead th:nth-child(3) {
+    width: 25%;
+  }
+
+  .mg-groups-table thead th:nth-child(4),
+  .mg-pool-table thead th:nth-child(4) {
+    width: 30%;
+  }
+}
+
+/* Small-screen tablet */
+@media (max-width: 768px) {
+  .mg-row {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .mg-control {
+    min-width: 140px;
+    width: auto;
+    flex: 1;
+  }
+
+  .mg-inline-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .mg-inline-row .mg-actions {
+    margin-left: 0;
+    display: flex;
+    gap: 8px;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .mg-inline-row .mg-control {
+    min-width: 120px;
+  }
+
+  .quick-mg-panel {
+    width: 95vw;
+    left: -10px;
+    max-height: 60vh;
+  }
+
+  /* Quick-mg-toggle adjustments for small screens */
+  #quick-mg-toggle {
+    padding: 0.4rem 0.8rem;
+    font-size: var(--font-size-smaller);
+  }
+
+  /* Table button adjustments */
+  .mg-pool-table .btn,
+  .mg-groups-table .btn {
+    padding: 3px 6px;
+    font-size: var(--font-size-smaller);
+    min-height: 1.6rem;
+    margin-left: 2px;
+  }
+}
+
+@media (max-width: 480px) {
+  .mg-section {
+    padding: var(--spacing-sm);
+  }
+
+  .mg-modal-grid {
+    gap: var(--spacing-sm);
+  }
+
+  .mg-control {
+    min-width: 100px;
+  }
+
+  .mg-inline-row .mg-actions {
+    justify-content: center;
+  }
+
+  .quick-mg-panel {
+    width: 98vw;
+    left: -15px;
+    max-height: 70vh;
+  }
+
+  /* Table responsive: stacked display */
+  .mg-groups-table thead,
+  .mg-pool-table thead {
+    display: none;
+  }
+
+  .mg-groups-table,
+  .mg-groups-table tbody,
+  .mg-groups-table tr,
+  .mg-groups-table td,
+  .mg-pool-table,
+  .mg-pool-table tbody,
+  .mg-pool-table tr,
+  .mg-pool-table td {
+    display: block;
+    width: 100%;
+  }
+
+  .mg-groups-table tr,
+  .mg-pool-table tr {
+    margin-bottom: 12px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--spacing-xs);
+    padding: 8px;
+    background: var(--color-panel);
+  }
+
+  .mg-groups-table td,
+  .mg-pool-table td {
+    padding: 6px 0;
+    border-bottom: none;
+    position: relative;
+    padding-left: 35%;
+  }
+
+  .mg-groups-table td::before,
+  .mg-pool-table td::before {
+    position: absolute;
+    left: 0;
+    top: 6px;
+    width: 30%;
+    white-space: nowrap;
+    font-weight: 600;
+    color: var(--color-text);
+    opacity: 0.8;
+    font-size: var(--font-size-smaller);
+  }
+
+  /* Model Groups table labels */
+  .mg-groups-table td:nth-of-type(1)::before {
+    content: 'Name:';
+  }
+
+  .mg-groups-table td:nth-of-type(2)::before {
+    content: 'Chat:';
+  }
+
+  .mg-groups-table td:nth-of-type(3)::before {
+    content: 'Utility:';
+  }
+
+  .mg-groups-table td:nth-of-type(4)::before {
+    content: 'Actions:';
+  }
+
+  /* Pool table labels */
+  .mg-pool-table td:nth-of-type(1)::before {
+    content: 'Provider:';
+  }
+
+  .mg-pool-table td:nth-of-type(2)::before {
+    content: 'Name:';
+  }
+
+  .mg-pool-table td:nth-of-type(3)::before {
+    content: 'API Base:';
+  }
+
+  .mg-pool-table td:nth-of-type(4)::before {
+    content: 'Actions:';
+  }
+
+  /* Mobile button optimizations */
+  .mg-pool-table .btn,
+  .mg-groups-table .btn {
+    padding: 4px 8px;
+    font-size: var(--font-size-smaller);
+    min-height: 1.8rem;
+    margin: 2px;
+  }
+
+  /* Special handling for Actions column on mobile */
+  .mg-groups-table td:nth-of-type(4),
+  .mg-pool-table td:nth-of-type(4) {
+    padding-left: 0;
+    text-align: center;
+    margin-top: 8px;
+  }
+
+  .mg-groups-table td:nth-of-type(4)::before,
+  .mg-pool-table td:nth-of-type(4)::before {
+    display: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .mg-modal-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mg-column+.mg-column {
+    order: 2;
+  }
+}
+
+@media (max-width: 900px) {
+  .mg-modal-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mg-column+.mg-column {
+    order: 2;
+  }
+}
+
+/* Light mode support */
+.light-mode .mg-btn-native {
+  background-color: var(--color-background);
+  color: var(--color-text-light);
+}
+
+.light-mode .mg-btn-native:hover {
+  background-color: var(--color-secondary-light);
+}
+
+.light-mode .mg-input-native {
+  background-color: var(--color-input-light);
+  color: var(--color-text-light);
+}
+
+.light-mode .mg-input-native:focus {
+  background-color: var(--color-input-focus-light);
+}
+
+.light-mode .mg-groups-table tbody tr.selected {
+  background: linear-gradient(90deg, rgba(56, 70, 83, 0.06), rgba(56, 70, 83, 0.02));
+  border-left: 4px solid var(--color-primary-light);
+}
+
+.light-mode .mg-pool-table .btn,
+.light-mode .mg-groups-table .btn {
+  background-color: var(--color-background-light);
+  color: var(--color-text-light);
+}
+
+.light-mode .mg-pool-table .btn:hover,
+.light-mode .mg-groups-table .btn:hover {
+  background-color: var(--color-secondary-light);
+}
+
+/* Delete button special style in light mode */
+.light-mode .mg-btn-native.btn-delete,
+.light-mode .mg-pool-table .btn.btn-delete,
+.light-mode .mg-groups-table .btn.btn-delete {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.light-mode .mg-btn-native.btn-delete:hover,
+.light-mode .mg-pool-table .btn.btn-delete:hover,
+.light-mode .mg-groups-table .btn.btn-delete:hover {
+  background-color: var(--color-accent);
+  color: var(--color-text-light);
+  opacity: 1;
+}
+
+/* Quick-mg-toggle styles in light mode */
+.light-mode #quick-mg-toggle {
+  background-color: var(--color-background-light);
+  color: var(--color-text-light);
+}
+
+.light-mode #quick-mg-toggle:hover {
+  background-color: var(--color-secondary-light);
+}
+
+.light-mode .quick-mg-list li:hover,
+.light-mode .quick-mg-list li.focused {
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+/* Touch device optimizations */
+@media (hover: none) and (pointer: coarse) {
+
+  .mg-btn-native,
+  .mg-pool-table .btn,
+  .mg-groups-table .btn {
+    min-height: 2.2rem;
+    padding: 6px 12px;
+  }
+
+  .mg-input-native {
+    min-height: 2.6rem;
+    padding: 8px 12px;
+  }
+
+  select.mg-input-native {
+    min-height: 2.8rem;
+  }
+
+  /* Quick-mg-toggle optimizations on touch devices */
+  #quick-mg-toggle {
+    padding: 0.6rem 1.2rem;
+    min-height: 44px;
+  }
+
+  /* Increase touch target size */
+  .quick-mg-list li {
+    padding: 12px 8px;
+    min-height: 44px;
+  }
+
+  .mg-list .mg-card {
+    padding: 12px;
+    min-height: 44px;
+  }
+}
+
+/* Accessibility and animation optimizations */
+@media (prefers-reduced-motion: reduce) {
+
+  .quick-mg-panel,
+  .mg-btn-native,
+  .mg-groups-table tbody tr,
+  .mg-pool-table tbody tr,
+  .quick-mg-list li,
+  .mg-list .mg-card,
+  .mg-input-native {
+    transition: none !important;
+  }
+
+  .loading::after {
+    animation: none !important;
+  }
+}
+
+/* High-contrast mode support */
+@media (prefers-contrast: high) {
+
+  .mg-btn-native,
+  .mg-pool-table .btn,
+  .mg-groups-table .btn {
+    border-width: 2px;
+  }
+
+  .mg-input-native {
+    border-width: 2px;
+  }
+
+  .mg-groups-table thead th,
+  .mg-pool-table thead th {
+    border-bottom-width: 2px;
+  }
+}

--- a/webui/index.html
+++ b/webui/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="css/history.css">
     <link rel="stylesheet" href="css/scheduler-datepicker.css">
     <link rel="stylesheet" href="css/notification.css">
+    <link rel="stylesheet" href="css/model-groups.css">
 
     <!-- Flatpickr for datetime picker -->
     <link rel="stylesheet" href="vendor/flatpickr/flatpickr.min.css">
@@ -162,7 +163,11 @@
                     <button class="config-button" id="newChat" @click="newChat()">New Chat</button>
                     <button class="config-button" id="loadChats" @click="loadChats()">Load Chat</button>
                     <button class="config-button" id="loadChat" @click="saveChat()">Save Chat</button>
-                    <button class="config-button" id="restart" @click="restart()">Restart</button>
+                    <button class="config-button" id="manage-model-groups"
+                        @click.prevent="$root.openModelGroupsModal ? $root.openModelGroupsModal() : window.openModelGroupsModal()">Models</button>
+                    <button class="config-button" id="memory-dash"
+                        @click="openModal('settings/memory/memory-dashboard.html');">Memory</button>
+                    <button class="config-button" id="restart" @click="restart()">Restart</button> 
                     <button class="config-button" id="settings" @click="settingsModalProxy.openModal()"><svg
                             xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="-5.0 -17.0 110.0 135.0"
                             fill="currentColor" width="24" height="24">
@@ -173,8 +178,6 @@
                                 d="m50.301 66.5c-9 0-16.398-7.3008-16.398-16.398 0-9.1016 7.3008-16.398 16.398-16.398 9.1016 0 16.398 7.3008 16.398 16.398 0 9.0977-7.3984 16.398-16.398 16.398zm0-25.5c-5 0-9.1016 4.1016-9.1016 9.1016s4.1016 9.1016 9.1016 9.1016 9.1016-4.1016 9.1016-9.1016c-0.003906-5-4.1016-9.1016-9.1016-9.1016z">
                             </path>
                         </svg>Settings</button>
-                    <button class="config-button" id="memory-dash"
-                        @click="openModal('settings/memory/memory-dashboard.html');">Memory</button>
 
 
                 </div>
@@ -422,7 +425,9 @@
                     <div id="chat-input-container" style="position: relative;">
                         <textarea id="chat-input" placeholder="Type your message here..." rows="1"></textarea>
 
-                        <!-- Expand button inside the textarea container -->
+                        <!-- Right-side controls inside the textarea container: expand + models -->
+                        <div class="input-right-controls">
+                            <!-- Expand button -->
                         <button id="expand-button" @click="$store.fullScreenInputModal.openModal()"
                             aria-label="Expand input">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
@@ -430,6 +435,16 @@
                                     d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
                             </svg>
                         </button>
+
+                            <!-- Quick Model Groups selector -->
+                            <div id="quick-mg-container" class="quick-mg-container">
+                                <button id="quick-mg-toggle" class="btn btn-field" title="Quick Model Groups">Models ▾</button>
+                                <div id="quick-mg-panel" class="quick-mg-panel" style="display:none;" aria-hidden="true">
+                                    <input id="quick-mg-search" class="quick-mg-search" placeholder="Search models..." />
+                                    <ul id="quick-mg-list" class="quick-mg-list"></ul>
+                                </div>
+                            </div>
+                        </div>
                     </div>
 
                     <div id="chat-buttons-wrapper">
@@ -567,6 +582,9 @@
                             </div>
                         </div>
 
+                        <!-- Model Groups component placeholder (migrated to separate component) -->
+                        <div data-mg-placeholder></div>
+
                         <!-- Display settings sections for agent, external, developer, mcp, backup tabs -->
                         <div id="settings-sections" x-show="activeTab !== 'scheduler'">
                             <nav>
@@ -607,32 +625,33 @@
                                             <div class="field-control">
                                                 <!-- Input field -->
                                                 <template x-if="field.type === 'text'">
-                                                    <input type="text" :class="field.classes" :value="field.value"
+                                                    <input type="text" :class="field.classes" x-model="field.value"
                                                         :readonly="field.readonly === true"
-                                                        @input="field.value = $event.target.value">
+                                                        :id="field.id" :name="field.id">
                                                 </template>
 
                                                 <!-- Number field -->
                                                 <template x-if="field.type === 'number'">
-                                                    <input type="number" :class="field.classes" :value="field.value"
+                                                    <input type="number" :class="field.classes" x-model="field.value"
                                                         :readonly="field.readonly === true"
-                                                        @input="field.value = $event.target.value" :min="field.min"
+                                                        :id="field.id" :name="field.id"
                                                         :max="field.max" :step="field.step">
                                                 </template>
 
 
                                                 <!-- Password field -->
                                                 <template x-if="field.type === 'password'">
-                                                    <input type="password" :class="field.classes" :value="field.value"
+                                                    <input type="password" :class="field.classes" x-model="field.value"
                                                         :readonly="field.readonly === true" :id="field.id"
-                                                        autocomplete="off" @input="field.value = $event.target.value">
+                                                        :id="field.id" :name="field.id"
+                                                        autocomplete="off">
                                                 </template>
 
                                                 <!-- Textarea field -->
                                                 <template x-if="field.type === 'textarea'">
-                                                    <textarea :class="field.classes" :value="field.value"
+                                                    <textarea :class="field.classes" x-model="field.value"
                                                         :readonly="field.readonly === true"
-                                                        @input="field.value = $event.target.value"
+                                                        :id="field.id" :name="field.id"
                                                         :style="field.style"></textarea>
                                                 </template>
 
@@ -650,9 +669,8 @@
                                                 <template x-if="field.type === 'range'">
                                                     <div class="field-control">
                                                         <input type="range" :min="field.min" :max="field.max"
-                                                            :step="field.step" :value="field.value"
+                                                            :step="field.step" x-model="field.value"
                                                             :disabled="field.readonly === true"
-                                                            @input="field.value = $event.target.value"
                                                             :class="field.classes">
                                                         <span class="range-value" x-text="field.value"></span>
                                                     </div>
@@ -665,15 +683,22 @@
                                                         @click="handleFieldButton(field)" x-text="field.value"></button>
                                                 </template>
 
-                                                <!-- Select field -->
-                                                <template x-if="field.type === 'select'">
+                                                <!-- Select field (exclude model_group - we keep only Manage Model Groups button) -->
+                                                <template x-if="field.type === 'select' && field.id !== 'model_group'">
                                                     <select :class="field.classes" x-model="field.value"
-                                                        :disabled="field.readonly === true">
+                                                        :disabled="field.readonly === true" :id="field.id" :name="field.id">
                                                         <template x-for="option in field.options" :key="option.value">
                                                             <option :value="option.value" x-text="option.label"
                                                                 :selected="option.value === field.value"></option>
                                                         </template>
                                                     </select>
+                                                </template>
+
+                                                <!-- Manage Model Groups button (shown next to model_group select) -->
+                                                <template x-if="field.type === 'select' && field.id === 'model_group'">
+                                                    <div class="mt-2 mg-manage-row">
+                                                        <button class="btn btn-field" @click.prevent="$root.openModelGroupsModal ? $root.openModelGroupsModal() : window.openModelGroupsModal()">Manage Model Groups</button>
+                                                    </div>
                                                 </template>
 
                                                 <!-- HTML field -->
@@ -1749,6 +1774,10 @@
 
     <!-- Drag and Drop Overlay Component -->
     <x-component path="chat/attachments/dragDropOverlay.html"></x-component>
+
+    <!-- Model Groups component (migrated files) -->
+    <x-component path="settings/model-groups/model-groups.html" />
+    <script src="components/settings/model-groups/model-groups.js"></script>
 
     <!-- Register Service Worker for offline support and caching -->
     <script>

--- a/webui/index.js
+++ b/webui/index.js
@@ -7,6 +7,9 @@ import { store as speechStore } from "/components/chat/speech/speech-store.js";
 import { store as notificationStore } from "/components/notifications/notification-store.js";
 
 globalThis.fetchApi = api.fetchApi; // TODO - backward compatibility for non-modular scripts, remove once refactored to alpine
+globalThis.callJsonApi = api.callJsonApi;
+globalThis.listModelGroups = api.listModelGroups;
+globalThis.selectModelGroup = api.selectModelGroup;
 
 const leftPanel = document.getElementById("left-panel");
 const rightPanel = document.getElementById("right-panel");

--- a/webui/js/settings.js
+++ b/webui/js/settings.js
@@ -284,6 +284,27 @@ const settingsModalProxy = {
         } else if (field.id === "memory_dashboard") {
             openModal("settings/memory/memory-dashboard.html");
         }
+    },
+
+    // Add method to open model groups modal
+    async openModelGroupsModal() {
+        // Use the Alpine store instead of local property
+        Alpine.store('modelGroups').open();
+
+        // Call the global function to populate the modal
+        if (typeof window.openModelGroupsModal === 'function') {
+            await window.openModelGroupsModal();
+        }
+    },
+
+    // Add method to close model groups modal
+    closeModelGroupsModal() {
+        // Use the Alpine store instead of local property
+        Alpine.store('modelGroups').close();
+
+        if (typeof window.closeModelGroupsModal === 'function') {
+            window.closeModelGroupsModal();
+        }
     }
 };
 
@@ -312,6 +333,30 @@ document.addEventListener('alpine:init', function () {
 
         toggleSettings() {
             this.isOpen = !this.isOpen;
+        },
+
+        // Add openModelGroupsModal method to root store
+        async openModelGroupsModal() {
+            // Open the model groups modal by setting the store state
+            Alpine.store('modelGroups').isOpen = true;
+
+            // Call the global function to populate the modal
+            if (typeof window.openModelGroupsModal === 'function') {
+                await window.openModelGroupsModal();
+            }
+        }
+    });
+
+    // Create a dedicated store for model groups modal state
+    Alpine.store('modelGroups', {
+        isOpen: false,
+
+        open() {
+            this.isOpen = true;
+        },
+
+        close() {
+            this.isOpen = false;
         }
     });
 


### PR DESCRIPTION
Model Groups provides a visual modal interface that allows users to:

	•	Create / Edit / Delete model groups, with each group able to specify both a chat model reference and a utility model reference.
	•	Manage the model pool: add individual model entries into the pool (including provider, name, and optional api_base) for groups to reference.

<img width="1569" height="1200" alt="CleanShot 2025-09-29 at 09 25 50" src="https://github.com/user-attachments/assets/dc6fde2e-0289-4eeb-9812-3b1923774c6a" />
<img width="1569" height="1200" alt="CleanShot 2025-09-29 at 09 25 37" src="https://github.com/user-attachments/assets/1ccb954c-425c-47d4-aaf5-8d7a6f10a6f9" />
