### PR TITLE
Fix: KeyError 'message' in response.py when both keys missing

### DIFF
--- a/python/tools/response.py
+++ b/python/tools/response.py
@@ -4,7 +4,8 @@ from python.helpers.tool import Tool, Response
 class ResponseTool(Tool):
 
     async def execute(self, **kwargs):
-        return Response(message=self.args["text"] if "text" in self.args else self.args["message"], break_loop=True)
+        message_text = self.args.get("text") or self.args.get("message", "")
+        return Response(message=message_text, break_loop=True)
 
     async def before_execution(self, **kwargs):
         # self.log = self.agent.context.log.log(type="response", heading=f"{self.agent.agent_name}: Responding", content=self.args.get("text", ""))


### PR DESCRIPTION
## Bug Description

`response.py` `execute()` crashes with `KeyError: 'message'` when neither `text` nor `message` keys exist in `self.args` dictionary.

## Current Buggy Code (line 7)

```python
return Response(message=self.args["text"] if "text" in self.args else self.args["message"], break_loop=True)
```

When both keys are missing, this throws `KeyError: 'message'` and causes the agent to completely stall.

## Proposed Fix

```python
message_text = self.args.get("text") or self.args.get("message", "")
return Response(message=message_text, break_loop=True)
```

Using `.get()` with a safe fallback prevents the crash.

## Impact

- Causes agents to completely stall when edge case occurs
- Confirmed on multiple Agent Zero instances
- Works fine in normal cases (happy path) but fails on error handling edge cases

## Testing

1. Trigger response tool with missing text/message args (edge case)
2. With fix: Returns empty response safely instead of crashing
3. Normal usage: No change in behavior

---
*Note: This PR replaces #925 which incorrectly targeted `main` instead of `development`.*
