### PR TITLE
fix: action buttons copy

### DIFF
--- a/webui/components/messages/action-buttons/simple-action-buttons.css
+++ b/webui/components/messages/action-buttons/simple-action-buttons.css
@@ -12,6 +12,7 @@
   opacity: 0;
   transition: opacity 0.2s ease-in-out;
   pointer-events: none;
+  user-select: none;
 }
 
 .step-action-buttons .expand-btn {


### PR DESCRIPTION
Fixes `open_in_full`, `content_copy` etc appearing on pasting manually selected and copied text