### PR TITLE
Add AWS Bedrock provider support

### DIFF
--- a/conf/model_providers.yaml
+++ b/conf/model_providers.yaml
@@ -64,6 +64,9 @@ chat:
   azure:
     name: OpenAI Azure
     litellm_provider: azure
+  bedrock:
+    name: AWS Bedrock
+    litellm_provider: bedrock
   openrouter:
     name: OpenRouter
     litellm_provider: openrouter
@@ -110,6 +113,9 @@ embedding:
   azure:
     name: OpenAI Azure
     litellm_provider: azure
+  bedrock:
+    name: AWS Bedrock
+    litellm_provider: bedrock
   # TODO: OpenRouter not yet supported by LiteLLM, replace with native litellm_provider openrouter and remove api_base when ready
   openrouter:
     name: OpenRouter

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,5 +45,6 @@ soundfile==0.13.1
 imapclient>=3.0.1
 html2text>=2024.2.26
 beautifulsoup4>=4.12.3
+boto3>=1.35.0
 exchangelib>=5.4.3
 pywinpty==3.0.2; sys_platform == "win32"


### PR DESCRIPTION
## Summary
- Add AWS Bedrock to chat providers with native LiteLLM support
- Add AWS Bedrock to embedding providers

## Available Models

**Claude 4.5 Series:**
- `anthropic.claude-opus-4-5-20251101-v1:0` (Opus 4.5)
- `anthropic.claude-sonnet-4-5-20250929-v1:0` (Sonnet 4.5)
- `anthropic.claude-haiku-4-5-20251001-v1:0` (Haiku 4.5)

**Amazon Nova:**
- `amazon.nova-pro-v1:0`, `amazon.nova-lite-v1:0`, `amazon.nova-micro-v1:0`
- `amazon.nova-2-lite-v1:0`, `amazon.nova-2-sonic-v1:0`

**Qwen 3:**
- `qwen.qwen3-235b-a22b-2507-v1:0`
- `qwen.qwen3-coder-480b-a35b-v1:0`

**Others:**
- MiniMax M2: `minimax.minimax-m2`
- Mistral Large 3: `mistral.mistral-large-3-675b-instruct`
- DeepSeek: `deepseek.r1-v1:0`, `deepseek.v3-v1:0`
- Llama 3.3: `meta.llama3-3-70b-instruct-v1:0`
- Titan Embeddings: `amazon.titan-embed-text-v2:0`

## Configuration
Set `BEDROCK_API_KEY` in the Settings UI (uses new AWS Bedrock API key bearer token authentication).

## Test plan
- [x] Set BEDROCK_API_KEY in settings
- [x] Select "AWS Bedrock" as provider
- [x] Enter model name (e.g., `anthropic.claude-sonnet-4-5-20250929-v1:0`)
- [x] Verify chat completion works

🤖 Generated with [Claude Code](https://claude.com/claude-code)