### PR TITLE
feat: collapsible standalone msgs with fade-out gradient

### DIFF
--- a/webui/css/messages.css
+++ b/webui/css/messages.css
@@ -803,3 +803,64 @@
 .dark-mode .message {
   box-shadow: none;
 }
+
+/* ===========================================
+   Collapsible Standalone Messages
+   Shows ~10 lines with fade-out, expand button reveals full content
+   =========================================== */
+
+.message.message-collapsible .message-body {
+  position: relative;
+  max-height: 15em !important;
+  overflow: hidden;
+  transition: max-height 0.3s ease-out;
+}
+
+.message.message-collapsible .message-body::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 3em;
+  background: linear-gradient(transparent, var(--color-chat-background));
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.3s ease-out;
+}
+
+/* Expanded state */
+.message.message-collapsible.expanded .message-body {
+  max-height: none !important;
+}
+
+.message.message-collapsible.expanded .message-body::after {
+  opacity: 0;
+}
+
+/* No fade when content fits */
+.message.message-collapsible:not(.has-overflow) .message-body::after {
+  opacity: 0;
+}
+
+/* Expand button - hidden by default, shown when overflow */
+.message.message-collapsible .expand-btn {
+  display: none;
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  font-family: "Rubik", Arial, Helvetica, sans-serif;
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+  padding: var(--spacing-xs) 0;
+  opacity: 0.7;
+  transition: opacity 0.15s ease;
+}
+
+.message.message-collapsible .expand-btn:hover {
+  opacity: 1;
+}
+
+.message.message-collapsible.has-overflow .expand-btn {
+  display: block;
+}

--- a/webui/js/messages.js
+++ b/webui/js/messages.js
@@ -668,6 +668,22 @@ function drawStandaloneMessage({
     mainClass,
   });
 
+  // Collapsible: show ~10 lines with fade, expand button reveals full content
+  messageDiv.classList.add("message-collapsible");
+
+  const expandBtn = ensureChild(messageDiv, ".expand-btn", "button", "expand-btn");
+  expandBtn.textContent = messageDiv.classList.contains("expanded") ? "Show less" : "Show more";
+  expandBtn.onclick = () => {
+    messageDiv.classList.toggle("expanded");
+    expandBtn.textContent = messageDiv.classList.contains("expanded") ? "Show less" : "Show more";
+  };
+
+  // Detect overflow after render - CSS handles visibility based on .has-overflow class
+  requestAnimationFrame(() => {
+    const body = messageDiv.querySelector(".message-body");
+    messageDiv.classList.toggle("has-overflow", body.scrollHeight > body.clientHeight);
+  });
+
   // Render action buttons: get/create container, clear, append
   const actionButtonsContainer = ensureChild(
     messageDiv,
@@ -965,6 +981,22 @@ export function drawMessageResponse({
     markdown: true,
     latex: true,
     mainClass: "message-agent-response",
+  });
+
+  // Collapsible: show ~10 lines with fade, expand button reveals full content
+  messageDiv.classList.add("message-collapsible");
+
+  const expandBtn = ensureChild(messageDiv, ".expand-btn", "button", "expand-btn");
+  expandBtn.textContent = messageDiv.classList.contains("expanded") ? "Show less" : "Show more";
+  expandBtn.onclick = () => {
+    messageDiv.classList.toggle("expanded");
+    expandBtn.textContent = messageDiv.classList.contains("expanded") ? "Show less" : "Show more";
+  };
+
+  // Detect overflow after render - CSS handles visibility based on .has-overflow class
+  requestAnimationFrame(() => {
+    const body = messageDiv.querySelector(".message-body");
+    messageDiv.classList.toggle("has-overflow", body.scrollHeight > body.clientHeight);
   });
 
   // Render action buttons: get/create container, clear, append


### PR DESCRIPTION
Enhances readability by collapsing long standalone messages (responses, warnings, errors) to ~10 lines with a subtle gradient fade. 

- Expand button reveals full content on demand
- Minimal JS (~10 lines), CSS driven
- Copy and speak actions preserved after the Show more/Show less element