### PR TITLE
frontend: step detail modals, errors, autoscroll, responses, duration

### DIFF
--- a/webui/components/messages/action-buttons/simple-action-buttons.css
+++ b/webui/components/messages/action-buttons/simple-action-buttons.css
@@ -14,6 +14,24 @@
   pointer-events: none;
 }
 
+.step-action-buttons .expand-btn {
+  display: inline-flex;
+  align-items: center;
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  font-family: "Rubik", Arial, Helvetica, sans-serif;
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+  padding: var(--spacing-xs) 0;
+  opacity: 0.7;
+  transition: opacity 0.15s ease;
+}
+
+.step-action-buttons .expand-btn:hover {
+  opacity: 1;
+}
+
 .step-action-buttons .action-button,
 .action-button {
   display: flex;
@@ -53,6 +71,55 @@
   font-variation-settings: 'FILL' 1, 'wght' 500, 'GRAD' 0, 'opsz' 20;
 }
 
+.show-more-btn,
+.show-less-btn {
+  display: none;
+}
+
+.message.message-collapsible.has-overflow:not(.expanded) > .step-action-buttons {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.message.message-collapsible.has-overflow:not(.expanded)
+  > .step-action-buttons
+  .show-more-btn {
+  display: inline-flex;
+  pointer-events: auto;
+}
+
+.device-pointer
+  .message.message-collapsible.has-overflow:not(.expanded)
+  > .step-action-buttons
+  .action-button {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.device-pointer
+  .message.message-collapsible.has-overflow:not(.expanded):hover
+  > .step-action-buttons
+  .action-button {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.device-pointer
+  .message.message-collapsible.has-overflow.expanded:hover
+  > .step-action-buttons
+  .show-less-btn {
+  display: inline-flex;
+  pointer-events: auto;
+}
+
+.device-touch
+  .message.message-collapsible.has-overflow.expanded
+  > .step-action-buttons
+  .show-less-btn {
+  display: inline-flex;
+  pointer-events: auto;
+}
+
 /* User messages: right-aligned */
 .message-user .step-action-buttons {
   justify-content: flex-end;
@@ -70,6 +137,7 @@
 
 .device-pointer .message-user:hover > .step-action-buttons,
 .device-pointer .message-agent-response:hover > .step-action-buttons,
+.device-pointer .message.message-collapsible.expanded:hover > .step-action-buttons,
 .device-pointer .process-step:hover > .process-step-detail .step-action-buttons {
   opacity: 1;
   pointer-events: auto;

--- a/webui/components/messages/action-buttons/simple-action-buttons.css
+++ b/webui/components/messages/action-buttons/simple-action-buttons.css
@@ -15,7 +15,7 @@
 }
 
 .step-action-buttons .expand-btn {
-  display: inline-flex;
+  display: none;
   align-items: center;
   background: transparent;
   border: none;

--- a/webui/components/messages/process-group/process-group.css
+++ b/webui/components/messages/process-group/process-group.css
@@ -415,6 +415,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   margin-left: var(--spacing-xs);
+  min-width: 0;
 }
 
 /* Step expand icon - CSS triangle (no Material Icons) */
@@ -453,6 +454,7 @@
   scrollbar-width: none; /* Firefox */
   -ms-overflow-style: none; /* IE/Edge */
   overscroll-behavior: contain; /* avoid scroll chaining */
+  max-width: 100%;
 }
 
 .process-step:not(.expanded) > .process-step-detail {
@@ -508,6 +510,8 @@
   font-size: var(--font-size-xs);
   line-height: 1.5;
   overflow-y: auto;
+  overflow-x: hidden;
+  max-width: 100%;
   -webkit-overflow-scrolling: touch; /* smooth scrolling on iOS */
   scrollbar-width: none; /* Firefox */
   -ms-overflow-style: none; /* IE/Edge */
@@ -527,7 +531,7 @@
 /* KVPs in step detail - CSS Grid for aligned columns */
 .process-step-detail-scroll .step-kvps {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto minmax(0, 1fr);
   gap: var(--spacing-xs) var(--spacing-sm);
   align-items: start;
 }
@@ -543,6 +547,7 @@
   display: flex;
   align-items: center;
   justify-content: end;
+  white-space: nowrap;
 }
 
 .process-step-detail-scroll .step-kvp-key .material-symbols-outlined {
@@ -554,9 +559,17 @@
   /* color: var(--color-text); */
   opacity: 0.85;
   word-break: break-word;
+  overflow-wrap: anywhere;
   white-space: pre-wrap;
   font-size: 0.75rem;
   line-height: 1.5;
+  min-width: 0;
+}
+
+.process-step-detail-scroll .step-kvp-value p {
+  margin: 0;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 
@@ -769,6 +782,8 @@
   color: var(--color-text);
   opacity: 0.9;
   margin: var(--spacing-xs) 0;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .process-step-detail-scroll .step-response-content p {

--- a/webui/components/messages/process-group/process-group.css
+++ b/webui/components/messages/process-group/process-group.css
@@ -346,6 +346,7 @@
               border-color 0.2s ease-out;
   overflow: hidden;
   color: var(--color-text-muted);
+  max-width: 100%;
 }
 
 .process-group-content > .process-steps {
@@ -366,6 +367,8 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 /* Individual Process Step */
@@ -374,6 +377,8 @@
   flex-direction: column;
   padding: 0.1em;
   transition: background-color 0.15s ease;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 /* Utility/Info/Hint steps have subtle background tint */
@@ -404,6 +409,8 @@
   user-select: none;
   gap: 4px;
   min-height: 18px;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 /* Step title */
@@ -488,13 +495,17 @@
 .process-step.expanded > .process-step-detail {
   /* grid-template-rows: 1fr; */
   opacity: 1;
-  overflow: visible;
+  overflow: hidden;
   margin-top: var(--spacing-xs);
+  max-width: 100%;
 }
 
 .process-step.expanded > .process-step-detail > .process-step-detail-scroll {
   max-height: 40em;
   overflow-y: auto;
+  max-width: 100%;
+  width: fit-content;
+  box-sizing: content-box;
   border-radius: var(--border-radius-sm);
 }
 
@@ -635,6 +646,7 @@
 } */
 
 
+/* Terminal output - self-contained scrollable block */
 .process-step-detail .terminal-output {
   margin: var(--spacing-xs) 0 0 0;
   padding: var(--spacing-xs);
@@ -644,12 +656,11 @@
   white-space: pre;
   font-family: monospace;
   max-width: fit-content;
-  /* max-height: 300px; */
   overflow: auto;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: thin;
   scrollbar-color: rgba(255,255,255,0.2) transparent;
-  overscroll-behavior-x: contain;
+  overscroll-behavior: contain;
 }
 
 .process-step-detail .terminal-output::-webkit-scrollbar {
@@ -752,6 +763,7 @@
   overflow: hidden;
   transition: grid-template-rows 0.25s ease-out, opacity 0.2s ease-out;
   gap: 2px;
+  max-width: 100%;
 }
 
 /* Only show nested container when parent step is expanded */
@@ -768,6 +780,8 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 /* All nested containers have same indentation (no cascading) */

--- a/webui/components/modals/memory/memory-detail-modal.html
+++ b/webui/components/modals/memory/memory-detail-modal.html
@@ -139,10 +139,8 @@
         </template>
         <style>
             .modal-header-compact {
-                background: linear-gradient(135deg, var(--color-panel) 0%, var(--color-background) 100%);
                 position: sticky;
                 padding-left: 0.8rem;
-                border-radius: 6px;
                 top: 0;
                 z-index: 100;
             }

--- a/webui/components/modals/process-step-detail/process-step-detail.html
+++ b/webui/components/modals/process-step-detail/process-step-detail.html
@@ -15,9 +15,6 @@
                 <!-- Compact Modal Header -->
                 <div class="modal-header modal-header-compact">
                     <div class="header-info">
-                        <span class="status-badge"
-                              :class="$store.stepDetail.selectedStepForDetail?.statusClass || ''"
-                              x-text="$store.stepDetail.selectedStepForDetail?.statusCode || ''"></span>
                         <span class="step-type-label" x-text="$store.stepDetail.formatStepType($store.stepDetail.selectedStepForDetail?.type)"></span>
                         <template x-if="$store.stepDetail.selectedStepForDetail?.headerLabels">
                             <template x-for="(label, index) in $store.stepDetail.selectedStepForDetail?.headerLabels || []" :key="index">
@@ -27,12 +24,12 @@
                     </div>
                     <div class="header-actions">
                         <button class="btn btn-action-header copy-all" 
-                                @click.stop="$store.stepDetail.copyToClipboard($store.stepDetail.formatStepForCopy($store.stepDetail.selectedStepForDetail)).then(() => { $el.classList.add('copied'); setTimeout(() => $el.classList.remove('copied'), 1500) })"
+                                @click.stop="$store.stepDetail.copyToClipboard($store.stepDetail.formatStepForCopy($store.stepDetail.selectedStepForDetail))"
                                 title="Copy Complete Step with Metadata">
                             <span class="material-symbols-outlined">copy_all</span> All
                         </button>
                         <button class="btn btn-action-header copy-content" 
-                                @click.stop="$store.stepDetail.copyToClipboard($store.stepDetail.getStepPrimaryContent($store.stepDetail.selectedStepForDetail)).then(() => { $el.classList.add('copied'); setTimeout(() => $el.classList.remove('copied'), 1500) })"
+                                @click.stop="$store.stepDetail.copyToClipboard($store.stepDetail.getStepPrimaryContent($store.stepDetail.selectedStepForDetail))"
                                 title="Copy Raw LLM Response">
                             <span class="material-symbols-outlined">content_copy</span> Content
                         </button>
@@ -53,12 +50,13 @@
                     </div>
 
                     <!-- Formatted View -->
-                    <div class="formatted-content" x-show="!showRaw">
+                    <div class="formatted-content" x-show="!showRaw" x-init="$nextTick(() => $store.stepDetail.renderSegmentButtons())">
                         <!-- Heading/Title Section -->
                         <template x-if="$store.stepDetail.selectedStepForDetail?.heading">
                             <div class="content-block">
                                 <h4>Heading</h4>
                                 <div class="content-text" x-text="$store.stepDetail.cleanHeading($store.stepDetail.selectedStepForDetail?.heading)"></div>
+                                <div class="step-action-buttons" data-segment="heading"></div>
                             </div>
                         </template>
 
@@ -66,14 +64,8 @@
                         <template x-if="$store.stepDetail.selectedStepForDetail?.kvps">
                             <div class="content-block">
                                 <h4>Details</h4>
-                                <div class="kvps-display">
-                                    <template x-for="[key, value] in Object.entries($store.stepDetail.selectedStepForDetail?.kvps || {})" :key="key">
-                                        <div class="kvp-item">
-                                            <span class="kvp-key" x-text="$store.stepDetail.formatKey(key)"></span>
-                                            <span class="kvp-value" x-text="$store.stepDetail.formatValue(value)"></span>
-                                        </div>
-                                    </template>
-                                </div>
+                                <div class="kvps-display"><template x-for="[key, value] in Object.entries($store.stepDetail.selectedStepForDetail?.kvps || {})" :key="key"><span class="kvp-line"><span class="kvp-key" x-text="$store.stepDetail.formatKey(key)"></span><span class="kvp-value" x-text="$store.stepDetail.formatValue(value)"></span></span></template></div>
+                                <div class="step-action-buttons" data-segment="details"></div>
                             </div>
                         </template>
 
@@ -82,6 +74,7 @@
                             <div class="content-block">
                                 <h4>Content</h4>
                                 <pre class="result-content" x-text="$store.stepDetail.selectedStepForDetail?.content"></pre>
+                                <div class="step-action-buttons" data-segment="content"></div>
                             </div>
                         </template>
                     </div>
@@ -99,10 +92,8 @@
         }
 
         .modal-header-compact {
-            background: linear-gradient(135deg, var(--color-panel) 0%, var(--color-background) 100%);
             position: sticky;
             padding: 0.75rem 1rem;
-            border-radius: 6px 6px 0 0;
             top: 0;
             z-index: 100;
             display: flex;
@@ -170,11 +161,6 @@
             border-color: var(--color-primary);
         }
 
-        .btn-action-header.copied {
-            background: var(--color-success, #22c55e);
-            border-color: var(--color-success, #22c55e);
-            color: white;
-        }
 
         .modal-body {
             flex: 1;
@@ -211,10 +197,7 @@
         }
 
         .content-block {
-            background: var(--color-panel);
-            border: 1px solid var(--color-border);
-            border-radius: 6px;
-            padding: 1rem;
+            padding: var(--spacing-xs) 0;
         }
 
         .content-block h4 {
@@ -233,10 +216,7 @@
         }
 
         .result-content {
-            background: var(--color-background);
-            padding: 1rem;
-            border-radius: 8px;
-            font-family: var(--font-mono);
+            font-family: monospace !important;
             font-size: 0.85rem;
             margin: 0;
             max-height: 40vh;
@@ -248,32 +228,39 @@
         .kvps-display {
             display: flex;
             flex-direction: column;
-            gap: 0.5rem;
+            gap: 0.25rem;
+            font-size: 0.9rem;
+            line-height: 1.5;
         }
 
-        .kvp-item {
-            display: flex;
-            flex-direction: column;
-            gap: 0.25rem;
-            padding: 0.5rem;
-            background: var(--color-background);
-            border-radius: 8px;
-            border: 1px solid var(--color-border);
+        .kvp-line {
+            display: block;
         }
 
         .kvp-key {
-            font-weight: 600;
-            color: var(--color-text);
-            opacity: 0.7;
-            font-size: 0.8rem;
-            text-transform: uppercase;
+            color: var(--color-text-muted);
+            margin-right: 0.5rem;
+        }
+
+        .kvp-key::after {
+            content: ':';
         }
 
         .kvp-value {
             color: var(--color-text);
-            font-size: 0.9rem;
             white-space: pre-wrap;
             word-break: break-word;
+        }
+
+        .step-action-buttons {
+            display: flex;
+            gap: 0.5rem;
+            justify-content: flex-start;
+            margin-top: 0.75rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid var(--color-border);
+            opacity: 1;
+            pointer-events: auto;
         }
 
         .modal-scroll::-webkit-scrollbar {

--- a/webui/components/modals/process-step-detail/process-step-detail.html
+++ b/webui/components/modals/process-step-detail/process-step-detail.html
@@ -60,12 +60,16 @@
                             </div>
                         </template>
 
-                        <!-- Generic KVPs for all types -->
+                        <!-- Flattened KVPs -->
                         <template x-if="$store.stepDetail.selectedStepForDetail?.kvps">
-                            <div class="content-block">
-                                <h4>Details</h4>
-                                <div class="kvps-display"><template x-for="[key, value] in Object.entries($store.stepDetail.selectedStepForDetail?.kvps || {})" :key="key"><span class="kvp-line"><span class="kvp-key" x-text="$store.stepDetail.formatKey(key)"></span><span class="kvp-value" x-text="$store.stepDetail.formatValue(value)"></span></span></template></div>
-                                <div class="step-action-buttons" data-segment="details"></div>
+                            <div class="kvp-boxes">
+                                <template x-for="[key, value] in Object.entries($store.stepDetail.flattenKvps($store.stepDetail.selectedStepForDetail?.kvps) || {})" :key="key">
+                                    <div class="content-block kvp-box">
+                                        <h4 x-text="key"></h4>
+                                        <pre class="kvp-value-content" x-text="$store.stepDetail.formatFlatValue(value)"></pre>
+                                        <div class="step-action-buttons kvp-box-actions" x-init="$store.stepDetail.renderKvpCopyButton($el, key, value)"></div>
+                                    </div>
+                                </template>
                             </div>
                         </template>
 
@@ -225,31 +229,22 @@
             word-break: break-word;
         }
 
-        .kvps-display {
+        .kvp-boxes {
             display: flex;
             flex-direction: column;
-            gap: 0.25rem;
-            font-size: 0.9rem;
-            line-height: 1.5;
+            gap: 1rem;
         }
 
-        .kvp-line {
-            display: block;
-        }
-
-        .kvp-key {
-            color: var(--color-text-muted);
-            margin-right: 0.5rem;
-        }
-
-        .kvp-key::after {
-            content: ':';
-        }
-
-        .kvp-value {
+        .kvp-value-content {
             color: var(--color-text);
             white-space: pre-wrap;
             word-break: break-word;
+            margin: 0;
+            font-size: 0.85rem;
+        }
+
+        .kvp-box-actions {
+            margin-top: 0.5rem;
         }
 
         .step-action-buttons {

--- a/webui/components/sidebar/bottom/preferences/preferences-store.js
+++ b/webui/components/sidebar/bottom/preferences/preferences-store.js
@@ -73,6 +73,7 @@ const model = {
   // Detail mode options for UI sidebar
   detailModeOptions: [
     { label: "NONE", value: "collapsed", title: "All collapsed" },
+    { label: "LIST", value: "list", title: "Steps collapsed" },
     { label: "STEP", value: "current", title: "Current step only" },
     { label: "ALL", value: "expanded", title: "All expanded" },
   ],

--- a/webui/css/messages.css
+++ b/webui/css/messages.css
@@ -281,136 +281,22 @@
   background-color: transparent;
 }
 
-/* Collapsible Error Group */
-
-.message-error-group {
-  background: transparent;
-  border: none !important;
-  padding: 0 !important;
-}
-
-.error-group {
-  display: inline-flex;
-  flex-direction: column;
-  position: relative;
-  z-index: 1;
-  margin: var(--spacing-xs) 0;
-  padding: var(--spacing-xs) 0;
-  min-width: 200px;
-  max-width: 100%;
-  box-sizing: border-box;
-  flex-shrink: 0;
-}
-
-/* Error Group Header */
-.error-group-header {
+/* Error messages styled like process groups */
+.message-error .msg-heading {
   display: flex;
   align-items: center;
-  padding: 0;
-  cursor: pointer;
-  user-select: none;
-  transition: opacity 0.15s ease;
-  min-height: 22px;
   gap: 6px;
-  white-space: nowrap;
+  margin-bottom: var(--spacing-xs);
 }
 
-.error-group-header:hover {
-  opacity: 0.85;
-}
-
-/* Expand/collapse triangle */
-.error-group-header .expand-icon {
-  display: inline-block;
-  width: 0;
-  height: 0;
-  border-style: solid;
-  border-width: 4px 0 4px 6px;
-  border-color: transparent transparent transparent #ef4444;
-  opacity: 0.7;
-  transition:
-    transform 0.2s ease,
-    opacity 0.15s ease;
-  flex-shrink: 0;
-  font-size: 0;
-  margin-right: 2px;
-}
-
-.error-group-header:hover .expand-icon {
-  opacity: 1;
-}
-
-.error-group.expanded .error-group-header .expand-icon {
-  transform: rotate(90deg);
-}
-
-/* Error title */
-.error-group-header .error-title {
-  flex: 0 0 auto;
+.message-error .msg-heading h4 {
+  display: flex;
+  align-items: center;
   font-size: var(--font-size-medium);
-  font-weight: 600;
+  font-weight: 500;
   color: var(--color-error-text);
-}
-
-/* Error subtitle (short description) */
-.error-group-header .error-subtitle {
-  flex: 1 1 auto;
-  font-size: 0.75rem;
-  color: var(--color-text);
-  opacity: 0.7;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin-left: var(--spacing-xs);
-  font-family: var(--font-family-code);
-}
-
-/* Error Group Content - Animated expand/collapse */
-.error-group-content {
-  display: grid;
-  grid-template-rows: 0fr;
-  opacity: 0;
-  margin-top: 0;
-  padding-top: 0;
-  transition:
-    grid-template-rows 0.25s ease-out,
-    opacity 0.2s ease-out,
-    margin-top 0.25s ease-out,
-    padding-top 0.25s ease-out;
-  overflow: hidden;
-}
-
-.error-group-content > .error-content-inner {
-  min-height: 0;
-}
-
-.error-group.expanded .error-group-content {
-  grid-template-rows: 1fr;
-  opacity: 1;
-  margin-top: var(--spacing-xs);
-  padding-top: var(--spacing-xs);
-}
-
-.error-content-inner {
-  padding: var(--spacing-md);
-  border-radius: 8px;
-  /* border: 1px solid var(--color-error-text); */
-  margin-left: var(--spacing-md);
-}
-
-/* Callstack styling */
-.error-callstack {
-  margin: 0;
-  white-space: pre-wrap;
-  word-break: break-word;
-  font-family: var(--font-family-code);
-  font-size: 0.72rem;
-  line-height: 1.5;
-  color: var(--color-error-text);
-  max-height: 30vh;
-  overflow-y: auto;
-  scrollbar-width: thin;
-  scrollbar-color: var(--color-error-text) transparent;
+  opacity: 0.9;
+  margin-bottom: var(--spacing-sm);
 }
 
 /* Terminal styling moved to new terminal block above */

--- a/webui/css/messages.css
+++ b/webui/css/messages.css
@@ -846,24 +846,3 @@
   opacity: 0;
 }
 
-/* Expand button - hidden by default, shown when overflow */
-.message.message-collapsible .expand-btn {
-  display: none;
-  background: transparent;
-  border: none;
-  color: var(--color-text-muted);
-  font-family: "Rubik", Arial, Helvetica, sans-serif;
-  font-size: var(--font-size-xs);
-  cursor: pointer;
-  padding: var(--spacing-xs) 0;
-  opacity: 0.7;
-  transition: opacity 0.15s ease;
-}
-
-.message.message-collapsible .expand-btn:hover {
-  opacity: 1;
-}
-
-.message.message-collapsible.has-overflow .expand-btn {
-  display: block;
-}

--- a/webui/index.js
+++ b/webui/index.js
@@ -200,14 +200,7 @@ updateUserTime();
 setInterval(updateUserTime, 1000);
 
 function setMessages(...params) {
-  const chatHistoryEl = document.getElementById("chat-history");
-  let scroller;
-
-  if (preferencesStore.autoScroll && chatHistoryEl) scroller = new msgs.Scroller(chatHistoryEl)
-  const result = msgs.setMessages(...params);
-  if (scroller) scroller.reApplyScroll();
-
-  return result;
+  return msgs.setMessages(...params);
 }
 
 globalThis.loadKnowledge = async function () {

--- a/webui/js/messages.js
+++ b/webui/js/messages.js
@@ -2067,10 +2067,15 @@ function setupCollapsible(messageDiv, containerSelector, initialExpanded, action
   if (!messageDiv.classList.contains("has-overflow")) {
     requestAnimationFrame(() => {
       const body = messageDiv.querySelector(".message-body");
-      const wasExp = messageDiv.classList.contains("expanded");
-      messageDiv.classList.remove("expanded");
-      messageDiv.classList.toggle("has-overflow", body?.scrollHeight > body?.clientHeight);
-      messageDiv.classList.toggle("expanded", wasExp);
+      if (!body) return;
+      
+      // calculate max height without touching DOM (no scroll jitter)
+      const fontSize = parseFloat(getComputedStyle(body).fontSize || "16");
+      const maxHeight = messageDiv.classList.contains("expanded") 
+        ? fontSize * 15 
+        : body.clientHeight;
+        
+      messageDiv.classList.toggle("has-overflow", body.scrollHeight > maxHeight);
     });
   }
 }

--- a/webui/js/messages.js
+++ b/webui/js/messages.js
@@ -505,7 +505,7 @@ export function _drawMessage({
       headingElement.appendChild(headingH4);
     }
     headingH4.innerHTML = convertIcons(escapeHTML(heading));
-
+  } else {
     // Remove heading if it exists but heading is null
     const existingHeading = messageDiv.querySelector(".msg-heading");
     if (existingHeading) {
@@ -1304,6 +1304,8 @@ export function drawMessageError({
   ...additional
 }) {
   const contentText = String(content ?? "");
+  const errorText = kvps?.text || "Error";
+  const errorHeading = errorText ? `Error - ${errorText}` : "Error";
   const actionButtons = [
     createActionButton("detail", "", () =>
       stepDetailStore.showStepDetail(
@@ -1317,12 +1319,11 @@ export function drawMessageError({
 
   return drawStandaloneMessage({
     id,
-    heading,
+    heading: errorHeading,
     content,
     position: "mid",
     containerClasses: ["ai-container", "center-container"],
     mainClass: "message-error",
-    kvps,
     actionButtons,
   });
 }


### PR DESCRIPTION
Refactors the collapsible message system for cleaner architecture and adds per-segment copy buttons to the step detail modal, while simplifying their design.

Changes
- Extracted collapsible logic into a reusable setupCollapsible function, eliminating ~70 lines of duplicated code across drawStandaloneMessage and drawMessageResponse
- Moved collapsible CSS from messages.css to dedicated simple-action-buttons.css
- Preserves expansion state (expanded, has-overflow) when message classes are updated

- Added individual copy buttons for each segment (heading, details, content) in the step detail modal
- Copy actions now show toast notification feedback ("Copied to clipboard!"), they weren't
- Cleaned up modal HTML structure
- Added CSS constraints for <p> elements in thought/process groups to prevent overflow

Others:
- [x] - Flatten out kvps in step details
- [x] - Smoother scroller in chat container, terminals, steps generation
- [x] - Attach duration element to calculation between first step and start of response generation (end of process group)
- [x] - Added LIST mode where we collapse all steps and keep only process groups expanded