### PR TITLE
fix: autoscroll breaking during streaming

### DIFF
--- a/webui/components/sidebar/chats/chats-store.js
+++ b/webui/components/sidebar/chats/chats-store.js
@@ -4,12 +4,12 @@ import {
   getContext,
   setContext,
   poll as triggerPoll,
-  updateAfterScroll,
   toastFetchError,
   toast,
   justToast,
   getConnectionStatus,
 } from "/index.js";
+import { updateAfterScroll } from "/js/messages.js";
 import { store as notificationStore } from "/components/notifications/notification-store.js";
 import { store as tasksStore } from "/components/sidebar/tasks/tasks-store.js";
 

--- a/webui/index.js
+++ b/webui/index.js
@@ -580,27 +580,6 @@ globalThis.toast = toast;
 
 // OLD: hideToast function removed - now using new notification system
 
-function scrollChanged(isAtBottom) {
-  // Reflect scroll state into preferences store; UI is bound via x-model
-  preferencesStore.autoScroll = isAtBottom;
-}
-
-export function updateAfterScroll() {
-  // const toleranceEm = 1; // Tolerance in em units
-  // const tolerancePx = toleranceEm * parseFloat(getComputedStyle(document.documentElement).fontSize); // Convert em to pixels
-  // Larger trigger zone near bottom for autoscroll
-  const tolerancePx = 80;
-  const chatHistory = document.getElementById("chat-history");
-  if (!chatHistory) return;
-
-  const isAtBottom =
-    chatHistory.scrollHeight - chatHistory.scrollTop <=
-    chatHistory.clientHeight + tolerancePx;
-
-  scrollChanged(isAtBottom);
-}
-globalThis.updateAfterScroll = updateAfterScroll;
-
 import { store as _chatNavigationStore } from "/components/chat/navigation/chat-navigation-store.js";
 
 
@@ -653,7 +632,7 @@ document.addEventListener("DOMContentLoaded", function () {
   // Sidebar and input event listeners are now handled by their respective stores
 
   if (chatHistory) {
-    chatHistory.addEventListener("scroll", updateAfterScroll);
+    chatHistory.addEventListener("scroll", msgs.updateAfterScroll);
   }
 
   // Start polling for updates

--- a/webui/js/messages.js
+++ b/webui/js/messages.js
@@ -1647,6 +1647,16 @@ export class Scroller {
   }
 }
 
+export function updateAfterScroll() {
+  const history = document.getElementById("chat-history");
+  if (!history) return;
+
+  const isAtBottom =
+    history.scrollHeight - history.scrollTop <= history.clientHeight + 80;
+
+  preferencesStore.autoScroll = isAtBottom;
+}
+
 /**
  * Create a new collapsible process group
  */
@@ -2129,6 +2139,10 @@ function smoothRender(element, newContent, delay = 350) {
 
     // Keep container height stable while layers are absolute
     element.style.height = `${nextLayer.scrollHeight}px`;
+    
+    // Maintain scroll position if autoscroll enabled
+    const history = document.getElementById("chat-history");
+    preferencesStore.autoScroll && history && (history.scrollTop = history.scrollHeight);
   }, delay);
 
   element.dataset.smoothTimeoutId = String(timeoutId);


### PR DESCRIPTION
Root cause: `smoothRender` was adding content with delayed animations but not maintaining scroll position, causing autoscroll to stop working when new content arrived.

Solution: Added scroll maintenance in `smoothRender` after content updates. Also moved scroll logic from `index.js` to `messages.js` where it belongs as discussed.