### PR TITLE
Fix prompt fence stripping policy

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -564,7 +564,7 @@ class Agent:
             self.handle_critical_exception(e)
 
         error_message = errors.format_error(e)
-        
+
         self.context.log.log(
             type="warning", content="Critical error occurred, retrying..."
         )
@@ -628,7 +628,10 @@ class Agent:
     def read_prompt(self, file: str, **kwargs) -> str:
         dirs = subagents.get_paths(self, "prompts")
         prompt = files.read_prompt_file(file, _directories=dirs, _agent=self, **kwargs)
-        prompt = files.remove_code_fences(prompt)
+        # Only strip code fences when the *entire* prompt is a JSON template (e.g. fw.initial_message.md),
+        # so embedded fenced examples in markdown prompts remain intact.
+        if files.is_full_json_template(prompt):
+            prompt = files.remove_code_fences(prompt)
         return prompt
 
     def get_data(self, field: str):

--- a/tests/test_prompt_fence_policy.py
+++ b/tests/test_prompt_fence_policy.py
@@ -1,0 +1,40 @@
+import sys
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from agent import Agent
+
+
+class _DummyContext:
+    def get_data(self, key: str, recursive: bool = True):
+        return None
+
+
+def _dummy_agent(profile: str = "agent0"):
+    # Agent.read_prompt only needs config.profile and context.get_data() to resolve prompt paths.
+    return SimpleNamespace(config=SimpleNamespace(profile=profile), context=_DummyContext())
+
+
+def test_agent_read_prompt_preserves_embedded_fenced_examples_in_markdown_prompts():
+    dummy = _dummy_agent()
+    text = Agent.read_prompt(dummy, "agent.system.tool.response.md")
+
+    assert "usage:" in text
+    assert "~~~json" in text
+    assert "~~~" in text
+
+
+def test_agent_read_prompt_strips_full_json_template_fences_for_json_consumers():
+    dummy = _dummy_agent()
+    text = Agent.read_prompt(dummy, "fw.initial_message.md")
+
+    assert "```" not in text
+    assert "~~~" not in text
+
+    parsed = json.loads(text)
+    assert parsed.get("tool_name") == "response"

--- a/tests/test_remove_code_fences.py
+++ b/tests/test_remove_code_fences.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from python.helpers.files import remove_code_fences
+
+
+def test_remove_code_fences_does_not_strip_inline_tildes_or_join_lines():
+    src = (
+        "full message is automatically markdown do not wrap ~~~markdown\n"
+        "use emojis as icons improve readability\n"
+        "usage:\n"
+        "~~~json\n"
+        "{\n"
+        '  \"a\": 1\n'
+        "}\n"
+        "~~~\n"
+    )
+
+    out = remove_code_fences(src)
+
+    assert "wrap ~~~markdown\nuse emojis" in out
+    assert "wrap ~~~markdownuse emojis" not in out
+    assert "~~~json" not in out
+    assert "\n~~~\n" not in out
+    assert '"a": 1' in out


### PR DESCRIPTION
- Restrict code fence stripping to fences at start-of-line (prevents inline "~~~markdown" from being treated as a fence and merging lines)
- Only strip fences for full JSON templates in Agent.read_prompt() and files.parse_file()
- Preserve fenced examples in markdown/tool prompts while keeping json-only prompts parseable
- Add regression tests for fence stripping and prompt fence policy