### PR TITLE
Fix zombie messages persisting after Clear Chat

### DIFF
--- a/python/extensions/before_main_llm_call/_10_log_for_stream.py
+++ b/python/extensions/before_main_llm_call/_10_log_for_stream.py
@@ -10,6 +10,8 @@ import math
 class LogForStream(Extension):
 
     async def execute(self, loop_data: LoopData = LoopData(), text: str = "", **kwargs):
+        if self.is_stale():
+            return
         # create log message and store it in loop data temporary params
         if "log_item_generating" not in loop_data.params_temporary:
             loop_data.params_temporary["log_item_generating"] = (

--- a/python/extensions/message_loop_prompts_after/_50_recall_memories.py
+++ b/python/extensions/message_loop_prompts_after/_50_recall_memories.py
@@ -24,6 +24,9 @@ class RecallMemories(Extension):
 
         set = settings.get_settings()
 
+        if self.is_stale():
+            return
+
         # turned off in settings?
         if not set["memory_recall_enabled"]:
             return

--- a/python/extensions/monologue_end/_50_memorize_fragments.py
+++ b/python/extensions/monologue_end/_50_memorize_fragments.py
@@ -11,7 +11,8 @@ from python.tools.memory_load import DEFAULT_THRESHOLD as DEFAULT_MEMORY_THRESHO
 class MemorizeMemories(Extension):
 
     async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
-        # try:
+        if self.is_stale():
+            return
 
         set = settings.get_settings()
 
@@ -29,7 +30,6 @@ class MemorizeMemories(Extension):
         return task
 
     async def memorize(self, loop_data: LoopData, log_item: LogItem, **kwargs):
-
         set = settings.get_settings()
 
         db = await Memory.get(self.agent)

--- a/python/extensions/monologue_end/_51_memorize_solutions.py
+++ b/python/extensions/monologue_end/_51_memorize_solutions.py
@@ -11,7 +11,8 @@ from python.tools.memory_load import DEFAULT_THRESHOLD as DEFAULT_MEMORY_THRESHO
 class MemorizeSolutions(Extension):
 
     async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
-        # try:
+        if self.is_stale():
+            return
 
         set = settings.get_settings()
 

--- a/python/extensions/monologue_start/_10_memory_init.py
+++ b/python/extensions/monologue_start/_10_memory_init.py
@@ -7,6 +7,8 @@ import asyncio
 class MemoryInit(Extension):
 
     async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
+        if self.is_stale():
+            return
         db = await memory.Memory.get(self.agent)
         
 

--- a/python/helpers/defer.py
+++ b/python/helpers/defer.py
@@ -56,7 +56,10 @@ class EventLoopThread:
             thread.join()
 
         if not loop.is_closed():
-            loop.close()
+            try:
+                loop.close()
+            except Exception:
+                pass
 
         with self.__class__._lock:
             if self.thread_name in self.__class__._instances:

--- a/python/helpers/extension.py
+++ b/python/helpers/extension.py
@@ -19,6 +19,11 @@ class Extension:
         self.agent: "Agent" = agent  # type: ignore < here we ignore the type check as there are currently no extensions without an agent
         self.kwargs = kwargs
 
+    def is_stale(self) -> bool:
+        """Check if this extension's agent has been replaced by a new agent0 (e.g., after reset)."""
+        agent0 = getattr(self.agent.context, "agent0", None)
+        return bool(agent0 and self.agent != agent0)
+
     @abstractmethod
     async def execute(self, **kwargs) -> Any:
         pass

--- a/python/helpers/log.py
+++ b/python/helpers/log.py
@@ -150,7 +150,12 @@ class LogItem:
         update_progress: ProgressUpdate | None = None,
         **kwargs,
     ):
-        if self.guid == self.log.guid:
+        # update only if this item is still the owner of its slot
+        if (
+            self.guid == self.log.guid
+            and self.no < len(self.log.logs)
+            and self.log.logs[self.no] is self
+        ):
             self.log._update_item(
                 self.no,
                 type=type,
@@ -212,7 +217,6 @@ class Log:
         id: Optional[str] = None,
         **kwargs,
     ) -> LogItem:
-
         # add a minimal item to the log
         # Determine agent number from streaming agent
         agent_number = 0


### PR DESCRIPTION
When sending a message and immediately clicking "Clear Chat", utility messages like "Memorizing solutions..." and "Initializing VectorDB..." would spawn in the cleared chat.

Root Cause: `task.kill()` without `terminate_thread=True` only cancelled the future but didn't stop running coroutines. Old tasks continued executing and writing to the log after the context was reset. Some extensions were spawning messages even after task termination, not updating the old log entry, but creating a new one, making messages visible anyway even with the log identity check in place.

### Core Fixes
- `AgentContext.reset()`: Terminate old task in background thread with `terminate_thread=True` for non-blocking UI response when clicking Clear Chat btn
- `Agent.monologue()`: Added stale-agent guard to exit immediately if replaced (if removed, you're going to see "Building prompt" messages in the progress bar).
- `LogItem.update()`: Identity check ensures stale items cannot modify the current log (GUID + slot + object identity)

### Extension Guards
- Added `Extension.is_stale()` helper for centralized stale detection
- Applied guard to: `_10_log_for_stream`, `_10_memory_init`, `_50_recall_memories`, `_50_memorize_fragments`, `_51_memorize_solutions`.

## defer.py
- Safe `loop.close()` in `defer.py` to prevent crashes during termination, these errors are not important because we're tearing down the task anyway.