### PR TITLE
Disable systemd OSC metadata in SSH session

### DIFF
--- a/python/helpers/shell_ssh.py
+++ b/python/helpers/shell_ssh.py
@@ -62,7 +62,8 @@ class SSHInteractiveSession:
                 # invoke interactive shell
                 self.shell = self.client.invoke_shell(width=100, height=50)
 
-                initial_command = "stty -echo"
+                # disable systemd/OSC prompt metadata and disable local echo
+                initial_command = "unset PROMPT_COMMAND PS0; stty -echo"
                 if self.cwd:
                     initial_command = f"cd {self.cwd}; {initial_command}"
                 self.shell.send(f"{initial_command}\n".encode())


### PR DESCRIPTION
- Unset `PROMPT_COMMAND` and `PS0` on shell startup to prevent systemd from injecting OSC escape sequences (cwd/command markers) into interactive SSH sessions.