### PR TITLE
Fix: API keys saved with correct API_KEY_ prefix

### DIFF
--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -430,7 +430,7 @@ def _remove_sensitive_settings(settings: Settings):
 def _write_sensitive_settings(settings: Settings):
     for key, val in settings["api_keys"].items():
         if val != API_KEY_PLACEHOLDER:
-            dotenv.save_dotenv_value(key.upper(), val)
+            dotenv.save_dotenv_value(f"API_KEY_{key.upper()}", val)
 
     dotenv.save_dotenv_value(dotenv.KEY_AUTH_LOGIN, settings["auth_login"])
     if settings["auth_password"] != PASSWORD_PLACEHOLDER:


### PR DESCRIPTION
## Bug Description

UI-saved API keys were stored as `PROVIDER=key` instead of `API_KEY_PROVIDER=key`.

This caused `settings.py` `_write_sensitive_settings()` to save keys that `models.get_api_key()` could not find (it looks for `API_KEY_PROVIDER` format).

## Symptom

All API providers failing with 401 auth errors despite correct keys being entered in Settings UI, because stale `.env` values were used instead of the newly-saved keys.

## Root Cause

In `python/helpers/settings.py` line 433, `_write_sensitive_settings()` was saving:
```python
dotenv.save_dotenv_value(key.upper(), val)  # Saves as: VENICE=key
```

But `models.get_api_key()` looks for:
```python
dotenv.get_dotenv_value(f"API_KEY_{service.upper()}")  # Looks for: API_KEY_VENICE
```

## Fix

Add the `API_KEY_` prefix when saving:
```python
dotenv.save_dotenv_value(f"API_KEY_{key.upper()}", val)
```

## Testing

1. Enter API key in Settings → API Keys → any provider
2. Save settings
3. Verify key works for model calls (previously would 401)
4. Verify `.env` now contains `API_KEY_PROVIDER=key` format
