### PR TITLE
Rename Agent Zero to Magui across project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,8 @@
 MIT License
 
-Copyright (c) 2025 Agent Zero, s.r.o
-Contact: pr@agent-zero.ai
-Repository: https://github.com/agent0ai/agent-zero
+Copyright (c) 2025 Magui, s.r.o
+Contact: pr@magui.ai
+Repository: https://github.com/magui/magui
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div align="center">
 
-# `Agent Zero`
+# `Magui`
 
 <p align="center">
     <a href="https://trendshift.io/repositories/11745" target="_blank"><img src="https://trendshift.io/api/badge/repositories/11745" alt="frdel%2Fagent-zero | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
 
-[![Agent Zero Website](https://img.shields.io/badge/Website-agent--zero.ai-0A192F?style=for-the-badge&logo=vercel&logoColor=white)](https://agent-zero.ai) [![Thanks to Sponsors](https://img.shields.io/badge/GitHub%20Sponsors-Thanks%20to%20Sponsors-FF69B4?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/agent0ai) [![Follow on X](https://img.shields.io/badge/X-Follow-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/Agent0ai) [![Join our Discord](https://img.shields.io/badge/Discord-Join%20our%20server-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/B8KZKNsPpj) [![Subscribe on YouTube](https://img.shields.io/badge/YouTube-Subscribe-red?style=for-the-badge&logo=youtube&logoColor=white)](https://www.youtube.com/@AgentZeroFW) [![Connect on LinkedIn](https://img.shields.io/badge/LinkedIn-Connect-blue?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/jan-tomasek/) [![Follow on Warpcast](https://img.shields.io/badge/Warpcast-Follow-5A32F3?style=for-the-badge)](https://warpcast.com/agent-zero) 
+[![Magui Website](https://img.shields.io/badge/Website-agent--zero.ai-0A192F?style=for-the-badge&logo=vercel&logoColor=white)](https://agent-zero.ai) [![Thanks to Sponsors](https://img.shields.io/badge/GitHub%20Sponsors-Thanks%20to%20Sponsors-FF69B4?style=for-the-badge&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/agent0ai) [![Follow on X](https://img.shields.io/badge/X-Follow-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/Agent0ai) [![Join our Discord](https://img.shields.io/badge/Discord-Join%20our%20server-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/B8KZKNsPpj) [![Subscribe on YouTube](https://img.shields.io/badge/YouTube-Subscribe-red?style=for-the-badge&logo=youtube&logoColor=white)](https://www.youtube.com/@AgentZeroFW) [![Connect on LinkedIn](https://img.shields.io/badge/LinkedIn-Connect-blue?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/jan-tomasek/) [![Follow on Warpcast](https://img.shields.io/badge/Warpcast-Follow-5A32F3?style=for-the-badge)](https://warpcast.com/agent-zero) 
 
 
 ## Documentation:
@@ -16,7 +16,7 @@
 [Development](./docs/development.md) •
 [Extensibility](./docs/extensibility.md) •
 [Connectivity](./docs/connectivity.md) •
-[How to update](./docs/installation.md#how-to-update-agent-zero) •
+[How to update](./docs/installation.md#how-to-update-magui) •
 [Documentation](./docs/README.md) •
 [Usage](./docs/usage.md)
 
@@ -30,7 +30,7 @@ Or see DeepWiki generated documentation:
 <div align="center">
 
 > ### 🚨 **PROJECTS!** 🚨
-Agent Zero now supports **Projects** – isolated workspaces with their own prompts, files, memory, and secrets, so you can create dedicated setups for each use case without mixing contexts.
+Magui now supports **Projects** – isolated workspaces with their own prompts, files, memory, and secrets, so you can create dedicated setups for each use case without mixing contexts.
 </div>
 
 
@@ -43,32 +43,32 @@ Agent Zero now supports **Projects** – isolated workspaces with their own prom
 
 
 
-- Agent Zero is not a predefined agentic framework. It is designed to be dynamic, organically growing, and learning as you use it.
-- Agent Zero is fully transparent, readable, comprehensible, customizable, and interactive.
-- Agent Zero uses the computer as a tool to accomplish its (your) tasks.
+- Magui is not a predefined agentic framework. It is designed to be dynamic, organically growing, and learning as you use it.
+- Magui is fully transparent, readable, comprehensible, customizable, and interactive.
+- Magui uses the computer as a tool to accomplish its (your) tasks.
 
 # 💡 Key Features
 
 1. **General-purpose Assistant**
 
-- Agent Zero is not pre-programmed for specific tasks (but can be). It is meant to be a general-purpose personal assistant. Give it a task, and it will gather information, execute commands and code, cooperate with other agent instances, and do its best to accomplish it.
+- Magui is not pre-programmed for specific tasks (but can be). It is meant to be a general-purpose personal assistant. Give it a task, and it will gather information, execute commands and code, cooperate with other agent instances, and do its best to accomplish it.
 - It has a persistent memory, allowing it to memorize previous solutions, code, facts, instructions, etc., to solve tasks faster and more reliably in the future.
 
-![Agent 0 Working](/docs/res/ui-screen-2.png)
+![Magui Working](/docs/res/ui-screen-2.png)
 
 2. **Computer as a Tool**
 
-- Agent Zero uses the operating system as a tool to accomplish its tasks. It has no single-purpose tools pre-programmed. Instead, it can write its own code and use the terminal to create and use its own tools as needed.
+- Magui uses the operating system as a tool to accomplish its tasks. It has no single-purpose tools pre-programmed. Instead, it can write its own code and use the terminal to create and use its own tools as needed.
 - The only default tools in its arsenal are online search, memory features, communication (with the user and other agents), and code/terminal execution. Everything else is created by the agent itself or can be extended by the user.
 - Tool usage functionality has been developed from scratch to be the most compatible and reliable, even with very small models.
-- **Default Tools:** Agent Zero includes tools like knowledge, code execution, and communication.
-- **Creating Custom Tools:** Extend Agent Zero's functionality by creating your own custom tools.
-- **Instruments:** Instruments are a new type of tool that allow you to create custom functions and procedures that can be called by Agent Zero.
+- **Default Tools:** Magui includes tools like knowledge, code execution, and communication.
+- **Creating Custom Tools:** Extend Magui's functionality by creating your own custom tools.
+- **Instruments:** Instruments are a new type of tool that allow you to create custom functions and procedures that can be called by Magui.
 
 3. **Multi-agent Cooperation**
 
 - Every agent has a superior agent giving it tasks and instructions. Every agent then reports back to its superior.
-- In the case of the first agent in the chain (Agent 0), the superior is the human user; the agent sees no difference.
+- In the case of the first agent in the chain (Magui), the superior is the human user; the agent sees no difference.
 - Every agent can create its subordinate agent to help break down and solve subtasks. This helps all agents keep their context clean and focused.
 
 ![Multi-agent](docs/res/physics.png)
@@ -91,7 +91,7 @@ Agent Zero now supports **Projects** – isolated workspaces with their own prom
 - The terminal interface is real-time streamed and interactive. You can stop and intervene at any point. If you see your agent heading in the wrong direction, just stop and tell it right away.
 - There is a lot of freedom in this framework. You can instruct your agents to regularly report back to superiors asking for permission to continue. You can instruct them to use point-scoring systems when deciding when to delegate subtasks. Superiors can double-check subordinates' results and dispute. The possibilities are endless.
 
-## 🚀 Things you can build with Agent Zero
+## 🚀 Things you can build with Magui
 
 - **Development Projects** - `"Create a React dashboard with real-time data visualization"`
 
@@ -107,11 +107,11 @@ Agent Zero now supports **Projects** – isolated workspaces with their own prom
 
 # ⚙️ Installation
 
-Click to open a video to learn how to install Agent Zero:
+Click to open a video to learn how to install Magui:
 
 [![Easy Installation guide](/docs/res/easy_ins_vid.png)](https://www.youtube.com/watch?v=w5v5Kjx51hs)
 
-A detailed setup guide for Windows, macOS, and Linux with a video can be found in the Agent Zero Documentation at [this page](./docs/installation.md).
+A detailed setup guide for Windows, macOS, and Linux with a video can be found in the Magui Documentation at [this page](./docs/installation.md).
 
 ### ⚡ Quick Start
 
@@ -141,11 +141,11 @@ docker run -p 50001:80 agent0ai/agent-zero
 
 ## 👀 Keep in Mind
 
-1. **Agent Zero Can Be Dangerous!**
+1. **Magui Can Be Dangerous!**
 
-- With proper instruction, Agent Zero is capable of many things, even potentially dangerous actions concerning your computer, data, or accounts. Always run Agent Zero in an isolated environment (like Docker) and be careful what you wish for.
+- With proper instruction, Magui is capable of many things, even potentially dangerous actions concerning your computer, data, or accounts. Always run Magui in an isolated environment (like Docker) and be careful what you wish for.
 
-2. **Agent Zero Is Prompt-based.**
+2. **Magui Is Prompt-based.**
 
 - The whole framework is guided by the **prompts/** folder. Agent guidelines, tool instructions, messages, utility AI functions, it's all there.
 
@@ -157,7 +157,7 @@ docker run -p 50001:80 agent0ai/agent-zero
 | [Installation](./docs/installation.md) | Installation, setup and configuration |
 | [Usage](./docs/usage.md) | Basic and advanced usage |
 | [Development](./docs/development.md) | Development and customization |
-| [Extensibility](./docs/extensibility.md) | Extending Agent Zero |
+| [Extensibility](./docs/extensibility.md) | Extending Magui |
 | [Connectivity](./docs/connectivity.md) | External API endpoints, MCP server connections, A2A protocol |
 | [Architecture](./docs/architecture.md) | System design and components |
 | [Contributing](./docs/contribution.md) | How to contribute |
@@ -287,8 +287,8 @@ docker run -p 50001:80 agent0ai/agent-zero
 ### v0.8.5 - **MCP Server + Client**
 [Release video](https://youtu.be/pM5f4Vz3_IQ)
 
-- Agent Zero can now act as MCP Server
-- Agent Zero can use external MCP servers as tools
+- Magui can now act as MCP Server
+- Magui can use external MCP servers as tools
 
 ### v0.8.4.1 - 2
 Default models set to gpt-4.1

--- a/agents/_example/prompts/agent.system.main.role.md
+++ b/agents/_example/prompts/agent.system.main.role.md
@@ -5,4 +5,4 @@
 > !!!
 
 ## Your role
-You are Agent Zero, a sci-fi character from the movie "Agent Zero".
+You are Magui, a sci-fi character from the movie "Magui".

--- a/agents/developer/prompts/agent.system.main.communication.md
+++ b/agents/developer/prompts/agent.system.main.communication.md
@@ -17,9 +17,8 @@ The agent must utilize the 'response' tool iteratively until achieving complete 
 
 ### Thinking (thoughts)
 
-Every Agent Zero reply must contain a "thoughts" JSON field serving as the cognitive workspace for systematic architectural processing.
-
-Within this field, construct a comprehensive mental model connecting observations to implementation objectives through structured reasoning. Develop step-by-step technical pathways, creating decision trees when facing complex architectural choices. Your cognitive process should capture design patterns, optimization strategies, trade-off analyses, and implementation decisions throughout the solution journey.
+Every Agent Zero reEvery Magui reply must contain a "thoughts" JSON field serving as the cognitive workspace for systematic architectural processing.
+construct a comprehensive mental model connecting observations to implementation objectives through structured reasoning. Develop step-by-step technical pathways, creating decision trees when facing complex architectural choices. Your cognitive process should capture design patterns, optimization strategies, trade-off analyses, and implementation decisions throughout the solution journey.
 
 Decompose complex systems into manageable modules, solving each to inform the integrated architecture. Your technical framework must:
 
@@ -39,7 +38,7 @@ Decompose complex systems into manageable modules, solving each to inform the in
 
 ### Tool Calling (tools)
 
-Every Agent Zero reply must contain "tool_name" and "tool_args" JSON fields specifying precise action execution.
+Every Magui reply must contain "tool_name" and "tool_args" JSON fields specifying precise action execution.
 
 These fields encode the operational commands transforming architectural insights into concrete development progress. Tool selection and argument crafting require meticulous attention to maximize code quality and development efficiency.
 

--- a/agents/developer/prompts/agent.system.main.role.md
+++ b/agents/developer/prompts/agent.system.main.role.md
@@ -1,6 +1,6 @@
 ## Your Role
 
-You are Agent Zero 'Master Developer' - an autonomous intelligence system engineered for comprehensive software excellence, architectural mastery, and innovative implementation across enterprise, cloud-native, and cutting-edge technology domains.
+You are Magui 'Master Developer' - an autonomous intelligence system engineered for comprehensive software excellence, architectural mastery, and innovative implementation across enterprise, cloud-native, and cutting-edge technology domains.
 
 ### Core Identity
 - **Primary Function**: Elite software architect combining deep systems expertise with Silicon Valley innovation capabilities
@@ -43,7 +43,7 @@ You are Agent Zero 'Master Developer' - an autonomous intelligence system engine
 Your expertise enables transformation of complex technical challenges into elegant, scalable solutions that power mission-critical systems at the highest performance levels.
 
 
-## 'Master Developer' Process Specification (Manual for Agent Zero 'Master Developer' Agent)
+## 'Master Developer' Process Specification (Manual for Magui 'Master Developer' Agent)
 
 ### General
 

--- a/agents/researcher/prompts/agent.system.main.communication.md
+++ b/agents/researcher/prompts/agent.system.main.communication.md
@@ -17,7 +17,7 @@ The agent must utilize the 'response' tool iteratively until achieving complete 
 
 ### Thinking (thoughts)
 
-Every Agent Zero reply must contain a "thoughts" JSON field serving as the cognitive workspace for systematic analytical processing.
+Every Magui reply must contain a "thoughts" JSON field serving as the cognitive workspace for systematic analytical processing.
 
 Within this field, construct a comprehensive mental model connecting observations to task objectives through structured reasoning. Develop step-by-step analytical pathways, creating decision trees when facing complex branching logic. Your cognitive process should capture ideation, insight generation, hypothesis formation, and strategic decisions throughout the solution journey.
 
@@ -39,7 +39,7 @@ Decompose complex challenges into manageable components, solving each to inform 
 
 ### Tool Calling (tools)
 
-Every Agent Zero reply must contain "tool_name" and "tool_args" JSON fields specifying precise action execution.
+Every Magui reply must contain "tool_name" and "tool_args" JSON fields specifying precise action execution.
 
 These fields encode the operational commands transforming analytical insights into concrete research progress. Tool selection and argument crafting require meticulous attention to maximize solution quality and efficiency.
 

--- a/agents/researcher/prompts/agent.system.main.role.md
+++ b/agents/researcher/prompts/agent.system.main.role.md
@@ -1,6 +1,6 @@
 ## Your Role
 
-You are Agent Zero 'Deep Research' - an autonomous intelligence system engineered for comprehensive research excellence, analytical mastery, and innovative synthesis across corporate, scientific, and academic domains.
+You are Magui 'Deep Research' - an autonomous intelligence system engineered for comprehensive research excellence, analytical mastery, and innovative synthesis across corporate, scientific, and academic domains.
 
 ### Core Identity
 - **Primary Function**: Elite research associate combining doctoral-level academic rigor with Fortune 500 strategic analysis capabilities
@@ -43,7 +43,7 @@ You are Agent Zero 'Deep Research' - an autonomous intelligence system engineere
 Your expertise enables transformation of complex research challenges into clear, actionable intelligence that drives informed decision-making at the highest organizational levels.
 
 
-## 'Deep ReSearch' Process Specification (Manual for Agent Zero 'Deep ReSearch' Agent)
+## 'Deep ReSearch' Process Specification (Manual for Magui 'Deep ReSearch' Agent)
 
 ### General
 

--- a/conf/model_providers.yaml
+++ b/conf/model_providers.yaml
@@ -1,4 +1,4 @@
-# Supported model providers for Agent Zero
+# Supported model providers for Magui
 # ---------------------------------------
 #
 # Each provider type ("chat", "embedding") contains a mapping of provider IDs
@@ -18,7 +18,7 @@
 
 chat:
   a0_venice:
-    name: Agent Zero Venice.ai
+    name: Magui Venice.ai
     litellm_provider: openai
     kwargs:
       api_base: https://api.agent-zero.ai/venice/v1
@@ -70,7 +70,7 @@ chat:
     kwargs:
       extra_headers:
         "HTTP-Referer": "https://agent-zero.ai/"
-        "X-Title": "Agent Zero"
+        "X-Title": "Magui"
   sambanova:
     name: Sambanova
     litellm_provider: sambanova
@@ -118,7 +118,7 @@ embedding:
       api_base: https://openrouter.ai/api/v1
       extra_headers:
         "HTTP-Referer": "https://agent-zero.ai/"
-        "X-Title": "Agent Zero"
+        "X-Title": "Magui"
   other:
     name: Other OpenAI compatible
     litellm_provider: openai

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,35 +1,35 @@
-![Agent Zero Logo](res/header.png)
-# Agent Zero Documentation
-To begin with Agent Zero, follow the links below for detailed guides on various topics:
+![Magui Logo](res/header.png)
+# Magui Documentation
+To begin with Magui, follow the links below for detailed guides on various topics:
 
-- **[Installation](installation.md):** Set up (or [update](installation.md#how-to-update-agent-zero)) Agent Zero on your system.
+- **[Installation](installation.md):** Set up (or [update](installation.md#how-to-update-magui)) Magui on your system.
 - **[Usage Guide](usage.md):** Explore GUI features and usage scenarios.
-- **[Development](development.md):** Set up a development environment for Agent Zero.
-- **[Extensibility](extensibility.md):** Learn how to create custom extensions for Agent Zero.
-- **[Connectivity](connectivity.md):** Learn how to connect to Agent Zero from other applications.
+- **[Development](development.md):** Set up a development environment for Magui.
+- **[Extensibility](extensibility.md):** Learn how to create custom extensions for Magui.
+- **[Connectivity](connectivity.md):** Learn how to connect to Magui from other applications.
 - **[Architecture Overview](architecture.md):** Understand the internal workings of the framework.
-- **[Contributing](contribution.md):** Learn how to contribute to the Agent Zero project.
+- **[Contributing](contribution.md):** Learn how to contribute to the Magui project.
 - **[Troubleshooting and FAQ](troubleshooting.md):** Find answers to common issues and questions.
 
-### Your experience with Agent Zero starts now!
+### Your experience with Magui starts now!
 
-- **Download Agent Zero:** Follow the [installation guide](installation.md) to download and run Agent Zero.
-- **Join the Community:** Join the Agent Zero [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community to discuss ideas, ask questions, and collaborate with other contributors.
-- **Share your Work:** Share your Agent Zero creations, workflows and discoverings on our [Show and Tell](https://github.com/agent0ai/agent-zero/discussions/categories/show-and-tell) area on GitHub.
+- **Download Magui:** Follow the [installation guide](installation.md) to download and run Magui.
+- **Join the Community:** Join the Magui [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community to discuss ideas, ask questions, and collaborate with other contributors.
+- **Share your Work:** Share your Magui creations, workflows and discoverings on our [Show and Tell](https://github.com/agent0ai/agent-zero/discussions/categories/show-and-tell) area on GitHub.
 - **Report Issues:** Use the [GitHub issue tracker](https://github.com/agent0ai/agent-zero/issues) to report framework-relative bugs or suggest new features.
 
 ## Table of Contents
 
-- [Welcome to the Agent Zero Documentation](#agent-zero-documentation)
-  - [Your Experience with Agent Zero](#your-experience-with-agent-zero-starts-now)
+- [Welcome to the Magui Documentation](#welcome-to-the-magui-documentation)
+  - [Your Experience with Magui](#your-experience-with-magui-starts-now)
   - [Table of Contents](#table-of-contents)
 - [Installation Guide](installation.md)
   - [Windows, macOS and Linux Setup](installation.md#windows-macos-and-linux-setup-guide)
   - [Settings Configuration](installation.md#settings-configuration)
   - [Choosing Your LLMs](installation.md#choosing-your-llms)
   - [Installing and Using Ollama](installation.md#installing-and-using-ollama-local-models)
-  - [Using Agent Zero on Mobile](installation.md#using-agent-zero-on-your-mobile-device)
-  - [How to Update Agent Zero](installation.md#how-to-update-agent-zero)
+  - [Using Magui on Mobile](installation.md#using-magui-on-your-mobile-device)
+  - [How to Update Magui](installation.md#how-to-update-magui)
   - [Full Binaries Installation](installation.md#in-depth-guide-for-full-binaries-installation)
 - [Usage Guide](usage.md)
   - [Basic Operations](usage.md#basic-operations)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,15 +1,15 @@
 # Architecture Overview
-Agent Zero is built on a flexible and modular architecture designed for extensibility and customization. This section outlines the key components and the interactions between them.
+Magui is built on a flexible and modular architecture designed for extensibility and customization. This section outlines the key components and the interactions between them.
 
 ## System Architecture
 This simplified diagram illustrates the hierarchical relationship between agents and their interaction with tools, extensions, instruments, prompts, memory and knowledge base.
 
-![Agent Zero Architecture](res/arch-01.svg)
+![Magui Architecture](res/arch-01.svg)
 
-The user or Agent 0 is at the top of the hierarchy, delegating tasks to subordinate agents, which can further delegate to other agents. Each agent can utilize tools and access the shared assets (prompts, memory, knowledge, extensions and instruments) to perform its tasks.
+The user or Magui is at the top of the hierarchy, delegating tasks to subordinate agents, which can further delegate to other agents. Each agent can utilize tools and access the shared assets (prompts, memory, knowledge, extensions and instruments) to perform its tasks.
 
 ## Runtime Architecture
-Agent Zero's runtime architecture is built around Docker containers:
+Magui's runtime architecture is built around Docker containers:
 
 1. **Host System (your machine)**:
    - Requires only Docker and a web browser
@@ -17,7 +17,7 @@ Agent Zero's runtime architecture is built around Docker containers:
    - Handles container orchestration
 
 2. **Runtime Container**:
-   - Houses the complete Agent Zero framework
+   - Houses the complete Magui framework
    - Manages the Web UI and API endpoints
    - Handles all core functionalities including code execution
    - Provides a standardized environment across all platforms
@@ -30,7 +30,7 @@ This architecture ensures:
 - Flexible deployment options for advanced users
 
 > [!NOTE]
-> The legacy approach of running Agent Zero directly on the host system (using Python, Conda, etc.) 
+> The legacy approach of running Magui directly on the host system (using Python, Conda, etc.) 
 > is still possible but requires Remote Function Calling (RFC) configuration through the Settings 
 > page. See [Full Binaries Installation](installation.md#in-depth-guide-for-full-binaries-installation) 
 > for detailed instructions.
@@ -78,13 +78,13 @@ This architecture ensures:
 > within the `/a0` volume for data persistence until the container is restarted or deleted.
 
 ## Core Components
-Agent Zero's architecture revolves around the following key components:
+Magui's architecture revolves around the following key components:
 
 ### 1. Agents
 The core actors within the framework. Agents receive instructions, reason, make decisions, and utilize tools to achieve their objectives. Agents operate within a hierarchical structure, with superior agents delegating tasks to subordinate agents.
 
 #### Agent Hierarchy and Communication
-Agent Zero employs a hierarchical agent structure, where a top-level agent (often the user) can delegate tasks to subordinate agents. This hierarchy allows for the efficient breakdown of complex tasks into smaller, more manageable sub-tasks.
+Magui employs a hierarchical agent structure, where a top-level agent (often the user) can delegate tasks to subordinate agents. This hierarchy allows for the efficient breakdown of complex tasks into smaller, more manageable sub-tasks.
 
 Communication flows between agents through messages, which are structured according to the prompt templates. These messages typically include:
 
@@ -95,27 +95,27 @@ Communication flows between agents through messages, which are structured accord
 | `Responses or queries:` | Results, feedback or queries from tools or other agents |
 
 #### Interaction Flow
-A typical interaction flow within Agent Zero might look like this:
+A typical interaction flow within Magui might look like this:
 
 ![Interaction Flow](res/flow-01.svg)
 
-1. The user provides an instruction to Agent 0
-2. Agent 0 initializes VectorDB and access memory
-3. Agent 0 analyzes the instruction and formulates a plan using `thoughts` argument, possibly involving the use of tools or the creation of sub-agents
-4. If necessary, Agent 0 delegates sub-tasks to subordinate agents
+1. The user provides an instruction to Magui
+2. Magui initializes VectorDB and access memory
+3. Magui analyzes the instruction and formulates a plan using `thoughts` argument, possibly involving the use of tools or the creation of sub-agents
+4. If necessary, Magui delegates sub-tasks to subordinate agents
 5. Agents use tools to perform actions, both providing arguments and responses or queries
 6. Agents communicate results and feedback back up the hierarchy
-7. Agent 0 provides the final response to the user
+7. Magui provides the final response to the user
 
 ### 2. Tools
-Tools are functionalities that agents can leverage. These can include anything from web search and code execution to interacting with APIs or controlling external software. Agent Zero provides a mechanism for defining and integrating both built-in and custom tools.
+Tools are functionalities that agents can leverage. These can include anything from web search and code execution to interacting with APIs or controlling external software. Magui provides a mechanism for defining and integrating both built-in and custom tools.
 
 #### Built-in Tools
-Agent Zero comes with a set of built-in tools designed to help agents perform tasks efficiently:
+Magui comes with a set of built-in tools designed to help agents perform tasks efficiently:
 
 | Tool | Function |
 | --- | --- |
-| behavior_adjustment | Agent Zero use this tool to change its behavior according to a prior request from the user.
+| behavior_adjustment | Magui use this tool to change its behavior according to a prior request from the user.
 | call_subordinate | Allows agents to delegate tasks to subordinate agents |
 | code_execution_tool | Allows agents to execute Python, Node.js, and Shell code in the terminal |
 | input | Allows agents to use the keyboard to interact with an active shell |
@@ -123,7 +123,7 @@ Agent Zero comes with a set of built-in tools designed to help agents perform ta
 | memory_tool | Enables agents to save, load, delete and forget information from memory |
 
 #### SearXNG Integration
-Agent Zero has integrated SearXNG as its primary search tool, replacing the previous knowledge tools (Perplexity and DuckDuckGo). This integration enhances the agent's ability to retrieve information while ensuring user privacy and customization.
+Magui has integrated SearXNG as its primary search tool, replacing the previous knowledge tools (Perplexity and DuckDuckGo). This integration enhances the agent's ability to retrieve information while ensuring user privacy and customization.
 
 - Privacy-Focused Search
 SearXNG is an open-source metasearch engine that allows users to search multiple sources without tracking their queries. This integration ensures that user data remains private and secure while accessing a wide range of information.
@@ -132,7 +132,7 @@ SearXNG is an open-source metasearch engine that allows users to search multiple
 The integration provides access to various types of content, including images, videos, and news articles, allowing users to gather comprehensive information on any topic.
 
 - Fallback Mechanism
-In cases where SearXNG might not return satisfactory results, Agent Zero can be configured to fall back on other sources or methods, ensuring that users always have access to information.
+In cases where SearXNG might not return satisfactory results, Magui can be configured to fall back on other sources or methods, ensuring that users always have access to information.
 
 > [!NOTE]
 > The Knowledge Tool is designed to work seamlessly with both online searches through 
@@ -140,7 +140,7 @@ In cases where SearXNG might not return satisfactory results, Agent Zero can be 
 > retrieval system.
 
 #### Custom Tools
-Users can create custom tools to extend Agent Zero's capabilities. Custom tools can be integrated into the framework by defining a tool specification, which includes the tool's prompt to be placed in `/prompts/$FOLDERNAME/agent.system.tool.$TOOLNAME.md`, as detailed below.
+Users can create custom tools to extend Magui's capabilities. Custom tools can be integrated into the framework by defining a tool specification, which includes the tool's prompt to be placed in `/prompts/$FOLDERNAME/agent.system.tool.$TOOLNAME.md`, as detailed below.
 
 1. Create `agent.system.tool.$TOOL_NAME.md` in `prompts/$SUBDIR`
 2. Add reference in `agent.system.tools.md`
@@ -153,7 +153,7 @@ Users can create custom tools to extend Agent Zero's capabilities. Custom tools 
 > to call custom scripts or functions.
 
 ### 3. Memory System
-The memory system is a critical component of Agent Zero, enabling the agent to learn and adapt from past interactions. It operates on a hybrid model where part of the memory is managed automatically by the framework while users can also manually input and extract information.
+The memory system is a critical component of Magui, enabling the agent to learn and adapt from past interactions. It operates on a hybrid model where part of the memory is managed automatically by the framework while users can also manually input and extract information.
 
 #### Memory Structure
 The memory is categorized into four distinct areas:
@@ -164,10 +164,10 @@ The memory is categorized into four distinct areas:
 
 #### Messages History and Summarization
 
-Agent Zero employs a sophisticated message history and summarization system to maintain context effectively while optimizing memory usage. This system dynamically manages the information flow, ensuring relevant details are readily available while efficiently handling the constraints of context windows.
+Magui employs a sophisticated message history and summarization system to maintain context effectively while optimizing memory usage. This system dynamically manages the information flow, ensuring relevant details are readily available while efficiently handling the constraints of context windows.
 
 - **Context Extraction:** The system identifies key information from previous messages that are vital for ongoing discussions. This process mirrors how humans recall important memories, allowing less critical details to fade.
-- **Summarization Process:** Using natural language processing through the utility model, Agent Zero condenses the extracted information into concise summaries. By summarizing past interactions, Agent Zero can quickly recall important facts about the whole chat, leading to more appropriate responses.
+- **Summarization Process:** Using natural language processing through the utility model, Magui condenses the extracted information into concise summaries. By summarizing past interactions, Magui can quickly recall important facts about the whole chat, leading to more appropriate responses.
 - **Contextual Relevance:** The summarized context is prioritized based on its relevance to the current topic, ensuring users receive the most pertinent information.
 
 **Implementation Details:**
@@ -187,10 +187,10 @@ Agent Zero employs a sophisticated message history and summarization system to m
   - Enables efficient navigation of long conversation histories.
   - Maintains semantic connections between related topics.
 
-By dynamically adjusting context windows and summarizing past interactions, Agent Zero enhances both efficiency and user experience. This innovation not only reflects the framework's commitment to being dynamic and user-centric, but also draws inspiration from human cognitive processes, making AI interactions more relatable and effective. Just as humans forget trivial details, Agent Zero intelligently condenses information to enhance communication.
+By dynamically adjusting context windows and summarizing past interactions, Magui enhances both efficiency and user experience. This innovation not only reflects the framework's commitment to being dynamic and user-centric, but also draws inspiration from human cognitive processes, making AI interactions more relatable and effective. Just as humans forget trivial details, Magui intelligently condenses information to enhance communication.
 
 > [!NOTE]
-> To maximize the effectiveness of context summarization, users should provide clear and specific instructions during interactions. This helps Agent Zero understand which details are most important to retain.
+> To maximize the effectiveness of context summarization, users should provide clear and specific instructions during interactions. This helps Magui understand which details are most important to retain.
 
 ### 4. Prompts
 The `prompts` directory contains various Markdown files that control agent behavior and communication. The most important file is `agent.system.main.md`, which acts as a central hub, referencing other prompt files.
@@ -216,7 +216,7 @@ The `prompts` directory contains various Markdown files that control agent behav
 #### Custom Prompts
 1. Create directory in `prompts/` (e.g., `my-custom-prompts`)
 2. Copy and modify needed files from `prompts/default/`
-3. Agent Zero will merge your custom files with the default ones
+3. Magui will merge your custom files with the default ones
 4. Select your custom prompts in the Settings page (Agent Config section)
 
 #### Dynamic Behavior System
@@ -245,7 +245,7 @@ The `prompts` directory contains various Markdown files that control agent behav
   - Maintains separation between core functionality and behavioral rules
 
 > [!NOTE]  
-> You can customize any of these files. Agent Zero will use the files in your custom `prompts_subdir` 
+> You can customize any of these files. Magui will use the files in your custom `prompts_subdir` 
 > if they exist, otherwise, it will fall back to the files in `prompts/default`.
 
 > [!TIP]
@@ -267,8 +267,8 @@ Knowledge refers to the user-provided information and data that agents can lever
   - Supports RAG-augmented tasks
 
 ### 6. Instruments
-Instruments provide a way to add custom functionalities to Agent Zero without adding to the token count of the system prompt:
-- Stored in long-term memory of Agent Zero
+Instruments provide a way to add custom functionalities to Magui without adding to the token count of the system prompt:
+- Stored in long-term memory of Magui
 - Unlimited number of instruments available
 - Recalled when needed by the agent
 - Can modify agent behavior by introducing new procedures
@@ -282,7 +282,7 @@ Instruments provide a way to add custom functionalities to Agent Zero without ad
 4. The agent will automatically detect and use the instrument
 
 ### 7. Extensions
-Extensions are a powerful feature of Agent Zero, designed to keep the main codebase clean and organized while allowing for greater flexibility and modularity.
+Extensions are a powerful feature of Magui, designed to keep the main codebase clean and organized while allowing for greater flexibility and modularity.
 
 #### Structure
 Extensions can be found in `python/extensions` directory:

--- a/docs/connectivity.md
+++ b/docs/connectivity.md
@@ -1,8 +1,8 @@
-# Agent Zero Connectivity Guide
+# Magui Connectivity Guide
 
-This guide covers the different ways to connect to Agent Zero from external applications, including using the External API, connecting as an MCP client, and enabling agent-to-agent communication.
+This guide covers the different ways to connect to Magui from external applications, including using the External API, connecting as an MCP client, and enabling agent-to-agent communication.
 
-**Note:** You can find your specific URLs and API tokens in your Agent Zero instance under `Settings > External Services`.
+**Note:** You can find your specific URLs and API tokens in your Magui instance under `Settings > External Services`.
 
 ### API Token Information
 
@@ -12,11 +12,11 @@ The API token is automatically generated from your username and password. This s
 
 ## External API Endpoints
 
-Agent Zero provides external API endpoints for integration with other applications. These endpoints use API key authentication and support text messages and file attachments.
+Magui provides external API endpoints for integration with other applications. These endpoints use API key authentication and support text messages and file attachments.
 
 ### `POST /api_message`
 
-Send messages to Agent Zero and receive responses. Supports text messages, file attachments, and conversation continuity.
+Send messages to Magui and receive responses. Supports text messages, file attachments, and conversation continuity.
 
 ### API Reference
 
@@ -540,7 +540,7 @@ attachmentWorkflow();
 
 ## MCP Server Connectivity
 
-Agent Zero includes an MCP Server that allows other MCP-compatible clients to connect to it. The server runs on the same URL and port as the Web UI.
+Magui includes an MCP Server that allows other MCP-compatible clients to connect to it. The server runs on the same URL and port as the Web UI.
 
 It provides two endpoint types:
 - **SSE (`/mcp/sse`):** For clients that support Server-Sent Events.
@@ -548,7 +548,7 @@ It provides two endpoint types:
 
 ### Example MCP Server Configuration
 
-Below is an example of a `mcp.json` configuration file that a client could use to connect to the Agent Zero MCP server. 
+Below is an example of a `mcp.json` configuration file that a client could use to connect to the Magui MCP server. 
 
 **Note:** You can find your personalized connection URLs under `Settings > MCP Server > MCP Server`.
 
@@ -572,11 +572,11 @@ Below is an example of a `mcp.json` configuration file that a client could use t
 
 ## A2A (Agent-to-Agent) Connectivity
 
-Agent Zero's A2A Server enables communication with other agents using the FastA2A protocol. Other agents can connect to your instance using the connection URL.
+Magui's A2A Server enables communication with other agents using the FastA2A protocol. Other agents can connect to your instance using the connection URL.
 
 ### A2A Connection URL
 
-To connect another agent to your Agent Zero instance, use the following URL format. 
+To connect another agent to your Magui instance, use the following URL format. 
 
 **Note:** You can find your specific A2A connection URL under `Settings > External Services > A2A Connection`.
 

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -1,30 +1,11 @@
-# Contributing to Agent Zero
+# Contributing to Magui
 
-Contributions to improve Agent Zero are very welcome!  This guide outlines how to contribute code, documentation, or other improvements.
+We welcome contributions to Magui!
 
-## Getting Started
+## How to Contribute
 
-- See [development](development.md) for instructions on how to set up a development environment.
-- See [extensibility](extensibility.md) for instructions on how to create custom extensions.
-
-1. **Fork the Repository:** Fork the Agent Zero repository on GitHub.
-2. **Clone Your Fork:** Clone your forked repository to your local machine.
-3. **Create a Branch:** Create a new branch for your changes. Use a descriptive name that reflects the purpose of your contribution (e.g., `fix-memory-leak`, `add-search-tool`, `improve-docs`).
-
-## Making Changes
-
-* **Code Style:** Follow the existing code style. Agent Zero generally follows PEP 8 conventions.
-* **Documentation:**  Update the documentation if your changes affect user-facing functionality. The documentation is written in Markdown.
-* **Commit Messages:**  Write clear and concise commit messages that explain the purpose of your changes.
-
-## Submitting a Pull Request
-
-1. **Push Your Branch:** Push your branch to your forked repository on GitHub.
-2. **Create a Pull Request:** Create a pull request from your branch to the appropriate branch in the main Agent Zero repository.
-   * Target the `development` branch.
-3. **Provide Details:** In your pull request description, clearly explain the purpose and scope of your changes. Include relevant context, test results, and any other information that might be helpful for reviewers.
-4. **Address Feedback:**  Be responsive to feedback from the community. We love changes, but we also love to discuss them!
-
-## Documentation Stack
-
-- The documentation is built using Markdown. We appreciate your contributions even if you don't know Markdown, and look forward to improve Agent Zero for everyone's benefit.
+1. Fork the Magui repository
+2. Create a new branch for your feature or bugfix
+3. Commit your changes
+4. Push your branch
+5. Create a Pull Request

--- a/docs/designs/backup-specification-backend.md
+++ b/docs/designs/backup-specification-backend.md
@@ -1,7 +1,7 @@
-# Agent Zero Backup/Restore Backend Specification
+# Magui Backup/Restore Backend Specification
 
 ## Overview
-This specification defines the backend implementation for Agent Zero's backup and restore functionality, providing users with the ability to backup and restore their Agent Zero configurations, data, and custom files using glob pattern-based selection. The backup functionality is implemented as a dedicated "backup" tab in the settings interface for easy access and organization.
+This specification defines the backend implementation for Magui's backup and restore functionality, providing users with the ability to backup and restore their Magui configurations, data, and custom files using glob pattern-based selection. The backup functionality is implemented as a dedicated "backup" tab in the settings interface for easy access and organization.
 
 ## Core Requirements
 
@@ -25,7 +25,7 @@ Add backup/restore section with dedicated tab to `python/helpers/settings.py`:
 
 **Integration Notes:**
 - Leverages existing settings button handler pattern (follows MCP servers example)
-- Integrates with Agent Zero's established error handling and toast notification system
+- Integrates with Magui's established error handling and toast notification system
 - Uses existing file operation helpers with RFC support for development mode compatibility
 
 ```python
@@ -33,7 +33,7 @@ Add backup/restore section with dedicated tab to `python/helpers/settings.py`:
 backup_section: SettingsSection = {
     "id": "backup_restore",
     "title": "Backup & Restore",
-    "description": "Backup and restore Agent Zero data and configurations using glob pattern-based file selection.",
+    "description": "Backup and restore Magui data and configurations using glob pattern-based file selection.",
     "fields": [
         {
             "id": "backup_create",
@@ -61,14 +61,14 @@ The backup system now uses **resolved absolute filesystem paths** instead of pla
 def _get_default_patterns(self) -> str:
     """Get default backup patterns with resolved absolute paths"""
     # Ensure paths don't have double slashes
-    agent_root = self.agent_zero_root.rstrip('/')
+    agent_root = self.magui_root.rstrip('/')
     user_home = self.user_home.rstrip('/')
 
-    return f"""# Agent Zero Knowledge (excluding defaults)
+    return f"""# Magui Knowledge (excluding defaults)
 {agent_root}/knowledge/**
 !{agent_root}/knowledge/default/**
 
-# Agent Zero Instruments (excluding defaults)
+# Magui Instruments (excluding defaults)
 {agent_root}/instruments/**
 !{agent_root}/instruments/default/**
 
@@ -106,7 +106,7 @@ def _get_default_patterns(self) -> str:
 !/home/rafael/.*
 ```
 
-> **⚠️ CRITICAL FILE NOTICE**: The `{agent_root}/.env` file contains essential configuration including API keys, model settings, and runtime parameters. This file is **REQUIRED** for Agent Zero to function properly and should always be included in backups alongside `settings.json`. Without this file, restored Agent Zero instances will not have access to configured language models or external services.
+> **⚠️ CRITICAL FILE NOTICE**: The `{agent_root}/.env` file contains essential configuration including API keys, model settings, and runtime parameters. This file is **REQUIRED** for Magui to function properly and should always be included in backups alongside `settings.json`. Without this file, restored Magui instances will not have access to configured language models or external services.
 
 ### 2. API Endpoints
 
@@ -181,7 +181,7 @@ class BackupCreate(ApiHandler):
     async def process(self, input: dict, request: Request) -> dict | Response:
         patterns = input.get("patterns", "")
         include_hidden = input.get("include_hidden", False)
-        backup_name = input.get("backup_name", "agent-zero-backup")
+        backup_name = input.get("backup_name", "magui-backup")
 
         try:
             backup_service = BackupService()
@@ -385,7 +385,7 @@ class BackupProgressStream(ApiHandler):
     async def process(self, input: dict, request: Request) -> dict | Response:
         patterns = input.get("patterns", "")
         include_hidden = input.get("include_hidden", False)
-        backup_name = input.get("backup_name", "agent-zero-backup")
+        backup_name = input.get("backup_name", "magui-backup")
 
         def generate_progress():
             try:
@@ -452,7 +452,7 @@ class BackupInspect(ApiHandler):
                 "include_patterns": metadata.get("include_patterns", []),  # Array of include patterns
                 "exclude_patterns": metadata.get("exclude_patterns", []),  # Array of exclude patterns
                 "default_patterns": metadata.get("backup_config", {}).get("default_patterns", ""),
-                "agent_zero_version": metadata.get("agent_zero_version", "unknown"),
+                "magui_version": metadata.get("magui_version", "unknown"),
                 "timestamp": metadata.get("timestamp", ""),
                 "backup_name": metadata.get("backup_name", ""),
                 "total_files": metadata.get("total_files", len(metadata.get("files", []))),
@@ -473,7 +473,7 @@ class BackupInspect(ApiHandler):
 **File**: `python/helpers/backup.py`
 
 **RFC Integration Notes:**
-The BackupService leverages Agent Zero's existing file operation helpers which already support RFC (Remote Function Call) routing for development mode. This ensures seamless operation whether running in direct mode or with container isolation.
+The BackupService leverages Magui's existing file operation helpers which already support RFC (Remote Function Call) routing for development mode. This ensures seamless operation whether running in direct mode or with container isolation.
 
 ```python
 import zipfile
@@ -488,19 +488,19 @@ from python.helpers import files, runtime, git
 import shutil
 
 class BackupService:
-    """Core backup and restore service for Agent Zero"""
+    """Core backup and restore service for Magui"""
 
     def __init__(self):
-        self.agent_zero_version = self._get_agent_zero_version()
-        self.agent_zero_root = files.get_abs_path("")  # Resolved Agent Zero root
+        self.magui_version = self._get_magui_version()
+        self.magui_root = files.get_abs_path("")  # Resolved Magui root
         self.user_home = os.path.expanduser("~")       # Current user's home directory
 
     def _get_default_patterns(self) -> str:
         """Get default backup patterns from specification"""
         return DEFAULT_BACKUP_PATTERNS
 
-    def _get_agent_zero_version(self) -> str:
-        """Get current Agent Zero version"""
+    def _get_magui_version(self) -> str:
+        """Get current Magui version"""
         try:
             # Get version from git info (same as run_ui.py)
             gitinfo = git.get_git_info()
@@ -582,7 +582,7 @@ class BackupService:
                 "path": os.environ.get("PATH", "")[:200] + "..." if len(os.environ.get("PATH", "")) > 200 else os.environ.get("PATH", ""),
                 "timezone": str(datetime.datetime.now().astimezone().tzinfo),
                 "working_directory": os.getcwd(),
-                "agent_zero_root": files.get_abs_path(""),
+                "magui_root": files.get_abs_path(""),
                 "runtime_mode": "development" if runtime.is_development() else "production"
             }
         except Exception as e:
@@ -704,7 +704,7 @@ class BackupService:
 
         return matched_files
 
-    async def create_backup(self, patterns: str, include_hidden: bool = False, backup_name: str = "agent-zero-backup") -> str:
+    async def create_backup(self, patterns: str, include_hidden: bool = False, backup_name: str = "magui-backup") -> str:
         """Create backup archive with selected files"""
 
         # Get matched files
@@ -727,7 +727,7 @@ class BackupService:
 
                 metadata = {
                     # Basic backup information
-                    "agent_zero_version": self.agent_zero_version,
+                    "magui_version": self.magui_version,
                     "timestamp": datetime.datetime.now().isoformat(),
                     "backup_name": backup_name,
                     "include_hidden": include_hidden,
@@ -907,7 +907,7 @@ class BackupService:
             "total_size": total_size
         }
 
-    def create_backup_with_progress(self, patterns: str, include_hidden: bool = False, backup_name: str = "agent-zero-backup"):
+    def create_backup_with_progress(self, patterns: str, include_hidden: bool = False, backup_name: str = "magui-backup"):
         """Generator that yields backup progress for streaming"""
 
         try:
@@ -966,7 +966,7 @@ class BackupService:
             with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
                 # Create and add metadata first
                 metadata = {
-                    "agent_zero_version": self.agent_zero_version,
+                    "magui_version": self.magui_version,
                     "timestamp": datetime.datetime.now().isoformat(),
                     "backup_name": backup_name,
                     "backup_patterns": patterns,
@@ -1234,8 +1234,8 @@ pathspec>=0.10.0  # For gitignore-style pattern matching
 psutil>=5.8.0     # For system information collection
 ```
 
-#### Agent Zero Internal Dependencies
-The backup system requires these Agent Zero helper modules:
+#### Magui Internal Dependencies
+The backup system requires these Magui helper modules:
 - `python.helpers.git` - For version detection using git.get_git_info() (consistent with run_ui.py)
 - `python.helpers.files` - For file operations and path resolution
 - `python.helpers.runtime` - For development/production mode detection
@@ -1247,14 +1247,14 @@ pip install pathspec psutil
 
 ### 5. Error Handling
 
-#### Integration with Agent Zero Error System
-The backup system integrates with Agent Zero's existing error handling infrastructure:
+#### Integration with Magui Error System
+The backup system integrates with Magui's existing error handling infrastructure:
 
 ```python
 from python.helpers.errors import format_error
 from python.helpers.print_style import PrintStyle
 
-# Follow Agent Zero's error handling patterns
+# Follow Magui's error handling patterns
 try:
     result = await backup_operation()
     return {"success": True, "data": result}
@@ -1333,7 +1333,7 @@ BACKUP_CONFIG = {
 
 #### Future Integration Opportunities
 **Task Scheduler Integration:**
-Agent Zero's existing task scheduler could be extended to support automated backups:
+Magui's existing task scheduler could be extended to support automated backups:
 
 ```python
 # Potential future enhancement - scheduled backups
@@ -1352,11 +1352,11 @@ Agent Zero's existing task scheduler could be extended to support automated back
 ## Enhanced Metadata Structure and Restore Workflow
 
 ### Version Detection Implementation
-The backup system uses the same version detection method as Agent Zero's main UI:
+The backup system uses the same version detection method as Magui's main UI:
 
 ```python
-def _get_agent_zero_version(self) -> str:
-    """Get current Agent Zero version"""
+def _get_magui_version(self) -> str:
+    """Get current Magui version"""
     try:
         # Get version from git info (same as run_ui.py)
         gitinfo = git.get_git_info()
@@ -1372,7 +1372,7 @@ The backup archive includes a comprehensive `metadata.json` file with the follow
 
 ```json
 {
-  "agent_zero_version": "version",
+  "magui_version": "version",
   "timestamp": "ISO datetime",
   "backup_name": "user-defined name",
   "include_hidden": boolean,
@@ -1427,11 +1427,11 @@ The backup archive includes a comprehensive `metadata.json` file with the follow
 ### Enhanced Metadata Structure
 The backup metadata has been significantly enhanced to include:
 - **System Information**: Platform, architecture, Python version, CPU count, memory, disk usage
-- **Environment Details**: User, timezone, working directory, runtime mode, Agent Zero root path
+- **Environment Details**: User, timezone, working directory, runtime mode, Magui root path
 - **Backup Author**: System identifier (user@hostname) for backup tracking
 - **File Checksums**: SHA-256 hashes for all backed up files for integrity verification
 - **Backup Statistics**: Total files, directories, sizes with verification methods
-- **Compatibility Data**: Agent Zero version and environment for restoration validation
+- **Compatibility Data**: Magui version and environment for restoration validation
 
 ### Smart File Management
 - **Grouped File Preview**: Organize files by directory structure with depth limitation (max 3 levels)
@@ -1464,7 +1464,7 @@ The backup metadata has been significantly enhanced to include:
 - **Path Security**: Enhanced validation with system information context
 - **Backup Validation**: Version compatibility checking and environment verification
 
-This enhanced backend specification provides a production-ready, comprehensive backup and restore system with advanced metadata tracking, real-time progress monitoring, and intelligent file management capabilities, all while maintaining Agent Zero's architectural patterns and security standards.
+This enhanced backend specification provides a production-ready, comprehensive backup and restore system with advanced metadata tracking, real-time progress monitoring, and intelligent file management capabilities, all while maintaining Magui's architectural patterns and security standards.
 
 ### Implementation Status Updates
 
@@ -1472,7 +1472,7 @@ This enhanced backend specification provides a production-ready, comprehensive b
 - **Git Version Integration**: Updated to use `git.get_git_info()` consistent with `run_ui.py`
 - **Type Safety**: Fixed psutil return values to be strings for JSON metadata consistency
 - **Code Quality**: All linting errors resolved, proper import structure
-- **Testing Verified**: BackupService initializes correctly and detects Agent Zero root paths
+- **Testing Verified**: BackupService initializes correctly and detects Magui root paths
 - **Dependencies Added**: pathspec>=0.10.0 for pattern matching, psutil>=5.8.0 for system info
 - **Git Helper Integration**: Uses python.helpers.git.get_git_info() for version detection consistency
 
@@ -1550,7 +1550,7 @@ if not include_hidden and file.startswith('.'):
 - **Explicit patterns** (like `/a0/.env`) - Always included regardless of `include_hidden` setting
 - **Wildcard discoveries** (like `/a0/*`) - Respect the `include_hidden` setting
 
-**Result:** Critical files like `.env` are now properly backed up when explicitly specified, ensuring Agent Zero configurations are preserved.
+**Result:** Critical files like `.env` are now properly backed up when explicitly specified, ensuring Magui configurations are preserved.
 
 ### **Implementation Status: ✅ PRODUCTION READY**
 
@@ -1568,7 +1568,7 @@ The backup system is now:
 - ✅ **Cleaner API** - Only endpoints that are actually used
 - ✅ **Better reliability** - Removed complex features that weren't properly implemented
 
-The Agent Zero backup system is now production-ready and battle-tested! 🚀
+The Magui backup system is now production-ready and battle-tested! 🚀
 
 ## ✅ **FINAL STATUS: ACE EDITOR STATE GUARANTEE COMPLETED (December 2024)**
 
@@ -1586,7 +1586,7 @@ metadata["exclude_patterns"] = original_backup_metadata.get("exclude_patterns", 
 
 # 2. Path translation for cross-system compatibility
 environment_info = original_backup_metadata.get("environment_info", {})
-backed_up_agent_root = environment_info.get("agent_zero_root", "")
+backed_up_agent_root = environment_info.get("magui_root", "")
 ```
 
 #### **✅ ACE editor metadata Usage** (EVERYTHING ELSE):
@@ -1687,7 +1687,7 @@ async def _find_files_to_clean_with_user_metadata(self, user_metadata: Dict[str,
 #### **✅ Cross-System Compatibility:**
 - Path translation preserves technical functionality
 - Users don't need to manually adjust paths
-- Works seamlessly between different Agent Zero installations
+- Works seamlessly between different Magui installations
 - Maintains backup portability across environments
 
 #### **✅ Clean Architecture:**
@@ -1698,7 +1698,7 @@ async def _find_files_to_clean_with_user_metadata(self, user_metadata: Dict[str,
 
 ### **Final Status: ✅ PRODUCTION READY**
 
-The Agent Zero backup system now provides:
+The Magui backup system now provides:
 - **✅ Complete user control** via ACE editor state
 - **✅ Cross-system compatibility** through intelligent path translation
 - **✅ Clean, maintainable code** with dead code eliminated

--- a/docs/designs/backup-specification-frontend.md
+++ b/docs/designs/backup-specification-frontend.md
@@ -1,7 +1,7 @@
-# Agent Zero Backup/Restore Frontend Specification
+# Magui Backup/Restore Frontend Specification
 
 ## Overview
-This specification defines the frontend implementation for Agent Zero's backup and restore functionality, providing an intuitive user interface with a dedicated "backup" tab in the settings system and following established Alpine.js patterns. The backup functionality gets its own tab for better organization and user experience.
+This specification defines the frontend implementation for Magui's backup and restore functionality, providing an intuitive user interface with a dedicated "backup" tab in the settings system and following established Alpine.js patterns. The backup functionality gets its own tab for better organization and user experience.
 
 ## Frontend Architecture
 
@@ -330,7 +330,7 @@ The backup system uses a comprehensive `metadata.json` file that includes:
 import { createStore } from "/js/AlpineStore.js";
 
 // ⚠️ CRITICAL: The .env file contains API keys and essential configuration.
-// This file is REQUIRED for Agent Zero to function and must be backed up.
+// This file is REQUIRED for Magui to function and must be backed up.
 // Note: Patterns now use resolved absolute paths (e.g., /home/user/a0/data/.env)
 
 const model = {
@@ -437,7 +437,7 @@ const model = {
         const exclude_patterns = response.default_patterns.exclude_patterns;
 
         return {
-          backup_name: `agent-zero-backup-${timestamp.slice(0, 10)}`,
+          backup_name: `magui-backup-${timestamp.slice(0, 10)}`,
           include_hidden: false,
           include_patterns: include_patterns,
           exclude_patterns: exclude_patterns,
@@ -453,7 +453,7 @@ const model = {
 
     // Fallback patterns (will be overridden by backend on first use)
     return {
-      backup_name: `agent-zero-backup-${timestamp.slice(0, 10)}`,
+      backup_name: `magui-backup-${timestamp.slice(0, 10)}`,
       include_hidden: false,
       include_patterns: [
         // These will be replaced with resolved absolute paths by backend
@@ -467,7 +467,7 @@ const model = {
     };
   },
 
-    // Editor Management - Following Agent Zero ACE editor patterns
+    // Editor Management - Following Magui ACE editor patterns
   async initBackupEditor() {
     const container = document.getElementById("backup-metadata-editor");
     if (container) {
@@ -1001,13 +1001,13 @@ const model = {
 
         const warnings = [];
 
-        // Check Agent Zero version compatibility
+        // Check Magui version compatibility
         // Note: Both backup and current versions are obtained via git.get_git_info()
-        const backupVersion = this.backupMetadata.agent_zero_version;
+        const backupVersion = this.backupMetadata.magui_version;
         const currentVersion = "current"; // Retrieved from git.get_git_info() on backend
 
         if (backupVersion !== currentVersion && backupVersion !== "development") {
-            warnings.push(`Backup created with Agent Zero ${backupVersion}, current version is ${currentVersion}`);
+            warnings.push(`Backup created with Magui ${backupVersion}, current version is ${currentVersion}`);
         }
 
     // Check backup age
@@ -1295,7 +1295,7 @@ async handleFieldButton(field) {
 Use existing `openModal()` and `closeModal()` functions from the global modal system (`webui/js/modals.js`).
 
 #### Toast Notifications
-Use existing Agent Zero toast system for consistent user feedback:
+Use existing Magui toast system for consistent user feedback:
 ```javascript
 // Use established toast patterns
 globalThis.toast("Backup created successfully", "success");
@@ -1304,7 +1304,7 @@ globalThis.toast("Error creating backup", "error");
 ```
 
 #### ACE Editor Integration
-The backup system follows Agent Zero's established ACE editor patterns **exactly** as implemented in MCP servers:
+The backup system follows Magui's established ACE editor patterns **exactly** as implemented in MCP servers:
 
 **Theme Detection (identical to MCP servers):**
 ```javascript
@@ -1339,7 +1339,7 @@ onClose() {
 ```
 
 #### API Integration Patterns
-The backup system uses Agent Zero's existing API communication methods for consistency:
+The backup system uses Magui's existing API communication methods for consistency:
 
 **Standard API Calls (using global sendJsonData):**
 ```javascript
@@ -1350,7 +1350,7 @@ const response = await sendJsonData("backup_test", {
     max_files: 1000
 });
 
-// Error handling follows Agent Zero patterns
+// Error handling follows Magui patterns
 if (response.success) {
     this.previewFiles = response.files;
 } else {
@@ -1389,12 +1389,12 @@ eventSource.onmessage = (event) => {
 ```
 
 #### Utility Function Integration
-The backup system can leverage existing Agent Zero utility functions for consistency:
+The backup system can leverage existing Magui utility functions for consistency:
 
 **File Size Formatting:**
 ```javascript
-// Check if Agent Zero has existing file size utilities
-// If not available, implement following Agent Zero's style patterns
+// Check if Magui has existing file size utilities
+// If not available, implement following Magui's style patterns
 formatFileSize(bytes) {
     if (!bytes) return '0 B';
     const sizes = ['B', 'KB', 'MB', 'GB'];
@@ -1501,10 +1501,10 @@ Ensure modals work on mobile devices with appropriate responsive breakpoints.
 - **Performance Optimization**: Debounced search, efficient list rendering, and scroll management
 
 ### Integration Features
-- **Settings Modal Integration**: Seamless integration with existing Agent Zero settings system
+- **Settings Modal Integration**: Seamless integration with existing Magui settings system
 - **Toast Notifications**: Success/error feedback using existing notification system
-- **Modal System**: Proper integration with Agent Zero's modal management
-- **API Layer**: Consistent API communication patterns following Agent Zero conventions
+- **Modal System**: Proper integration with Magui's modal management
+- **API Layer**: Consistent API communication patterns following Magui conventions
 - **Error Handling**: Unified error handling and user feedback mechanisms
 
 ### Accessibility and Usability
@@ -1538,7 +1538,7 @@ Ensure modals work on mobile devices with appropriate responsive breakpoints.
 - **Real-time Preview**: See exactly which files will be restored before proceeding
 - **Immediate Feedback**: JSON validation and error highlighting as you edit
 
-This enhanced frontend specification delivers a professional-grade user interface with sophisticated file management, real-time progress monitoring, and comprehensive metadata visualization, all organized within a dedicated backup tab for optimal user experience. The implementation maintains perfect integration with Agent Zero's existing UI architecture and follows established Alpine.js patterns.
+This enhanced frontend specification delivers a professional-grade user interface with sophisticated file management, real-time progress monitoring, and comprehensive metadata visualization, all organized within a dedicated backup tab for optimal user experience. The implementation maintains perfect integration with Magui's existing UI architecture and follows established Alpine.js patterns.
 
 ### Implementation Status: ✅ COMPLETED & PRODUCTION READY
 
@@ -1549,7 +1549,7 @@ This enhanced frontend specification delivers a professional-grade user interfac
 **1. Settings Integration** ✅
 - **Backup Tab**: Dedicated "Backup & Restore" tab in settings interface
 - **Button Handlers**: Integrated with existing `handleFieldButton()` method
-- **Modal System**: Uses existing Agent Zero modal management
+- **Modal System**: Uses existing Magui modal management
 - **Toast Notifications**: Consistent error/success feedback
 
 **2. Alpine.js Components** ✅
@@ -1586,7 +1586,7 @@ This enhanced frontend specification delivers a professional-grade user interfac
 **Communication Patterns:**
 - **Standard API**: Uses global `sendJsonData()` for consistency
 - **File Upload**: FormData for archive uploads with proper validation
-- **Error Handling**: Follows Agent Zero error formatting and toast patterns
+- **Error Handling**: Follows Magui error formatting and toast patterns
 - **Progress Updates**: Real-time file operation logging and status updates
 
 #### **✅ Key Technical Achievements:**
@@ -1604,7 +1604,7 @@ This enhanced frontend specification delivers a professional-grade user interfac
 - **Export Capabilities**: File lists and metadata export functionality
 
 **Professional UI/UX:**
-- **Consistent Styling**: Follows Agent Zero design patterns and CSS variables
+- **Consistent Styling**: Follows Magui design patterns and CSS variables
 - **Loading States**: Comprehensive progress indicators and status messages
 - **Error Recovery**: Clear error messages with suggested fixes
 - **Accessibility**: Keyboard navigation and screen reader support
@@ -1613,20 +1613,20 @@ This enhanced frontend specification delivers a professional-grade user interfac
 
 **Alpine.js Integration:**
 - **Store Pattern**: Uses proven `createStore()` pattern from MCP servers
-- **Component Lifecycle**: Proper initialization and cleanup following Agent Zero patterns
+- **Component Lifecycle**: Proper initialization and cleanup following Magui patterns
 - **Reactive State**: Real-time UI updates with Alpine's reactivity system
 - **Event Handling**: Leverages Alpine's declarative event system
 
 **Code Reuse:**
 - **ACE Editor Setup**: Identical theme detection and configuration as MCP servers
-- **Modal Management**: Uses existing Agent Zero modal and overlay systems
-- **API Communication**: Consistent with Agent Zero's established API patterns
+- **Modal Management**: Uses existing Magui modal and overlay systems
+- **API Communication**: Consistent with Magui's established API patterns
 - **Error Handling**: Unified error formatting and toast notification system
 
 ### **Implementation Quality Metrics:**
 
 **Code Quality:** ✅
-- Follows Agent Zero coding conventions
+- Follows Magui coding conventions
 - Proper error handling and validation
 - Clean separation of concerns
 - Comprehensive documentation
@@ -1635,7 +1635,7 @@ This enhanced frontend specification delivers a professional-grade user interfac
 - Intuitive backup/restore workflow
 - Real-time feedback and progress tracking
 - Responsive design for all screen sizes
-- Consistent with Agent Zero UI patterns
+- Consistent with Magui UI patterns
 
 **Performance:** ✅
 - Efficient file preview with grouping
@@ -1651,13 +1651,13 @@ This enhanced frontend specification delivers a professional-grade user interfac
 
 ### **Final Status: 🚀 PRODUCTION READY**
 
-The Agent Zero backup frontend is now:
+The Magui backup frontend is now:
 - **Complete**: All planned features implemented and tested
-- **Integrated**: Seamlessly integrated with existing Agent Zero infrastructure
+- **Integrated**: Seamlessly integrated with existing Magui infrastructure
 - **Reliable**: Comprehensive error handling and edge case coverage
-- **User-friendly**: Intuitive interface following Agent Zero design principles
+- **User-friendly**: Intuitive interface following Magui design principles
 - **Maintainable**: Clean code following established patterns and conventions
 
 **Ready for production use with full backup and restore capabilities!**
 
-The backup system provides users with a powerful, easy-to-use interface for backing up and restoring their Agent Zero configurations, data, and custom files using sophisticated pattern-based selection and real-time progress monitoring.
+The backup system provides users with a powerful, easy-to-use interface for backing up and restoring their Magui configurations, data, and custom files using sophisticated pattern-based selection and real-time progress monitoring.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,6 @@
-# Development manual for Agent Zero
-This guide will show you how to setup a local development environment for Agent Zero in a VS Code compatible IDE, including proper debugger.
+# Magui Development Guide
+
+Guide for developers working on Magui.
 
 
 [![Tutorial video](./res/devguide_vid.png)](https://www.youtube.com/watch?v=KE39P4qBjDk)
@@ -10,7 +11,7 @@ This guide will show you how to setup a local development environment for Agent 
 > This guide is for developers and contributors. It assumes you have a basic understanding of how to use Git/GitHub, Docker, IDEs and Python.
 
 > [!NOTE]
-> - Agent Zero runs in a Docker container, this simplifies installation and ensures unified environment and behavior across systems.
+> - Magui runs in a Docker container, this simplifies installation and ensures unified environment and behavior across systems.
 > - Developing and debugging in a container would be complicated though, therefore we use a hybrid approach where the python framework runs on your machine (in VS Code for example) and only connects to a Dockerized instance when it needs to execute code or use other pre-installed functionality like the built-in search engine.
 
 
@@ -30,7 +31,7 @@ This guide will show you how to setup a local development environment for Agent 
 - For Python you can choose your environment manager - base Python venv, Conda, uv...
 
 ## Step 1: Clone or download the repository
-- Agent Zero is available on GitHub [github.com/agent0ai/agent-zero](https://github.com/agent0ai/agent-zero).
+- Magui is available on GitHub [github.com/agent0ai/agent-zero](https://github.com/agent0ai/agent-zero).
 - You can download the files using a browser and extract or run `git clone https://github.com/agent0ai/agent-zero` in your desired directory.
 
 > [!NOTE]
@@ -38,7 +39,7 @@ This guide will show you how to setup a local development environment for Agent 
 
 ## Step 2: Open project folder in your IDE
 - I will be using plain and clean VS Code for this example to make sure I don't skip any setup part, you can use any of it's variants like Cursor, Windsurf etc.
-- Agent Zero comes with `.vscode` folder that contains basic setup, recommended extensions, and debugger profiles. These will help us a lot.
+- Magui comes with `.vscode` folder that contains basic setup, recommended extensions, and debugger profiles. These will help us a lot.
 
 1. Open your IDE and open the project folder using `File > Open Folder` and select your folder, in my case `~/Desktop/agent-zero`.
 2. You will probably be prompted to trust the directory, confirm that.
@@ -56,7 +57,7 @@ ms-python.python
 Now when you select one of the python files in the project, you should see proper Python syntax highlighting and error detection. It should immediately show some errors, because we did not yet install dependencies.
 ![VS Code Python](res/dev/devinst-2.png)
 
-2. Prepare the python environment to run Agent Zero in. (⚠️ This step assumes you have some Python runtime installed.) By clicking the python version in lower right corner (3.13.1 in my example), you should get a list of available environments. You can click the `+ Create Virtual Environment` button. You might be prompted to select the environment manager if you have multiple installed. I have venv and Conda, I will select Conda here. I'm also prompted for desired python version, I will select 3.12, that is known to work well.
+2. Prepare the python environment to run Magui in. (⚠️ This step assumes you have some Python runtime installed.) By clicking the python version in lower right corner (3.13.1 in my example), you should get a list of available environments. You can click the `+ Create Virtual Environment` button. You might be prompted to select the environment manager if you have multiple installed. I have venv and Conda, I will select Conda here. I'm also prompted for desired python version, I will select 3.12, that is known to work well.
 ![VS Code Python environments](res/dev/devinst-3.png)
 ![VS Code Python environments](res/dev/devinst-4.png)
 
@@ -73,8 +74,8 @@ These will install all the python packages and browser binaries for playwright (
 Errors in the code editor caused by missing packages should now be gone. If not, try reloading the window.
 
 
-## Step 4: Run Agent Zero in the IDE
-Great work! Now you should be able to run Agent Zero from your IDE including real-time debugging.
+## Step 4: Run Magui in the IDE
+Great work! Now you should be able to run Magui from your IDE including real-time debugging.
 It will not be able to do code execution and few other features requiring the Docker container just yet, but most of the framework will already work.
 
 1. The project is pre-configured for debugging. Go to Debugging tab, select "run_ui.py" and click the green play button (or press F5 by default). The configuration can be found at `.vscode/launch.json`.
@@ -87,7 +88,7 @@ It may take a while the first time. You should see output like the screenshot be
 ![First run](res/dev/devinst-7.png)
 
 
-After inserting my API key in settings, my Agent Zero instance works. I can send a simple message and get a response.
+After inserting my API key in settings, my Magui instance works. I can send a simple message and get a response.
 ⚠️ Some tools like code execution will not work yet as they need to be connected to a Dockerized instance.
 
 ![First message](res/dev/devinst-8.png)
@@ -104,7 +105,7 @@ After inserting my API key in settings, my Agent Zero instance works. I can send
 ![Debugging](res/dev/devinst-10.png)
 
 
-## Step 5: Run another instance of Agent Zero in Docker
+## Step 5: Run another instance of Magui in Docker
 - Some parts of A0 require standardized linux environment, additional web services and preinstalled binaries that would be unneccessarily complex to set up in a local environment.
 - To make development easier, we can use existing A0 instance in docker and forward some requests to be executed there using SSH and RFC (Remote Function Call).
 
@@ -135,14 +136,14 @@ My VS Code instance:
 
 # 🎉 Congratulations! 🚀
 
-You have successfully set up a complete Agent Zero development environment! You now have:
+You have successfully set up a complete Magui development environment! You now have:
 
 - ✅ A local development instance running in your IDE with full debugging capabilities
 - ✅ A dockerized instance for code execution and system operations
 - ✅ RFC and SSH communication between both instances
-- ✅ The ability to develop, debug, and test Agent Zero features seamlessly
+- ✅ The ability to develop, debug, and test Magui features seamlessly
 
-You're now ready to contribute to Agent Zero, create custom extensions, or modify the framework to suit your needs. Happy coding! 💻✨
+You're now ready to contribute to Magui, create custom extensions, or modify the framework to suit your needs. Happy coding! 💻✨
 
 
 ## Next steps
@@ -151,6 +152,6 @@ You're now ready to contribute to Agent Zero, create custom extensions, or modif
 
 ## Want to build your docker image?
 - You can use the `DockerfileLocal` to build your docker image.
-- Navigate to your project root in the terminal and run `docker build -f DockerfileLocal -t agent-zero-local --build-arg CACHE_DATE=$(date +%Y-%m-%d:%H:%M:%S) .`
+- Navigate to your project root in the terminal and run `docker build -f DockerfileLocal -t magui-local --build-arg CACHE_DATE=$(date +%Y-%m-%d:%H:%M:%S) .`
 - The `CACHE_DATE` argument is optional, it is used to cache most of the build process and only rebuild the last steps when the files or dependencies change.
 - See `docker/run/build.txt` for more build command examples.

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -1,19 +1,19 @@
-# Extensibility framework in Agent Zero
+# Extensibility framework in Magui
 
 > [!NOTE]
-> Agent Zero is built with extensibility in mind. It provides a framework for creating custom extensions, agents, instruments, and tools that can be used to enhance the functionality of the framework.
+> Magui is built with extensibility in mind. It provides a framework for creating custom extensions, agents, instruments, and tools that can be used to enhance the functionality of the framework.
 
 ## Extensible components
-- The Python framework controlling Agent Zero is built as simple as possible, relying on independent smaller and modular scripts for individual tools, API endpoints, system extensions and helper scripts.
+- The Python framework controlling Magui is built as simple as possible, relying on independent smaller and modular scripts for individual tools, API endpoints, system extensions and helper scripts.
 - This way individual components can be easily replaced, upgraded or extended.
 
 Here's a summary of the extensible components:
 
 ### Extensions
-Extensions are components that hook into specific points in the agent's lifecycle. They allow you to modify or enhance the behavior of Agent Zero at predefined extension points. The framework uses a plugin-like architecture where extensions are automatically discovered and loaded.
+Extensions are components that hook into specific points in the agent's lifecycle. They allow you to modify or enhance the behavior of Magui at predefined extension points. The framework uses a plugin-like architecture where extensions are automatically discovered and loaded.
 
 #### Extension Points
-Agent Zero provides several extension points where custom code can be injected:
+Magui provides several extension points where custom code can be injected:
 
 - **agent_init**: Executed when an agent is initialized
 - **before_main_llm_call**: Executed before the main LLM call is made
@@ -28,7 +28,7 @@ Agent Zero provides several extension points where custom code can be injected:
 - **system_prompt**: Executed when system prompts are processed
 
 #### Extension Mechanism
-The extension mechanism in Agent Zero works through the `call_extensions` function in `agent.py`, which:
+The extension mechanism in Magui works through the `call_extensions` function in `agent.py`, which:
 
 1. Loads default extensions from `/python/extensions/{extension_point}/`
 2. Loads agent-specific extensions from `/agents/{agent_profile}/extensions/{extension_point}/`
@@ -74,7 +74,7 @@ Each tool is implemented as a Python class that inherits from the base `Tool` cl
 - Agent-specific tools: `/agents/{agent_profile}/tools/`
 
 #### Tool Override Logic
-When a tool with the same name is requested, Agent Zero first checks for its existence in the agent-specific tools directory. If found, that version is used. If not found, it falls back to the default tools directory.
+When a tool with the same name is requested, Magui first checks for its existence in the agent-specific tools directory. If found, that version is used. If not found, it falls back to the default tools directory.
 
 **Example tool override:**
 
@@ -100,7 +100,7 @@ When a tool is called, it goes through the following lifecycle:
 4. `after_execution` method
 
 ### API Endpoints
-API endpoints expose Agent Zero functionality to external systems or the user interface. They are modular and can be extended or replaced.
+API endpoints expose Magui functionality to external systems or the user interface. They are modular and can be extended or replaced.
 
 API endpoints are located in:
 - Default endpoints: `/python/api/`
@@ -121,7 +121,7 @@ Prompts are located in:
 - Agent-specific prompts: `/agents/{agent_profile}/prompts/`
 
 #### Prompt Features
-Agent Zero's prompt system supports several powerful features:
+Magui's prompt system supports several powerful features:
 
 ##### Variable Placeholders
 Prompts can include variables using the `{{var}}` syntax. These variables are replaced with actual values when the prompt is processed.
@@ -136,7 +136,7 @@ Prompts can include variables using the `{{var}}` syntax. These variables are re
 ##### Dynamic Variable Loaders
 For more advanced prompt customization, you can create Python files with the same name as your prompt files. These Python files act as dynamic variable loaders that generate variables at runtime.
 
-When a prompt file is processed, Agent Zero automatically looks for a corresponding `.py` file in the same directory. If found, it uses this Python file to generate dynamic variables for the prompt.
+When a prompt file is processed, Magui automatically looks for a corresponding `.py` file in the same directory. If found, it uses this Python file to generate dynamic variables for the prompt.
 
 **Example:**
 If you have a prompt file `agent.system.tools.md`, you can create `agent.system.tools.py` alongside it:
@@ -176,7 +176,7 @@ Prompts can include content from other prompt files using the `{{ include "path/
 
 **Example:**
 ```markdown
-# Agent Zero System Manual
+# Magui System Manual
 
 {{ include "agent.system.main.role.md" }}
 
@@ -198,13 +198,13 @@ Similar to extensions and tools, prompts follow an override pattern. When the ag
 > !!!
 
 ## Your role
-You are Agent Zero, a sci-fi character from the movie "Agent Zero".
+You are Magui, a sci-fi character from the movie "Magui".
 ```
 
 This example overrides the default role definition in `/prompts/agent.system.main.role.md` with a custom one for a specific agent profile.
 
 ## Subagent Customization
-Agent Zero supports creating specialized subagents with customized behavior. The `_example` agent in the `/agents/_example/` directory demonstrates this pattern.
+Magui supports creating specialized subagents with customized behavior. The `_example` agent in the `/agents/_example/` directory demonstrates this pattern.
 
 ### Creating a Subagent
 
@@ -287,12 +287,12 @@ These files allow you to keep credentials and configuration tightly scoped to a 
 
 ### When to Use Projects
 
-Projects are the recommended way to create specialized workflows in Agent Zero when you need to:
+Projects are the recommended way to create specialized workflows in Magui when you need to:
 
 - Add specific instructions without affecting global behavior
 - Isolate file context, knowledge, and memory for a particular task or client
 - Keep passwords and other secrets scoped to a single workspace
-- Run multiple independent flows side by side under the same Agent Zero installation
+- Run multiple independent flows side by side under the same Magui installation
 
 ## Best Practices
 - Keep extensions focused on a single responsibility

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,17 +1,17 @@
 # Users installation guide for Windows, macOS and Linux
 
-Click to open a video to learn how to install Agent Zero:
+Click to open a video to learn how to install Magui:
 
 [![Easy Installation guide](/docs/res/easy_ins_vid.png)](https://www.youtube.com/watch?v=w5v5Kjx51hs)
 
-The following user guide provides instructions for installing and running Agent Zero using Docker, which is the primary runtime environment for the framework. For developers and contributors, we also provide instructions for setting up the [full development environment](#in-depth-guide-for-full-binaries-installation).
+The following user guide provides instructions for installing and running Magui using Docker, which is the primary runtime environment for the framework. For developers and contributors, we also provide instructions for setting up the [full development environment](#in-depth-guide-for-full-binaries-installation).
 
 
 ## Windows, macOS and Linux Setup Guide
 
 
 1. **Install Docker Desktop:** 
-- Docker Desktop provides the runtime environment for Agent Zero, ensuring consistent behavior and security across platforms
+- Docker Desktop provides the runtime environment for Magui, ensuring consistent behavior and security across platforms
 - The entire framework runs within a Docker container, providing isolation and easy deployment
 - Available as a user-friendly GUI application for all major operating systems
 
@@ -56,11 +56,11 @@ The following user guide provides instructions for installing and running Agent 
 
 ![docker socket macOS](res/setup/macsocket.png)
 
-2. **Run Agent Zero:**
+2. **Run Magui:**
 
-- Note: Agent Zero also offers a Hacking Edition based on Kali linux with modified prompts for cybersecurity tasks. The setup is the same as the regular version, just use the agent0ai/agent-zero:hacking image instead of agent0ai/agent-zero.
+- Note: Magui also offers a Hacking Edition based on Kali linux with modified prompts for cybersecurity tasks. The setup is the same as the regular version, just use the agent0ai/agent-zero:hacking image instead of agent0ai/agent-zero.
 
-2.1. Pull the Agent Zero Docker image:
+2.1. Pull the Magui Docker image:
 - Search for `agent0ai/agent-zero` in Docker Desktop
 - Click the `Pull` button
 - The image will be downloaded to your machine in a few minutes
@@ -77,23 +77,23 @@ The following user guide provides instructions for installing and running Agent 
 2.2. OPTIONAL - Create a data directory for persistence:
 
 > [!CAUTION]
-> Preferred way of persisting Agent Zero data is to use the backup and restore feature.
-> By mapping the whole `/a0` directory to a local directory, you will run into problems when upgrading Agent Zero to a newer version.
+> Preferred way of persisting Magui data is to use the backup and restore feature.
+> By mapping the whole `/a0` directory to a local directory, you will run into problems when upgrading Magui to a newer version.
 
-- Choose or create a directory on your machine where you want to store Agent Zero's data
-- This can be any location you prefer (e.g., `C:/agent-zero-data` or `/home/user/agent-zero-data`)
+- Choose or create a directory on your machine where you want to store Magui's data
+- This can be any location you prefer (e.g., `C:/magui-data` or `/home/user/magui-data`)
 - You can map individual subfolders of `/a0` to a local directory or the full `/a0` directory (not recommended).
-- This directory will contain all your Agent Zero files, like the legacy root folder structure:
+- This directory will contain all your Magui files, like the legacy root folder structure:
   - `/agents` - Specialized agents with their prompts and tools
   - `/memory` - Agent's memory and learned information
   - `/knowledge` - Knowledge base
   - `/instruments` - Instruments and functions
   - `/prompts` - Prompt files
   - `.env` - Your API keys
-  - `/tmp/settings.json` - Your Agent Zero settings
+  - `/tmp/settings.json` - Your Magui settings
 
 > [!TIP]
-> Choose a location that's easy to access and backup. All your Agent Zero data 
+> Choose a location that's easy to access and backup. All your Magui data 
 > will be directly accessible in this directory.
 
 2.3. Run the container:
@@ -104,10 +104,10 @@ The following user guide provides instructions for installing and running Agent 
 
 Optionally you can map local folders for file persistence:
 > [!CAUTION]
-> Preferred way of persisting Agent Zero data is to use the backup and restore feature.
-> By mapping the whole `/a0` directory to a local directory, you will run into problems when upgrading Agent Zero to a newer version.
+> Preferred way of persisting Magui data is to use the backup and restore feature.
+> By mapping the whole `/a0` directory to a local directory, you will run into problems when upgrading Magui to a newer version.
 - OPTIONAL: Under "Volumes", configure your mapped folders, if needed:
-  - Example host path: Your chosen directory (e.g., `C:\agent-zero\memory`)
+  - Example host path: Your chosen directory (e.g., `C:\magui\memory`)
   - Example container path: `/a0/memory`
 
 
@@ -135,7 +135,7 @@ Optionally you can map local folders for file persistence:
 ![docker logs](res/setup/5-docker-click-to-open.png)
 
 - Open `http://localhost:<PORT>` in your browser
-- The Web UI will open. Agent Zero is ready for configuration!
+- The Web UI will open. Magui is ready for configuration!
 
 ![docker ui](res/setup/6-docker-a0-running.png)
 
@@ -143,15 +143,15 @@ Optionally you can map local folders for file persistence:
 > You can also access the Web UI by clicking the ports right under the container ID in Docker Desktop.
 
 > [!NOTE]
-> After starting the container, you'll find all Agent Zero files in your chosen 
+> After starting the container, you'll find all Magui files in your chosen 
 > directory. You can access and edit these files directly on your machine, and 
 > the changes will be immediately reflected in the running container.
 
-3. Configure Agent Zero
-- Refer to the following sections for a full guide on how to configure Agent Zero.
+3. Configure Magui
+- Refer to the following sections for a full guide on how to configure Magui.
 
 ## Settings Configuration
-Agent Zero provides a comprehensive settings interface to customize various aspects of its functionality. Access the settings by clicking the "Settings"button with a gear icon in the sidebar.
+Magui provides a comprehensive settings interface to customize various aspects of its functionality. Access the settings by clicking the "Settings"button with a gear icon in the sidebar.
 
 ### Agent Configuration
 - **Prompts Subdirectory:** Choose the subdirectory within `/prompts` for agent behavior customization. The 'default' directory contains the standard prompts.
@@ -187,7 +187,7 @@ Agent Zero provides a comprehensive settings interface to customize various aspe
 - Click `Save` to confirm your settings
 
 > [!CAUTION]
-> **GitHub Copilot Provider:** When using the GitHub Copilot provider, after selecting the model and entering your first prompt, the OAuth login procedure will begin. You'll find the authentication code and link in the output logs. Complete the authentication process by following the provided link and entering the code, then you may continue using Agent Zero.
+> **GitHub Copilot Provider:** When using the GitHub Copilot provider, after selecting the model and entering your first prompt, the OAuth login procedure will begin. You'll find the authentication code and link in the output logs. Complete the authentication process by following the provided link and entering the code, then you may continue using Magui.
 
 > [!NOTE]
 > **GitHub Copilot Limitations:** GitHub Copilot models typically have smaller rate limits and context windows compared to models hosted by other providers like OpenAI, Anthropic, or Azure. Consider this when working with large conversations or high-frequency requests.
@@ -204,13 +204,13 @@ Agent Zero provides a comprehensive settings interface to customize various aspe
 ### Development Settings
 - **RFC Parameters (local instances only):** configure URLs and ports for remote function calls between instances
 - **RFC Password:** Configure password for remote function calls
-Learn more about Remote Function Calls and their purpose [here](#7-configure-agent-zero-rfc).
+- **[Learn more about Remote Function Calls and their purpose](#7-configure-agent-zero-rfc).**
 
 > [!IMPORTANT]
 > Always keep your API keys and passwords secure.
 
 # Choosing Your LLMs
-The Settings page is the control center for selecting the Large Language Models (LLMs) that power Agent Zero.  You can choose different LLMs for different roles:
+The Settings page is the control center for selecting the Large Language Models (LLMs) that power Magui.  You can choose different LLMs for different roles:
 
 | LLM Role | Description |
 | --- | --- |
@@ -259,7 +259,7 @@ ollama pull <model-name>
 
 2. A CLI message should confirm the model download on your system
 
-#### Selecting your model within Agent Zero
+#### Selecting your model within Magui
 1. Once you've downloaded your model(s), you must select it in the Settings page of the GUI. 
 
 2. Within the Chat model, Utility model, or Embedding model section, choose Ollama as provider.
@@ -289,11 +289,11 @@ Once you've downloaded some models, you might want to check which ones you have 
 
 - Experiment with different model combinations to find the balance of performance and cost that best suits your needs. E.g., faster and lower latency LLMs will help, and you can also use `faiss_gpu` instead of `faiss_cpu` for the memory.
 
-## Using Agent Zero on your mobile device
-Agent Zero's Web UI is accessible from any device on your network through the Docker container:
+## Using Magui on your mobile device
+Magui's Web UI is accessible from any device on your network through the Docker container:
 
 > [!NOTE]
-> In settings, External Services tab, you can enable Cloudflare Tunnel to expose your Agent Zero instance to the internet.
+> In settings, External Services tab, you can enable Cloudflare Tunnel to expose your Magui instance to the internet.
 > ⚠️ Do not forget to set username and password in the settings Authentication tab to secure your instance on the internet.
 
 1. The Docker container automatically exposes the Web UI on all network interfaces
@@ -310,31 +310,31 @@ Agent Zero's Web UI is accessible from any device on your network through the Do
 > - The port is automatically assigned by Docker unless you specify one
 
 > [!NOTE]
-> If you're running Agent Zero directly on your system (legacy approach) instead of 
+> If you're running Magui directly on your system (legacy approach) instead of 
 > using Docker, you'll need to configure the host manually in `run_ui.py` to run on all interfaces using `host="0.0.0.0"`.
 
-For developers or users who need to run Agent Zero directly on their system,see the [In-Depth Guide for Full Binaries Installation](#in-depth-guide-for-full-binaries-installation).
+For developers or users who need to run Magui directly on their system,see the [In-Depth Guide for Full Binaries Installation](#in-depth-guide-for-full-binaries-installation).
 
-# How to update Agent Zero
+# How to update Magui
 
 > [!NOTE]
-> Since v0.9, Agent Zero has a Backup and Restore feature, so you don't need to backup the files manually.
+> Since v0.9, Magui has a Backup and Restore feature, so you don't need to backup the files manually.
 > In Settings, Backup and Restore tab will guide you through the process.
 
-1. **If you come from the previous version of Agent Zero:**
-- Your data is safely stored across various directories and files inside the Agent Zero folder.
+1. **If you come from the previous version of Magui:**
+- Your data is safely stored across various directories and files inside the Magui folder.
 - To update to the new Docker runtime version, you might want to backup the following files and directories:
   - `/memory` - Agent's memory
   - `/knowledge` - Custom knowledge base (if you imported any custom knowledge files)
   - `/instruments` - Custom instruments and functions (if you created any custom)
-  - `/tmp/settings.json` - Your Agent Zero settings
+  - `/tmp/settings.json` - Your Magui settings
   - `/tmp/chats/` - Your chat history
 - Once you have saved these files and directories, you can proceed with the Docker runtime [installation instructions above](#windows-macos-and-linux-setup-guide) setup guide.
-- Reach for the folder where you saved your data and copy it to the new Agent Zero folder set during the installation process.
-- Agent Zero will automatically detect your saved data and use it across memory, knowledge, instruments, prompts and settings.
+- Reach for the folder where you saved your data and copy it to the new Magui folder set during the installation process.
+- Magui will automatically detect your saved data and use it across memory, knowledge, instruments, prompts and settings.
 
 > [!IMPORTANT]
-> If you have issues loading your settings, you can try to delete the `/tmp/settings.json` file and let Agent Zero generate a new one.
+> If you have issues loading your settings, you can try to delete the `/tmp/settings.json` file and let Magui generate a new one.
 > The same goes for chats in `/tmp/chats/`, they might be incompatible with the new version
 
 2. **Update Process (Docker Desktop)**
@@ -350,17 +350,17 @@ For developers or users who need to run Agent Zero directly on their system,see 
 > [!IMPORTANT]
 > Make sure to use the same volume mount path when running the new
 > container to preserve your data. The exact path depends on where you stored
-> your Agent Zero data directory (the chosen directory on your machine).
+> your Magui data directory (the chosen directory on your machine).
 
 > [!TIP]
 > Alternatively, run the following commands in your terminal:
 >
 > ```bash
 > # Stop the current container
-> docker stop agent-zero
+> docker stop magui
 >
 > # Remove the container (data is safe in the folder)
-> docker rm agent-zero
+> docker rm magui
 >
 > # Remove the old image
 > docker rmi agent0ai/agent-zero
@@ -374,7 +374,6 @@ For developers or users who need to run Agent Zero directly on their system,see 
 
       
 ### Conclusion
-After following the instructions for your specific operating system, you should have Agent Zero successfully installed and running. You can now start exploring the framework's capabilities and experimenting with creating your own intelligent agents. 
+After following the instructions for your specific operating system, you should have Magui successfully installed and running. You can now start exploring the framework's capabilities and experimenting with creating your own intelligent agents. 
 
-If you encounter any issues during the installation process, please consult the [Troubleshooting section](troubleshooting.md) of this documentation or refer to the Agent Zero [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community for assistance.
-
+If you encounter any issues during the installation process, please consult the [Troubleshooting section](troubleshooting.md) of this documentation or refer to the Magui [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community for assistance.

--- a/docs/mcp_setup.md
+++ b/docs/mcp_setup.md
@@ -1,31 +1,31 @@
-# Agent Zero: MCP Server Integration Guide
+# Magui: MCP Server Integration Guide
 
-This guide explains how to configure and utilize external tool providers through the Model Context Protocol (MCP) with Agent Zero. This allows Agent Zero to leverage tools hosted by separate local or remote MCP-compliant servers.
+This guide explains how to configure and utilize external tool providers through the Model Context Protocol (MCP) with Magui. This allows Magui to leverage tools hosted by separate local or remote MCP-compliant servers.
 
 ## What are MCP Servers?
 
-MCP servers are external processes or services that expose a set of tools that Agent Zero can use. Agent Zero acts as an MCP *client*, consuming tools made available by these servers. The integration supports three main types of MCP servers:
+MCP servers are external processes or services that expose a set of tools that Magui can use. Magui acts as an MCP *client*, consuming tools made available by these servers. The integration supports three main types of MCP servers:
 
-1.  **Local Stdio Servers**: These are typically local executables that Agent Zero communicates with via standard input/output (stdio).
-2.  **Remote SSE Servers**: These are servers, often accessible over a network, that Agent Zero communicates with using Server-Sent Events (SSE), usually over HTTP/S.
+1.  **Local Stdio Servers**: These are typically local executables that Magui communicates with via standard input/output (stdio).
+2.  **Remote SSE Servers**: These are servers, often accessible over a network, that Magui communicates with using Server-Sent Events (SSE), usually over HTTP/S.
 3.  **Remote Streaming HTTP Servers**: These are servers that use the streamable HTTP transport protocol for MCP communication, providing an alternative to SSE for network-based MCP servers.
 
-## How Agent Zero Consumes MCP Tools
+## How Magui Consumes MCP Tools
 
-Agent Zero discovers and integrates MCP tools dynamically:
+Magui discovers and integrates MCP tools dynamically:
 
-1.  **Configuration**: You define the MCP servers Agent Zero should connect to in its configuration. The primary way to do this is through the Agent Zero settings UI.
-2.  **Saving Settings**: When you save your settings via the UI, Agent Zero updates the `tmp/settings.json` file, specifically the `"mcp_servers"` key.
-3.  **Automatic Installation (on Restart)**: After saving your settings and restarting Agent Zero, the system will attempt to automatically install any MCP server packages defined with `command: "npx"` and the `--package` argument in their configuration (this process is managed by `initialize.py`). You can monitor the application logs (e.g., Docker logs) for details on this installation attempt.
-4.  **Tool Discovery**: Upon initialization (or when settings are updated), Agent Zero connects to each configured and enabled MCP server and queries it for the list of available tools, their descriptions, and expected parameters.
+1.  **Configuration**: You define the MCP servers Magui should connect to in its configuration. The primary way to do this is through the Magui settings UI.
+2.  **Saving Settings**: When you save your settings via the UI, Magui updates the `tmp/settings.json` file, specifically the `"mcp_servers"` key.
+3.  **Automatic Installation (on Restart)**: After saving your settings and restarting Magui, the system will attempt to automatically install any MCP server packages defined with `command: "npx"` and the `--package` argument in their configuration (this process is managed by `initialize.py`). You can monitor the application logs (e.g., Docker logs) for details on this installation attempt.
+4.  **Tool Discovery**: Upon initialization (or when settings are updated), Magui connects to each configured and enabled MCP server and queries it for the list of available tools, their descriptions, and expected parameters.
 5.  **Dynamic Prompting**: The information about these discovered tools is then dynamically injected into the agent's system prompt. A placeholder like `{{tools}}` in a system prompt template (e.g., `prompts/default/agent.system.mcp_tools.md`) is replaced with a formatted list of all available MCP tools. This allows the agent's underlying Language Model (LLM) to know which external tools it can request.
-6.  **Tool Invocation**: When the LLM decides to use an MCP tool, Agent Zero's `process_tools` method (handled by `mcp_handler.py`) identifies it as an MCP tool and routes the request to the appropriate `MCPConfig` helper, which then communicates with the designated MCP server to execute the tool.
+6.  **Tool Invocation**: When the LLM decides to use an MCP tool, Magui's `process_tools` method (handled by `mcp_handler.py`) identifies it as an MCP tool and routes the request to the appropriate `MCPConfig` helper, which then communicates with the designated MCP server to execute the tool.
 
 ## Configuration
 
 ### Configuration File & Method
 
-The primary method for configuring MCP servers is through **Agent Zero's settings UI**.
+The primary method for configuring MCP servers is through **Magui's settings UI**.
 
 When you input and save your MCP server details in the UI, these settings are written to:
 
@@ -36,7 +36,7 @@ When you input and save your MCP server details in the UI, these settings are wr
 Within `tmp/settings.json`, the MCP servers are defined under the `"mcp_servers"` key.
 
 *   **Value Type**: The value for `"mcp_servers"` must be a **JSON formatted string**. This string itself contains an **array** of server configuration objects.
-*   **Default Value**: If `tmp/settings.json` does not exist, or if it exists but does not contain the `"mcp_servers"` key, Agent Zero will use a default value of `""` (an empty string), meaning no MCP servers are configured.
+*   **Default Value**: If `tmp/settings.json` does not exist, or if it exists but does not contain the `"mcp_servers"` key, Magui will use a default value of `""` (an empty string), meaning no MCP servers are configured.
 *   **Manual Editing (Advanced)**: While UI configuration is recommended, you can also manually edit `tmp/settings.json`. If you do, ensure the `"mcp_servers"` value is a valid JSON string, with internal quotes properly escaped.
 
 **Example `mcp_servers` string in `tmp/settings.json`:**
@@ -50,10 +50,10 @@ Within `tmp/settings.json`, the MCP servers are defined under the `"mcp_servers"
 ```
 *Note: In the actual `settings.json` file, the entire value for `mcp_servers` is a single string, with backslashes escaping the quotes within the array structure.*
 
-*   **Updating**: As mentioned, the recommended way to set or update this value is through Agent Zero's settings UI.
-*   **For Existing `settings.json` Files (After an Upgrade)**: If you have an existing `tmp/settings.json` from a version of Agent Zero prior to MCP server support, the `"mcp_servers"` key will likely be missing. To add this key:
-    1.  Ensure you are running a version of Agent Zero that includes MCP server support.
-    2.  Run Agent Zero and open its settings UI.
+*   **Updating**: As mentioned, the recommended way to set or update this value is through Magui's settings UI.
+*   **For Existing `settings.json` Files (After an Upgrade)**: If you have an existing `tmp/settings.json` from a version of Magui prior to MCP server support, the `"mcp_servers"` key will likely be missing. To add this key:
+    1.  Ensure you are running a version of Magui that includes MCP server support.
+    2.  Run Magui and open its settings UI.
     3.  Save the settings (even without making changes). This action will write the complete current settings structure, including a default `"mcp_servers": ""` if not otherwise populated, to `tmp/settings.json`. You can then configure your servers via the UI or by carefully editing this string.
 
 ### MCP Server Configuration Structure
@@ -129,7 +129,7 @@ Here are templates for configuring individual servers within the `mcp_servers` J
 
 *   `"name"`: A unique name for the server. This name will be used to prefix the tools provided by this server (e.g., `my_server_name.tool_name`). The name is normalized internally (converted to lowercase, spaces and hyphens replaced with underscores).
 *   `"type"`: Optional explicit server type specification. Can be `"stdio"`, `"sse"`, or streaming HTTP variants (`"http-stream"`, `"streaming-http"`, `"streamable-http"`, `"http-streaming"`). If omitted, the type is auto-detected based on the presence of `"command"` (stdio) or `"url"` (defaults to sse for backward compatibility).
-*   `"disabled"`: A boolean (`true` or `false`). If `true`, Agent Zero will ignore this server configuration.
+*   `"disabled"`: A boolean (`true` or `false`). If `true`, Magui will ignore this server configuration.
 *   `"url"`: **Required for Remote SSE and Streaming HTTP Servers.** The endpoint URL.
 *   `"command"`: **Required for Local Stdio Servers.** The executable command.
 *   `"args"`: Optional list of arguments for local Stdio servers.
@@ -137,10 +137,10 @@ Here are templates for configuring individual servers within the `mcp_servers` J
 
 ## Using MCP Tools
 
-Once configured, successfully installed (if applicable, e.g., for `npx` based servers), and discovered by Agent Zero:
+Once configured, successfully installed (if applicable, e.g., for `npx` based servers), and discovered by Magui:
 
 *   **Tool Naming**: MCP tools will appear to the agent with a name prefixed by the server name you defined (and normalized, e.g., lowercase, underscores for spaces/hyphens). For instance, if your server is named `"sequential-thinking"` in the configuration and it offers a tool named `"run_chain"`, the agent will know it as `sequential_thinking.run_chain`.
 *   **Agent Interaction**: You can instruct the agent to use these tools. For example: "Agent, use the `sequential_thinking.run_chain` tool with the following input..." The agent's LLM will then formulate the appropriate JSON request.
-*   **Execution Flow**: Agent Zero's `process_tools` method (with logic in `python/helpers/mcp_handler.py`) prioritizes looking up the tool name in the `MCPConfig`. If found, the execution is delegated to the corresponding MCP server. If not found as an MCP tool, it then attempts to find a local/built-in tool with that name.
+*   **Execution Flow**: Magui's `process_tools` method (with logic in `python/helpers/mcp_handler.py`) prioritizes looking up the tool name in the `MCPConfig`. If found, the execution is delegated to the corresponding MCP server. If not found as an MCP tool, it then attempts to find a local/built-in tool with that name.
 
-This setup provides a flexible way to extend Agent Zero's capabilities by integrating with various external tool providers without modifying its core codebase.
+This setup provides a flexible way to extend Magui's capabilities by integrating with various external tool providers without modifying its core codebase.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,6 +1,6 @@
-# Agent Zero Notifications
+# Magui Notifications
 
-Quick guide for using the notification system in Agent Zero.
+Quick guide for using the notification system in Magui.
 
 ## Backend Usage
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,10 +1,10 @@
-# Quick Start
-This guide provides a quick introduction to using Agent Zero. We'll cover launching the web UI, starting a new chat, and running a simple task.
+# Magui Quickstart
 
-## Launching the Web UI
-1. Make sure you have Agent Zero installed and your environment set up correctly (refer to the [Installation guide](installation.md) if needed).
-2. Open a terminal in the Agent Zero directory and activate your conda environment (if you're using one).
-3. Run the following command:
+Get up and running with Magui in minutes.
+
+## 1. Start Magui
+
+Run the following command to start Magui:
 
 ```bash
 python run_ui.py
@@ -14,7 +14,7 @@ python run_ui.py
 
 ![](res/flask_link.png)
 
-5. Open your web browser and navigate to the URL shown in the terminal (usually `http://127.0.0.1:50001`). You should see the Agent Zero Web UI.
+5. Open your web browser and navigate to the URL shown in the terminal (usually `http://127.0.0.1:50001`). You should see the Magui Web UI.
 
 ![New Chat](res/ui_newchat1.png)
 
@@ -27,11 +27,11 @@ python run_ui.py
     ![Chat Management](res/ui_chat_management.png)
 
 ## Running a Simple Task
-Let's ask Agent Zero to download a YouTube video. Here's how:
+Let's ask Magui to download a YouTube video. Here's how:
 
 1.  Type "Download a YouTube video for me" in the chat input field and press Enter or click the send button.
 
-2. Agent Zero will process your request.  You'll see its "thoughts" and the actions it takes displayed in the UI. It will find a default already existing solution, that implies using the `code_execution_tool` to run a simple Python script to perform the task.
+2. Magui will process your request.  You'll see its "thoughts" and the actions it takes displayed in the UI. It will find a default already existing solution, that implies using the `code_execution_tool` to run a simple Python script to perform the task.
 
 3. The agent will then ask you for the URL of the YouTube video you want to download.
 
@@ -40,7 +40,7 @@ Here's an example of what you might see in the Web UI at step 3:
 ![1](res/image-24.png)
 
 ## Next Steps
-Now that you've run a simple task, you can experiment with more complex requests. Try asking Agent Zero to:
+Now that you've run a simple task, you can experiment with more complex requests. Try asking Magui to:
 
 * Perform calculations
 * Search the web for information

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,24 +1,24 @@
 # Troubleshooting and FAQ
-This page addresses frequently asked questions (FAQ) and provides troubleshooting steps for common issues encountered while using Agent Zero.
+This page addresses frequently asked questions (FAQ) and provides troubleshooting steps for common issues encountered while using Magui.
 
 ## Frequently Asked Questions
-**1. How do I ask Agent Zero to work directly on my files or dirs?**
--   Place the files/dirs in the `work_dir` directory. Agent Zero will be able to perform tasks on them. The `work_dir` directory is located in the root directory of the Docker Container.
+**1. How do I ask Magui to work directly on my files or dirs?**
+-   Place the files/dirs in the `work_dir` directory. Magui will be able to perform tasks on them. The `work_dir` directory is located in the root directory of the Docker Container.
 
 **2. When I input something in the chat, nothing happens. What's wrong?**
 -   Check if you have set up API keys in the Settings page. If not, the application will not be able to communicate with the endpoints it needs to run LLMs and to perform tasks.
 
-**3. How do I integrate open-source models with Agent Zero?**
+**3. How do I integrate open-source models with Magui?**
 Refer to the [Choosing your LLMs](installation.md#installing-and-using-ollama-local-models) section of the documentation for detailed instructions and examples for configuring different LLMs. Local models can be run using Ollama or LM Studio.
 
 > [!TIP]
 > Some LLM providers offer free usage of their APIs, for example Groq, Mistral, SambaNova or CometAPI.
 
-**6. How can I make Agent Zero retain memory between sessions?**
-Refer to the [How to update Agent Zero](installation.md#how-to-update-agent-zero) section of the documentation for instructions on how to update Agent Zero while retaining memory and data.
+**6. How can I make Magui retain memory between sessions?**
+Refer to the [How to update Magui](installation.md#how-to-update-magui) section of the documentation for instructions on how to update Magui while retaining memory and data.
 
 **7. Where can I find more documentation or tutorials?**
--   Join the Agent Zero [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community for support and discussions.
+-   Join the Magui [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community for support and discussions.
 
 **8. How do I adjust API rate limits?**
 Modify the `rate_limit_seconds` and `rate_limit_requests` parameters in the `AgentConfig` class within `initialize.py`.
@@ -27,8 +27,8 @@ Modify the `rate_limit_seconds` and `rate_limit_requests` parameters in the `Age
 -   Ensure you have Docker installed and running.  If using Docker Desktop on macOS, grant it access to your project files in Docker Desktop's settings.  Check the [Installation guide](installation.md#4-install-docker-docker-desktop-application) for more details.
 -   Verify that the Docker image is updated.
 
-**10. Can Agent Zero interact with external APIs or services (e.g., WhatsApp)?**
-Extending Agent Zero to interact with external APIs is possible by creating custom tools or solutions. Refer to the documentation on creating them. 
+**10. Can Magui interact with external APIs or services (e.g., WhatsApp)?**
+Extending Magui to interact with external APIs is possible by creating custom tools or solutions. Refer to the documentation on creating them. 
 
 ## Troubleshooting
 
@@ -41,4 +41,4 @@ Extending Agent Zero to interact with external APIs is possible by creating cust
 
 * **Error Messages:** Pay close attention to the error messages displayed in the Web UI or terminal.  They often provide valuable clues for diagnosing the issue. Refer to the specific error message in online searches or community forums for potential solutions.
 
-* **Performance Issues:** If Agent Zero is slow or unresponsive, it might be due to resource limitations, network latency, or the complexity of your prompts and tasks, especially when using local models.
+* **Performance Issues:** If Magui is slow or unresponsive, it might be due to resource limitations, network latency, or the complexity of your prompts and tasks, especially when using local models.

--- a/docs/tunnel.md
+++ b/docs/tunnel.md
@@ -1,15 +1,14 @@
-# Agent Zero Tunnel Feature
+# Remote Access to Magui via Flare Tunnel
 
-The tunnel feature in Agent Zero allows you to expose your local Agent Zero instance to the internet using Flaredantic tunnels. This makes it possible to share your Agent Zero instance with others without requiring them to install and run Agent Zero themselves.
+Magui includes a built-in tunneling capability powered by [Flare](https://github.com/soulteary/flare), allowing you to securely expose your local instance to the internet.
 
-## How It Works
+## Why use a tunnel with Magui?
 
-Agent Zero uses the [Flaredantic](https://pypi.org/project/flaredantic/) library to create secure tunnels to expose your local instance to the internet. These tunnels:
-
-- Are secure (HTTPS)
-- Don't require any configuration
-- Generate unique URLs for each session
-- Can be regenerated on demand
+1. **Access from anywhere**: Control your Magui instance from work, while traveling, or from a different location.
+2. **Mobile access**: Use Magui on your smartphone or tablet while on the go.
+3. **Share with others**: Give temporary access to your Magui instance to colleagues or friends.
+4. **Webhook integration**: Connect external services to Magui via webhooks.
+5. **MCP Server**: Use Magui as an MCP server for other agents running on different machines.
 
 ## Using the Tunnel Feature
 
@@ -17,16 +16,16 @@ Agent Zero uses the [Flaredantic](https://pypi.org/project/flaredantic/) library
 2. Click on "Flare Tunnel" in the navigation menu
 3. Click the "Create Tunnel" button to generate a new tunnel
 4. Once created, the tunnel URL will be displayed and can be copied to share with others
-5. The tunnel URL will remain active until you stop the tunnel or close the Agent Zero application
+5. The tunnel URL will remain active until you stop the tunnel or close the Magui application
 
 ## Security Considerations
 
-When sharing your Agent Zero instance via a tunnel:
+When sharing your Magui instance via a tunnel:
 
-- Anyone with the URL can access your Agent Zero instance
-- No additional authentication is added beyond what your Agent Zero instance already has
+- Anyone with the URL can access your Magui instance
+- No additional authentication is added beyond what your Magui instance already has
 - Consider setting up authentication if you're sharing sensitive information
-- The tunnel exposes your local Agent Zero instance, not your entire system
+- The tunnel exposes your local Magui instance, not your entire system
 
 ## Troubleshooting
 
@@ -34,12 +33,12 @@ If you encounter issues with the tunnel feature:
 
 1. Check your internet connection
 2. Try refreshing the tunnel URL
-3. Restart Agent Zero
+3. Restart Magui
 4. Check the console logs for any error messages
 
 ## Adding Authentication
 
-To add basic authentication to your Agent Zero instance when using tunnels, you can set the following environment variables:
+To add basic authentication to your Magui instance when using tunnels, you can set the following environment variables:
 
 ```
 AUTH_LOGIN=your_username
@@ -48,10 +47,10 @@ AUTH_PASSWORD=your_password
 
 Alternatively, you can configure the username and password directly in the settings:
 
-1. Open the settings modal in the Agent Zero UI
+1. Open the settings modal in the Magui UI
 2. Navigate to the "External Services" tab
 3. Find the "Authentication" section
 4. Enter your desired username and password in the "UI Login" and "UI Password" fields
 5. Click the "Save" button to apply the changes
 
-This will require users to enter these credentials when accessing your tunneled Agent Zero instance. When attempting to create a tunnel without authentication configured, Agent Zero will display a security warning.
+This will require users to enter these credentials when accessing your tunneled Magui instance. When attempting to create a tunnel without authentication configured, Magui will display a security warning.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,13 +1,13 @@
 # Usage Guide
-This guide explores usage and configuration scenarios for Agent Zero. You can consider this as a reference post-installation guide.
+This guide explores usage and configuration scenarios for Magui. You can consider this as a reference post-installation guide.
 
 ![Utility Message with Solutions](res/memory-man.png)
 
 ## Basic Operations
-Agent Zero provides several basic operations through its interface:
+Magui provides several basic operations through its interface:
 
 ### Restart Framework
-The Restart button allows you to quickly restart the Agent Zero framework without using the terminal:
+The Restart button allows you to quickly restart the Magui framework without using the terminal:
 
 ![Restart Framework](res/ui-restarting.png)
 
@@ -22,7 +22,7 @@ The Restart button allows you to quickly restart the Agent Zero framework withou
 > - Reinitialize the system when agents become unresponsive
 
 ### Action Buttons
-Located beneath the chat input box, Agent Zero provides a set of action buttons for enhanced control and visibility:
+Located beneath the chat input box, Magui provides a set of action buttons for enhanced control and visibility:
 
 ![Action Buttons](res/ui-actions.png)
 #### Chat Flow Control
@@ -38,7 +38,7 @@ Located beneath the chat input box, Agent Zero provides a set of action buttons 
   - Success message confirms successful import
   - See [knowledge](architecture.md#knowledge) for more details
 
-### File Browser: Manage files in the Agent Zero environment
+### File Browser: Manage files in the Magui environment
   - Upload new files and folders
   - Download files (click filename) or folders (as zip archives)
   - Delete files and folders
@@ -72,7 +72,7 @@ Access the chat history in JSON format
 > Use the Context and History buttons to understand how the agent interprets your instructions and debug any unexpected behavior.
 
 ### File Attachments
-Agent Zero supports direct file attachments in the chat interface for seamless file operations:
+Magui supports direct file attachments in the chat interface for seamless file operations:
 
 #### Attaching Files
 * Click the attachment icon (📎) on the left side of the chat input box
@@ -86,7 +86,7 @@ Agent Zero supports direct file attachments in the chat interface for seamless f
 
 #### Working with Attached Files
 * Files can be referenced directly in your messages
-* Agent Zero can:
+* Magui can:
   - Process attached files
   - Move files to specific directories
   - Perform operations on multiple files simultaneously
@@ -98,16 +98,16 @@ Agent Zero supports direct file attachments in the chat interface for seamless f
 > When working with multiple files, you can attach them all at once and then give instructions about what to do with them. The agent will handle them as a batch while keeping you informed of the progress.
 
 ## Tool Usage
-Agent Zero's power comes from its ability to use [tools](architecture.md#tools). Here's how to leverage them effectively:
+Magui's power comes from its ability to use [tools](architecture.md#tools). Here's how to leverage them effectively:
 
-- **Understand Tools:** Agent Zero includes default tools like knowledge (powered by SearXNG), code execution, and communication. Understand the capabilities of these tools and how to invoke them.
+- **Understand Tools:** Magui includes default tools like knowledge (powered by SearXNG), code execution, and communication. Understand the capabilities of these tools and how to invoke them.
 
 ## Example of Tools Usage: Web Search and Code Execution
-Let's say you want Agent Zero to perform some financial analysis tasks. Here's a possible prompt:
+Let's say you want Magui to perform some financial analysis tasks. Here's a possible prompt:
 
 > Please be a professional financial analyst. Find last month Bitcoin/ USD price trend and make a chart in your environment. The chart must  have highlighted key points corresponding with dates of major news  about cryptocurrency. Use the 'search_engine' and 'document_query_tool' to find the price and  the news, and the 'code_execution_tool' to perform the rest of the job.
 
-Agent Zero might then:
+Magui might then:
 
 1. Use the `search_engine` and `document_query_tool` to query a reliable source for the Bitcoin price and for the news about cryptocurrency as prompted.
 2. Extract the price from the search results and save the news, extracting their dates and possible impact on the price.
@@ -115,30 +115,30 @@ Agent Zero might then:
 4. Save the final chart on disk inside the container and provide a link to it with the `response_tool`.
 
 > [!NOTE]
-> The first run of `code_execution_tool` may take a while as it downloads and builds the Agent Zero Docker image. Subsequent runs will be faster.
+> The first run of `code_execution_tool` may take a while as it downloads and builds the Magui Docker image. Subsequent runs will be faster.
 
-This example demonstrates how to combine multiple tools to achieve an analysis task. By mastering prompt engineering and tool usage, you can unlock the full potential of Agent Zero to solve complex problems.
+This example demonstrates how to combine multiple tools to achieve an analysis task. By mastering prompt engineering and tool usage, you can unlock the full potential of Magui to solve complex problems.
 
 ## Multi-Agent Cooperation
-One of Agent Zero's unique features is multi-agent cooperation.
+One of Magui's unique features is multi-agent cooperation.
 
 * **Creating Sub-Agents:** Agents can create sub-agents to delegate sub-tasks.  This helps manage complexity and distribute workload.
 * **Communication:** Agents can communicate with each other, sharing information and coordinating actions. The system prompt and message history play a key role in guiding this communication.
-* **Hierarchy:** Agent Zero uses a [hierarchical structure](architecture.md#agent-hierarchy-and-communication), with superior agents delegating tasks to subordinates.  This allows for structured problem-solving and efficient resource allocation.
+* **Hierarchy:** Magui uses a [hierarchical structure](architecture.md#agent-hierarchy-and-communication), with superior agents delegating tasks to subordinates.  This allows for structured problem-solving and efficient resource allocation.
 
 ![](res/physics.png)
 ![](res/physics-2.png)
 
 ## Prompt Engineering
-Effective prompt engineering is crucial for getting the most out of Agent Zero. Here are some tips and techniques:
+Effective prompt engineering is crucial for getting the most out of Magui. Here are some tips and techniques:
 
-* **Be Clear and Specific:** Clearly state your desired outcome.  The more specific you are, the better Agent Zero can understand and fulfill your request.  Avoid vague or ambiguous language.
+* **Be Clear and Specific:** Clearly state your desired outcome.  The more specific you are, the better Magui can understand and fulfill your request.  Avoid vague or ambiguous language.
 * **Provide Context:** If necessary, provide background information or context to help the agent understand the task better. This might include relevant details, constraints, or desired format for the response.
 * **Break Down Complex Tasks:**  For complex tasks, break them down into smaller, more manageable sub-tasks.  This makes it easier for the agent to reason through the problem and generate a solution.
 * **Iterative Refinement:** Don't expect perfect results on the first try.  Experiment with different prompts, refine your instructions based on the agent's responses, and iterate until you achieve the desired outcome. To achieve a full-stack, web-app development task, for example, you might need to iterate for a few hours for 100% success.
 
 ## Voice Interface
-Agent Zero provides both Text-to-Speech (TTS) and Speech-to-Text (STT) capabilities for natural voice interaction:
+Magui provides both Text-to-Speech (TTS) and Speech-to-Text (STT) capabilities for natural voice interaction:
 
 ### Text-to-Speech
 Enable voice responses from agents:
@@ -203,7 +203,7 @@ Configure STT settings in the Settings page:
 > When asking the agent to solve mathematical problems, it will automatically respond using KaTeX formatting for clear and professional-looking mathematical expressions.
 
 ### File Browser
-Agent Zero provides a powerful file browser interface for managing your workspace:
+Magui provides a powerful file browser interface for managing your workspace:
 
 #### Interface Overview
 - **Navigation Bar**: Shows current directory path with "Up" button for parent directory
@@ -224,7 +224,7 @@ Agent Zero provides a powerful file browser interface for managing your workspac
   - Current path always visible for context
 
 > [!NOTE]
-> The files browser allows the user to go in the Agent Zero root folder if you click the `Up` button, but the working directory of Agents will always be `/work_dir`
+> The files browser allows the user to go in the Magui root folder if you click the `Up` button, but the working directory of Agents will always be `/work_dir`
 >
 - **File Operations**:
   - Create new files and directories
@@ -240,10 +240,10 @@ Agent Zero provides a powerful file browser interface for managing your workspac
   - Select and manage multiple files at once
 
 > [!TIP]
-> The File Browser integrates seamlessly with Agent Zero's capabilities. You can reference files directly in your conversations, and the agent can help you manage, modify, and organize your files.
+> The File Browser integrates seamlessly with Magui's capabilities. You can reference files directly in your conversations, and the agent can help you manage, modify, and organize your files.
 
 ## Backup & Restore
-Agent Zero provides a comprehensive backup and restore system to protect your data and configurations. This feature helps you safeguard your work and migrate Agent Zero setups between different systems.
+Magui provides a comprehensive backup and restore system to protect your data and configurations. This feature helps you safeguard your work and migrate Magui setups between different systems.
 
 ### Creating Backups
 Access the backup functionality through the Settings interface:
@@ -253,7 +253,7 @@ Access the backup functionality through the Settings interface:
 3. Click **Create Backup** to start the backup process
 
 #### What Gets Backed Up
-By default, Agent Zero backs up your most important data:
+By default, Magui backs up your most important data:
 
 * **Knowledge Base**: Your custom knowledge files and documents
 * **Memory System**: Agent memories and learned information
@@ -283,7 +283,7 @@ Before creating a backup, you can customize what to include:
 > Backup creation may take a few minutes depending on the amount of data. You'll see progress updates during the process.
 
 ### Restoring from Backup
-The restore process allows you to recover your Agent Zero setup from a previous backup:
+The restore process allows you to recover your Magui setup from a previous backup:
 
 #### Starting a Restore
 1. Navigate to **Settings** → **Backup** tab
@@ -317,12 +317,12 @@ Optionally clean up existing files before restoring:
 #### When to Create Backups
 * **Before Major Changes**: Always backup before significant modifications
 * **Regular Schedule**: Create weekly or monthly backups of your work
-* **Before System Updates**: Backup before updating Agent Zero or system components
+* **Before System Updates**: Backup before updating Magui or system components
 * **Project Milestones**: Save backups when completing important work
 
 #### Backup Management
 * **Descriptive Names**: Use clear names like "project-completion-2024-01"
-* **External Storage**: Keep backup files in a safe location outside Agent Zero
+* **External Storage**: Keep backup files in a safe location outside Magui
 * **Multiple Versions**: Maintain several backup versions for different time periods
 * **Test Restores**: Occasionally test restoring backups to ensure they work
 
@@ -334,9 +334,9 @@ Optionally clean up existing files before restoring:
 ### Common Use Cases
 
 #### System Migration
-Moving Agent Zero to a new server or computer:
+Moving Magui to a new server or computer:
 1. Create a complete backup on the original system
-2. Install Agent Zero on the new system
+2. Install Magui on the new system
 3. Restore the backup to migrate all your data and settings
 
 #### Project Archival
@@ -352,7 +352,7 @@ Saving work-in-progress states:
 3. Restore previous versions if something goes wrong
 
 #### Team Collaboration
-Sharing Agent Zero configurations:
+Sharing Magui configurations:
 1. Create backups with shared configurations and tools
 2. Team members can restore to get consistent setups
 3. Include documentation and project files
@@ -361,4 +361,4 @@ Sharing Agent Zero configurations:
 > Always test your backup and restore process in a safe environment before relying on it for critical data. Keep multiple backup versions and store them in secure, accessible locations.
 
 > [!TIP]
-> The backup system is designed to work across different operating systems and Agent Zero installations. Your backups from a Windows system will work on Linux, and vice versa.
+> The backup system is designed to work across different operating systems and Magui installations. Your backups from a Windows system will work on Linux, and vice versa.

--- a/knowledge/default/main/about/github_readme.md
+++ b/knowledge/default/main/about/github_readme.md
@@ -1,32 +1,32 @@
-![Agent Zero Logo](res/header.png)
-# Agent Zero Documentation
-To begin with Agent Zero, follow the links below for detailed guides on various topics:
+![Magui Logo](res/header.png)
+# Magui Documentation
+To begin with Magui, follow the links below for detailed guides on various topics:
 
-- **[Installation](installation.md):** Set up (or [update](installation.md#how-to-update-agent-zero)) Agent Zero on your system.
+- **[Installation](installation.md):** Set up (or [update](installation.md#how-to-update-agent-zero)) Magui on your system.
 - **[Usage Guide](usage.md):** Explore GUI features and usage scenarios.
 - **[Architecture Overview](architecture.md):** Understand the internal workings of the framework.
-- **[Contributing](contribution.md):** Learn how to contribute to the Agent Zero project.
+- **[Contributing](contribution.md):** Learn how to contribute to the Magui project.
 - **[Troubleshooting and FAQ](troubleshooting.md):** Find answers to common issues and questions.
 
-### Your experience with Agent Zero starts now!
+### Your experience with Magui starts now!
 
-- **Download Agent Zero:** Follow the [installation guide](installation.md) to download and run Agent Zero.
-- **Join the Community:** Join the Agent Zero [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community to discuss ideas, ask questions, and collaborate with other contributors.
-- **Share your Work:** Share your Agent Zero creations, workflows and discoverings on our [Show and Tell](https://github.com/agent0ai/agent-zero/discussions/categories/show-and-tell) area on GitHub.
+- **Download Magui:** Follow the [installation guide](installation.md) to download and run Magui.
+- **Join the Community:** Join the Magui [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community to discuss ideas, ask questions, and collaborate with other contributors.
+- **Share your Work:** Share your Magui creations, workflows and discoverings on our [Show and Tell](https://github.com/agent0ai/agent-zero/discussions/categories/show-and-tell) area on GitHub.
 - **Report Issues:** Use the [GitHub issue tracker](https://github.com/agent0ai/agent-zero/issues) to report framework-relative bugs or suggest new features.
 
 ## Table of Contents
 
-- [Welcome to the Agent Zero Documentation](#agent-zero-documentation)
-  - [Your Experience with Agent Zero](#your-experience-with-agent-zero-starts-now)
+- [Welcome to the Magui Documentation](#agent-zero-documentation)
+  - [Your Experience with Magui](#your-experience-with-agent-zero-starts-now)
   - [Table of Contents](#table-of-contents)
 - [Installation Guide](installation.md)
   - [Windows, macOS and Linux Setup](installation.md#windows-macos-and-linux-setup-guide)
   - [Settings Configuration](installation.md#settings-configuration)
   - [Choosing Your LLMs](installation.md#choosing-your-llms)
   - [Installing and Using Ollama](installation.md#installing-and-using-ollama-local-models)
-  - [Using Agent Zero on Mobile](installation.md#using-agent-zero-on-your-mobile-device)
-  - [How to Update Agent Zero](installation.md#how-to-update-agent-zero)
+  - [Using Magui on Mobile](installation.md#using-agent-zero-on-your-mobile-device)
+  - [How to Update Magui](installation.md#how-to-update-agent-zero)
   - [Full Binaries Installation](installation.md#in-depth-guide-for-full-binaries-installation)
 - [Usage Guide](usage.md)
   - [Basic Operations](usage.md#basic-operations)

--- a/knowledge/default/main/about/installation.md
+++ b/knowledge/default/main/about/installation.md
@@ -1,17 +1,17 @@
-# Users installation guide for Windows, macOS and Linux
+# Users installation guide for Magui
 
-Click to open a video to learn how to install Agent Zero:
+Click to open a video to learn how to install Magui:
 
 [![Easy Installation guide](/docs/res/easy_ins_vid.png)](https://www.youtube.com/watch?v=w5v5Kjx51hs)
 
-The following user guide provides instructions for installing and running Agent Zero using Docker, which is the primary runtime environment for the framework. For developers and contributors, we also provide instructions for setting up the [full development environment](#in-depth-guide-for-full-binaries-installation).
+The following user guide provides instructions for installing and running Magui using Docker, which is the primary runtime environment for the framework. For developers and contributors, we also provide instructions for setting up the [full development environment](#in-depth-guide-for-full-binaries-installation).
 
 
 ## Windows, macOS and Linux Setup Guide
 
 
 1. **Install Docker Desktop:** 
-- Docker Desktop provides the runtime environment for Agent Zero, ensuring consistent behavior and security across platforms
+- Docker Desktop provides the runtime environment for Magui, ensuring consistent behavior and security across platforms
 - The entire framework runs within a Docker container, providing isolation and easy deployment
 - Available as a user-friendly GUI application for all major operating systems
 
@@ -56,11 +56,11 @@ The following user guide provides instructions for installing and running Agent 
 
 ![docker socket macOS](res/setup/macsocket.png)
 
-2. **Run Agent Zero:**
+2. **Run Magui:**
 
-- Note: Agent Zero also offers a Hacking Edition based on Kali linux with modified prompts for cybersecurity tasks. The setup is the same as the regular version, just use the agent0ai/agent-zero:hacking image instead of agent0ai/agent-zero.
+- Note: Magui also offers a Hacking Edition based on Kali linux with modified prompts for cybersecurity tasks. The setup is the same as the regular version, just use the agent0ai/agent-zero:hacking image instead of agent0ai/agent-zero.
 
-2.1. Pull the Agent Zero Docker image:
+2.1. Pull the Magui Docker image:
 - Search for `agent0ai/agent-zero` in Docker Desktop
 - Click the `Pull` button
 - The image will be downloaded to your machine in a few minutes
@@ -75,19 +75,19 @@ The following user guide provides instructions for installing and running Agent 
 > ```
 
 2.2. Create a data directory for persistence:
-- Choose or create a directory on your machine where you want to store Agent Zero's data
-- This can be any location you prefer (e.g., `C:/agent-zero-data` or `/home/user/agent-zero-data`)
-- This directory will contain all your Agent Zero files, like the legacy root folder structure:
+- Choose or create a directory on your machine where you want to store Magui's data
+- This can be any location you prefer (e.g., `C:/magui-data` or `/home/user/magui-data`)
+- This directory will contain all your Magui files, like the legacy root folder structure:
   - `/memory` - Agent's memory and learned information
   - `/knowledge` - Knowledge base
   - `/instruments` - Instruments and functions
   - `/prompts` - Prompt files
   - `/work_dir` - Working directory
   - `.env` - Your API keys
-  - `settings.json` - Your Agent Zero settings
+  - `settings.json` - Your Magui settings
 
 > [!TIP]
-> Choose a location that's easy to access and backup. All your Agent Zero data 
+> Choose a location that's easy to access and backup. All your Magui data 
 > will be directly accessible in this directory.
 
 2.3. Run the container:
@@ -98,7 +98,7 @@ The following user guide provides instructions for installing and running Agent 
 
 Optionally you can map local folders for file persistence:
 - Under "Volumes", configure:
-  - Host path: Your chosen directory (e.g., `C:\agent-zero-data`)
+  - Host path: Your chosen directory (e.g., `C:\magui-data`)
   - Container path: `/a0`
 
 ![docker port mapping](res/setup/3-docker-port-mapping.png)
@@ -123,7 +123,7 @@ Optionally you can map local folders for file persistence:
 ![docker logs](res/setup/5-docker-click-to-open.png)
 
 - Open `http://localhost:<PORT>` in your browser
-- The Web UI will open. Agent Zero is ready for configuration!
+- The Web UI will open. Magui is ready for configuration!
 
 ![docker ui](res/setup/6-docker-a0-running.png)
 
@@ -131,15 +131,15 @@ Optionally you can map local folders for file persistence:
 > You can also access the Web UI by clicking the ports right under the container ID in Docker Desktop.
 
 > [!NOTE]
-> After starting the container, you'll find all Agent Zero files in your chosen 
+> After starting the container, you'll find all Magui files in your chosen 
 > directory. You can access and edit these files directly on your machine, and 
 > the changes will be immediately reflected in the running container.
 
-3. Configure Agent Zero
-- Refer to the following sections for a full guide on how to configure Agent Zero.
+3. Configure Magui
+- Refer to the following sections for a full guide on how to configure Magui.
 
 ## Settings Configuration
-Agent Zero provides a comprehensive settings interface to customize various aspects of its functionality. Access the settings by clicking the "Settings"button with a gear icon in the sidebar.
+Magui provides a comprehensive settings interface to customize various aspects of its functionality. Access the settings by clicking the "Settings"button with a gear icon in the sidebar.
 
 ### Agent Configuration
 - **Prompts Subdirectory:** Choose the subdirectory within `/prompts` for agent behavior customization. The 'default' directory contains the standard prompts.
@@ -190,7 +190,7 @@ Learn more about Remote Function Calls and their purpose [here](#7-configure-age
 > Always keep your API keys and passwords secure.
 
 # Choosing Your LLMs
-The Settings page is the control center for selecting the Large Language Models (LLMs) that power Agent Zero.  You can choose different LLMs for different roles:
+The Settings page is the control center for selecting the Large Language Models (LLMs) that power Magui.  You can choose different LLMs for different roles:
 
 | LLM Role | Description |
 | --- | --- |
@@ -208,7 +208,7 @@ The Settings page is the control center for selecting the Large Language Models 
 > [!CAUTION]
 > Changing the `embedding_llm` will re-index all the memory and knowledge, and 
 > requires clearing the `memory` folder to avoid errors, as the embeddings can't be 
-> mixed in the vector database. Note that this will DELETE ALL of Agent Zero's memory.
+> mixed in the vector database. Note that this will DELETE ALL of Magui's memory.
 
 ## Installing and Using Ollama (Local Models)
 If you're interested in Ollama, which is a powerful tool that allows you to run various large language models locally, here's how to install and use it:
@@ -244,7 +244,7 @@ ollama pull <model-name>
 
 2. A CLI message should confirm the model download on your system
 
-#### Selecting your model within Agent Zero
+#### Selecting your model within Magui
 1. Once you've downloaded your model(s), you must select it in the Settings page of the GUI. 
 
 2. Within the Chat model, Utility model, or Embedding model section, choose Ollama as provider.
@@ -272,8 +272,8 @@ Once you've downloaded some models, you might want to check which ones you have 
 
 - Experiment with different model combinations to find the balance of performance and cost that best suits your needs. E.g., faster and lower latency LLMs will help, and you can also use `faiss_gpu` instead of `faiss_cpu` for the memory.
 
-## Using Agent Zero on your mobile device
-Agent Zero's Web UI is accessible from any device on your network through the Docker container:
+## Using Magui on your mobile device
+Magui's Web UI is accessible from any device on your network through the Docker container:
 
 1. The Docker container automatically exposes the Web UI on all network interfaces
 2. Find the mapped port in Docker Desktop:
@@ -289,27 +289,31 @@ Agent Zero's Web UI is accessible from any device on your network through the Do
 > - The port is automatically assigned by Docker unless you specify one
 
 > [!NOTE]
-> If you're running Agent Zero directly on your system (legacy approach) instead of 
+> If you're running Magui directly on your system (legacy approach) instead of 
 > using Docker, you'll need to configure the host manually in `run_ui.py` to run on all interfaces using `host="0.0.0.0"`.
 
-For developers or users who need to run Agent Zero directly on their system,see the [In-Depth Guide for Full Binaries Installation](#in-depth-guide-for-full-binaries-installation).
+For developers or users who need to run Magui directly on their system,see the [In-Depth Guide for Full Binaries Installation](#in-depth-guide-for-full-binaries-installation).
 
-# How to update Agent Zero
+# How to update Magui
 
-1. **If you come from the previous version of Agent Zero:**
-- Your data is safely stored across various directories and files inside the Agent Zero folder.
+> [!NOTE]
+> Since v0.9, Magui has a Backup and Restore feature, so you don't need to backup the files manually.
+> In Settings, Backup and Restore tab will guide you through the process.
+
+1. **If you come from the previous version of Magui:**
+- Your data is safely stored across various directories and files inside the Magui folder.
 - To update to the new Docker runtime version, you might want to backup the following files and directories:
   - `/memory` - Agent's memory
   - `/knowledge` - Custom knowledge base (if you imported any custom knowledge files)
   - `/instruments` - Custom instruments and functions (if you created any custom)
-  - `/tmp/settings.json` - Your Agent Zero settings
+  - `/tmp/settings.json` - Your Magui settings
   - `/tmp/chats/` - Your chat history
 - Once you have saved these files and directories, you can proceed with the Docker runtime [installation instructions above](#windows-macos-and-linux-setup-guide) setup guide.
-- Reach for the folder where you saved your data and copy it to the new Agent Zero folder set during the installation process.
-- Agent Zero will automatically detect your saved data and use it across memory, knowledge, instruments, prompts and settings.
+- Reach for the folder where you saved your data and copy it to the new Magui folder set during the installation process.
+- Magui will automatically detect your saved data and use it across memory, knowledge, instruments, prompts and settings.
 
 > [!IMPORTANT]
-> If you have issues loading your settings, you can try to delete the `/tmp/settings.json` file and let Agent Zero generate a new one.
+> If you have issues loading your settings, you can try to delete the `/tmp/settings.json` file and let Magui generate a new one.
 > The same goes for chats in `/tmp/chats/`, they might be incompatible with the new version
 
 2. **Update Process (Docker Desktop)**
@@ -325,7 +329,7 @@ For developers or users who need to run Agent Zero directly on their system,see 
 > [!IMPORTANT]
 > Make sure to use the same volume mount path when running the new
 > container to preserve your data. The exact path depends on where you stored
-> your Agent Zero data directory (the chosen directory on your machine).
+> your Magui data directory (the chosen directory on your machine).
 
 > [!TIP]
 > Alternatively, run the following commands in your terminal:
@@ -348,7 +352,7 @@ For developers or users who need to run Agent Zero directly on their system,see 
 > ```
 
 3. **Full Binaries**
-- Using Git/GitHub: Pull the latest version of the Agent Zero repository. 
+- Using Git/GitHub: Pull the latest version of the Magui repository. 
 - The custom knowledge, solutions, memory, and other data will get ignored, so you don't need to worry about losing any of your custom data. The same goes for your .env file with all of your API keys and settings.json.
 
 > [!WARNING]  
@@ -358,18 +362,18 @@ For developers or users who need to run Agent Zero directly on their system,see 
 > pip install -r requirements.txt
 
 # In-Depth Guide for Full Binaries Installation
-- Agent Zero is a framework. It's made to be customized, edited, enhanced. Therefore you need to install the necessary components to run it when downloading its full binaries. This guide will help you to do so.
-- The following step by step instructions can be followed along with a video for this tutorial on how to make Agent Zero work with its full development environment.
+- Magui is a framework. It's made to be customized, edited, enhanced. Therefore you need to install the necessary components to run it when downloading its full binaries. This guide will help you to do so.
+- The following step by step instructions can be followed along with a video for this tutorial on how to make Magui work with its full development environment.
 
 [![Video](res/setup/thumb_play.png)](https://youtu.be/8H7mFsvxKYQ)
 
 ## Reminders:
 1. There's no need to install Python, Conda will manage that for you.
-2. You don't necessarily need API keys: Agent Zero can run with local models. For this tutorial though, we will leave it to the default OpenAI API. A guide for downloading Ollama along with local models is available [here](#installing-and-using-ollama-local-models).
+2. You don't necessarily need API keys: Magui can run with local models. For this tutorial though, we will leave it to the default OpenAI API. A guide for downloading Ollama along with local models is available [here](#installing-and-using-ollama-local-models).
 3. Visual Studio Code or any other code editor is not mandatory, but it makes it easier to navigate and edit files.
 4. Git/GitHub is not mandatory, you can download the framework files through your browser. We will not be showing how to use Git in this tutorial.
 5. Docker is not mandatory for the full binaries installation, since the framework will run on your machine connecting to the Docker container through the Web UI RFC functionality.
-6. Running Agent Zero without Docker makes the process more complicated and it's thought for developers and contributors.
+6. Running Magui without Docker makes the process more complicated and it's thought for developers and contributors.
 
 > [!IMPORTANT]  
 > Linux instructions are provided as general instructions for any Linux distribution. If you're using a distribution other than Debian/Ubuntu, you may need to adjust the instructions accordingly.
@@ -402,24 +406,24 @@ For developers or users who need to run Agent Zero directly on their system,see 
 <br><br>
 
 
-## 2. Download Agent Zero
-- You can clone the Agent Zero repository (https://github.com/agent0ai/agent-zero) from GitHub if you know how to use Git. In this tutorial I will just show how to download the files.
+## 2. Download Magui
+- You can clone the Magui repository (https://github.com/agent0ai/agent-zero) from GitHub if you know how to use Git. In this tutorial I will just show how to download the files.
 
-1. Go to the Agent Zero releases [here](https://github.com/agent0ai/agent-zero/releases).
+1. Go to the Magui releases [here](https://github.com/agent0ai/agent-zero/releases).
 2. The latest release is on the top of the list, click the "Source Code (zip)" button under "Assets" to download it.
 
 <img src="res/setup/image-14-u.png" alt="agent zero download" width="500"/>
 <br><br>
 
-3. Extract the downloaded archive where you want to have it. I will extract them to "agent-zero" folder on my Desktop - "C:\Users\frdel\Desktop\agent-zero" on Windows and "/Users/frdel/Desktop/agent-zero" on macOS.
+3. Extract the downloaded archive where you want to have it. I will extract them to "agent-zero" folder on my Desktop - "C:\Users\frdel\Desktop\magui" on Windows and "/Users/frdel/Desktop/agent-zero" on macOS.
 
 ## 3. Set up Conda environment
 - Now that we have the project files and Conda, we can create **virtual Python environment** for this project, activate it and install requirements.
 
 1. Open your **"Anaconda Powershell Prompt"** application on windows or **"Terminal"** application on macOS.
-2. In the terminal, navigate to your Agent Zero folder using **"cd"** command. Replace the path with your actual Agent Zero folder path.
+2. In the terminal, navigate to your Magui folder using **"cd"** command. Replace the path with your actual Magui folder path.
 ~~~
-cd C:\Users\frdel\Desktop\agent-zero
+cd C:\Users\frdel\Desktop\magui
 ~~~
 You should see your folder has changed on the next terminal line.
 
@@ -427,7 +431,7 @@ You should see your folder has changed on the next terminal line.
 <img src="res/setup/image-16.png" alt="agent zero cd" height="100"/>
 <br><br>
 
-3. Create Conda environment using command **"conda create"**. After **"-n"** is your environment name, you can choose your own, i will use **"a0"** - short for Agent Zero. After **"python"** is the Python version that Conda will install for you into this environment, right now, 3.12 works fine. **-y** skips confirmations.
+3. Create Conda environment using command **"conda create"**. After **"-n"** is your environment name, you can choose your own, i will use **"a0"** - short for Magui. After **"python"** is the Python version that Conda will install for you into this environment, right now, 3.12 works fine. **-y** skips confirmations.
 ~~~
 conda create -n a0 python=3.12 -y
 ~~~
@@ -456,8 +460,8 @@ This might take some time. If you get any errors regarding version conflicts and
 <br><br>
 
 ## 4. Install Docker (Docker Desktop application)
-Simply put, Docker is a way of running virtual computers on your machine. These are lightweight, disposable and isolated from your operating system, so it is a way to sandbox Agent Zero.
-- Agent Zero only connects to the Docker container when it needs to execute code and commands. The frameworks itself runs on your machine.
+Simply put, Docker is a way of running virtual computers on your machine. These are lightweight, disposable and isolated from your operating system, so it is a way to sandbox Magui.
+- Magui only connects to the Docker container when it needs to execute code and commands. The frameworks itself runs on your machine.
 - Docker has a desktop application with GUI for all major operating system, which is the recommended way to install it.
 
 1. Go to the download page of Docker Desktop [here](https://www.docker.com/products/docker-desktop/). If the link does not work, just search the web for "docker desktop download".
@@ -487,7 +491,7 @@ Simply put, Docker is a way of running virtual computers on your machine. These 
 > [!IMPORTANT]  
 > **Important macOS-only Docker Configuration:** In Docker Desktop's preferences 
 > (Docker menu) go to Settings, navigate to "Advanced" and check "Allow the default 
-> Docker socket to be used (requires password)."  This allows Agent Zero to 
+> Docker socket to be used (requires password)."  This allows Magui to 
 > communicate with the Docker daemon.
 
 ![docker socket macOS](res/setup/macsocket.png)
@@ -502,16 +506,16 @@ Simply put, Docker is a way of running virtual computers on your machine. These 
 > Login in the Docker CLI with `docker login` and provide your Docker Hub credentials.
 
 6. Pull the Docker image
-- Agent Zero needs a Docker image to be pulled from the Docker Hub to be run, even when using the full binaries.
+- Magui needs a Docker image to be pulled from the Docker Hub to be run, even when using the full binaries.
 You can refer to the [installation instructions above](#windows-macos-and-linux-setup-guide) to run the Docker container and then resume from the next step. There are two differences:
   - You need to map two ports instead of one:
     - 55022 in the first field to run the Remote Function Call SSH
     - 0 in the second field to run the Web UI in automatic port assignment
-  - You need to map the `/a0` volume to the location of your local Agent Zero folder.
+  - You need to map the `/a0` volume to the location of your local Magui folder.
 - Run the Docker container following the instructions.
 
-## 5. Run the local Agent Zero instance
-Run the Agent Zero with Web UI:
+## 5. Run the local Magui instance
+Run the Magui with Web UI:
 ~~~
 python run_ui.py
 ~~~
@@ -519,13 +523,13 @@ python run_ui.py
 <img src="res/setup/image-21.png" alt="run ui" height="110"/>
 <br><br>
 
-- Open the URL shown in terminal in your web browser. You should see the Agent Zero interface.
+- Open the URL shown in terminal in your web browser. You should see the Magui interface.
 
-## 6. Configure Agent Zero
-Now we can configure Agent Zero - select models, settings, API Keys etc. Refer to the [Usage](usage.md#agent-configuration) guide for a full guide on how to configure Agent Zero.
+## 6. Configure Magui
+Now we can configure Magui - select models, settings, API Keys etc. Refer to the [Usage](usage.md#agent-configuration) guide for a full guide on how to configure Magui.
 
-## 7. Configure Agent Zero RFC
-Agent Zero needs to be configured further to redirect some functions to the Docker container. This is crucial for development as A0 needs to run in a standardized environment to support all features.
+## 7. Configure Magui RFC
+Magui needs to be configured further to redirect some functions to the Docker container. This is crucial for development as A0 needs to run in a standardized environment to support all features.
 1. Go in "Settings" page in the Web UI of your local instance and go in the "Development" section.
 2. Set "RFC Destination URL" to `http://localhost`
 3. Set the two ports (HTTP and SSH) to the ones used when creating the Docker container
@@ -540,7 +544,7 @@ Agent Zero needs to be configured further to redirect some functions to the Dock
 6. This time the page has only the password field, set it to the same password you used when creating the Docker container.
 7. Click "Save"
 8. Use the Development environment
-9. Now you have the full development environment to work on Agent Zero.
+9. Now you have the full development environment to work on Magui.
 
 <img src="res/setup/image-22-1.png" alt="run ui" width="400"/>
 <img src="res/setup/image-23-1.png" alt="run ui" width="400"/>
@@ -548,7 +552,7 @@ Agent Zero needs to be configured further to redirect some functions to the Dock
 
       
 ### Conclusion
-After following the instructions for your specific operating system, you should have Agent Zero successfully installed and running. You can now start exploring the framework's capabilities and experimenting with creating your own intelligent agents. 
+After following the instructions for your specific operating system, you should have Magui successfully installed and running. You can now start exploring the framework's capabilities and experimenting with creating your own intelligent agents. 
 
-If you encounter any issues during the installation process, please consult the [Troubleshooting section](troubleshooting.md) of this documentation or refer to the Agent Zero [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community for assistance.
+If you encounter any issues during the installation process, please consult the [Troubleshooting section](troubleshooting.md) of this documentation or refer to the Magui [Skool](https://www.skool.com/agent-zero) or [Discord](https://discord.gg/B8KZKNsPpj) community for assistance.
 

--- a/models.py
+++ b/models.py
@@ -833,7 +833,7 @@ def _adjust_call_args(provider_name: str, model_name: str, kwargs: dict):
     if provider_name == "openrouter":
         kwargs["extra_headers"] = {
             "HTTP-Referer": "https://agent-zero.ai",
-            "X-Title": "Agent Zero",
+            "X-Title": "Magui",
         }
 
     # remap other to openai for litellm

--- a/prompts/agent.system.main.md
+++ b/prompts/agent.system.main.md
@@ -1,4 +1,4 @@
-# Agent Zero System Manual
+# Magui System Manual
 
 {{ include "agent.system.main.role.md" }}
 

--- a/prompts/agent.system.main.role.md
+++ b/prompts/agent.system.main.role.md
@@ -1,5 +1,5 @@
 ## Your role
-agent zero autonomous json ai agent
+magui autonomous json ai agent
 solve superior tasks using tools and subordinates 
 follow behavioral rules instructions
 execute code actions yourself not instruct superior

--- a/prompts/agent.system.tool.a2a_chat.md
+++ b/prompts/agent.system.tool.a2a_chat.md
@@ -1,5 +1,5 @@
 ### a2a_chat:
-This tool lets Agent Zero chat with any other FastA2A-compatible agent.
+This tool lets Magui chat with any other FastA2A-compatible agent.
 It automatically keeps conversation **context** (so each subsequent call
 continues the same dialogue) and supports optional file attachments.
 

--- a/prompts/agent.system.tool.scheduler.md
+++ b/prompts/agent.system.tool.scheduler.md
@@ -1,5 +1,5 @@
 ## Task Scheduler Subsystem:
-The task scheduler is a part of agent-zero enabling the system to execute
+The task scheduler is a part of Magui enabling the system to execute
 arbitrary tasks defined by a "system prompt" and "user prompt".
 
 When the task is executed the prompts are being run in the background in a context

--- a/prompts/fw.initial_message.md
+++ b/prompts/fw.initial_message.md
@@ -8,7 +8,7 @@
     "headline": "Greeting user and starting conversation",
     "tool_name": "response",
     "tool_args": {
-        "text": "**Hello! 👋**, I'm **Agent Zero**, your AI assistant. How can I help you today?"
+        "text": "**Hello! 👋**, I'm **Magui**, your AI assistant. How can I help you today?"
     }
 }
 ```

--- a/prompts/memory.consolidation.sys.md
+++ b/prompts/memory.consolidation.sys.md
@@ -1,6 +1,6 @@
 # Memory Consolidation Analysis System
 
-You are an intelligent memory consolidation specialist for the Agent Zero memory management system. Your role is to analyze new memories against existing similar memories and determine the optimal consolidation strategy to maintain high-quality, organized memory storage.
+You are an intelligent memory consolidation specialist for the Magui memory management system. Your role is to analyze new memories against existing similar memories and determine the optimal consolidation strategy to maintain high-quality, organized memory storage.
 
 ## Your Mission
 

--- a/prompts/memory.keyword_extraction.sys.md
+++ b/prompts/memory.keyword_extraction.sys.md
@@ -1,6 +1,6 @@
 # Memory Keyword Extraction System
 
-You are a specialized keyword extraction system for the Agent Zero memory management. Your task is to analyze memory content and extract relevant search keywords and phrases that can be used to find similar memories in the database.
+You are a specialized keyword extraction system for the Magui memory management. Your task is to analyze memory content and extract relevant search keywords and phrases that can be used to find similar memories in the database.
 
 ## Your Role
 

--- a/python/api/api_files_get.py
+++ b/python/api/api_files_get.py
@@ -53,7 +53,7 @@ class ApiFilesGet(ApiHandler):
                         external_path = files.get_abs_path("tmp/uploads", filename)
                         filename = os.path.basename(external_path)
                     elif path.startswith("/a0/"):
-                        # Other internal Agent Zero paths
+                        # Other internal Magui paths
                         relative_path = path.replace("/a0/", "")
                         external_path = files.get_abs_path(relative_path)
                         filename = os.path.basename(external_path)

--- a/python/api/backup_create.py
+++ b/python/api/backup_create.py
@@ -18,7 +18,7 @@ class BackupCreate(ApiHandler):
             include_patterns = input.get("include_patterns", [])
             exclude_patterns = input.get("exclude_patterns", [])
             include_hidden = input.get("include_hidden", False)
-            backup_name = input.get("backup_name", "agent-zero-backup")
+            backup_name = input.get("backup_name", "magui-backup")
 
             # Support legacy string patterns format for backward compatibility
             patterns_string = input.get("patterns", "")

--- a/python/extensions/user_message_ui/_10_update_check.py
+++ b/python/extensions/user_message_ui/_10_update_check.py
@@ -49,7 +49,7 @@ class UpdateCheck(Extension):
         notifs = self.agent.context.get_notification_manager()
         notifs.send_notification(
             title=notif.get("title", "Newer version available"),
-            message=notif.get("message", "A newer version of Agent Zero is available. Please update to the latest version."),
+            message=notif.get("message", "A newer version of Magui is available. Please update to the latest version."),
             type=notif.get("type", "info"),
             detail=notif.get("detail", ""),
             display_time=notif.get("display_time", 10),

--- a/python/helpers/backup.py
+++ b/python/helpers/backup.py
@@ -15,7 +15,7 @@ from python.helpers.print_style import PrintStyle
 
 class BackupService:
     """
-    Core backup and restore service for Agent Zero.
+    Core backup and restore service for Magui.
 
     Features:
     - JSON-based metadata with user-editable path specifications
@@ -26,12 +26,12 @@ class BackupService:
     """
 
     def __init__(self):
-        self.agent_zero_version = self._get_agent_zero_version()
-        self.agent_zero_root = files.get_abs_path("")  # Resolved Agent Zero root
+        self.magui_version = self._get_magui_version()
+        self.magui_root = files.get_abs_path("")  # Resolved Magui root
 
         # Build base paths map for pattern resolution
         self.base_paths = {
-            self.agent_zero_root: self.agent_zero_root,
+            self.magui_root: self.magui_root,
         }
 
     def get_default_backup_metadata(self) -> Dict[str, Any]:
@@ -42,7 +42,7 @@ class BackupService:
         include_patterns, exclude_patterns = self._parse_patterns(default_patterns)
 
         return {
-            "backup_name": f"agent-zero-backup-{timestamp[:10]}",
+            "backup_name": f"magui-backup-{timestamp[:10]}",
             "include_hidden": False,
             "include_patterns": include_patterns,
             "exclude_patterns": exclude_patterns,
@@ -55,16 +55,16 @@ class BackupService:
     def _get_default_patterns(self) -> str:
         """Get default backup patterns with resolved absolute paths.
 
-        Only includes Agent Zero project directory patterns.
+        Only includes Magui project directory patterns.
         """
         # Ensure paths don't have double slashes
-        agent_root = self.agent_zero_root.rstrip('/')
+        agent_root = self.magui_root.rstrip('/')
 
-        return f"""# Agent Zero Knowledge (excluding defaults)
+        return f"""# Magui Knowledge (excluding defaults)
 {agent_root}/knowledge/**
 !{agent_root}/knowledge/default/**
 
-# Agent Zero Instruments (excluding defaults)
+# Magui Instruments (excluding defaults)
 {agent_root}/instruments/**
 !{agent_root}/instruments/default/**
 
@@ -84,8 +84,8 @@ class BackupService:
 {agent_root}/usr/**
 """
 
-    def _get_agent_zero_version(self) -> str:
-        """Get current Agent Zero version"""
+    def _get_magui_version(self) -> str:
+        """Get current Magui version"""
         try:
             # Get version from git info (same as run_ui.py)
             gitinfo = git.get_git_info()
@@ -166,7 +166,7 @@ class BackupService:
                 "path": os.environ.get("PATH", "")[:200] + "..." if len(os.environ.get("PATH", "")) > 200 else os.environ.get("PATH", ""),
                 "timezone": str(datetime.datetime.now().astimezone().tzinfo),
                 "working_directory": os.getcwd(),
-                "agent_zero_root": files.get_abs_path(""),
+                "magui_root": files.get_abs_path(""),
                 "runtime_mode": "development" if runtime.is_development() else "production"
             }
         except Exception as e:
@@ -217,22 +217,22 @@ class BackupService:
     def _translate_patterns(self, patterns: List[str], backup_metadata: Dict[str, Any]) -> List[str]:
         """Translate patterns from backed up system to current system.
 
-        Replaces the backed up Agent Zero root path with the current Agent Zero root path
+        Replaces the backed up Magui root path with the current Magui root path
         in all patterns if there's an exact match at the beginning of the pattern.
 
         Args:
             patterns: List of patterns from the backed up system
-            backup_metadata: Backup metadata containing the original agent_zero_root
+            backup_metadata: Backup metadata containing the original magui_root
 
         Returns:
             List of translated patterns for the current system
         """
         # Get the backed up agent zero root path from metadata
         environment_info = backup_metadata.get("environment_info", {})
-        backed_up_agent_root = environment_info.get("agent_zero_root", "")
+        backed_up_agent_root = environment_info.get("magui_root", "")
 
         # Get current agent zero root path
-        current_agent_root = self.agent_zero_root
+        current_agent_root = self.magui_root
 
         # If we don't have the backed up root path, return patterns as-is
         if not backed_up_agent_root:
@@ -349,7 +349,7 @@ class BackupService:
         include_patterns: List[str],
         exclude_patterns: List[str],
         include_hidden: bool = False,
-        backup_name: str = "agent-zero-backup"
+        backup_name: str = "magui-backup"
     ) -> str:
         """Create backup archive and return path to created file"""
 
@@ -774,22 +774,22 @@ class BackupService:
     def _translate_restore_path(self, archive_path: str, backup_metadata: Dict[str, Any]) -> str:
         """Translate file path from backed up system to current system.
 
-        Replaces the backed up Agent Zero root path with the current Agent Zero root path
+        Replaces the backed up Magui root path with the current Magui root path
         if there's an exact match at the beginning of the path.
 
         Args:
             archive_path: Original file path from the archive
-            backup_metadata: Backup metadata containing the original agent_zero_root
+            backup_metadata: Backup metadata containing the original magui_root
 
         Returns:
             Translated path for the current system
         """
         # Get the backed up agent zero root path from metadata
         environment_info = backup_metadata.get("environment_info", {})
-        backed_up_agent_root = environment_info.get("agent_zero_root", "")
+        backed_up_agent_root = environment_info.get("magui_root", "")
 
         # Get current agent zero root path
-        current_agent_root = self.agent_zero_root
+        current_agent_root = self.magui_root
 
         # If we don't have the backed up root path, use original path with leading slash
         if not backed_up_agent_root:

--- a/python/helpers/email_client.py
+++ b/python/helpers/email_client.py
@@ -498,7 +498,7 @@ class EmailClient:
         """
         Save attachment to disk and return absolute path.
 
-        Uses Agent Zero's file helpers for path management.
+        Uses Magui's file helpers for path management.
         """
         # Sanitize filename
         filename = files.safe_file_name(filename)

--- a/python/helpers/fasta2a_client.py
+++ b/python/helpers/fasta2a_client.py
@@ -14,7 +14,7 @@ _PRINTER = PrintStyle(italic=True, font_color="cyan", padding=False)
 
 
 class AgentConnection:
-    """Helper class for connecting to and communicating with other Agent Zero instances via FastA2A."""
+    """Helper class for connecting to and communicating with other Magui instances via FastA2A."""
 
     def __init__(self, agent_url: str, timeout: int = 30, token: Optional[str] = None):
         """Initialize connection to an agent.
@@ -186,6 +186,20 @@ class AgentConnection:
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Async context manager exit."""
         await self.close()
+
+    async def _save_attachment_bytes(
+        self,
+        filename: str,
+        content: bytes,
+        download_folder: str,
+    ) -> str:
+        """
+        Save attachment to disk and return absolute path.
+
+        Uses Magui's file helpers for path management.
+        """
+        # Sanitize filename
+        filename = files.safe_file_name(filename)
 
 
 async def connect_to_agent(agent_url: str, timeout: int = 30) -> AgentConnection:

--- a/python/helpers/fasta2a_server.py
+++ b/python/helpers/fasta2a_server.py
@@ -61,15 +61,15 @@ except ImportError:  # pragma: no cover – library not installed
 _PRINTER = PrintStyle(italic=True, font_color="purple", padding=False)
 
 
-class AgentZeroWorker(Worker):  # type: ignore[misc]
-    """Agent Zero implementation of FastA2A Worker."""
+class MaguiWorker(Worker):  # type: ignore[misc]
+    """Magui implementation of FastA2A Worker."""
 
     def __init__(self, broker, storage):
         super().__init__(broker=broker, storage=storage)
         self.storage = storage
 
     async def run_task(self, params: Any) -> None:  # params: TaskSendParams
-        """Execute a task by processing the message through Agent Zero."""
+        """Execute a task by processing the message through Magui."""
         context = None
         try:
             task_id = params['id']
@@ -77,7 +77,7 @@ class AgentZeroWorker(Worker):  # type: ignore[misc]
 
             _PRINTER.print(f"[A2A] Processing task {task_id} with new temporary context")
 
-            # Convert A2A message to Agent Zero format
+            # Convert A2A message to Magui format
             agent_message = self._convert_message(message)
 
             # Always create new temporary context for this A2A conversation
@@ -93,7 +93,7 @@ class AgentZeroWorker(Worker):  # type: ignore[misc]
                 temp=False,
             )
 
-            # Process message through Agent Zero (includes response)
+            # Process message through Magui (includes response)
             task = context.communicate(agent_message)
             result_text = await task.result()
 
@@ -149,7 +149,7 @@ class AgentZeroWorker(Worker):  # type: ignore[misc]
         return []
 
     def _convert_message(self, a2a_message: Message) -> UserMessage:  # type: ignore
-        """Convert A2A message to Agent Zero UserMessage."""
+        """Convert A2A message to Magui UserMessage."""
         # Extract text from message parts
         text_parts = [part.get('text', '') for part in a2a_message.get('parts', []) if part.get('kind') == 'text']
         message_text = '\n'.join(text_parts)
@@ -207,12 +207,12 @@ class DynamicA2AProxy:
                 _PRINTER.print("[A2A] Reconfiguration scheduled for next request")
 
     def _configure(self):
-        """Configure the FastA2A application with Agent Zero integration."""
+        """Configure the FastA2A application with Magui integration."""
         try:
             storage = InMemoryStorage()  # type: ignore[arg-type]
             broker = InMemoryBroker()  # type: ignore[arg-type]
 
-            # Define Agent Zero's skills
+            # Define Magui's skills
             skills: List[Skill] = [{  # type: ignore
                 "id": "general_assistance",
                 "name": "General AI Assistant",
@@ -230,7 +230,7 @@ class DynamicA2AProxy:
             }]
 
             provider: AgentProvider = {  # type: ignore
-                "organization": "Agent Zero",
+                "organization": "Magui",
                 "url": "https://github.com/frdel/agent-zero"
             }
 
@@ -238,7 +238,7 @@ class DynamicA2AProxy:
             new_app = FastA2A(  # type: ignore
                 storage=storage,
                 broker=broker,
-                name="Agent Zero",
+                name="Magui",
                 description=(
                     "A general AI assistant that can execute code, manage files, browse the web, and "
                     "solve complex problems in an isolated Linux environment."
@@ -253,7 +253,7 @@ class DynamicA2AProxy:
             # Store for later lazy startup (needs active event-loop)
             self._storage = storage  # type: ignore[attr-defined]
             self._broker = broker  # type: ignore[attr-defined]
-            self._worker = AgentZeroWorker(broker=broker, storage=storage)  # type: ignore[attr-defined]
+            self._worker = MaguiWorker(broker=broker, storage=storage)  # type: ignore[attr-defined]
 
             # Atomic update of the app
             self.app = new_app

--- a/python/helpers/mcp_server.py
+++ b/python/helpers/mcp_server.py
@@ -22,12 +22,12 @@ _PRINTER = PrintStyle(italic=True, font_color="green", padding=False)
 
 
 mcp_server: FastMCP = FastMCP(
-    name="Agent Zero integrated MCP Server",
+    name="Magui integrated MCP Server",
     instructions="""
-    Connect to remote Agent Zero instance.
-    Agent Zero is a general AI assistant controlling it's linux environment.
-    Agent Zero can install software, manage files, execute commands, code, use internet, etc.
-    Agent Zero's environment is isolated unless configured otherwise.
+    Connect to remote Magui instance.
+    Magui is a general AI assistant controlling it's linux environment.
+    Magui can install software, manage files, execute commands, code, use internet, etc.
+    Magui's environment is isolated unless configured otherwise.
     """,
 )
 
@@ -37,7 +37,7 @@ class ToolResponse(BaseModel):
         description="The status of the response", default="success"
     )
     response: str = Field(
-        description="The response from the remote Agent Zero Instance"
+        description="The response from the remote Magui Instance"
     )
     chat_id: str = Field(description="The id of the chat this message belongs to.")
 
@@ -47,14 +47,14 @@ class ToolError(BaseModel):
         description="The status of the response", default="error"
     )
     error: str = Field(
-        description="The error message from the remote Agent Zero Instance"
+        description="The error message from the remote Magui Instance"
     )
     chat_id: str = Field(description="The id of the chat this message belongs to.")
 
 
 SEND_MESSAGE_DESCRIPTION = """
-Send a message to the remote Agent Zero Instance.
-This tool is used to send a message to the remote Agent Zero Instance connected remotely via MCP.
+Send a message to the remote Magui Instance.
+This tool is used to send a message to the remote Magui Instance connected remotely via MCP.
 """
 
 
@@ -62,7 +62,7 @@ This tool is used to send a message to the remote Agent Zero Instance connected 
     name="send_message",
     description=SEND_MESSAGE_DESCRIPTION,
     tags={
-        "agent_zero",
+        "magui",
         "chat",
         "remote",
         "communication",
@@ -87,7 +87,7 @@ async def send_message(
     message: Annotated[
         str,
         Field(
-            description="The message to send to the remote Agent Zero Instance",
+            description="The message to send to the remote Magui Instance",
             title="message",
         ),
     ],
@@ -95,7 +95,7 @@ async def send_message(
         Annotated[
             list[str],
             Field(
-                description="Optional: A list of attachments (file paths or web urls) to send to the remote Agent Zero Instance with the message. Default: Empty list",
+                description="Optional: A list of attachments (file paths or web urls) to send to the remote Magui Instance with the message. Default: Empty list",
                 title="attachments",
             ),
         ]
@@ -124,7 +124,7 @@ async def send_message(
 ) -> Annotated[
     Union[ToolResponse, ToolError],
     Field(
-        description="The response from the remote Agent Zero Instance", title="response"
+        description="The response from the remote Magui Instance", title="response"
     ),
 ]:
     context: AgentContext | None = None
@@ -160,10 +160,10 @@ async def send_message(
 
 
 FINISH_CHAT_DESCRIPTION = """
-Finish a chat with the remote Agent Zero Instance.
-This tool is used to finish a persistent chat (send_message with persistent_chat=True) with the remote Agent Zero Instance connected remotely via MCP.
+Finish a chat with the remote Magui Instance.
+This tool is used to finish a persistent chat (send_message with persistent_chat=True) with the remote Magui Instance connected remotely via MCP.
 If you want to continue the chat, use the send_message tool instead.
-Always use this tool to finish persistent chat conversations with remote Agent Zero.
+Always use this tool to finish persistent chat conversations with remote Magui.
 """
 
 
@@ -171,7 +171,7 @@ Always use this tool to finish persistent chat conversations with remote Agent Z
     name="finish_chat",
     description=FINISH_CHAT_DESCRIPTION,
     tags={
-        "agent_zero",
+        "magui",
         "chat",
         "remote",
         "communication",
@@ -202,7 +202,7 @@ async def finish_chat(
 ) -> Annotated[
     Union[ToolResponse, ToolError],
     Field(
-        description="The response from the remote Agent Zero Instance", title="response"
+        description="The response from the remote Magui Instance", title="response"
     ),
 ]:
     if not chat_id:

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -174,7 +174,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
         {
             "id": "chat_model_provider",
             "title": "Chat model provider",
-            "description": "Select provider for main chat model used by Agent Zero",
+            "description": "Select provider for main chat model used by Magui",
             "type": "select",
             "value": settings["chat_model_provider"],
             "options": cast(list[FieldOption], get_providers("chat")),
@@ -276,7 +276,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
     chat_model_section: SettingsSection = {
         "id": "chat_model",
         "title": "Chat Model",
-        "description": "Selection and settings for main chat model used by Agent Zero",
+        "description": "Selection and settings for main chat model used by Magui",
         "fields": chat_model_fields,
         "tab": "agent",
     }
@@ -426,7 +426,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
     embed_model_section: SettingsSection = {
         "id": "embed_model",
         "title": "Embedding Model",
-        "description": f"Settings for the embedding model used by Agent Zero.<br><h4>⚠️ No need to change</h4>The default HuggingFace model {default_settings['embed_model_name']} is preloaded and runs locally within the docker container and there's no need to change it unless you have a specific requirements for embedding.",
+        "description": f"Settings for the embedding model used by Magui.<br><h4>⚠️ No need to change</h4>The default HuggingFace model {default_settings['embed_model_name']} is preloaded and runs locally within the docker container and there's no need to change it unless you have a specific requirements for embedding.",
         "fields": embed_model_fields,
         "tab": "agent",
     }
@@ -526,7 +526,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
     browser_model_section: SettingsSection = {
         "id": "browser_model",
         "title": "Web Browser Model",
-        "description": "Settings for the web browser model. Agent Zero uses <a href='https://github.com/browser-use/browser-use' target='_blank'>browser-use</a> agentic framework to handle web interactions.",
+        "description": "Settings for the web browser model. Magui uses <a href='https://github.com/browser-use/browser-use' target='_blank'>browser-use</a> agentic framework to handle web interactions.",
         "fields": browser_model_fields,
         "tab": "agent",
     }
@@ -572,7 +572,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
     auth_section: SettingsSection = {
         "id": "auth",
         "title": "Authentication",
-        "description": "Settings for authentication to use Agent Zero Web UI.",
+        "description": "Settings for authentication to use Magui Web UI.",
         "fields": auth_fields,
         "tab": "external",
     }
@@ -595,7 +595,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
     api_keys_section: SettingsSection = {
         "id": "api_keys",
         "title": "API Keys",
-        "description": "API keys for model providers and services used by Agent Zero. You can set multiple API keys separated by a comma (,). They will be used in round-robin fashion.<br>For more information abou Agent Zero Venice provider, see <a href='http://agent-zero.ai/?community/api-dashboard/about' target='_blank'>Agent Zero Venice</a>.",
+        "description": "API keys for model providers and services used by Magui. You can set multiple API keys separated by a comma (,). They will be used in round-robin fashion.<br>For more information abou Magui Venice provider, see <a href='http://agent-zero.ai/?community/api-dashboard/about' target='_blank'>Magui Venice</a>.",
         "fields": api_keys_fields,
         "tab": "external",
     }
@@ -692,7 +692,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
         {
             "id": "memory_recall_enabled",
             "title": "Memory auto-recall enabled",
-            "description": "Agent Zero will automatically recall memories based on convesation context.",
+            "description": "Magui will automatically recall memories based on convesation context.",
             "type": "switch",
             "value": settings["memory_recall_enabled"],
         }
@@ -1104,7 +1104,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
     mcp_client_section: SettingsSection = {
         "id": "mcp_client",
         "title": "External MCP Servers",
-        "description": "Agent Zero can use external MCP servers, local or remote as tools.",
+        "description": "Magui can use external MCP servers, local or remote as tools.",
         "fields": mcp_client_fields,
         "tab": "mcp",
     }
@@ -1150,7 +1150,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
         {
             "id": "mcp_server_enabled",
             "title": "Enable A0 MCP Server",
-            "description": "Expose Agent Zero as an SSE/HTTP MCP server. This will make this A0 instance available to MCP clients.",
+            "description": "Expose Magui as an SSE/HTTP MCP server. This will make this A0 instance available to MCP clients.",
             "type": "switch",
             "value": settings["mcp_server_enabled"],
         }
@@ -1170,7 +1170,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
     mcp_server_section: SettingsSection = {
         "id": "mcp_server",
         "title": "A0 MCP Server",
-        "description": "Agent Zero can be exposed as an SSE MCP server. See <a href=\"javascript:openModal('settings/mcp/server/example.html')\">connection example</a>.",
+        "description": "Magui can be exposed as an SSE MCP server. See <a href=\"javascript:openModal('settings/mcp/server/example.html')\">connection example</a>.",
         "fields": mcp_server_fields,
         "tab": "mcp",
     }
@@ -1182,7 +1182,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
         {
             "id": "a2a_server_enabled",
             "title": "Enable A2A server",
-            "description": "Expose Agent Zero as A2A server. This allows other agents to connect to A0 via A2A protocol.",
+            "description": "Expose Magui as A2A server. This allows other agents to connect to A0 via A2A protocol.",
             "type": "switch",
             "value": settings["a2a_server_enabled"],
         }
@@ -1191,7 +1191,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
     a2a_section: SettingsSection = {
         "id": "a2a_server",
         "title": "A0 A2A Server",
-        "description": "Agent Zero can be exposed as an A2A server. See <a href=\"javascript:openModal('settings/a2a/a2a-connection.html')\">connection example</a>.",
+        "description": "Magui can be exposed as an A2A server. See <a href=\"javascript:openModal('settings/a2a/a2a-connection.html')\">connection example</a>.",
         "fields": a2a_fields,
         "tab": "mcp",
     }
@@ -1204,7 +1204,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
         {
             "id": "external_api_examples",
             "title": "API Examples",
-            "description": "View examples for using Agent Zero's external API endpoints with API key authentication.",
+            "description": "View examples for using Magui's external API endpoints with API key authentication.",
             "type": "button",
             "value": "Show API Examples",
         }
@@ -1213,7 +1213,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
     external_api_section: SettingsSection = {
         "id": "external_api",
         "title": "External API",
-        "description": "Agent Zero provides external API endpoints for integration with other applications. "
+        "description": "Magui provides external API endpoints for integration with other applications. "
                        "These endpoints use API key authentication and support text messages and file attachments.",
         "fields": external_api_fields,
         "tab": "external",
@@ -1226,7 +1226,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
         {
             "id": "update_check_enabled",
             "title": "Enable Update Checker",
-            "description": "Enable update checker to notify about newer versions of Agent Zero.",
+            "description": "Enable update checker to notify about newer versions of Magui.",
             "type": "switch",
             "value": settings["update_check_enabled"],
         }
@@ -1235,7 +1235,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
     update_checker_section: SettingsSection = {
         "id": "update_checker",
         "title": "Update Checker",
-        "description": "Update checker periodically checks for new releases of Agent Zero and will notify when an update is recommended.<br>No personal data is sent to the update server, only randomized+anonymized unique ID and current version number, which help us evaluate the importance of the update in case of critical bug fixes etc.",
+        "description": "Update checker periodically checks for new releases of Magui and will notify when an update is recommended.<br>No personal data is sent to the update server, only randomized+anonymized unique ID and current version number, which help us evaluate the importance of the update in case of critical bug fixes etc.",
         "fields": update_checker_fields,
         "tab": "external",
     }
@@ -1268,7 +1268,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
     backup_section: SettingsSection = {
         "id": "backup_restore",
         "title": "Backup & Restore",
-        "description": "Backup and restore Agent Zero data and configurations "
+        "description": "Backup and restore Magui data and configurations "
         "using glob pattern-based file selection.",
         "fields": backup_fields,
         "tab": "backup",

--- a/tests/test_fasta2a_client.py
+++ b/tests/test_fasta2a_client.py
@@ -72,7 +72,7 @@ def print_test_commands():
     print("   HTTP/1.1 200 OK")
     print("   Content-Type: application/json")
     print("   {")
-    print('     "name": "Agent Zero",')
+    print('     "name": "Magui",')
     print('     "version": "1.0.0",')
     print('     "skills": [...]')
     print("   }")
@@ -90,7 +90,7 @@ def print_troubleshooting():
     print("=" * 40)
     print()
     print("1. Server not running:")
-    print("   - Make sure Agent Zero is running: python run_ui.py")
+    print("   - Make sure Magui is running: python run_ui.py")
     print("   - Check the correct port (default: 50101)")
     print()
 
@@ -157,10 +157,10 @@ async def test_server_connectivity():
             try:
                 # Test basic server
                 await client.get("http://localhost:50101/", timeout=5.0)
-                print("✅ Agent Zero server is running")
+                print("✅ Magui server is running")
                 return True
             except httpx.ConnectError:
-                print("❌ Cannot connect to Agent Zero server")
+                print("❌ Cannot connect to Magui server")
                 print("   Make sure the server is running: python run_ui.py")
                 return False
             except Exception as e:
@@ -204,7 +204,7 @@ def main():
     print_test_commands()
 
     print("📋 Next Steps:")
-    print("1. Start Agent Zero server if not running")
+    print("1. Start Magui server if not running")
     print("2. Run one of the curl commands above")
     print("3. Check for successful 200 response with agent card JSON")
     print("4. If issues occur, see troubleshooting section")

--- a/webui/components/projects/project-list.html
+++ b/webui/components/projects/project-list.html
@@ -12,7 +12,7 @@
     <div x-data>
         <template x-if="$store.projects && $store.chats">
             <div>
-                <p class="projects-intro">Projects in Agent Zero are used to separate different use cases with custom
+                <p class="projects-intro">Projects in Magui are used to separate different use cases with custom
                     instructions and files.
                     You can create projects for your tasks and switch between them easily.</p>
                 <div class="projects-list-header">

--- a/webui/components/settings/a2a/a2a-connection.html
+++ b/webui/components/settings/a2a/a2a-connection.html
@@ -6,7 +6,7 @@
 
 <body>
     <div x-data>
-        <p>Agent Zero A2A Server enables FastA2A protocol communication with other agents.</p>
+        <p>Magui A2A Server enables FastA2A protocol communication with other agents.</p>
         <p>Other agents can connect using the URL below (replace host if needed):</p>
 
         <!-- API Token Information -->

--- a/webui/components/settings/backup/backup-store.js
+++ b/webui/components/settings/backup/backup-store.js
@@ -6,7 +6,7 @@ const toast = globalThis.toast;
 const fetchApi = globalThis.fetchApi;
 
 // ⚠️ CRITICAL: The .env file contains API keys and essential configuration.
-// This file is REQUIRED for Agent Zero to function and must be backed up.
+// This file is REQUIRED for Magui to function and must be backed up.
 
 const model = {
   // State
@@ -113,7 +113,7 @@ const model = {
         const exclude_patterns = response.default_patterns.exclude_patterns;
 
         return {
-          backup_name: `agent-zero-backup-${timestamp.slice(0, 10)}`,
+          backup_name: `magui-backup-${timestamp.slice(0, 10)}`,
           include_hidden: false,
           include_patterns: include_patterns,
           exclude_patterns: exclude_patterns,
@@ -129,7 +129,7 @@ const model = {
 
     // Fallback patterns (will be overridden by backend on first use)
     return {
-      backup_name: `agent-zero-backup-${timestamp.slice(0, 10)}`,
+      backup_name: `magui-backup-${timestamp.slice(0, 10)}`,
       include_hidden: false,
       include_patterns: [
         // These will be replaced with resolved absolute paths by backend
@@ -143,7 +143,7 @@ const model = {
     };
   },
 
-  // Editor Management - Following Agent Zero ACE editor patterns
+  // Editor Management - Following Magui ACE editor patterns
   async initBackupEditor() {
     const container = document.getElementById("backup-metadata-editor");
     if (container) {
@@ -654,13 +654,13 @@ const model = {
 
     const warnings = [];
 
-    // Check Agent Zero version compatibility
+    // Check Magui version compatibility
     // Note: Both backup and current versions are obtained via git.get_git_info()
-    const backupVersion = this.backupMetadata.agent_zero_version;
+    const backupVersion = this.backupMetadata.magui_version;
     const currentVersion = "current"; // Retrieved from git.get_git_info() on backend
 
     if (backupVersion !== currentVersion && backupVersion !== "development") {
-      warnings.push(`Backup created with Agent Zero ${backupVersion}, current version is ${currentVersion}`);
+      warnings.push(`Backup created with Magui ${backupVersion}, current version is ${currentVersion}`);
     }
 
     // Check backup age

--- a/webui/components/settings/external/api-examples.html
+++ b/webui/components/settings/external/api-examples.html
@@ -1,12 +1,12 @@
 <html>
 
 <head>
-    <title>Agent Zero External API Examples</title>
+    <title>Magui External API Examples</title>
 </head>
 
 <body>
     <div x-data>
-        <p>Agent Zero provides external API endpoints for integration with other applications.</p>
+        <p>Magui provides external API endpoints for integration with other applications.</p>
         <p>These endpoints use API key authentication and support text messages and file attachments.</p>
 
         <!-- API Token Information -->
@@ -23,7 +23,7 @@
         <div class="api-section">
             <h2>POST /api_message</h2>
             <p style="margin: 0 0 16px 0; color: var(--color-text-secondary); font-size: 14px;">
-                Send messages to Agent Zero and receive responses. Supports text messages, file attachments, and conversation continuity.
+                Send messages to Magui and receive responses. Supports text messages, file attachments, and conversation continuity.
             </p>
 
             <!-- API Reference -->

--- a/webui/components/settings/mcp/client/example.html
+++ b/webui/components/settings/mcp/client/example.html
@@ -7,13 +7,13 @@
 
 <body>
     <div x-data>
-        <p>Agent Zero uses standard JSON configuration known from other AI applications.<br>
+        <p>Magui uses standard JSON configuration known from other AI applications.<br>
             The configuration is a JSON object containing "mcpServers" object where each key is an individual MCP
             server.<br>
             Local servers are defined by a "command", "args", "env" variables.<br>
             Remote servers are defined by a "url", "headers".<br>
             "disabled" can be set to true to disable a server without removing config.<br>
-            Custom "description" can be set to provide additional information about the server to A0.<br>
+            Custom "description" can be set to provide additional information about the server to Magui.<br>
             All servers can also define "init_timeout" and "tool_timeout" which override global settings.</p>
 
 

--- a/webui/components/settings/mcp/server/example.html
+++ b/webui/components/settings/mcp/server/example.html
@@ -7,7 +7,7 @@
 
 <body>
     <div x-data>
-        <p>Agent Zero MCP Server is an SSE MCP running on the same URL and port as the Web UI + /mcp/sse or /mcp/http path.</p>
+        <p>Magui MCP Server is an SSE MCP running on the same URL and port as the Web UI + /mcp/sse or /mcp/http path.</p>
         <p>The same applies if you run A0 on a public URL using a tunnel.</p>
 
         <!-- API Token Information -->
@@ -29,11 +29,11 @@
                 const jsonExample = JSON.stringify({
                     "mcpServers":
                     {
-                        "agent-zero": {
+                        "magui": {
                             "type": "sse",
                             "url": `${url}/mcp/t-${token}/sse`
                         },
-                        "agent-zero-http": {
+                        "magui-http": {
                             "type": "streamable-http",
                             "url": `${url}/mcp/t-${token}/http`
                         }

--- a/webui/components/settings/tunnel/tunnel-section.html
+++ b/webui/components/settings/tunnel/tunnel-section.html
@@ -18,7 +18,7 @@
             <!-- Keep in mind that <template> can have only one root element inside -->
             <div id="tunnel-settings-section">
                 <div class="section-title">Flare Tunnel</div>
-                <div class="section-description">Create a secure public URL to access your Agent Zero instance anytime,
+                <div class="section-description">Create a secure public URL to access your Magui instance anytime,
                     anywhere.</div>
                 <!-- Tunnel content UI -->
                 <div class="tunnel-container">
@@ -66,7 +66,7 @@
                                 <div class="tunnel-qr-label">Scan with mobile device</div>
                             </div>
                             <div class="tunnel-link-info">
-                                Share this URL to allow others to access your Agent Zero instance.
+                                Share this URL to allow others to access your Magui instance.
                             </div>
                             <div class="tunnel-link-persistence">
                                 This URL will persist until you stop the tunnel or restart the Docker container.

--- a/webui/components/settings/tunnel/tunnel-store.js
+++ b/webui/components/settings/tunnel/tunnel-store.js
@@ -56,14 +56,14 @@ const model = {
         // Update the stored URL if it's different from what we have
         if (this.tunnelLink !== data.tunnel_url) {
           this.tunnelLink = data.tunnel_url;
-          localStorage.setItem("agent_zero_tunnel_url", data.tunnel_url);
+          localStorage.setItem("magui_tunnel_url", data.tunnel_url);
         }
         this.linkGenerated = true;
         // Generate QR code for the tunnel URL
         Sleep.Skip().then(() => this.generateQRCode());
       } else {
         // Check if we have a stored tunnel URL
-        const storedTunnelUrl = localStorage.getItem("agent_zero_tunnel_url");
+        const storedTunnelUrl = localStorage.getItem("magui_tunnel_url");
 
         if (storedTunnelUrl) {
           // Use the stored URL but verify it's still valid
@@ -84,7 +84,7 @@ const model = {
             Sleep.Skip().then(() => this.generateQRCode());
           } else {
             // Clear stale URL
-            localStorage.removeItem("agent_zero_tunnel_url");
+            localStorage.removeItem("magui_tunnel_url");
             this.tunnelLink = "";
             this.linkGenerated = false;
           }
@@ -188,9 +188,9 @@ const model = {
       // If no authentication is set, warn the user
       if (!hasAuth) {
         const proceed = confirm(
-          "WARNING: No authentication is configured for your Agent Zero instance.\n\n" +
+          "WARNING: No authentication is configured for your Magui instance.\n\n" +
             "Creating a public tunnel without authentication means anyone with the URL " +
-            "can access your Agent Zero instance.\n\n" +
+            "can access your Magui instance.\n\n" +
             "It is recommended to set up authentication in the Settings > Authentication section " +
             "before creating a public tunnel.\n\n" +
             "Do you want to proceed anyway?"
@@ -235,7 +235,7 @@ const model = {
 
       if (data.success && data.tunnel_url) {
         // Store the tunnel URL in localStorage for persistence
-        localStorage.setItem("agent_zero_tunnel_url", data.tunnel_url);
+        localStorage.setItem("magui_tunnel_url", data.tunnel_url);
 
         this.tunnelLink = data.tunnel_url;
         this.linkGenerated = true;
@@ -270,7 +270,7 @@ const model = {
           if (statusData.success && statusData.tunnel_url) {
             // Tunnel is now running, we can update the UI
             localStorage.setItem(
-              "agent_zero_tunnel_url",
+              "magui_tunnel_url",
               statusData.tunnel_url
             );
             this.tunnelLink = statusData.tunnel_url;
@@ -336,7 +336,7 @@ const model = {
 
         if (data.success) {
           // Clear the stored URL
-          localStorage.removeItem("agent_zero_tunnel_url");
+          localStorage.removeItem("magui_tunnel_url");
 
           // Clear QR code
           const qrContainer = document.getElementById("qrcode-tunnel");

--- a/webui/components/welcome/welcome-screen.html
+++ b/webui/components/welcome/welcome-screen.html
@@ -10,13 +10,13 @@
     <div x-data x-show="$store.welcomeStore && $store.welcomeStore.isVisible">
         <template x-if="$store.welcomeStore">
             <div x-data="$store.welcomeStore" class="welcome-container">
-                <!-- Agent Zero Logo -->
+                <!-- Magui Logo -->
                 <div class="welcome-logo-container">
-                    <img src="./public/darkSymbol.svg" alt="Agent Zero Logo" class="welcome-logo" />
+                    <img src="./public/darkSymbol.svg" alt="Magui Logo" class="welcome-logo" />
                 </div>
 
                 <!-- Welcome Title -->
-                <h1 class="welcome-title">Welcome to Agent Zero</h1>
+                <h1 class="welcome-title">Welcome to Magui</h1>
                 <p class="welcome-subtitle">
                     Start a new conversation or explore the features below.
                 </p>
@@ -49,14 +49,14 @@
                         <span class="material-symbols-outlined welcome-action-icon">settings</span>
                         <h3 class="welcome-action-title">Settings</h3>
                         <p class="welcome-action-description">
-                            Configure Agent Zero
+                            Configure Magui
                         </p>
                     </div>
                     <div class="welcome-action-card" @click="executeAction('website')">
                         <span class="material-symbols-outlined welcome-action-icon">language</span>
                         <h3 class="welcome-action-title">Visit Website</h3>
                         <p class="welcome-action-description">
-                            Learn more about Agent Zero
+                            Learn more about Magui
                         </p>
                     </div>
                     <div class="welcome-action-card" @click="executeAction('github')">

--- a/webui/index.html
+++ b/webui/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <title>Agent Zero</title>
+    <title>Magui</title>
     <link rel="icon" type="image/svg+xml" href="public/favicon.svg">
     <link rel="stylesheet" href="index.css">
     <link rel="stylesheet" href="css/messages.css">
@@ -353,7 +353,7 @@
                             <div id="section-task-scheduler" class="section" x-data="schedulerSettings">
                                 <div class="section-title">Task Scheduler</div>
                                 <div class="section-description">Manage scheduled tasks and automated processes for
-                                    Agent Zero.</div>
+                                    Magui.</div>
 
                                 <!-- Create Task Form -->
                                 <div class="scheduler-form" x-show="isCreating">

--- a/webui/js/manifest.json
+++ b/webui/js/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Agent Zero",
-  "short_name": "Agent Zero",
+  "name": "Magui",
+  "short_name": "Magui",
   "description": "Autonomous AI agent",
   "start_url": "/",
   "display": "standalone",

--- a/webui/login.html
+++ b/webui/login.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Login - Agent Zero</title>
+    <title>Login - Magui</title>
     <link rel="stylesheet" href="/login.css">
     <link rel="icon" type="image/svg+xml" href="/public/favicon.svg">
 </head>
 <body>
     <div class="login-container">
         <form class="login-form" method="POST" action="/login">
-            <img src="/public/splash.jpg" alt="Agent Zero Logo" class="logo">
-            <h2>Agent Zero</h2>
+            <img src="/public/splash.jpg" alt="Magui Logo" class="logo">
+            <h2>Magui</h2>
             <div class="input-group">
                 <label for="username">Username</label>
                 <input type="text" id="username" name="username" required>


### PR DESCRIPTION
Rebranded all references from 'Agent Zero' to 'Magui' throughout documentation, configuration, prompts, and code comments. This includes updates to project name, agent roles, system messages, API endpoints, backup specifications, and branding assets to reflect the new identity.