### PR TITLE
feat: Add Cloud Provider Support (Azure OpenAI / AWS Bedrock)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ html2text>=2024.2.26
 beautifulsoup4>=4.12.3
 exchangelib>=5.4.3
 pywinpty==3.0.2; sys_platform == "win32"
+boto3>=1.34.0

--- a/webui/css/settings.css
+++ b/webui/css/settings.css
@@ -13,6 +13,11 @@
   grid-template-columns: 1fr;
 }
 
+.field.field-disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 /* Field Labels */
 .field-label {
   display: flex;

--- a/webui/index.html
+++ b/webui/index.html
@@ -238,9 +238,9 @@
                                     <div class="section-title" x-text="section.title"></div>
                                     <div class="section-description" x-html="section.description"></div>
 
-                                    <template x-for="(field, fieldIndex) in section.fields.filter(f => !f.hidden)"
+                                    <template x-for="(field, fieldIndex) in section.fields.filter(f => !f.hidden && (!f.depends_on || section.fields.find(df => df.id === f.depends_on.field)?.value === f.depends_on.value))"
                                         :key="fieldIndex">
-                                        <div :class="{'field': true, 'field-full': field.type === 'textarea'}">
+                                        <div :class="{'field': true, 'field-full': field.type === 'textarea', 'field-disabled': field.disabled_by && settings.sections.flatMap(s => s.fields).find(df => df.id === field.disabled_by.field)?.value !== field.disabled_by.not_value}">
                                             <div class="field-label" x-show="field.title || field.description">
                                                 <div class="field-title" x-text="field.title" x-show="field.title">
                                                 </div>


### PR DESCRIPTION
## Summary
Adds Cloud Provider dropdown in Settings → Provider Configuration to simplify Azure OpenAI and AWS Bedrock setup.

## Changes
- Add Cloud Provider dropdown (None/Azure/AWS) with conditional field visibility
- Disable Chat/Utility Model fields when cloud provider is selected
- Auto-sync cloud provider to Chat/Utility model providers on save
- Add boto3 dependency for AWS Bedrock support
- Fix _adjust_call_args to apply provider configs in all LLM code paths

## Files Modified
- [models.py](cci:7://file:///c:/Users/sagar/Documents/Agent%20Zero/agent-zero/models.py:0:0-0:0) - Fixed _adjust_call_args invocation
- [python/helpers/settings.py](cci:7://file:///c:/Users/sagar/Documents/Agent%20Zero/agent-zero/python/helpers/settings.py:0:0-0:0) - Added cloud_provider dropdown and depends_on/disabled_by logic
- [requirements.txt](cci:7://file:///c:/Users/sagar/Documents/Agent%20Zero/agent-zero/requirements.txt:0:0-0:0) - Added boto3
- [webui/index.html](cci:7://file:///c:/Users/sagar/Documents/Agent%20Zero/agent-zero/webui/index.html:0:0-0:0) - Added conditional visibility and field disabling
- [webui/css/settings.css](cci:7://file:///c:/Users/sagar/Documents/Agent%20Zero/agent-zero/webui/css/settings.css:0:0-0:0) - Added field-disabled styling