### PR TITLE
Add Codex (ChatGPT subscription) provider with global login, per-role models, fallback, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 [Installation](./docs/setup/installation.md) •
 [How to update](./docs/setup/installation.md#how-to-update-agent-zero) <br>
 [Development Setup](./docs/setup/dev-setup.md) •
-[Usage](./docs/guides/usage.md)
+[Usage](./docs/guides/usage.md) •
+[Codex Subscription](./docs/guides/codex-subscription.md)
 
 Or see DeepWiki generated documentation:
 
@@ -155,6 +156,7 @@ docker run -p 50001:80 agent0ai/agent-zero
 |-------|-------------|
 | [Installation](./docs/setup/installation.md) | Installation, setup and configuration |
 | [Usage](./docs/guides/usage.md) | Basic and advanced usage |
+| [Codex Subscription](./docs/guides/codex-subscription.md) | Connect ChatGPT subscription, select per-role Codex models, and verify setup |
 | [Guides](./docs/guides/) | Step-by-step guides: Usage, Projects, API Integration, MCP Setup, A2A Setup |
 | [Development Setup](./docs/setup/dev-setup.md) | Development and customization |
 | [WebSocket Infrastructure](./docs/developer/websockets.md) | Real-time WebSocket handlers, client APIs, filtering semantics, envelopes |

--- a/agent.py
+++ b/agent.py
@@ -730,6 +730,8 @@ class Agent:
             self.config.chat_model.provider,
             self.config.chat_model.name,
             model_config=self.config.chat_model,
+            a0_role="chat",
+            a0_context_id=self.context.id,
             **self.config.chat_model.build_kwargs(),
         )
 
@@ -738,6 +740,8 @@ class Agent:
             self.config.utility_model.provider,
             self.config.utility_model.name,
             model_config=self.config.utility_model,
+            a0_role="utility",
+            a0_context_id=self.context.id,
             **self.config.utility_model.build_kwargs(),
         )
 
@@ -746,6 +750,8 @@ class Agent:
             self.config.browser_model.provider,
             self.config.browser_model.name,
             model_config=self.config.browser_model,
+            a0_role="browser",
+            a0_context_id=self.context.id,
             **self.config.browser_model.build_kwargs(),
         )
 

--- a/conf/model_providers.yaml
+++ b/conf/model_providers.yaml
@@ -30,6 +30,9 @@ chat:
   cometapi:
     name: CometAPI
     litellm_provider: cometapi
+  codex:
+    name: Codex (ChatGPT subscription)
+    litellm_provider: codex
   deepseek:
     name: DeepSeek
     litellm_provider: deepseek

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Welcome to the Agent Zero documentation hub. Whether you're getting started or d
 ## User Guides
 
 - **[Usage Guide](guides/usage.md):** Comprehensive guide to Agent Zero's features and capabilities.
+- **[Codex Subscription Guide](guides/codex-subscription.md):** Use ChatGPT subscription via Codex CLI with global login and per-role model selection.
 - **[Projects Tutorial](guides/projects.md):** Learn to create isolated workspaces with dedicated context and memory.
 - **[API Integration](guides/api-integration.md):** Add external APIs without writing code.
 - **[MCP Setup](guides/mcp-setup.md):** Configure Model Context Protocol servers.
@@ -86,6 +87,7 @@ Welcome to the Agent Zero documentation hub. Whether you're getting started or d
     - [Voice Interface](guides/usage.md#voice-interface)
     - [Memory Management](guides/usage.md#memory-management)
     - [Backup & Restore](guides/usage.md#backup--restore)
+  - [Codex Subscription Guide](guides/codex-subscription.md)
   - [Projects Tutorial](guides/projects.md)
   - [API Integration](guides/api-integration.md)
   - [MCP Setup](guides/mcp-setup.md)

--- a/docs/guides/codex-subscription.md
+++ b/docs/guides/codex-subscription.md
@@ -1,0 +1,149 @@
+# Codex (ChatGPT Subscription) Guide
+
+This guide explains how to use Agent Zero with your ChatGPT subscription through the `Codex (ChatGPT subscription)` provider.
+
+## What This Integration Does
+
+- Uses local `codex` CLI authentication (your ChatGPT account), not OpenAI API billing.
+- Supports independent model selection for:
+  - Chat model
+  - Utility model
+  - Browser model
+- Keeps embedding model unchanged (embedding does not use Codex subscription mode).
+- Uses one global login, then lets you choose different models per role.
+
+## Prerequisites
+
+- `codex` CLI is installed and available in PATH.
+- You can run:
+
+```bash
+codex --version
+codex login status
+```
+
+- Agent Zero is running and you can open the Web UI settings.
+
+## UI Walkthrough
+
+### 1. Open Agent Settings
+
+- Go to **Settings → Agent Settings**.
+- You should see sections for `Chat Model`, `Utility model`, `Web Browser Model`, and `ChatGPT Subscription`.
+
+![Agent settings overview](../res/setup/codex/agent-settings-overview.svg)
+
+### 2. Connect Your ChatGPT Subscription (Global Login)
+
+- Open **ChatGPT Subscription** section.
+- Click **Connect ChatGPT**.
+- Complete authentication in the browser window opened by the login flow.
+- Click **Check Status** and confirm:
+  - Installed: `yes`
+  - Logged in: `yes`
+  - Login flow: `completed`
+- Click **Refresh Models** to fetch available Codex models for your account.
+
+![Subscription login panel](../res/setup/codex/subscription-panel.svg)
+
+> [!NOTE]
+> This login is global and shared by all Codex-backed roles. You do not log in separately for Chat/Utility/Browser.
+
+### 3. Set Providers and Models Per Role
+
+For each section below, set provider to `Codex (ChatGPT subscription)`:
+
+- **Chat Model**
+- **Utility model**
+- **Web Browser Model**
+
+Then choose model name independently per role. Example:
+
+- Chat model: `gpt-5.2-codex`
+- Utility model: `gpt-5.1-codex-mini`
+- Browser model: `gpt-5.2`
+
+Click **Save**.
+
+![Per-role model selectors](../res/setup/codex/per-role-models.svg)
+
+## How It Works Internally
+
+- Agent Zero runs Codex through local CLI (`codex exec --json`) for Chat/Utility/Browser roles.
+- A single ChatGPT login is reused globally.
+- Each role stores its own model setting (`chat_model_name`, `util_model_name`, `browser_model_name`).
+- Codex sessions are resumed per chat context and per role:
+  - New chat starts fresh Codex thread(s).
+  - Existing chat resumes relevant Codex thread for that role.
+- If Codex fails on a call, Agent Zero attempts a temporary per-call fallback to the previous non-Codex provider for that role and shows a warning banner.
+- Saved provider remains `codex` unless you change it manually.
+
+## Verify It Works (Checklist)
+
+### A. UI Verification
+
+- [ ] Chat role shows selected Chat model name correctly.
+- [ ] Utility role shows selected Utility model name correctly.
+- [ ] Browser role shows selected Browser model name correctly.
+- [ ] Reopening Settings still shows all three chosen values.
+
+### B. Backend Verification
+
+Run:
+
+```bash
+cd agent-zero
+./.venv/bin/python - <<'PY'
+from python.helpers import settings
+s=settings.get_settings()
+print("chat:", s["chat_model_name"])
+print("util:", s["util_model_name"])
+print("browser:", s["browser_model_name"])
+PY
+```
+
+Expected: values match what you selected in UI for each role.
+
+### C. Functional Verification
+
+- Send a normal chat prompt and confirm response arrives.
+- Trigger at least one utility-style task (summarization/memory operations) and verify no model misformat loop.
+- Trigger browser-use task and verify browser path still works.
+
+## Security Notes
+
+> [!CAUTION]
+> This setup can run Codex in unrestricted full-auto mode (`--dangerously-bypass-approvals-and-sandbox`), which can execute commands without additional sandbox/approval prompts. Use only in trusted environments.
+
+> [!IMPORTANT]
+> ChatGPT subscription login is not an API key replacement for non-Codex providers. If you switch back to OpenAI/OpenRouter/etc, configure API keys as usual.
+
+## Common Issues
+
+### UI shows the same model for all three roles
+
+- First verify backend values (command above).
+- If backend values are different, update to the latest UI patch and hard-refresh browser.
+- If mismatch persists, reopen settings after save and check model text fields again.
+
+### Codex status says not connected
+
+- Confirm `codex` is installed on the same machine/container where Agent Zero backend runs.
+- Run `codex login status` in terminal.
+- Return to **ChatGPT Subscription** and click **Check Status**.
+
+### No model list appears
+
+- Ensure login is completed first.
+- Click **Refresh Models**.
+- If still empty/unverified, use manual model entry (exact model ID) and re-check diagnostics in status panel.
+
+## Recommended Team Documentation Practice
+
+If you maintain a fork/team deployment:
+
+1. Keep this guide (`docs/guides/codex-subscription.md`) as the detailed source of truth.
+2. Keep README concise with a link to this guide.
+3. Add short troubleshooting bullets in `docs/guides/troubleshooting.md`.
+4. When UI changes, update screenshots in `docs/res/setup/codex/`.
+

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -14,6 +14,36 @@ This page addresses frequently asked questions (FAQ) and provides troubleshootin
 **4. Does ChatGPT Plus include API access?**
 - No. ChatGPT Plus does not include API credits. You must provide an OpenAI API key in Settings.
 
+**4a. Can I use ChatGPT subscription without OpenAI API billing?**
+- Yes, by using the `Codex (ChatGPT subscription)` provider for Chat/Utility/Browser roles.
+- This provider relies on your local `codex` login status instead of API keys.
+- Use **Settings → Agent Settings → ChatGPT Subscription** to connect/disconnect and verify status.
+
+**4b. Codex provider is selected but calls fail. What should I check?**
+- Verify `codex` is installed and available on PATH.
+- Run `codex login status` locally and confirm it reports logged in.
+- In Agent Zero Settings, check Codex status diagnostics for the selected role.
+- If Codex fails, Agent Zero can temporarily fallback to previous non-codex provider and show a warning banner.
+- If you enabled unrestricted full-auto for Codex, make sure you trust the execution environment.
+
+**4c. UI shows the same Codex model in Chat/Utility/Browser, but backend values are different.**
+- Confirm saved values with:
+  ```bash
+  cd agent-zero
+  ./.venv/bin/python - <<'PY'
+  from python.helpers import settings
+  s=settings.get_settings()
+  print("chat:", s["chat_model_name"])
+  print("util:", s["util_model_name"])
+  print("browser:", s["browser_model_name"])
+  PY
+  ```
+- If backend is correct, update to latest frontend patch and hard-refresh browser.
+- Reopen Settings and verify each role field shows its own value.
+
+**4d. Where is the full setup guide for ChatGPT subscription mode?**
+- See [Codex Subscription Guide](codex-subscription.md) for login flow, model selection, screenshots, and verification checklist.
+
 **5. Where is chat history stored?**
 - Chat history lives at `/a0/usr/chats/` inside the container.
 

--- a/docs/res/setup/codex/README.md
+++ b/docs/res/setup/codex/README.md
@@ -1,0 +1,16 @@
+# Codex Guide Images
+
+This folder contains visual assets for the Codex subscription setup guide:
+
+- `agent-settings-overview.svg`
+- `subscription-panel.svg`
+- `per-role-models.svg`
+
+These are placeholder illustrations so docs render cleanly in all environments.
+
+If you want real product screenshots, replace these files (or add PNG files and update links in `docs/guides/codex-subscription.md`) using captures from:
+
+1. Agent Settings overview
+2. ChatGPT Subscription connection panel
+3. Per-role model selection (Chat / Utility / Browser)
+

--- a/docs/res/setup/codex/agent-settings-overview.svg
+++ b/docs/res/setup/codex/agent-settings-overview.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+  <rect width="1280" height="720" fill="#101319"/>
+  <rect x="40" y="40" width="1200" height="640" rx="20" fill="#171b24" stroke="#2a3140"/>
+  <text x="80" y="120" fill="#f4f6fb" font-family="Arial, sans-serif" font-size="42" font-weight="700">
+    Agent Settings Overview
+  </text>
+  <text x="80" y="190" fill="#b7c0d4" font-family="Arial, sans-serif" font-size="26">
+    Replace this placeholder with an actual screenshot from your running UI.
+  </text>
+  <text x="80" y="260" fill="#8ea1c6" font-family="Arial, sans-serif" font-size="24">
+    Suggested capture: Settings page showing Chat / Utility / Browser / ChatGPT Subscription sections.
+  </text>
+  <rect x="80" y="320" width="520" height="300" rx="12" fill="#202838" stroke="#30405e"/>
+  <rect x="640" y="320" width="520" height="300" rx="12" fill="#202838" stroke="#30405e"/>
+  <text x="110" y="380" fill="#c8d2ea" font-family="Arial, sans-serif" font-size="22">Chat Model</text>
+  <text x="110" y="425" fill="#c8d2ea" font-family="Arial, sans-serif" font-size="22">Utility Model</text>
+  <text x="110" y="470" fill="#c8d2ea" font-family="Arial, sans-serif" font-size="22">Browser Model</text>
+  <text x="670" y="380" fill="#c8d2ea" font-family="Arial, sans-serif" font-size="22">ChatGPT Subscription</text>
+  <text x="670" y="425" fill="#c8d2ea" font-family="Arial, sans-serif" font-size="22">Connect / Check / Refresh</text>
+</svg>

--- a/docs/res/setup/codex/per-role-models.svg
+++ b/docs/res/setup/codex/per-role-models.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+  <rect width="1280" height="720" fill="#11141b"/>
+  <rect x="44" y="44" width="1192" height="632" rx="20" fill="#191f2b" stroke="#31394a"/>
+  <text x="84" y="114" fill="#f4f7fd" font-family="Arial, sans-serif" font-size="40" font-weight="700">
+    Per-Role Codex Models
+  </text>
+  <text x="84" y="174" fill="#bbc6dd" font-family="Arial, sans-serif" font-size="24">
+    Replace this placeholder with screenshot of Chat / Utility / Browser sections showing different model names.
+  </text>
+  <rect x="84" y="232" width="1112" height="116" rx="12" fill="#222b3a" stroke="#364863"/>
+  <rect x="84" y="368" width="1112" height="116" rx="12" fill="#222b3a" stroke="#364863"/>
+  <rect x="84" y="504" width="1112" height="116" rx="12" fill="#222b3a" stroke="#364863"/>
+  <text x="112" y="296" fill="#d9e1f3" font-family="Arial, sans-serif" font-size="28">Chat Model: gpt-5.2-codex</text>
+  <text x="112" y="432" fill="#d9e1f3" font-family="Arial, sans-serif" font-size="28">Utility Model: gpt-5.1-codex-mini</text>
+  <text x="112" y="568" fill="#d9e1f3" font-family="Arial, sans-serif" font-size="28">Browser Model: gpt-5.2</text>
+</svg>

--- a/docs/res/setup/codex/subscription-panel.svg
+++ b/docs/res/setup/codex/subscription-panel.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+  <rect width="1280" height="720" fill="#0f1218"/>
+  <rect x="48" y="48" width="1184" height="624" rx="18" fill="#181d27" stroke="#2d3342"/>
+  <text x="88" y="118" fill="#f5f7fc" font-family="Arial, sans-serif" font-size="40" font-weight="700">
+    ChatGPT Subscription Panel
+  </text>
+  <text x="88" y="178" fill="#b9c2d7" font-family="Arial, sans-serif" font-size="24">
+    Replace with screenshot after clicking: Connect ChatGPT / Check Status / Refresh Models
+  </text>
+  <rect x="88" y="228" width="1104" height="384" rx="12" fill="#212a39" stroke="#33445f"/>
+  <rect x="120" y="270" width="200" height="52" rx="10" fill="#3659d9"/>
+  <rect x="340" y="270" width="180" height="52" rx="10" fill="#2b3342"/>
+  <rect x="540" y="270" width="160" height="52" rx="10" fill="#2b3342"/>
+  <rect x="720" y="270" width="170" height="52" rx="10" fill="#2b3342"/>
+  <text x="145" y="303" fill="#ffffff" font-family="Arial, sans-serif" font-size="20">Connect</text>
+  <text x="370" y="303" fill="#d4dced" font-family="Arial, sans-serif" font-size="20">Check Status</text>
+  <text x="570" y="303" fill="#d4dced" font-family="Arial, sans-serif" font-size="20">Disconnect</text>
+  <text x="750" y="303" fill="#d4dced" font-family="Arial, sans-serif" font-size="20">Refresh Models</text>
+</svg>

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -295,6 +295,31 @@ Configure API keys for various service providers directly within the Web UI. Cli
 > [!NOTE]
 > **OpenAI API vs Plus subscription:** A ChatGPT Plus subscription does not include API credits. You must provide a separate API key for OpenAI usage in Agent Zero.
 
+> [!NOTE]
+> **Codex provider (ChatGPT subscription):** The `Codex (ChatGPT subscription)` provider uses your local `codex` login instead of OpenAI API keys.  
+> In the Settings panel, use **Agent Settings → ChatGPT Subscription** to connect and verify login status.
+
+> [!CAUTION]
+> **Codex execution mode:** If Codex is configured with unrestricted full-auto, it may execute commands without sandbox/approval prompts. Use this mode only in trusted environments.
+
+### Codex (ChatGPT subscription) quick setup
+
+Use this when you want Agent Zero to run through your ChatGPT subscription instead of OpenAI API billing.
+
+1. Open **Settings → Agent Settings → ChatGPT Subscription**.
+2. Click **Connect ChatGPT** and finish login in browser.
+3. Click **Check Status** (must show logged in) and **Refresh Models**.
+4. In each model section (`Chat`, `Utility`, `Web Browser`), set provider to `Codex (ChatGPT subscription)`.
+5. Choose model name per role and click **Save**.
+
+![Codex setup flow](../res/setup/codex/subscription-panel.svg)
+
+> [!NOTE]
+> Login is global, but model selection is per role. You can run different models for Chat, Utility, and Browser.
+
+> [!TIP]
+> See the full walkthrough, screenshots, verification checklist, and internals in [Codex Subscription Guide](../guides/codex-subscription.md).
+
 > [!TIP]
 > For OpenAI-compatible providers (e.g., custom gateways or Z.AI/GLM), add the API key under **External Services → Other OpenAI-compatible API keys**, then select **OpenAI Compatible** as the provider in model settings.
 

--- a/python/api/codex_models_get.py
+++ b/python/api/codex_models_get.py
@@ -1,0 +1,15 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers import codex_exec
+
+
+class CodexModelsGet(ApiHandler):
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        force_refresh = bool(input.get("force_refresh", False))
+        models = codex_exec.get_codex_models(force_refresh=force_refresh)
+        status = codex_exec.get_codex_status()
+        return {"ok": True, "models": models, "status": status}
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["GET", "POST"]
+

--- a/python/api/codex_subscription_logout.py
+++ b/python/api/codex_subscription_logout.py
@@ -1,0 +1,18 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers import codex_exec
+
+
+class CodexSubscriptionLogout(ApiHandler):
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        codex_exec.cancel_codex_login()
+        result = codex_exec.logout_codex()
+        login = codex_exec.get_codex_login_state()
+        models = codex_exec.get_cached_codex_models()
+        return {
+            "ok": bool(result.get("ok", False)),
+            "message": str(result.get("message", "")),
+            "login": login,
+            "status": result.get("status", codex_exec.get_codex_status()),
+            "models": models,
+        }
+

--- a/python/api/codex_subscription_start.py
+++ b/python/api/codex_subscription_start.py
@@ -1,0 +1,11 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers import codex_exec
+
+
+class CodexSubscriptionStart(ApiHandler):
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        login = codex_exec.start_codex_login()
+        status = codex_exec.get_codex_status()
+        models = codex_exec.get_cached_codex_models()
+        return {"ok": True, "login": login, "status": status, "models": models}
+

--- a/python/api/codex_subscription_status.py
+++ b/python/api/codex_subscription_status.py
@@ -1,0 +1,15 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers import codex_exec
+
+
+class CodexSubscriptionStatus(ApiHandler):
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        login = codex_exec.get_codex_login_state()
+        status = codex_exec.get_codex_status()
+        models = codex_exec.get_cached_codex_models()
+        return {"ok": True, "login": login, "status": status, "models": models}
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["GET", "POST"]
+

--- a/python/extensions/banners/_20_missing_api_key.py
+++ b/python/extensions/banners/_20_missing_api_key.py
@@ -6,7 +6,7 @@ import models
 class MissingApiKeyCheck(Extension):
     """Check if API keys are configured for selected model providers."""
 
-    LOCAL_PROVIDERS = ["ollama", "lm_studio"]
+    LOCAL_PROVIDERS = ["ollama", "lm_studio", "codex"]
     LOCAL_EMBEDDING = ["huggingface"]
     MODEL_TYPE_NAMES = {
         "chat": "Chat Model",

--- a/python/extensions/banners/_25_codex_health.py
+++ b/python/extensions/banners/_25_codex_health.py
@@ -1,0 +1,46 @@
+from python.helpers.extension import Extension
+from python.helpers import codex_exec
+
+
+class CodexHealthBanner(Extension):
+    """Show latest Codex fallback/failure warning."""
+
+    async def execute(self, banners: list = [], frontend_context: dict = {}, **kwargs):
+        warning = codex_exec.get_latest_warning()
+        if not warning:
+            return
+
+        role = str(warning.get("role", "chat")).strip() or "chat"
+        message = str(warning.get("message", "")).strip() or "Codex backend warning."
+        fallback_provider = str(warning.get("fallback_provider", "")).strip()
+        fallback_model = str(warning.get("fallback_model", "")).strip()
+        diagnostic = str(warning.get("diagnostic", "")).strip()
+
+        fallback_part = ""
+        if fallback_provider:
+            fallback_part = f"Fallback used: <code>{fallback_provider}</code>"
+            if fallback_model:
+                fallback_part += f" / <code>{fallback_model}</code>"
+            fallback_part += ".<br>"
+
+        diagnostic_part = ""
+        if diagnostic:
+            diagnostic_part = f"<details><summary>Diagnostic</summary><pre>{diagnostic}</pre></details>"
+
+        banners.append(
+            {
+                "id": "codex-health-warning",
+                "type": "warning",
+                "priority": 95,
+                "title": f"Codex warning ({role})",
+                "html": (
+                    f"{message}<br>"
+                    f"{fallback_part}"
+                    "Open <a href=\"#\" onclick=\"document.getElementById('settings').click(); return false;\">Settings</a> "
+                    "to verify Codex login/model configuration.<br>"
+                    f"{diagnostic_part}"
+                ),
+                "dismissible": True,
+                "source": "backend",
+            }
+        )

--- a/python/helpers/codex_exec.py
+++ b/python/helpers/codex_exec.py
@@ -1,0 +1,629 @@
+import json
+import re
+import shutil
+import subprocess
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+
+_CODEX_BIN = "codex"
+_CODEX_CONFIG_OVERRIDES = [
+    'model_reasoning_effort="high"',
+    "mcp_servers={}",
+]
+_CODEX_MODEL_CANDIDATES = [
+    "gpt-5.3-codex",
+    "gpt-5.2-codex",
+    "gpt-5.1-codex-max",
+    "gpt-5.2",
+    "gpt-5.1-codex-mini",
+    "gpt-5-codex",
+]
+_MODEL_PROBE_PROMPT = "Reply with exactly: OK"
+_MODEL_CACHE_TTL_SECONDS = 30 * 60
+
+_login_lock = threading.RLock()
+_login_process: Optional[subprocess.Popen[str]] = None
+_login_state: dict[str, Any] = {
+    "session_id": "",
+    "status": "idle",
+    "auth_url": "",
+    "message": "",
+    "started_at": "",
+    "finished_at": "",
+    "stdout_tail": [],
+    "stderr_tail": [],
+}
+_model_cache: dict[str, Any] = {
+    "timestamp": 0.0,
+    "verified": False,
+    "models": [],
+    "diagnostic": "",
+}
+
+_latest_warning: Optional[dict[str, Any]] = None
+
+
+@dataclass
+class CodexExecResult:
+    ok: bool
+    thread_id: str = ""
+    message: str = ""
+    reasoning: str = ""
+    errors: list[str] = field(default_factory=list)
+    events: list[dict[str, Any]] = field(default_factory=list)
+    stderr: str = ""
+    returncode: int = 0
+
+    @property
+    def diagnostic(self) -> str:
+        parts: list[str] = []
+        if self.errors:
+            parts.append("; ".join(self.errors))
+        if self.stderr.strip():
+            parts.append(self.stderr.strip())
+        return " | ".join(p for p in parts if p).strip()
+
+
+def _base_cmd(model: str) -> list[str]:
+    cmd: list[str] = [_CODEX_BIN]
+    for override in _CODEX_CONFIG_OVERRIDES:
+        cmd.extend(["-c", override])
+    cmd.extend(
+        [
+            "exec",
+            "--json",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "-m",
+            model.strip() or "gpt-5-codex",
+        ]
+    )
+    return cmd
+
+
+def _parse_event(line: str) -> Optional[dict[str, Any]]:
+    try:
+        parsed = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def run_codex_exec(
+    prompt: str,
+    model: str = "gpt-5-codex",
+    resume_thread_id: str = "",
+    cwd: Optional[str] = None,
+    timeout_seconds: int = 300,
+) -> CodexExecResult:
+    cmd = _base_cmd(model)
+    if resume_thread_id:
+        cmd.extend(["resume", resume_thread_id])
+
+    result = CodexExecResult(ok=False)
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=cwd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except FileNotFoundError:
+        return CodexExecResult(
+            ok=False,
+            errors=["codex executable not found on PATH"],
+            returncode=127,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stderr = (exc.stderr or "").strip() if isinstance(exc.stderr, str) else ""
+        return CodexExecResult(
+            ok=False,
+            errors=[f"codex exec timed out after {timeout_seconds}s"],
+            stderr=stderr,
+            returncode=124,
+        )
+    except Exception as exc:
+        return CodexExecResult(
+            ok=False,
+            errors=[f"failed to execute codex: {type(exc).__name__}: {exc}"],
+            returncode=1,
+        )
+
+    result.returncode = completed.returncode
+    result.stderr = completed.stderr or ""
+
+    for line in (completed.stdout or "").splitlines():
+        event = _parse_event(line.strip())
+        if not event:
+            continue
+        result.events.append(event)
+
+        event_type = str(event.get("type", ""))
+        if event_type == "thread.started":
+            result.thread_id = str(event.get("thread_id", "")) or result.thread_id
+            continue
+        if event_type == "item.completed":
+            item = event.get("item", {})
+            if not isinstance(item, dict):
+                continue
+            item_type = str(item.get("type", ""))
+            text = str(item.get("text", "") or "")
+            if item_type == "agent_message" and text:
+                result.message = text
+            elif item_type == "reasoning" and text:
+                result.reasoning = (result.reasoning + "\n" + text).strip()
+            continue
+        if event_type == "error":
+            message = str(event.get("message", "")).strip()
+            if message:
+                result.errors.append(message)
+            continue
+        if event_type == "turn.failed":
+            err_obj = event.get("error", {})
+            if isinstance(err_obj, dict):
+                msg = str(err_obj.get("message", "")).strip()
+                if msg:
+                    result.errors.append(msg)
+
+    if completed.returncode == 0 and result.message:
+        result.ok = True
+        return result
+
+    if completed.returncode != 0 and not result.errors:
+        result.errors.append(f"codex exited with status {completed.returncode}")
+    if not result.message and not result.errors:
+        result.errors.append("codex returned no assistant message")
+    return result
+
+
+def get_codex_status(timeout_seconds: int = 8) -> dict[str, Any]:
+    status = {
+        "installed": False,
+        "version": "",
+        "logged_in": False,
+        "auth_mode": "unknown",
+        "diagnostic": "",
+    }
+
+    if not shutil.which(_CODEX_BIN):
+        status["diagnostic"] = "codex-cli not found on PATH"
+        return status
+
+    status["installed"] = True
+    try:
+        version_cmd = [_CODEX_BIN, "--version"]
+        version_cp = subprocess.run(
+            version_cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        version_line = (version_cp.stdout or "").strip().splitlines()
+        if version_line:
+            status["version"] = version_line[0].strip()
+    except Exception as exc:
+        status["diagnostic"] = f"failed to read codex version: {exc}"
+        return status
+
+    cmd: list[str] = [_CODEX_BIN]
+    for override in _CODEX_CONFIG_OVERRIDES:
+        cmd.extend(["-c", override])
+    cmd.extend(["login", "status"])
+    try:
+        cp = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except Exception as exc:
+        status["diagnostic"] = f"failed to check codex auth: {exc}"
+        return status
+
+    text = "\n".join(
+        [line for line in [(cp.stdout or "").strip(), (cp.stderr or "").strip()] if line]
+    ).strip()
+    lowered = text.lower()
+
+    if cp.returncode == 0:
+        status["logged_in"] = True
+        if "chatgpt" in lowered:
+            status["auth_mode"] = "chatgpt"
+        elif "api key" in lowered:
+            status["auth_mode"] = "api_key"
+        else:
+            status["auth_mode"] = "unknown"
+        status["diagnostic"] = ""
+    else:
+        status["logged_in"] = False
+        status["auth_mode"] = "none"
+        status["diagnostic"] = text or f"codex login status exited with {cp.returncode}"
+
+    return status
+
+
+def set_latest_warning(
+    role: str,
+    message: str,
+    fallback_provider: str = "",
+    fallback_model: str = "",
+    diagnostic: str = "",
+) -> None:
+    global _latest_warning
+    _latest_warning = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "role": role,
+        "message": message,
+        "fallback_provider": fallback_provider,
+        "fallback_model": fallback_model,
+        "diagnostic": diagnostic,
+    }
+
+
+def get_latest_warning() -> Optional[dict[str, Any]]:
+    if not _latest_warning:
+        return None
+    return dict(_latest_warning)
+
+
+def _format_model_label(model_id: str) -> str:
+    parts: list[str] = []
+    for part in model_id.split("-"):
+        token = part.strip().lower()
+        if token == "gpt":
+            parts.append("GPT")
+        elif token == "codex":
+            parts.append("Codex")
+        elif token == "max":
+            parts.append("Max")
+        elif token == "mini":
+            parts.append("Mini")
+        elif token.replace(".", "", 1).isdigit():
+            parts.append(part)
+        else:
+            parts.append(part.capitalize())
+    return "-".join(parts)
+
+
+def _default_codex_models() -> list[dict[str, Any]]:
+    return [
+        {"value": model, "label": _format_model_label(model), "available": None}
+        for model in _CODEX_MODEL_CANDIDATES
+    ]
+
+
+def get_cached_codex_models() -> dict[str, Any]:
+    with _login_lock:
+        if _model_cache.get("models"):
+            return {
+                "models": list(_model_cache.get("models", [])),
+                "verified": bool(_model_cache.get("verified", False)),
+                "diagnostic": str(_model_cache.get("diagnostic", "")),
+            }
+    return {"models": _default_codex_models(), "verified": False, "diagnostic": ""}
+
+
+def get_codex_models(force_refresh: bool = False) -> dict[str, Any]:
+    now = time.time()
+    with _login_lock:
+        cache_age = now - float(_model_cache.get("timestamp", 0.0))
+        if (
+            not force_refresh
+            and _model_cache.get("models")
+            and cache_age < _MODEL_CACHE_TTL_SECONDS
+        ):
+            return {
+                "models": list(_model_cache.get("models", [])),
+                "verified": bool(_model_cache.get("verified", False)),
+                "diagnostic": str(_model_cache.get("diagnostic", "")),
+            }
+
+    status = get_codex_status()
+    if not status.get("logged_in"):
+        result = {
+            "models": _default_codex_models(),
+            "verified": False,
+            "diagnostic": "Log in to ChatGPT subscription to verify available Codex models.",
+        }
+        with _login_lock:
+            _model_cache["timestamp"] = now
+            _model_cache["verified"] = False
+            _model_cache["models"] = list(result["models"])
+            _model_cache["diagnostic"] = result["diagnostic"]
+        return result
+
+    available: list[dict[str, Any]] = []
+    unavailable: list[str] = []
+    diagnostics: list[str] = []
+    for model in _CODEX_MODEL_CANDIDATES:
+        probe = run_codex_exec(
+            prompt=_MODEL_PROBE_PROMPT,
+            model=model,
+            timeout_seconds=25,
+        )
+        if probe.ok:
+            available.append(
+                {"value": model, "label": _format_model_label(model), "available": True}
+            )
+        else:
+            unavailable.append(model)
+            if probe.errors:
+                err = "; ".join(probe.errors[:2])
+                diagnostics.append(f"{model}: {err[:220]}")
+            elif probe.diagnostic:
+                diagnostics.append(f"{model}: {probe.diagnostic[:220]}")
+
+    models = available[:]
+    if not models:
+        models = _default_codex_models()
+        for item in models:
+            item["available"] = None
+        diagnostic = (
+            "Could not verify Codex model availability. Showing fallback model list."
+        )
+    else:
+        for model in unavailable:
+            models.append(
+                {"value": model, "label": _format_model_label(model), "available": False}
+            )
+        diagnostic = (
+            "Unavailable: " + ", ".join(unavailable)
+            if unavailable
+            else "Model availability verified."
+        )
+    if diagnostics:
+        diagnostic = f"{diagnostic} Details: {' | '.join(diagnostics[:3])}"
+
+    result = {
+        "models": models,
+        "verified": True,
+        "diagnostic": diagnostic,
+    }
+    with _login_lock:
+        _model_cache["timestamp"] = now
+        _model_cache["verified"] = True
+        _model_cache["models"] = list(models)
+        _model_cache["diagnostic"] = diagnostic
+    return result
+
+
+def _append_tail(buffer: list[str], line: str, max_len: int = 20) -> list[str]:
+    line = line.strip()
+    if not line:
+        return buffer
+    buffer.append(line)
+    if len(buffer) > max_len:
+        buffer = buffer[-max_len:]
+    return buffer
+
+
+def _extract_auth_url(text: str) -> str:
+    matches = re.findall(r"https://auth\.openai\.com/\S+", text)
+    return matches[0].strip() if matches else ""
+
+
+def _snapshot_login_state() -> dict[str, Any]:
+    with _login_lock:
+        snapshot = {
+            "session_id": str(_login_state.get("session_id", "")),
+            "status": str(_login_state.get("status", "idle")),
+            "auth_url": str(_login_state.get("auth_url", "")),
+            "message": str(_login_state.get("message", "")),
+            "started_at": str(_login_state.get("started_at", "")),
+            "finished_at": str(_login_state.get("finished_at", "")),
+            "stdout_tail": list(_login_state.get("stdout_tail", [])),
+            "stderr_tail": list(_login_state.get("stderr_tail", [])),
+        }
+        process = _login_process
+    if process and process.poll() is None:
+        snapshot["running"] = True
+    else:
+        snapshot["running"] = False
+    return snapshot
+
+
+def _read_login_stream(stream_name: str, pipe: Any) -> None:
+    if pipe is None:
+        return
+    try:
+        for raw_line in iter(pipe.readline, ""):
+            line = raw_line.strip()
+            if not line:
+                continue
+            with _login_lock:
+                tail_key = "stdout_tail" if stream_name == "stdout" else "stderr_tail"
+                tail = list(_login_state.get(tail_key, []))
+                _login_state[tail_key] = _append_tail(tail, line)
+                url = _extract_auth_url(line)
+                if url and not _login_state.get("auth_url"):
+                    _login_state["auth_url"] = url
+                    if _login_state.get("status") in ("starting", "idle"):
+                        _login_state["status"] = "waiting_browser"
+                        _login_state["message"] = "Open the login page and complete authorization."
+    except Exception:
+        return
+    finally:
+        try:
+            pipe.close()
+        except Exception:
+            pass
+
+
+def _wait_login_process(proc: subprocess.Popen[str], session_id: str) -> None:
+    returncode = proc.wait()
+    status = get_codex_status()
+    with _login_lock:
+        if _login_state.get("session_id") != session_id:
+            return
+        _login_state["finished_at"] = datetime.now(timezone.utc).isoformat()
+        if returncode == 0 and status.get("logged_in"):
+            _login_state["status"] = "completed"
+            _login_state["message"] = "ChatGPT subscription connected."
+        elif _login_state.get("status") == "cancelled":
+            _login_state["message"] = "Login cancelled."
+        else:
+            _login_state["status"] = "failed"
+            tail = _login_state.get("stderr_tail") or _login_state.get("stdout_tail") or []
+            if tail:
+                _login_state["message"] = str(tail[-1])
+            elif returncode != 0:
+                _login_state["message"] = f"codex login exited with status {returncode}"
+            else:
+                _login_state["message"] = "ChatGPT login failed."
+
+        global _login_process
+        _login_process = None
+
+
+def start_codex_login() -> dict[str, Any]:
+    with _login_lock:
+        global _login_process
+        if _login_process and _login_process.poll() is None:
+            current = _snapshot_login_state()
+            current["already_running"] = True
+            return current
+
+    cmd: list[str] = [_CODEX_BIN]
+    for override in _CODEX_CONFIG_OVERRIDES:
+        cmd.extend(["-c", override])
+    cmd.append("login")
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            universal_newlines=True,
+        )
+    except FileNotFoundError:
+        return {
+            "session_id": "",
+            "status": "failed",
+            "auth_url": "",
+            "message": "codex executable not found on PATH",
+            "running": False,
+        }
+    except Exception as exc:
+        return {
+            "session_id": "",
+            "status": "failed",
+            "auth_url": "",
+            "message": f"failed to start codex login: {exc}",
+            "running": False,
+        }
+
+    session_id = str(uuid.uuid4())
+    started_at = datetime.now(timezone.utc).isoformat()
+    with _login_lock:
+        _login_process = proc
+        _login_state["session_id"] = session_id
+        _login_state["status"] = "starting"
+        _login_state["auth_url"] = ""
+        _login_state["message"] = "Starting browser login..."
+        _login_state["started_at"] = started_at
+        _login_state["finished_at"] = ""
+        _login_state["stdout_tail"] = []
+        _login_state["stderr_tail"] = []
+
+    threading.Thread(
+        target=_read_login_stream, args=("stdout", proc.stdout), daemon=True
+    ).start()
+    threading.Thread(
+        target=_read_login_stream, args=("stderr", proc.stderr), daemon=True
+    ).start()
+    threading.Thread(
+        target=_wait_login_process, args=(proc, session_id), daemon=True
+    ).start()
+
+    deadline = time.time() + 2.5
+    while time.time() < deadline:
+        snapshot = _snapshot_login_state()
+        if snapshot.get("auth_url"):
+            break
+        if not snapshot.get("running"):
+            break
+        time.sleep(0.05)
+    return _snapshot_login_state()
+
+
+def cancel_codex_login() -> dict[str, Any]:
+    with _login_lock:
+        proc = _login_process
+        if not proc or proc.poll() is not None:
+            state = _snapshot_login_state()
+            state["message"] = state.get("message") or "No active login session."
+            return state
+        _login_state["status"] = "cancelled"
+        _login_state["message"] = "Cancelling login..."
+    try:
+        proc.terminate()
+        proc.wait(timeout=3)
+    except Exception:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+    return _snapshot_login_state()
+
+
+def logout_codex() -> dict[str, Any]:
+    cmd: list[str] = [_CODEX_BIN]
+    for override in _CODEX_CONFIG_OVERRIDES:
+        cmd.extend(["-c", override])
+    cmd.append("logout")
+    try:
+        cp = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except FileNotFoundError:
+        return {
+            "ok": False,
+            "message": "codex executable not found on PATH",
+            "status": get_codex_status(),
+        }
+    except Exception as exc:
+        return {"ok": False, "message": str(exc), "status": get_codex_status()}
+
+    output = "\n".join(
+        [line for line in [(cp.stdout or "").strip(), (cp.stderr or "").strip()] if line]
+    ).strip()
+    with _login_lock:
+        _model_cache["timestamp"] = 0.0
+        _model_cache["verified"] = False
+        _model_cache["models"] = []
+        _model_cache["diagnostic"] = ""
+    return {
+        "ok": cp.returncode == 0,
+        "message": output or ("Logged out." if cp.returncode == 0 else "Logout failed."),
+        "status": get_codex_status(),
+    }
+
+
+def get_codex_login_state() -> dict[str, Any]:
+    state = _snapshot_login_state()
+    if not state.get("running"):
+        status = get_codex_status()
+        if status.get("logged_in"):
+            if state.get("status") in ("idle", "starting", "waiting_browser", "failed"):
+                state["status"] = "completed"
+            if not state.get("message"):
+                state["message"] = "ChatGPT subscription connected."
+        elif state.get("status") == "completed":
+            state["status"] = "idle"
+            state["message"] = "Not logged in."
+    return state

--- a/tests/test_codex_chat_normalization.py
+++ b/tests/test_codex_chat_normalization.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import models
+from python.helpers import dirty_json
+
+
+def test_normalize_plain_text_wraps_response_tool():
+    out = models._normalize_codex_chat_message("Hi! How can I help?")
+    parsed = dirty_json.try_parse(out)
+    assert isinstance(parsed, dict)
+    assert parsed.get("tool_name") == "response"
+    assert isinstance(parsed.get("tool_args"), dict)
+    assert parsed["tool_args"].get("text") == "Hi! How can I help?"
+
+
+def test_normalize_existing_tool_request_keeps_tool_name_and_args():
+    raw = '{"tool_name":"response","tool_args":{"text":"ok"}}'
+    out = models._normalize_codex_chat_message(raw)
+    parsed = dirty_json.try_parse(out)
+    assert isinstance(parsed, dict)
+    assert parsed.get("tool_name") == "response"
+    assert parsed.get("tool_args", {}).get("text") == "ok"
+

--- a/tests/test_codex_exec_helper.py
+++ b/tests/test_codex_exec_helper.py
@@ -1,0 +1,127 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from python.helpers import codex_exec
+
+
+def test_base_cmd_contains_required_flags():
+    cmd = codex_exec._base_cmd("gpt-5-codex")
+    joined = " ".join(cmd)
+    assert "exec" in cmd
+    assert "--json" in cmd
+    assert "--dangerously-bypass-approvals-and-sandbox" in cmd
+    assert '-c model_reasoning_effort="high"' in joined
+    assert "-c mcp_servers={}" in joined
+    assert "-m gpt-5-codex" in joined
+
+
+def test_run_codex_exec_parses_thread_message_and_reasoning(monkeypatch):
+    stdout = "\n".join(
+        [
+            '{"type":"thread.started","thread_id":"thread-1"}',
+            '{"type":"item.completed","item":{"type":"reasoning","text":"Thinking..."}}',
+            '{"type":"item.completed","item":{"type":"agent_message","text":"HELLO"}}',
+            '{"type":"turn.completed","usage":{"output_tokens":5}}',
+        ]
+    )
+
+    def _fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(codex_exec.subprocess, "run", _fake_run)
+    result = codex_exec.run_codex_exec("Reply with HELLO", model="gpt-5-codex")
+
+    assert result.ok is True
+    assert result.thread_id == "thread-1"
+    assert result.message == "HELLO"
+    assert result.reasoning == "Thinking..."
+    assert result.errors == []
+
+
+def test_run_codex_exec_collects_failures(monkeypatch):
+    stdout = "\n".join(
+        [
+            '{"type":"thread.started","thread_id":"thread-2"}',
+            '{"type":"error","message":"Re-connecting... 1/5"}',
+            '{"type":"turn.failed","error":{"message":"model not found"}}',
+        ]
+    )
+
+    def _fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(codex_exec.subprocess, "run", _fake_run)
+    result = codex_exec.run_codex_exec("hello")
+
+    assert result.ok is False
+    assert result.thread_id == "thread-2"
+    assert "model not found" in result.diagnostic
+
+
+def test_run_codex_exec_resume_uses_stdin_prompt(monkeypatch):
+    captured = {}
+
+    def _fake_run(cmd, *args, **kwargs):
+        captured["cmd"] = cmd
+        captured["input"] = kwargs.get("input")
+        return SimpleNamespace(returncode=0, stdout='{"type":"item.completed","item":{"type":"agent_message","text":"OK"}}', stderr="")
+
+    monkeypatch.setattr(codex_exec.subprocess, "run", _fake_run)
+    result = codex_exec.run_codex_exec(
+        "resume-prompt",
+        model="gpt-5-codex",
+        resume_thread_id="thread-123",
+    )
+
+    assert result.ok is True
+    assert captured["input"] == "resume-prompt"
+    assert "resume" in captured["cmd"]
+    assert "thread-123" in captured["cmd"]
+    assert "resume-prompt" not in captured["cmd"]
+
+
+def test_get_codex_status_parses_chatgpt_login(monkeypatch):
+    monkeypatch.setattr(codex_exec.shutil, "which", lambda _bin: "/usr/local/bin/codex")
+
+    def _fake_run(cmd, *args, **kwargs):
+        if "--version" in cmd:
+            return SimpleNamespace(returncode=0, stdout="codex-cli 0.53.0\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="Logged in using ChatGPT\n", stderr="")
+
+    monkeypatch.setattr(codex_exec.subprocess, "run", _fake_run)
+    status = codex_exec.get_codex_status()
+
+    assert status["installed"] is True
+    assert status["version"] == "codex-cli 0.53.0"
+    assert status["logged_in"] is True
+    assert status["auth_mode"] == "chatgpt"
+    assert status["diagnostic"] == ""
+
+
+def test_get_cached_codex_models_defaults():
+    payload = codex_exec.get_cached_codex_models()
+    assert "models" in payload
+    assert isinstance(payload["models"], list)
+    assert any(item.get("value") == "gpt-5-codex" for item in payload["models"])
+
+
+def test_get_codex_models_without_login(monkeypatch):
+    monkeypatch.setattr(
+        codex_exec,
+        "get_codex_status",
+        lambda: {
+            "installed": True,
+            "version": "codex-cli test",
+            "logged_in": False,
+            "auth_mode": "none",
+            "diagnostic": "not logged in",
+        },
+    )
+    payload = codex_exec.get_codex_models(force_refresh=True)
+    assert payload["verified"] is False
+    assert "Log in to ChatGPT subscription" in payload["diagnostic"]

--- a/tests/test_codex_provider_fallback.py
+++ b/tests/test_codex_provider_fallback.py
@@ -1,0 +1,110 @@
+import copy
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import models
+from python.helpers import codex_exec
+from python.helpers import settings as settings_helper
+
+
+def test_get_chat_model_routes_codex_provider():
+    model = models.get_chat_model(
+        provider="codex",
+        name="gpt-5-codex",
+        a0_role="chat",
+        a0_context_id="ctx-1",
+    )
+    assert isinstance(model, models.CodexExecChatWrapper)
+
+
+@pytest.mark.asyncio
+async def test_codex_failure_falls_back_without_mutating_settings(monkeypatch):
+    cfg = settings_helper.get_default_settings()
+    cfg["chat_model_provider"] = "codex"
+    cfg["chat_model_name"] = "gpt-5-codex"
+    cfg["chat_model_provider_prev"] = "openai"
+    cfg["chat_model_name_prev"] = "gpt-4o-mini"
+    cfg["chat_model_api_base_prev"] = "https://api.openai.com/v1"
+    cfg["chat_model_kwargs_prev"] = {"temperature": "0"}
+    cfg_before = copy.deepcopy(cfg)
+
+    monkeypatch.setattr(settings_helper, "get_settings", lambda: cfg)
+    monkeypatch.setattr(
+        codex_exec,
+        "run_codex_exec",
+        lambda *args, **kwargs: codex_exec.CodexExecResult(
+            ok=False,
+            errors=["codex failed"],
+        ),
+    )
+
+    class DummyFallbackModel:
+        async def unified_call(self, **kwargs):
+            return "fallback-response", ""
+
+    original_get_chat_model = models.get_chat_model
+
+    def fake_get_chat_model(provider, name, model_config=None, **kwargs):
+        if provider == "codex":
+            return original_get_chat_model(
+                provider=provider,
+                name=name,
+                model_config=model_config,
+                **kwargs,
+            )
+        return DummyFallbackModel()
+
+    monkeypatch.setattr(models, "get_chat_model", fake_get_chat_model)
+
+    wrapper = models.CodexExecChatWrapper(
+        model="gpt-5-codex",
+        provider="codex",
+        a0_role="chat",
+        a0_context_id="ctx-1",
+    )
+    response, reasoning = await wrapper.unified_call(user_message="hello")
+
+    assert response == "fallback-response"
+    assert reasoning == ""
+    assert cfg == cfg_before
+
+    warning = codex_exec.get_latest_warning()
+    assert warning is not None
+    assert warning.get("fallback_provider") == "openai"
+
+
+@pytest.mark.asyncio
+async def test_codex_failure_without_valid_fallback_raises(monkeypatch):
+    cfg = settings_helper.get_default_settings()
+    cfg["chat_model_provider"] = "codex"
+    cfg["chat_model_name"] = "gpt-5-codex"
+    cfg["chat_model_provider_prev"] = "codex"
+    cfg["chat_model_name_prev"] = "gpt-5-codex"
+    cfg["chat_model_api_base_prev"] = ""
+    cfg["chat_model_kwargs_prev"] = {}
+
+    monkeypatch.setattr(settings_helper, "get_settings", lambda: cfg)
+    monkeypatch.setattr(
+        codex_exec,
+        "run_codex_exec",
+        lambda *args, **kwargs: codex_exec.CodexExecResult(
+            ok=False,
+            errors=["codex failed"],
+        ),
+    )
+
+    wrapper = models.CodexExecChatWrapper(
+        model="gpt-5-codex",
+        provider="codex",
+        a0_role="chat",
+        a0_context_id="ctx-2",
+    )
+
+    with pytest.raises(RuntimeError):
+        await wrapper.unified_call(user_message="hello")

--- a/tests/test_settings_codex_prev_snapshot.py
+++ b/tests/test_settings_codex_prev_snapshot.py
@@ -1,0 +1,58 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from python.helpers import settings as settings_helper
+
+
+def test_switching_to_codex_preserves_previous_snapshot():
+    cfg = settings_helper.get_default_settings()
+
+    cfg["chat_model_provider"] = "openai"
+    cfg["chat_model_name"] = "gpt-4o-mini"
+    cfg["chat_model_api_base"] = "https://api.openai.com/v1"
+    cfg["chat_model_kwargs"] = {"temperature": "0.2"}
+    settings_helper._sync_previous_model_snapshots(cfg)
+
+    assert cfg["chat_model_provider_prev"] == "openai"
+    assert cfg["chat_model_name_prev"] == "gpt-4o-mini"
+
+    cfg["chat_model_provider"] = "codex"
+    cfg["chat_model_name"] = "gpt-5-codex"
+    cfg["chat_model_api_base"] = ""
+    cfg["chat_model_kwargs"] = {"temperature": "0"}
+    settings_helper._sync_previous_model_snapshots(cfg)
+
+    assert cfg["chat_model_provider_prev"] == "openai"
+    assert cfg["chat_model_name_prev"] == "gpt-4o-mini"
+    assert cfg["chat_model_api_base_prev"] == "https://api.openai.com/v1"
+
+
+def test_non_codex_updates_previous_snapshot():
+    cfg = settings_helper.get_default_settings()
+
+    cfg["util_model_provider"] = "openrouter"
+    cfg["util_model_name"] = "google/gemini-2.0-flash-001"
+    cfg["util_model_kwargs"] = {"temperature": "0.1"}
+    settings_helper._sync_previous_model_snapshots(cfg)
+    assert cfg["util_model_provider_prev"] == "openrouter"
+
+    cfg["util_model_provider"] = "anthropic"
+    cfg["util_model_name"] = "claude-3-5-sonnet"
+    cfg["util_model_api_base"] = ""
+    cfg["util_model_kwargs"] = {"temperature": "0"}
+    settings_helper._sync_previous_model_snapshots(cfg)
+
+    assert cfg["util_model_provider_prev"] == "anthropic"
+    assert cfg["util_model_name_prev"] == "claude-3-5-sonnet"
+
+
+def test_embedding_model_not_part_of_codex_snapshot_logic():
+    cfg = settings_helper.get_default_settings()
+    settings_helper._sync_previous_model_snapshots(cfg)
+
+    assert "embed_model_provider_prev" not in cfg
+    assert "embed_model_name_prev" not in cfg

--- a/webui/components/settings/agent/agent-settings.html
+++ b/webui/components/settings/agent/agent-settings.html
@@ -57,6 +57,12 @@
                   <span>Workdir</span>
                 </a>
               </li>
+              <li>
+                <a href="#section-codex-subscription">
+                  <img src="/public/auth.svg" alt="ChatGPT Subscription" />
+                  <span>ChatGPT Subscription</span>
+                </a>
+              </li>
             </ul>
           </nav>
 
@@ -91,6 +97,10 @@
 
           <div id="section-workdir" class="section">
             <x-component path="settings/agent/workdir.html"></x-component>
+          </div>
+
+          <div id="section-codex-subscription" class="section">
+            <x-component path="settings/agent/chatgpt_subscription.html"></x-component>
           </div>
 
           

--- a/webui/components/settings/agent/browser_model.html
+++ b/webui/components/settings/agent/browser_model.html
@@ -19,7 +19,7 @@
             </div>
             <div class="field-control">
               <select x-model="$store.settings.settings.browser_model_provider">
-                <template x-for="option in $store.settings.additional?.chat_providers" :key="option.value">
+                <template x-for="option in $store.settings.additional?.chat_providers" :key="'browser-provider-' + option.value">
                   <option :value="option.value" :selected="option.value === $store.settings.settings.browser_model_provider" x-text="option.label"></option>
                 </template>
               </select>
@@ -29,26 +29,73 @@
           <div class="field">
             <div class="field-label">
               <div class="field-title">Web browser model name</div>
-              <div class="field-description">Exact name of model from selected provider</div>
+              <div class="field-description">
+                Exact model name. When provider is Codex, choose from available subscription models.
+              </div>
             </div>
             <div class="field-control">
-              <input type="text" x-model="$store.settings.settings.browser_model_name" />
+              <template x-if="!$store.settings.isCodexProvider($store.settings.settings.browser_model_provider)">
+                <input type="text" x-model="$store.settings.settings.browser_model_name" />
+              </template>
+              <template x-if="$store.settings.isCodexProvider($store.settings.settings.browser_model_provider)">
+                <div style="display:flex; gap:8px; flex-wrap:wrap;">
+                  <input type="text"
+                         list="codex-browser-models"
+                         x-model="$store.settings.settings.browser_model_name" />
+                  <datalist id="codex-browser-models">
+                    <template x-for="model in $store.settings.getCodexModelOptions($store.settings.settings.browser_model_name, 'browser-model')" :key="model.key">
+                      <option :value="model.value" x-text="model.label + (model.available === false ? ' (unavailable)' : '')"></option>
+                    </template>
+                  </datalist>
+                  <button class="btn btn-cancel"
+                          :disabled="$store.settings.codexActionLoading"
+                          @click="$store.settings.refreshCodexModels(true)">
+                    Refresh
+                  </button>
+                </div>
+              </template>
             </div>
           </div>
 
-          <div class="field">
-            <div class="field-label">
-              <div class="field-title">API key</div>
-              <div class="field-description">API key for the selected web browser model provider</div>
+          <template x-if="!$store.settings.isCodexProvider($store.settings.settings.browser_model_provider)">
+            <div class="field">
+              <div class="field-label">
+                <div class="field-title">API key</div>
+                <div class="field-description">API key for the selected web browser model provider</div>
+              </div>
+              <div class="field-control">
+                <input
+                  type="text"
+                  x-model="$store.settings.settings.api_keys[$store.settings.settings.browser_model_provider]"
+                  autocomplete="off"
+                />
+              </div>
             </div>
-            <div class="field-control">
-              <input
-                type="text"
-                x-model="$store.settings.settings.api_keys[$store.settings.settings.browser_model_provider]"
-                autocomplete="off"
-              />
+          </template>
+
+          <template x-if="$store.settings.isCodexProvider($store.settings.settings.browser_model_provider)">
+            <div class="field">
+              <div class="field-label">
+                <div class="field-title">Codex status</div>
+                <div class="field-description">
+                  API key is not used for Codex. Manage login in
+                  <a href="#section-codex-subscription">ChatGPT Subscription</a>.
+                </div>
+              </div>
+              <div class="field-control">
+                <div class="field-description">
+                  Status:
+                  <strong x-text="$store.settings.getCodexStatus()?.logged_in ? 'Connected' : 'Not connected'"></strong>
+                </div>
+                <template x-if="$store.settings.getCodexStatus()?.diagnostic">
+                  <div class="field-description">
+                    Diagnostic:
+                    <code x-text="$store.settings.getCodexStatus()?.diagnostic"></code>
+                  </div>
+                </template>
+              </div>
             </div>
-          </div>
+          </template>
 
           <div class="field">
             <div class="field-label">

--- a/webui/components/settings/agent/chat_model.html
+++ b/webui/components/settings/agent/chat_model.html
@@ -19,7 +19,7 @@
             </div>
             <div class="field-control">
               <select x-model="$store.settings.settings.chat_model_provider">
-                <template x-for="option in $store.settings.additional?.chat_providers" :key="option.value">
+                <template x-for="option in $store.settings.additional?.chat_providers" :key="'chat-provider-' + option.value">
                   <option :value="option.value" :selected="option.value === $store.settings.settings.chat_model_provider" x-text="option.label"></option>
                 </template>
               </select>
@@ -29,26 +29,73 @@
           <div class="field">
             <div class="field-label">
               <div class="field-title">Chat model name</div>
-              <div class="field-description">Exact name of model from selected provider</div>
+              <div class="field-description">
+                Exact model name. When provider is Codex, choose from available subscription models.
+              </div>
             </div>
             <div class="field-control">
-              <input type="text" x-model="$store.settings.settings.chat_model_name" />
+              <template x-if="!$store.settings.isCodexProvider($store.settings.settings.chat_model_provider)">
+                <input type="text" x-model="$store.settings.settings.chat_model_name" />
+              </template>
+              <template x-if="$store.settings.isCodexProvider($store.settings.settings.chat_model_provider)">
+                <div style="display:flex; gap:8px; flex-wrap:wrap;">
+                  <input type="text"
+                         list="codex-chat-models"
+                         x-model="$store.settings.settings.chat_model_name" />
+                  <datalist id="codex-chat-models">
+                    <template x-for="model in $store.settings.getCodexModelOptions($store.settings.settings.chat_model_name, 'chat-model')" :key="model.key">
+                      <option :value="model.value" x-text="model.label + (model.available === false ? ' (unavailable)' : '')"></option>
+                    </template>
+                  </datalist>
+                  <button class="btn btn-cancel"
+                          :disabled="$store.settings.codexActionLoading"
+                          @click="$store.settings.refreshCodexModels(true)">
+                    Refresh
+                  </button>
+                </div>
+              </template>
             </div>
           </div>
 
-          <div class="field">
-            <div class="field-label">
-              <div class="field-title">API key</div>
-              <div class="field-description">API key for the selected chat model provider</div>
+          <template x-if="!$store.settings.isCodexProvider($store.settings.settings.chat_model_provider)">
+            <div class="field">
+              <div class="field-label">
+                <div class="field-title">API key</div>
+                <div class="field-description">API key for the selected chat model provider</div>
+              </div>
+              <div class="field-control">
+                <input
+                  type="text"
+                  x-model="$store.settings.settings.api_keys[$store.settings.settings.chat_model_provider]"
+                  autocomplete="off"
+                />
+              </div>
             </div>
-            <div class="field-control">
-              <input
-                type="text"
-                x-model="$store.settings.settings.api_keys[$store.settings.settings.chat_model_provider]"
-                autocomplete="off"
-              />
+          </template>
+
+          <template x-if="$store.settings.isCodexProvider($store.settings.settings.chat_model_provider)">
+            <div class="field">
+              <div class="field-label">
+                <div class="field-title">Codex status</div>
+                <div class="field-description">
+                  API key is not used for Codex. Manage login in
+                  <a href="#section-codex-subscription">ChatGPT Subscription</a>.
+                </div>
+              </div>
+              <div class="field-control">
+                <div class="field-description">
+                  Status:
+                  <strong x-text="$store.settings.getCodexStatus()?.logged_in ? 'Connected' : 'Not connected'"></strong>
+                </div>
+                <template x-if="$store.settings.getCodexStatus()?.diagnostic">
+                  <div class="field-description">
+                    Diagnostic:
+                    <code x-text="$store.settings.getCodexStatus()?.diagnostic"></code>
+                  </div>
+                </template>
+              </div>
             </div>
-          </div>
+          </template>
 
           <div class="field">
             <div class="field-label">

--- a/webui/components/settings/agent/chatgpt_subscription.html
+++ b/webui/components/settings/agent/chatgpt_subscription.html
@@ -1,0 +1,117 @@
+<html>
+  <head>
+    <title>ChatGPT Subscription</title>
+  </head>
+
+  <body>
+    <div x-data>
+      <template x-if="$store.settings.settings">
+        <div>
+          <div class="section-title">ChatGPT Subscription</div>
+          <div class="section-description">
+            Connect your ChatGPT account once for all Codex model roles (Chat, Utility, Browser).
+          </div>
+
+          <div class="field">
+            <div class="field-label">
+              <div class="field-title">Connection status</div>
+              <div class="field-description">Global login used by Codex provider.</div>
+            </div>
+            <div class="field-control">
+              <div class="field-description">
+                Installed:
+                <strong x-text="$store.settings.getCodexStatus()?.installed ? 'yes' : 'no'"></strong>
+              </div>
+              <div class="field-description">
+                Logged in:
+                <strong x-text="$store.settings.getCodexStatus()?.logged_in ? 'yes' : 'no'"></strong>
+              </div>
+              <div class="field-description">
+                Auth mode:
+                <strong x-text="$store.settings.getCodexStatus()?.auth_mode || 'unknown'"></strong>
+              </div>
+              <div class="field-description">
+                Login flow:
+                <strong x-text="$store.settings.getCodexLoginState()?.status || 'idle'"></strong>
+              </div>
+              <template x-if="$store.settings.getCodexStatus()?.diagnostic">
+                <div class="field-description">
+                  Diagnostic:
+                  <code x-text="$store.settings.getCodexStatus()?.diagnostic"></code>
+                </div>
+              </template>
+              <template x-if="$store.settings.codexLastMessage">
+                <div class="field-description">
+                  Message:
+                  <code x-text="$store.settings.codexLastMessage"></code>
+                </div>
+              </template>
+            </div>
+          </div>
+
+          <div class="field">
+            <div class="field-label">
+              <div class="field-title">Account actions</div>
+              <div class="field-description">
+                Use Connect to open ChatGPT authorization. No email/password is stored in Agent Zero.
+              </div>
+            </div>
+            <div class="field-control">
+              <div style="display:flex; gap:8px; flex-wrap:wrap;">
+                <button class="btn btn-ok"
+                        :disabled="$store.settings.codexActionLoading"
+                        @click="$store.settings.connectChatGptSubscription()">
+                  Connect ChatGPT
+                </button>
+                <button class="btn btn-cancel"
+                        :disabled="$store.settings.codexActionLoading"
+                        @click="$store.settings.refreshCodexSubscriptionStatus()">
+                  Check Status
+                </button>
+                <button class="btn btn-cancel"
+                        :disabled="$store.settings.codexActionLoading"
+                        @click="$store.settings.disconnectChatGptSubscription()">
+                  Disconnect
+                </button>
+                <button class="btn btn-cancel"
+                        :disabled="$store.settings.codexActionLoading || !$store.settings.getCodexStatus()?.logged_in"
+                        @click="$store.settings.refreshCodexModels(true)">
+                  Refresh Models
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div class="field">
+            <div class="field-label">
+              <div class="field-title">Available Codex models</div>
+              <div class="field-description">
+                These options appear in Chat/Utility/Browser model selectors when provider is Codex.
+              </div>
+            </div>
+            <div class="field-control">
+              <div class="field-description">
+                Verified:
+                <strong x-text="$store.settings.getCodexModelPayload()?.verified ? 'yes' : 'no'"></strong>
+              </div>
+              <template x-if="$store.settings.getCodexModelPayload()?.diagnostic">
+                <div class="field-description">
+                  Model check:
+                  <code x-text="$store.settings.getCodexModelPayload()?.diagnostic"></code>
+                </div>
+              </template>
+              <div class="field-description">
+                <template x-for="model in $store.settings.getCodexModelOptions('', 'subscription-model')" :key="model.key">
+                  <div>
+                    <code x-text="model.value"></code>
+                    <span x-text="model.available === true ? ' (available)' : (model.available === false ? ' (unavailable)' : '')"></span>
+                  </div>
+                </template>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+    </div>
+  </body>
+</html>

--- a/webui/components/settings/agent/util_model.html
+++ b/webui/components/settings/agent/util_model.html
@@ -19,7 +19,7 @@
             </div>
             <div class="field-control">
               <select x-model="$store.settings.settings.util_model_provider">
-                <template x-for="option in $store.settings.additional?.chat_providers" :key="option.value">
+                <template x-for="option in $store.settings.additional?.chat_providers" :key="'util-provider-' + option.value">
                   <option :value="option.value" :selected="option.value === $store.settings.settings.util_model_provider" x-text="option.label"></option>
                 </template>
               </select>
@@ -29,26 +29,73 @@
           <div class="field">
             <div class="field-label">
               <div class="field-title">Utility model name</div>
-              <div class="field-description">Exact name of model from selected provider</div>
+              <div class="field-description">
+                Exact model name. When provider is Codex, choose from available subscription models.
+              </div>
             </div>
             <div class="field-control">
-              <input type="text" x-model="$store.settings.settings.util_model_name" />
+              <template x-if="!$store.settings.isCodexProvider($store.settings.settings.util_model_provider)">
+                <input type="text" x-model="$store.settings.settings.util_model_name" />
+              </template>
+              <template x-if="$store.settings.isCodexProvider($store.settings.settings.util_model_provider)">
+                <div style="display:flex; gap:8px; flex-wrap:wrap;">
+                  <input type="text"
+                         list="codex-util-models"
+                         x-model="$store.settings.settings.util_model_name" />
+                  <datalist id="codex-util-models">
+                    <template x-for="model in $store.settings.getCodexModelOptions($store.settings.settings.util_model_name, 'util-model')" :key="model.key">
+                      <option :value="model.value" x-text="model.label + (model.available === false ? ' (unavailable)' : '')"></option>
+                    </template>
+                  </datalist>
+                  <button class="btn btn-cancel"
+                          :disabled="$store.settings.codexActionLoading"
+                          @click="$store.settings.refreshCodexModels(true)">
+                    Refresh
+                  </button>
+                </div>
+              </template>
             </div>
           </div>
 
-          <div class="field">
-            <div class="field-label">
-              <div class="field-title">API key</div>
-              <div class="field-description">API key for the selected utility model provider</div>
+          <template x-if="!$store.settings.isCodexProvider($store.settings.settings.util_model_provider)">
+            <div class="field">
+              <div class="field-label">
+                <div class="field-title">API key</div>
+                <div class="field-description">API key for the selected utility model provider</div>
+              </div>
+              <div class="field-control">
+                <input
+                  type="text"
+                  x-model="$store.settings.settings.api_keys[$store.settings.settings.util_model_provider]"
+                  autocomplete="off"
+                />
+              </div>
             </div>
-            <div class="field-control">
-              <input
-                type="text"
-                x-model="$store.settings.settings.api_keys[$store.settings.settings.util_model_provider]"
-                autocomplete="off"
-              />
+          </template>
+
+          <template x-if="$store.settings.isCodexProvider($store.settings.settings.util_model_provider)">
+            <div class="field">
+              <div class="field-label">
+                <div class="field-title">Codex status</div>
+                <div class="field-description">
+                  API key is not used for Codex. Manage login in
+                  <a href="#section-codex-subscription">ChatGPT Subscription</a>.
+                </div>
+              </div>
+              <div class="field-control">
+                <div class="field-description">
+                  Status:
+                  <strong x-text="$store.settings.getCodexStatus()?.logged_in ? 'Connected' : 'Not connected'"></strong>
+                </div>
+                <template x-if="$store.settings.getCodexStatus()?.diagnostic">
+                  <div class="field-description">
+                    Diagnostic:
+                    <code x-text="$store.settings.getCodexStatus()?.diagnostic"></code>
+                  </div>
+                </template>
+              </div>
             </div>
-          </div>
+          </template>
 
           <div class="field">
             <div class="field-label">


### PR DESCRIPTION
This PR adds a new `codex` model provider to Agent Zero that uses local Codex CLI auth (ChatGPT subscription), not OpenAI API billing. It supports Chat/Utility/Browser roles, preserves per-role model selection, resumes Codex sessions per chat+role, and falls back per-call to the previous non-Codex provider on failures.

Global login works from Settings → Agent Settings → ChatGPT Subscription.
Chat/Utility/Browser can each use Codex (ChatGPT subscription).
Role model values persist independently after save/reopen.
Backend settings reflect role-specific model values.
Codex failure triggers temporary per-call fallback and warning, without changing saved provider.

Notes
Requires codex CLI installed and available in PATH.
Requires successful codex login.


Why
This will allow ChatGPT subscribers to use their subscription an NOT API usage:
- global ChatGPT login
- independent model choice for Chat/Utility/Browser
- minimal setup (no API key for Codex mode)
- resilient runtime behavior when Codex fails

What Changed
Provider + Runtime
- Added `codex` to model providers.
- Added runtime settings payload fields:
- `codex_status`
- `codex_models`
- `codex_login`

Codex Execution Helper
- Added `python/helpers/codex_exec.py`:
- runs `codex exec --json`
- supports fresh/resume calls
- parses JSONL events for thread/message/errors
- checks login status
- supports login start/status/logout
- fetches/refreshes available Codex models

Model Layer / Agent Integration
- Added Codex chat wrapper integration in `models.py`.
- Added per-chat + per-role thread persistence via `AgentContext.data["codex_threads"]`.
- Added Codex output normalization for chat role to avoid message/tool misformat loops.
- Added per-call fallback to previous non-Codex provider/model snapshot with warning.
- Passed role/context metadata from `agent.py` for Chat/Utility/Browser calls.

Settings + Fallback Snapshots
- Extended settings with per-role previous provider snapshot keys (`*_prev`).
- Snapshot logic keeps last non-Codex config for fallback.
- Embedding path remains unchanged.

UI
- Added "ChatGPT Subscription" section in Agent Settings.
- Added connect/check/disconnect/refresh actions for Codex login/models.
- In Chat/Utility/Browser settings:
- hides API key input when provider is `codex`
- shows Codex status panel + guidance link
- allows Codex model selection per role
- Fixed UI binding/display issue where role selectors appeared to show same model despite distinct backend values.

Banners
- Excluded `codex` from missing API key banner.
- Added Codex health/fallback warning banner.

Docs
- Added full guide: `docs/guides/codex-subscription.md`
- Updated:
- `README.md`
- `docs/README.md`
- `docs/setup/installation.md`
- `docs/guides/troubleshooting.md`
- Added Codex guide image placeholders in `docs/res/setup/codex/`.

Tests
Added:
- `tests/test_codex_exec_helper.py`
- `tests/test_codex_provider_fallback.py`
- `tests/test_settings_codex_prev_snapshot.py`
- `tests/test_codex_chat_normalization.py`

Executed:
```bash
python -m pytest -q \
  tests/test_codex_exec_helper.py \
  tests/test_codex_provider_fallback.py \
  tests/test_settings_codex_prev_snapshot.py \
  tests/test_codex_chat_normalization.py
Result: 15 passed