### PR TITLE
feat: Auto-install Playwright browsers on container start

### DIFF
--- a/docker/run/fs/exe/run_A0.sh
+++ b/docker/run/fs/exe/run_A0.sh
@@ -3,6 +3,19 @@
 . "/ins/setup_venv.sh" "$@"
 . "/ins/copy_A0.sh" "$@"
 
+# === Playwright Browser Setup ===
+# Auto-install Playwright browsers if not present (survives container restarts)
+# Only installs Chromium by default; add firefox/webkit if needed
+PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-/root/.cache/ms-playwright}"
+if command -v playwright &> /dev/null; then
+    if [ ! -d "$PLAYWRIGHT_BROWSERS_PATH/chromium"* ] 2>/dev/null; then
+        echo "Installing Playwright browsers..."
+        playwright install chromium 2>/dev/null || echo "WARNING: Playwright browser install failed"
+    else
+        echo "Playwright browsers already installed"
+    fi
+fi
+
 python /a0/prepare.py --dockerized=true
 # python /a0/preload.py --dockerized=true # no need to run preload if it's done during container build
 


### PR DESCRIPTION
## Problem

When using Playwright for browser automation in Agent Zero, browsers need to be installed separately. If the container is rebuilt or the Playwright cache is cleared, browser automation fails silently.

## Solution

Add Playwright browser auto-installation to the container entrypoint script (run_A0.sh). This ensures browsers are always available without manual intervention.

## Changes

File: docker/run/fs/exe/run_A0.sh

- Check if playwright command is available
- Only install if browsers are not already present  
- Install only Chromium by default (lightweight)
- Silent failure does not break container startup
- Respects PLAYWRIGHT_BROWSERS_PATH environment variable

## Notes

For Playwright to work, system packages (libgstreamer, libnss3, libcups2, etc.) should be in the base image.

## Testing

1. Remove Playwright cache in container
2. Restart container
3. Verify browsers auto-install in logs
4. Test browser automation works