### PR TITLE
Add Z.AI provider support for general and coding APIs

### DIFF
--- a/conf/model_providers.yaml
+++ b/conf/model_providers.yaml
@@ -84,6 +84,16 @@ chat:
   xai:
     name: xAI
     litellm_provider: xai
+  zai:
+    name: Z.AI
+    litellm_provider: openai
+    kwargs:
+      api_base: https://api.z.ai/api/paas/v4
+  zai_coding:
+    name: Z.AI Coding
+    litellm_provider: openai
+    kwargs:
+      api_base: https://api.z.ai/api/coding/paas/v4
   other:
     name: Other OpenAI compatible
     litellm_provider: openai


### PR DESCRIPTION
## Summary
- Add Z.AI provider with base URL `https://api.z.ai/api/paas/v4`
- Add Z.AI Coding provider with base URL `https://api.z.ai/api/coding/paas/v4`
- Both use OpenAI-compatible protocol via LiteLLM

## Available Models
- `glm-4.6` (latest general model)
- `glm-4.6v` (multimodal with vision)
- `glm-4.5`
- `glm-4.5-air` (faster, lightweight)

## Configuration
Users need to set in `.env`:
```
ZAI_API_KEY=your-api-key
ZAI_CODING_API_KEY=your-api-key
```

## Test plan
- [x] Set ZAI_API_KEY environment variable
- [x] Select "Z.AI" or "Z.AI Coding" as provider in settings
- [x] Enter model name (e.g., `glm-4.6`)
- [x] Verify chat completion works

🤖 Generated with [Claude Code](https://claude.com/claude-code)