### PR TITLE
fix deepwiki mcp example

### DIFF
--- a/webui/components/settings/mcp/client/example.html
+++ b/webui/components/settings/mcp/client/example.html
@@ -48,7 +48,8 @@
                         },
                         "deep-wiki": {
                             "description": "Use this MCP to analyze github repositories",
-                            "url": "https://mcp.deepwiki.com/sse"
+                            "url": "https://mcp.deepwiki.com/mcp",
+                            "type": "streamable-http"
                         }
                     }
                 }, null, 2);


### PR DESCRIPTION
/sse changed to /mcp for the DeepWiki MCP example. It wasn't working as published in the old example (also without http-streamable type).