### PR TITLE
Improving the nudge

### DIFF
--- a/initialize.py
+++ b/initialize.py
@@ -82,6 +82,8 @@ def initialize_agent(override_settings: dict | None = None):
         knowledge_subdirs=[current_settings["agent_knowledge_subdir"], "default"],
         mcp_servers=current_settings["mcp_servers"],
         browser_http_headers=current_settings["browser_http_headers"],
+        auto_nudge_enabled=current_settings["auto_nudge_enabled"],
+        auto_nudge_timeout=current_settings["auto_nudge_timeout"],
         # code_exec params get initialized in _set_runtime_config
         # additional = {},
     )

--- a/python/extensions/monologue_start/_50_auto_nudge_tracker.py
+++ b/python/extensions/monologue_start/_50_auto_nudge_tracker.py
@@ -1,0 +1,7 @@
+import time
+from python.helpers.extension import Extension
+
+class AutoNudgeTracker(Extension):
+    async def execute(self, **kwargs):
+        # Update last activity time
+        self.agent.context.set_data("last_activity_time", time.time())

--- a/python/extensions/response_stream_chunk/_50_auto_nudge_activity.py
+++ b/python/extensions/response_stream_chunk/_50_auto_nudge_activity.py
@@ -1,0 +1,7 @@
+import time
+from python.helpers.extension import Extension
+
+class AutoNudgeActivity(Extension):
+    async def execute(self, **kwargs):
+        # Update last activity time
+        self.agent.context.set_data("last_activity_time", time.time())

--- a/python/extensions/tool_execute_after/_50_auto_nudge_activity.py
+++ b/python/extensions/tool_execute_after/_50_auto_nudge_activity.py
@@ -1,0 +1,7 @@
+import time
+from python.helpers.extension import Extension
+
+class AutoNudgeActivity(Extension):
+    async def execute(self, **kwargs):
+        # Update last activity time
+        self.agent.context.set_data("last_activity_time", time.time())

--- a/python/extensions/tool_execute_before/_50_auto_nudge_activity.py
+++ b/python/extensions/tool_execute_before/_50_auto_nudge_activity.py
@@ -1,0 +1,7 @@
+import time
+from python.helpers.extension import Extension
+
+class AutoNudgeActivity(Extension):
+    async def execute(self, **kwargs):
+        # Update last activity time
+        self.agent.context.set_data("last_activity_time", time.time())

--- a/python/helpers/auto_nudge_monitor.py
+++ b/python/helpers/auto_nudge_monitor.py
@@ -1,0 +1,83 @@
+import asyncio
+import time
+from python.helpers import defer
+from python.helpers.print_style import PrintStyle
+import python.helpers.log as Log
+
+class AutoNudgeMonitor:
+    _instance = None
+    _task = None
+
+    @classmethod
+    def start(cls):
+        if cls._instance is None:
+            cls._instance = AutoNudgeMonitor()
+        if cls._task is None:
+            cls._task = defer.DeferredTask(thread_name="AutoNudgeMonitor")
+            cls._task.start_task(cls._instance._monitor_loop)
+
+    @classmethod
+    def stop(cls):
+        if cls._task:
+            cls._task.kill()
+            cls._task = None
+
+    async def _monitor_loop(self):
+        from agent import AgentContext
+        
+        while True:
+            try:
+                await asyncio.sleep(5)  # Check every 5 seconds
+                
+                contexts = AgentContext.all()
+                
+                for context in contexts:
+                    
+                    if not context.config.auto_nudge_enabled:
+                        continue
+                    
+                    if context.paused:
+                        continue
+                        
+                    # Check if context has a running task
+                    if not context.task or not context.task.is_alive():
+                        continue
+                        
+                    # Check for timeout
+                    if self._is_stuck(context):
+                        self._trigger_nudge(context)
+                
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                # PrintStyle(font_color="red").print(f"AutoNudgeMonitor error: {e}")
+                await asyncio.sleep(5)
+
+    def _is_stuck(self, context) -> bool:
+        # Get last activity timestamp
+        last_activity = context.get_data("last_activity_time")
+        
+        if not last_activity:
+            # If no activity recorded yet, skip
+            return False
+            
+        # Check timeout
+        timeout = context.config.auto_nudge_timeout
+        elapsed = time.time() - last_activity
+        
+        if elapsed > timeout:
+            return True
+            
+        return False
+
+    def _trigger_nudge(self, context):
+        PrintStyle(font_color="yellow").print(f"Auto-nudging context {context.id} due to inactivity")
+        context.log.log(type="warning", content="Auto-nudge triggered due to inactivity.")
+        
+        # Reset activity timer to avoid immediate re-nudge
+        context.set_data("last_activity_time", time.time())
+        
+        try:
+            context.nudge()
+        except Exception as e:
+            PrintStyle(font_color="red").print(f"Failed to auto-nudge context {context.id}: {e}")

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -113,6 +113,9 @@ class Settings(TypedDict):
 
     update_check_enabled: bool
 
+    auto_nudge_enabled: bool
+    auto_nudge_timeout: int
+
 class PartialSettings(Settings, total=False):
     pass
 
@@ -651,6 +654,26 @@ def convert_out(settings: Settings) -> SettingsOutput:
                 {"value": subdir, "label": subdir}
                 for subdir in files.get_subdirectories("knowledge", exclude="default")
             ],
+        }
+    )
+
+    agent_fields.append(
+        {
+            "id": "auto_nudge_enabled",
+            "title": "Enable Auto-Nudge",
+            "description": "Automatically nudge the agent if it gets stuck (no activity for a specified timeout).",
+            "type": "switch",
+            "value": settings["auto_nudge_enabled"],
+        }
+    )
+
+    agent_fields.append(
+        {
+            "id": "auto_nudge_timeout",
+            "title": "Auto-Nudge Timeout (seconds)",
+            "description": "Time in seconds to wait before auto-nudging a stuck agent.",
+            "type": "number",
+            "value": settings["auto_nudge_timeout"],
         }
     )
 
@@ -1533,6 +1556,8 @@ def get_default_settings() -> Settings:
         secrets="",
         litellm_global_kwargs={},
         update_check_enabled=True,
+        auto_nudge_enabled=False,
+        auto_nudge_timeout=300,
     )
 
 


### PR DESCRIPTION
# Fix subordinate agent nudge reset and enable auto-nudge monitoring

## Summary
This PR fixes a critical issue where manually nudging a subordinate agent would reset the entire agent chain back to Agent 0, losing the subordinate's context. It also finalizes the Auto-Nudge feature by fixing the activity tracking extensions and refining the monitoring logic.

## Problem
1.  **Manual Nudge Reset**: When a subordinate agent (e.g., Agent 1) was running and the "Nudge" button was pressed, the `nudge()` method would kill the process and default back to resuming execution from `agent0`. This caused the subordinate agent's context and the hierarchical chain to be lost.
2.  **Broken Auto-Nudge Tracking**: The extensions responsible for updating `last_activity_time` were implemented as standalone functions (`async def run`), but the framework requires extensions to be classes inheriting from `Extension`. As a result, activity was never tracked, rendering the auto-nudge monitor ineffective.

## Solution

### 1. Fix Manual Nudge (`agent.py`)
Updated `AgentContext.nudge()` to:
-   Capture the `current_agent` (the subordinate) **before** calling `kill_process()`, ensuring the reference isn't lost when `streaming_agent` is cleared.
-   Resume execution using `self._process_chain(current_agent, ...)` instead of directly running the monologue. This preserves the superior/subordinate relationship and callback chain.

### 2. Fix Auto-Nudge Extensions
Refactored the following extensions to use the correct class-based `Extension` pattern:
-   `python/extensions/monologue_start/_50_auto_nudge_tracker.py`
-   `python/extensions/response_stream_chunk/_50_auto_nudge_activity.py`
-   `python/extensions/tool_execute_before/_50_auto_nudge_activity.py`
-   `python/extensions/tool_execute_after/_50_auto_nudge_activity.py`

This ensures `last_activity_time` is correctly updated in the context data during agent activity.

### 3. Refine Auto-Nudge Monitor (`auto_nudge_monitor.py`)
-   Removed excessive debug logging.
-   Standardized the stuck detection logic to compare `last_activity_time` against the configured `auto_nudge_timeout`.
-   Ensures `context.nudge()` is triggered safely when a timeout occurs.

## Verification
-   **Manual Nudge**: Verified that nudging a subordinate agent now correctly resumes execution within that same subordinate agent, preserving the call stack to its superior.
-   **Auto-Nudge**: Confirmed that activity extensions are now loaded by the system and `last_activity_time` is updated, allowing the monitor to accurately detect and act on timeouts.