### PR TITLE
Tool progress

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -260,6 +260,7 @@ class LoopData:
         self.last_response = ""
         self.params_temporary: dict = {}
         self.params_persistent: dict = {}
+        self.current_tool = None
 
         # override values with kwargs
         for key, value in kwargs.items():
@@ -714,6 +715,13 @@ class Agent:
         ):  # if there is an intervention message, but not yet processed
             msg = self.intervention
             self.intervention = None  # reset the intervention message
+            # If a tool was running, save its progress to history
+            last_tool = self.loop_data.current_tool
+            if last_tool:
+                tool_progress = last_tool.progress.strip()
+                if tool_progress:
+                    self.hist_add_tool_result(last_tool.name, tool_progress)
+                    last_tool.set_progress(None)
             if progress.strip():
                 self.hist_add_ai_response(progress)
             # append the intervention message
@@ -766,27 +774,30 @@ class Agent:
                 )
 
             if tool:
-                await self.handle_intervention()
+                self.loop_data.current_tool = tool # type: ignore
+                try:
+                    await self.handle_intervention()
 
+                    # Call tool hooks for compatibility
+                    await tool.before_execution(**tool_args)
+                    await self.handle_intervention()
 
-                # Call tool hooks for compatibility
-                await tool.before_execution(**tool_args)
-                await self.handle_intervention()
+                    # Allow extensions to preprocess tool arguments
+                    await self.call_extensions("tool_execute_before", tool_args=tool_args or {}, tool_name=tool_name)
 
-                # Allow extensions to preprocess tool arguments
-                await self.call_extensions("tool_execute_before", tool_args=tool_args or {}, tool_name=tool_name)
+                    response = await tool.execute(**tool_args)
+                    await self.handle_intervention()
 
-                response = await tool.execute(**tool_args)
-                await self.handle_intervention()
+                    # Allow extensions to postprocess tool response
+                    await self.call_extensions("tool_execute_after", response=response, tool_name=tool_name)
+                    
+                    await tool.after_execution(response)
+                    await self.handle_intervention()
 
-                # Allow extensions to postprocess tool response
-                await self.call_extensions("tool_execute_after", response=response, tool_name=tool_name)
-                
-                await tool.after_execution(response)
-                await self.handle_intervention()
-
-                if response.break_loop:
-                    return response.message
+                    if response.break_loop:
+                        return response.message
+                finally:
+                    self.loop_data.current_tool = None
             else:
                 error_detail = (
                     f"Tool '{raw_tool_name}' not found or could not be initialized."

--- a/python/helpers/tool.py
+++ b/python/helpers/tool.py
@@ -22,10 +22,19 @@ class Tool:
         self.args = args
         self.loop_data = loop_data
         self.message = message
+        self.progress: str = ""
 
     @abstractmethod
     async def execute(self,**kwargs) -> Response:
         pass
+
+    def set_progress(self, content: str | None):
+        self.progress = content or ""
+
+    def add_progress(self, content: str | None):
+        if not content:
+            return
+        self.progress += content
 
     async def before_execution(self, **kwargs):
         PrintStyle(font_color="#1B4F72", padding=True, background_color="white", bold=True).print(f"{self.agent.agent_name}: Using tool '{self.name}'")

--- a/python/tools/code_execution_tool.py
+++ b/python/tools/code_execution_tool.py
@@ -277,6 +277,7 @@ class CodeExecution(Tool):
                 PrintStyle(font_color="#85C1E9").stream(partial_output)
                 # full_output += partial_output # Append new output
                 truncated_output = self.fix_full_output(full_output)
+                self.set_progress(truncated_output)
                 heading = self.get_heading_from_output(truncated_output, 0)
                 self.log.update(content=prefix + truncated_output, heading=heading)
                 last_output_time = now
@@ -383,6 +384,7 @@ class CodeExecution(Tool):
             timeout=1, reset_full_output=reset_full_output
         )
         truncated_output = self.fix_full_output(full_output)
+        self.set_progress(truncated_output)
         heading = self.get_heading_from_output(truncated_output, 0)
 
         last_lines = (


### PR DESCRIPTION
- Enhanced the base `Tool` class with a `progress` buffer to store real-time output during execution.
- Modified the `Agent`'s intervention handling to save any captured `progress` from the currently running tool into the message history, preserving its state.
- Updated `CodeExecutionTool` to continuously feed live terminal output into the `progress` buffer, enabling the capture of partial results.