### PR TITLE
ui: clock locale, chat bar resize fix, action buttons fix

### DIFF
--- a/webui/components/chat/input/chat-bar-input.html
+++ b/webui/components/chat/input/chat-bar-input.html
@@ -25,7 +25,8 @@
             <textarea id="chat-input" :placeholder="$store.chatInput.inputPlaceholder" rows="1"
                       @keydown.enter="if (!$event.shiftKey && !$event.isComposing && $event.keyCode !== 229) { $event.preventDefault(); $store.chatInput.sendMessage(); }"
                       @input="$store.chatInput.adjustTextareaHeight()"
-                      x-model="$store.chatInput.message"></textarea>
+                      x-model="$store.chatInput.message"
+                      x-effect="if (!$store.chatInput.message) $el.style.height = ''"></textarea>
             <button id="expand-button" @click="$store.fullScreenInputModal.openModal()" aria-label="Expand input">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>

--- a/webui/components/messages/action-buttons/simple-action-buttons.css
+++ b/webui/components/messages/action-buttons/simple-action-buttons.css
@@ -12,6 +12,8 @@
   opacity: 0;
   transition: opacity 0.2s ease-in-out;
   pointer-events: none;
+  user-select: none;
+  -moz-user-select: none;
 }
 
 .step-action-buttons .expand-btn {

--- a/webui/index.js
+++ b/webui/index.js
@@ -189,20 +189,16 @@ async function updateUserTime() {
   }
 
   const now = new Date();
-  const hours = now.getHours();
-  const minutes = now.getMinutes();
-  const seconds = now.getSeconds();
-  const ampm = hours >= 12 ? "pm" : "am";
-  const formattedHours = hours % 12 || 12;
-
-  // Format the time
-  const timeString = `${formattedHours}:${minutes
-    .toString()
-    .padStart(2, "0")}:${seconds.toString().padStart(2, "0")} ${ampm}`;
-
-  // Format the date
-  const options = { year: "numeric", month: "short", day: "numeric" };
-  const dateString = now.toLocaleDateString(undefined, options);
+  const timeString = now.toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit'
+  });
+  const dateString = now.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
 
   // Update the HTML
   userTimeElement.innerHTML = `${timeString}<br><span id="user-date">${dateString}</span>`;

--- a/webui/js/messages.js
+++ b/webui/js/messages.js
@@ -2046,9 +2046,10 @@ function updateProcessGroupHeader(group) {
   const startTimestamp = group.getAttribute("data-start-timestamp");
   if (timeMetricEl && startTimestamp) {
     const date = new Date(parseFloat(startTimestamp) * 1000);
-    const hours = String(date.getHours()).padStart(2, "0");
-    const minutes = String(date.getMinutes()).padStart(2, "0");
-    timeMetricEl.textContent = `${hours}:${minutes}`;
+    timeMetricEl.textContent = date.toLocaleTimeString(undefined, {
+      hour: 'numeric',
+      minute: '2-digit'
+    });
     if (timeMetricContainerEl) {
       const fullDateTime = date.toLocaleString(undefined, {
         dateStyle: "medium",


### PR DESCRIPTION
- index.js: Main clock is now localized (12h/24h depending on browser language)
- messages.js: Same clock locale fix to process metric timestamp for consistency with main clock
- simple-action-buttons.css: Action buttons no longer selectable. Currently manually selecting text (for example response text with markdown table) will add button text (`content_copy` and others) to copied content
- chat-bar-input.html: Message text field now properly resize back after sending message with 2+ lines