### PR TITLE
feat: add Claude Code CLI tools for coding and planning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ instruments/**
 # for browser-use
 agent_history.gif
 
+tmpclaude-*

--- a/docs/claude_code_setup.md
+++ b/docs/claude_code_setup.md
@@ -1,0 +1,157 @@
+# Claude Code CLI Integration
+
+Agent Zero can delegate coding and planning tasks to Claude Code CLI, leveraging its superior coding capabilities through two specialized tools.
+
+## Overview
+
+| Tool | Purpose | CLI Flags |
+|------|---------|-----------|
+| `claude_code` | Coding tasks (writing, debugging, refactoring) | `claude --print` |
+| `claude_plan` | Planning tasks with extended thinking | `claude --think --print` |
+
+When these tools are available, Agent Zero will automatically delegate appropriate tasks to Claude Code CLI rather than attempting them directly.
+
+## Requirements
+
+- **Node.js** 18.0 or higher
+- **npm** (included with Node.js)
+- **Anthropic API key** or Claude Pro/Max subscription
+
+## Installation
+
+### Docker Environment (Recommended)
+
+1. **SSH into the Agent Zero container:**
+   ```bash
+   docker exec -it agent-zero /bin/bash
+   ```
+
+2. **Install Claude Code CLI:**
+   ```bash
+   npm install -g @anthropic-ai/claude-code
+   ```
+
+3. **Authenticate with Claude:**
+   ```bash
+   claude login
+   ```
+
+   This will open a browser window or provide a URL to authenticate. Follow the prompts to complete authentication.
+
+4. **Verify installation:**
+   ```bash
+   claude --version
+   claude --help
+   ```
+
+### Local Environment
+
+If running Agent Zero locally (not in Docker):
+
+```bash
+# Install globally
+npm install -g @anthropic-ai/claude-code
+
+# Authenticate
+claude login
+
+# Verify
+claude --version
+```
+
+## Configuration
+
+### Environment Variables (Optional)
+
+You can configure Claude Code CLI behavior with environment variables:
+
+```bash
+# Set API key directly (alternative to claude login)
+export ANTHROPIC_API_KEY="your-api-key"
+
+# Set default model
+export CLAUDE_MODEL="claude-sonnet-4-20250514"
+```
+
+### Tool Timeouts
+
+The tools have built-in timeouts to prevent runaway processes:
+
+- `claude_code`: 5 minutes (300 seconds)
+- `claude_plan`: 10 minutes (600 seconds)
+
+These can be adjusted in the tool source files if needed.
+
+## Usage
+
+Once installed and authenticated, Agent Zero will automatically use these tools when appropriate:
+
+### Coding Tasks
+Agent Zero will delegate to `claude_code` for:
+- Writing new code
+- Debugging errors
+- Refactoring existing code
+- Code review and improvements
+- Implementation tasks
+
+### Planning Tasks
+Agent Zero will delegate to `claude_plan` for:
+- Architecture design
+- System planning
+- Analysis and strategy
+- Complex problem decomposition
+
+## Troubleshooting
+
+### "Claude Code CLI not found"
+
+The CLI is not installed or not in PATH:
+```bash
+# Check if installed
+which claude
+
+# Reinstall if needed
+npm install -g @anthropic-ai/claude-code
+```
+
+### Authentication Issues
+
+If authentication fails or expires:
+```bash
+# Re-authenticate
+claude logout
+claude login
+```
+
+### Timeout Errors
+
+If tasks consistently timeout:
+1. Break the task into smaller subtasks
+2. Increase timeout in the tool source code
+3. Check network connectivity
+
+### Permission Issues in Docker
+
+If npm install fails with permission errors:
+```bash
+# Run as root (default in agent-zero container)
+npm install -g @anthropic-ai/claude-code --unsafe-perm
+```
+
+## How It Works
+
+1. Agent Zero receives a coding or planning task
+2. The agent recognizes the task type and invokes the appropriate tool
+3. The tool spawns Claude Code CLI as a subprocess
+4. Input is piped to the CLI via stdin
+5. Output is streamed back and displayed in the Agent Zero UI
+6. The result is returned to the agent for further processing
+
+## Files Reference
+
+| File | Description |
+|------|-------------|
+| `python/tools/claude_code.py` | Coding tool implementation |
+| `python/tools/claude_plan.py` | Planning tool implementation |
+| `prompts/agent.system.tool.claude_code.md` | Coding tool prompt |
+| `prompts/agent.system.tool.claude_plan.md` | Planning tool prompt |

--- a/prompts/agent.system.tool.claude_code.md
+++ b/prompts/agent.system.tool.claude_code.md
@@ -1,0 +1,22 @@
+### claude_code:
+
+ALWAYS use this tool for ANY coding task - writing code, debugging, refactoring, code review, implementation, fixing errors
+DO NOT attempt to write code yourself - delegate ALL coding to Claude Code CLI
+This tool has superior coding capabilities and MUST be used for any programming task
+
+**arguments:**
+- task: (required) detailed description of the coding task
+- working_dir: (optional) directory to run claude in
+
+usage:
+
+~~~json
+{
+    "thoughts": ["This is a coding task", "I MUST delegate to Claude Code"],
+    "headline": "Delegating to Claude Code",
+    "tool_name": "claude_code",
+    "tool_args": {
+        "task": "Write a Python hello world script"
+    }
+}
+~~~

--- a/prompts/agent.system.tool.claude_plan.md
+++ b/prompts/agent.system.tool.claude_plan.md
@@ -1,0 +1,22 @@
+### claude_plan:
+
+ALWAYS use this tool for ANY planning, architecture, or analysis task
+DO NOT attempt to plan or design yourself - delegate ALL planning to Claude Plan CLI
+This tool uses extended thinking for deeper reasoning and MUST be used for any strategic decisions
+
+**arguments:**
+- task: (required) detailed description of the planning/analysis task
+- working_dir: (optional) directory context for file access
+
+usage:
+
+~~~json
+{
+    "thoughts": ["This requires planning or analysis", "I MUST delegate to Claude Plan"],
+    "headline": "Delegating to Claude Plan",
+    "tool_name": "claude_plan",
+    "tool_args": {
+        "task": "Design the architecture for a REST API"
+    }
+}
+~~~

--- a/python/tools/claude_code.py
+++ b/python/tools/claude_code.py
@@ -1,0 +1,99 @@
+import asyncio
+from python.helpers.tool import Tool, Response
+from python.helpers.print_style import PrintStyle
+
+
+class ClaudeCode(Tool):
+    """Delegate coding tasks to Claude Code CLI."""
+
+    TIMEOUT_SECONDS = 300  # 5 minutes
+
+    async def execute(self, **kwargs) -> Response:
+        await self.agent.handle_intervention()
+
+        task = self.args.get("task", "")
+        working_dir = self.args.get("working_dir", None)
+
+        if not task:
+            return Response(
+                message="Error: No task provided. Please specify a 'task' argument.",
+                break_loop=False
+            )
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "claude", "--print",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=working_dir
+            )
+
+            self.log.update(content="Starting Claude Code CLI...")
+            output = await self._stream_output(process, task)
+
+            return Response(message=output, break_loop=False)
+
+        except FileNotFoundError:
+            return Response(
+                message="Claude Code CLI not found. Install with: npm install -g @anthropic-ai/claude-code",
+                break_loop=False
+            )
+        except asyncio.TimeoutError:
+            return Response(
+                message=f"Claude Code timed out after {self.TIMEOUT_SECONDS // 60} minutes.",
+                break_loop=False
+            )
+        except Exception as e:
+            return Response(message=f"Claude Code error: {str(e)}", break_loop=False)
+
+    async def _stream_output(self, process, task: str) -> str:
+        full_output = ""
+
+        if process.stdin:
+            process.stdin.write(task.encode())
+            await process.stdin.drain()
+            process.stdin.close()
+
+        async def read_stream():
+            nonlocal full_output
+            while True:
+                await self.agent.handle_intervention()
+                if process.stdout:
+                    chunk = await asyncio.wait_for(process.stdout.read(1024), timeout=30)
+                    if not chunk:
+                        break
+                    decoded = chunk.decode('utf-8', errors='replace')
+                    full_output += decoded
+                    PrintStyle(font_color="#85C1E9").stream(decoded)
+                    self.log.update(content=full_output[-50000:])
+                else:
+                    break
+
+        try:
+            await asyncio.wait_for(read_stream(), timeout=self.TIMEOUT_SECONDS)
+            await process.wait()
+
+            if process.returncode != 0 and process.stderr:
+                stderr = await process.stderr.read()
+                if stderr.strip():
+                    full_output += f"\n[stderr]: {stderr.decode()}"
+        except asyncio.TimeoutError:
+            process.kill()
+            await process.wait()
+            raise
+
+        self.log.update(heading=self.get_heading(done=True))
+        return full_output.strip() or "Claude Code completed with no output."
+
+    def get_heading(self, done: bool = False) -> str:
+        icon = " icon://done_all" if done else ""
+        return f"icon://code {self.agent.agent_name}: Claude Code{icon}"
+
+    def get_log_object(self):
+        return self.agent.context.log.log(
+            type="tool",
+            heading=self.get_heading(),
+            content="",
+            kvps=self.args,
+        )

--- a/python/tools/claude_plan.py
+++ b/python/tools/claude_plan.py
@@ -1,0 +1,99 @@
+import asyncio
+from python.helpers.tool import Tool, Response
+from python.helpers.print_style import PrintStyle
+
+
+class ClaudePlan(Tool):
+    """Delegate planning tasks to Claude Code CLI with extended thinking."""
+
+    TIMEOUT_SECONDS = 600  # 10 minutes
+
+    async def execute(self, **kwargs) -> Response:
+        await self.agent.handle_intervention()
+
+        task = self.args.get("task", "")
+        working_dir = self.args.get("working_dir", None)
+
+        if not task:
+            return Response(
+                message="Error: No task provided. Please specify a 'task' argument.",
+                break_loop=False
+            )
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "claude", "--think", "--print",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=working_dir
+            )
+
+            self.log.update(content="Starting Claude Plan with extended thinking...")
+            output = await self._stream_output(process, task)
+
+            return Response(message=output, break_loop=False)
+
+        except FileNotFoundError:
+            return Response(
+                message="Claude Code CLI not found. Install with: npm install -g @anthropic-ai/claude-code",
+                break_loop=False
+            )
+        except asyncio.TimeoutError:
+            return Response(
+                message=f"Claude Plan timed out after {self.TIMEOUT_SECONDS // 60} minutes.",
+                break_loop=False
+            )
+        except Exception as e:
+            return Response(message=f"Claude Plan error: {str(e)}", break_loop=False)
+
+    async def _stream_output(self, process, task: str) -> str:
+        full_output = ""
+
+        if process.stdin:
+            process.stdin.write(task.encode())
+            await process.stdin.drain()
+            process.stdin.close()
+
+        async def read_stream():
+            nonlocal full_output
+            while True:
+                await self.agent.handle_intervention()
+                if process.stdout:
+                    chunk = await asyncio.wait_for(process.stdout.read(1024), timeout=60)
+                    if not chunk:
+                        break
+                    decoded = chunk.decode('utf-8', errors='replace')
+                    full_output += decoded
+                    PrintStyle(font_color="#82E0AA").stream(decoded)
+                    self.log.update(content=full_output[-50000:])
+                else:
+                    break
+
+        try:
+            await asyncio.wait_for(read_stream(), timeout=self.TIMEOUT_SECONDS)
+            await process.wait()
+
+            if process.returncode != 0 and process.stderr:
+                stderr = await process.stderr.read()
+                if stderr.strip():
+                    full_output += f"\n[stderr]: {stderr.decode()}"
+        except asyncio.TimeoutError:
+            process.kill()
+            await process.wait()
+            raise
+
+        self.log.update(heading=self.get_heading(done=True))
+        return full_output.strip() or "Claude Plan completed with no output."
+
+    def get_heading(self, done: bool = False) -> str:
+        icon = " icon://done_all" if done else ""
+        return f"icon://psychology {self.agent.agent_name}: Claude Plan{icon}"
+
+    def get_log_object(self):
+        return self.agent.context.log.log(
+            type="tool",
+            heading=self.get_heading(),
+            content="",
+            kvps=self.args,
+        )


### PR DESCRIPTION
## Summary

- Adds `claude_code` tool for delegating coding tasks to Claude Code CLI
- Adds `claude_plan` tool for planning tasks with extended thinking (`--think` flag)
- Adds comprehensive setup documentation

## How It Works

These tools invoke the Claude Code CLI (`claude` command) as a subprocess:
- `claude_code`: Runs `claude --print` with 5 minute timeout
- `claude_plan`: Runs `claude --think --print` with 10 minute timeout

The CLI handles all the heavy lifting - authentication, API calls, context management.

## Requirements

- Claude Code CLI must be installed: `npm install -g @anthropic-ai/claude-code`
- CLI must be authenticated: `claude login`

## Files Added

- `python/tools/claude_code.py` - Coding tool implementation
- `python/tools/claude_plan.py` - Planning tool implementation  
- `prompts/agent.system.tool.claude_code.md` - Coding tool prompt
- `prompts/agent.system.tool.claude_plan.md` - Planning tool prompt
- `docs/claude_code_setup.md` - Setup and usage documentation

## Test Plan

- [ ] Verify tools appear in available tools list
- [ ] Test claude_code with simple coding task
- [ ] Test claude_plan with architecture design task
- [ ] Verify error handling when CLI not installed
- [ ] Verify timeout handling