### PR TITLE
feat: structured output

### DIFF
--- a/initialize.py
+++ b/initialize.py
@@ -35,6 +35,7 @@ def initialize_agent(override_settings: dict | None = None):
         api_base=current_settings["chat_model_api_base"],
         ctx_length=current_settings["chat_model_ctx_length"],
         vision=current_settings["chat_model_vision"],
+        structured_output=current_settings["chat_model_structured_output"],
         limit_requests=current_settings["chat_model_rl_requests"],
         limit_input=current_settings["chat_model_rl_input"],
         limit_output=current_settings["chat_model_rl_output"],

--- a/models.py
+++ b/models.py
@@ -77,6 +77,7 @@ class ModelConfig:
     limit_input: int = 0
     limit_output: int = 0
     vision: bool = False
+    structured_output: bool = False
     kwargs: dict = field(default_factory=dict)
 
     def build_kwargs(self):

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -60,6 +60,7 @@ class Settings(TypedDict):
     chat_model_ctx_length: int
     chat_model_ctx_history: float
     chat_model_vision: bool
+    chat_model_structured_output: bool
     chat_model_rl_requests: int
     chat_model_rl_input: int
     chat_model_rl_output: int
@@ -459,6 +460,7 @@ def get_default_settings() -> Settings:
         chat_model_ctx_length=get_default_value("chat_model_ctx_length", 100000),
         chat_model_ctx_history=get_default_value("chat_model_ctx_history", 0.7),
         chat_model_vision=get_default_value("chat_model_vision", True),
+        chat_model_structured_output=get_default_value("chat_model_structured_output", True),
         chat_model_rl_requests=get_default_value("chat_model_rl_requests", 0),
         chat_model_rl_input=get_default_value("chat_model_rl_input", 0),
         chat_model_rl_output=get_default_value("chat_model_rl_output", 0),

--- a/webui/components/settings/agent/chat_model.html
+++ b/webui/components/settings/agent/chat_model.html
@@ -96,6 +96,21 @@
 
           <div class="field">
             <div class="field-label">
+              <div class="field-title">Structured output</div>
+              <div class="field-description">
+                Enables strict JSON output for responses to reduce agent message misformatting.
+              </div>
+            </div>
+            <div class="field-control">
+              <label class="toggle">
+                <input type="checkbox" x-model="$store.settingsStore.settings.chat_model_structured_output" />
+                <span class="toggler"></span>
+              </label>
+            </div>
+          </div>
+
+          <div class="field">
+            <div class="field-label">
               <div class="field-title">Requests per minute limit</div>
               <div class="field-description">
                 Limits the number of requests per minute to the chat model. Waits if the limit is exceeded. Set to 0 to disable rate limiting.


### PR DESCRIPTION
Adds [structured output](https://docs.litellm.ai/docs/completion/json_mode) option to reduce agent message misformats for longer tasks (even model like glm-4.7 sometimes starts message with plain text and confuses tool_args with args). `allow_structured_output` needed to not use structured output in document_query Q&A