### PR TITLE
Fix GitHub Copilot Vision Requests

### DIFF
--- a/conf/model_providers.yaml
+++ b/conf/model_providers.yaml
@@ -40,6 +40,7 @@ chat:
       extra_headers:
         "Editor-Version": "vscode/1.85.1"
         "Copilot-Integration-Id": "vscode-chat"
+        "Copilot-Vision-Request": "true"
   google:
     name: Google
     litellm_provider: gemini


### PR DESCRIPTION
Adds missing Copilot-Vision-Request header to GitHub Copilot provider kwargs to allow vision requests to work correctly.