### PR TITLE
fix: respect custom MCP timeout settings instead of capping at hardcoded values

### DIFF
--- a/python/helpers/mcp_handler.py
+++ b/python/helpers/mcp_handler.py
@@ -1072,8 +1072,8 @@ class MCPClientRemote(MCPClientBase):
         set = settings.get_settings()
 
         # Use lower timeouts for faster failure detection
-        init_timeout = min(server.init_timeout or set["mcp_client_init_timeout"], 5)
-        tool_timeout = min(server.tool_timeout or set["mcp_client_tool_timeout"], 10)
+        init_timeout = server.init_timeout or set["mcp_client_init_timeout"] or 5
+        tool_timeout = server.tool_timeout or set["mcp_client_tool_timeout"] or 10
 
         client_factory = CustomHTTPClientFactory(verify=server.verify)
         # Check if this is a streaming HTTP type


### PR DESCRIPTION
## Summary
Fixes #946 

The `min()` function was capping timeout values at hardcoded limits (5s for init, 10s for tool), which defeated the purpose of custom timeout settings. This change removes the artificial caps and respects user-configured timeout values.

## Changes
- Removed `min()` calls that capped `init_timeout` at 5 seconds
- Removed `min()` calls that capped `tool_timeout` at 10 seconds
- Timeout resolution order now: server-specific → global setting → default fallback

## Test Plan
- [ ] Set custom MCP timeout values above previous hardcoded limits (e.g., `init_timeout: 30`)
- [ ] Verify that timeouts are respected and not capped at 5/10 seconds
- [ ] Confirm that default values (5/10) still apply when no custom values are set

Closes #946