### PR TITLE
runtime: stop calling Windows a Unix imposter

### DIFF
--- a/python/helpers/runtime.py
+++ b/python/helpers/runtime.py
@@ -1,6 +1,7 @@
 import argparse
 import inspect
 import secrets
+from pathlib import Path
 from typing import TypeVar, Callable, Awaitable, Union, overload, cast
 from python.helpers import dotenv, rfc, settings, files
 import asyncio
@@ -82,7 +83,9 @@ async def call_development_function(func: Union[Callable[..., T], Callable[..., 
     if is_development():
         url = _get_rfc_url()
         password = _get_rfc_password()
-        module = files.deabsolute_path(func.__code__.co_filename).replace("/", ".").removesuffix(".py") # __module__ is not reliable
+        # Normalize path components to build a valid Python module path across OSes
+        module_path = Path(files.deabsolute_path(func.__code__.co_filename)).with_suffix("")
+        module = ".".join(module_path.parts) # __module__ is not reliable
         result = await rfc.call_rfc(
             url=url,
             password=password,

--- a/python/helpers/tty_session.py
+++ b/python/helpers/tty_session.py
@@ -210,7 +210,9 @@ async def _spawn_winpty(cmd, cwd, env, echo):
 
     cols, rows = 80, 25
     pty = winpty.PTY(cols, rows)  # type: ignore
-    child = pty.spawn(cmd, cwd=cwd or os.getcwd(), env=env)
+    # winpty expects env as None or list of "KEY=VALUE" strings, not a dict
+    winpty_env = None if env is None else [f"{k}={v}" for k, v in env.items()]
+    child = pty.spawn(cmd, cwd=cwd or os.getcwd(), env=winpty_env)
 
     master_r_fd = msvcrt.open_osfhandle(child.conout_pipe, os.O_RDONLY)  # type: ignore
     master_w_fd = msvcrt.open_osfhandle(child.conin_pipe, 0)  # type: ignore


### PR DESCRIPTION
This PR fixes a bug related to Windows RFC development scenarios with A0. A `ModuleNotFoundError` on Windows related to RFC calls when using the file browser and other features has been fixed by normalizing path separators in `python/helpers/runtime.py`.