### PR TITLE
fix: Skip empty AI messages in output_langchain to prevent API rejection

### DIFF
--- a/python/helpers/history.py
+++ b/python/helpers/history.py
@@ -519,12 +519,15 @@ def group_messages_abab(messages: list[BaseMessage]) -> list[BaseMessage]:
 def output_langchain(messages: list[OutputMessage]):
     result = []
     for m in messages:
+        content = _output_content_langchain(content=m["content"])
+        # Skip AI messages with empty/whitespace-only content
+        # (API spec requires assistant messages to have content or tool_calls)
         if m["ai"]:
-            # result.append(AIMessage(content=serialize_content(m["content"])))
-            result.append(AIMessage(_output_content_langchain(content=m["content"])))  # type: ignore
+            if not content or (isinstance(content, str) and not content.strip()):
+                continue
+            result.append(AIMessage(content))  # type: ignore
         else:
-            # result.append(HumanMessage(content=serialize_content(m["content"])))
-            result.append(HumanMessage(_output_content_langchain(content=m["content"])))  # type: ignore
+            result.append(HumanMessage(content))  # type: ignore
     # ensure message type alternation
     result = group_messages_abab(result)
     return result


### PR DESCRIPTION
## Problem
Empty or whitespace-only AI messages cause API validation errors with strict providers (OpenAI, Z.ai, GLM):
```
"Assistant messages must have either content or tool_calls"
```

## Root Cause
This is a companion fix to PR #927 (response.py KeyError fix). When that fix returns an empty string instead of crashing, the empty string can become an empty `AIMessage` that fails API validation.

The `output_langchain()` function creates `AIMessage` objects without validating that content exists.

## Solution
- Pre-compute content before creating message objects
- Skip AI messages where content is None, empty, or whitespace-only
- Human messages are not filtered (they can be empty per API spec)

## Testing
Deployed and validated on 4 production A0 instances running Z.ai/GLM providers.

## Changes
- `python/helpers/history.py`: Modified `output_langchain()` function (lines 519-533)