### PR TITLE
Fix: Remove hard-coded timeout caps on MCP tool execution

### DIFF
--- a/python/helpers/mcp_handler.py
+++ b/python/helpers/mcp_handler.py
@@ -1071,9 +1071,9 @@ class MCPClientRemote(MCPClientBase):
         server: MCPServerRemote = cast(MCPServerRemote, self.server)
         set = settings.get_settings()
 
-        # Use lower timeouts for faster failure detection
-        init_timeout = min(server.init_timeout or set["mcp_client_init_timeout"], 5)
-        tool_timeout = min(server.tool_timeout or set["mcp_client_tool_timeout"], 10)
+        # Resolve timeout: check server config first, then settings, defaulting to 5s/10s
+        init_timeout = server.init_timeout or set["mcp_client_init_timeout"] or 5
+        tool_timeout = server.tool_timeout or set["mcp_client_tool_timeout"] or 10
 
         client_factory = CustomHTTPClientFactory(verify=server.verify)
         # Check if this is a streaming HTTP type


### PR DESCRIPTION
Previously, MCP tool timeouts were strictly capped at 5s (init) and 10s (execution) regardless of configuration settings.

This prevented long-running operations (e.g., >30s SSE transport calls) from completing successfully.

Logic updated to fully respect mcp_client_init_timeout and mcp_client_tool_timeout settings, falling back to defaults only when no configuration is present.