### PR TITLE
add Moonshot AI provider support

### DIFF
--- a/conf/model_providers.yaml
+++ b/conf/model_providers.yaml
@@ -56,6 +56,9 @@ chat:
   mistral:
     name: Mistral AI
     litellm_provider: mistral
+  moonshot:
+    name: Moonshot AI
+    litellm_provider: moonshot
   ollama:
     name: Ollama
     litellm_provider: ollama


### PR DESCRIPTION
Added Moonshot AI as new provider in the provider config (moonshot → LiteLLM moonshot), which makes it available as the other providers.

.env behavior remains consistent:
API keys are resolved for Moonshot as API_KEY_MOONSHOT (primary) with MOONSHOT_API_KEY as fallback.
