### PR TITLE
fix: RFC module resolution on Windows

### DIFF
--- a/python/helpers/runtime.py
+++ b/python/helpers/runtime.py
@@ -1,6 +1,7 @@
 import argparse
 import inspect
 import secrets
+from pathlib import Path
 from typing import TypeVar, Callable, Awaitable, Union, overload, cast
 from python.helpers import dotenv, rfc, settings, files
 import asyncio
@@ -82,7 +83,9 @@ async def call_development_function(func: Union[Callable[..., T], Callable[..., 
     if is_development():
         url = _get_rfc_url()
         password = _get_rfc_password()
-        module = files.deabsolute_path(func.__code__.co_filename).replace("/", ".").removesuffix(".py") # __module__ is not reliable
+        # Normalize path components to build a valid Python module path across OSes
+        module_path = Path(files.deabsolute_path(func.__code__.co_filename)).with_suffix("")
+        module = ".".join(module_path.parts) # __module__ is not reliable
         result = await rfc.call_rfc(
             url=url,
             password=password,

--- a/python/helpers/tty_session.py
+++ b/python/helpers/tty_session.py
@@ -210,7 +210,9 @@ async def _spawn_winpty(cmd, cwd, env, echo):
 
     cols, rows = 80, 25
     pty = winpty.PTY(cols, rows)  # type: ignore
-    child = pty.spawn(cmd, cwd=cwd or os.getcwd(), env=env)
+    # winpty expects env as None or list of "KEY=VALUE" strings, not a dict
+    winpty_env = None if env is None else [f"{k}={v}" for k, v in env.items()]
+    child = pty.spawn(cmd, cwd=cwd or os.getcwd(), env=winpty_env)
 
     master_r_fd = msvcrt.open_osfhandle(child.conout_pipe, os.O_RDONLY)  # type: ignore
     master_w_fd = msvcrt.open_osfhandle(child.conin_pipe, 0)  # type: ignore


### PR DESCRIPTION
<img width="853" height="535" alt="image" src="https://github.com/user-attachments/assets/80cdb05a-ecf6-4f0b-ab65-f8f1d5b30770" />

## Fix #1: RFC path resolution on Windows
- Windows path separators broke importlib module imports in dev mode.
- Use pathlib.Path to normalize cross-platform instead of string replace().
- Fixes: ModuleNotFoundError for code_execution_tool and API endpoints

## Fix #2: winpty env format on Windows
- winpty.spawn() expects env as list of "KEY=VALUE" strings, not dict.
- Convert dict to list before spawning to avoid TypeError.
- Fixes: shell_interface=local on Windows development setups

On Windows, you must choose SSH over the Local Python TTY for the code_execution_tool to work at all. This is the only tradeoff, because we have very few Windows devs working locally and not messing directly with the Docker instance files.
---

## PARAMOUNT FOR DOCUMENTATION
### Windows Development Setup

For Windows developers working with Agent Zero:

1. Install pywinpty: Required for terminal session handling
   ```bash
   First activate your Python or conda env
   pip install pywinpty
   ```
2. Configure shell interface: In the WebUI settings, set:
- Shell Interface: SSH (connects to Docker container)
- RFC Port SSH: same as Docker instance

Why SSH over Local:
- Windows lacks native /bin/bash
- Choosing "Local Python TTY" on Windows will break code_execution_tool's functionality

Note: The shell_interface: "local" option is designed for Linux/Mac hosts running Agent Zero code through Local Python TTY.