### PR TITLE
Fix: Preserve profile when loading subordinate agent settings (follow-up to #788)

### DIFF
--- a/python/extensions/agent_init/_15_load_profile_settings.py
+++ b/python/extensions/agent_init/_15_load_profile_settings.py
@@ -4,7 +4,7 @@ from python.helpers.extension import Extension
 
 
 class LoadProfileSettings(Extension):
-    
+ 
     async def execute(self, **kwargs) -> None:
 
         if not self.agent or not self.agent.config.profile:
@@ -36,18 +36,18 @@ class LoadProfileSettings(Extension):
         if settings_override:
             # Preserve the original memory_subdir unless it's explicitly overridden
             current_memory_subdir = self.agent.config.memory_subdir
+            # FIX: Also preserve the original profile
+            original_profile = self.agent.config.profile
+            
             new_config = initialize_agent(override_settings=settings_override)
+            
             if (
                 "agent_memory_subdir" not in settings_override
                 and current_memory_subdir != "default"
             ):
                 new_config.memory_subdir = current_memory_subdir
+            
+            # FIX: Restore the original profile
+            new_config.profile = original_profile
+            
             self.agent.config = new_config
-            # self.agent.context.log.log(
-            #     type="info",
-            #     content=(
-            #         "Loaded custom settings for agent "
-            #         f"{self.agent.number} with profile '{self.agent.config.profile}'."
-            #     ),
-            # )
-


### PR DESCRIPTION
## Related Issue
Follows up on PR #788 (Subordinate agents settings override)

## Problem
When subordinate agents have a `settings.json` in their profile directory, the profile gets reset to `agent0` instead of preserving the intended profile.

### Root Cause
In `_15_load_profile_settings.py`, the extension:
1. Saves `memory_subdir` before calling `initialize_agent()`
2. Calls `initialize_agent(override_settings=...)` which creates a NEW config
3. The new config defaults `profile` to `"agent0"` from global settings
4. Restores `memory_subdir` but **forgets to restore `profile`**

### Why working profiles work
Profiles without `settings.json` (researcher, developer, hacker) skip this extension's logic entirely, so their profile is never overwritten.

## Solution
Apply the same preservation pattern used for `memory_subdir` to `profile`:

```python
# Before initialize_agent():
original_profile = self.agent.config.profile

# After initialize_agent():
new_config.profile = original_profile
```

## Testing
1. Create a profile with `settings.json` (e.g., `/agents/arachnia/settings.json`)
2. Call `call_subordinate(profile="arachnia", reset=True)`
3. **Before fix**: Subordinate loads as `agent0`
4. **After fix**: Subordinate loads correctly as `arachnia` ✅

## Checklist
- [x] Bug identified and root cause analyzed
- [x] Fix follows existing code patterns
- [x] Tested locally with custom profile
- [x] Minimal change (2 lines added)