### PR TITLE
Input tool control signals

### DIFF
--- a/prompts/agent.system.tool.input.md
+++ b/prompts/agent.system.tool.input.md
@@ -3,16 +3,34 @@ use keyboard arg for terminal program input
 use session arg for terminal session number
 answer dialogues enter passwords etc
 not for browser
+control signals:
+- <ctrl+c> interrupt 
+- <ctrl+d> EOF
 usage:
+
 ~~~json
 {
     "thoughts": [
         "The program asks for Y/N...",
     ],
-    "headline": "Responding to terminal program prompt",
+    "headline": "...",
     "tool_name": "input",
     "tool_args": {
         "keyboard": "Y",
+        "session": 0
+    }
+}
+~~~
+
+~~~json
+{
+    "thoughts": [
+        "The program is hanging..."
+    ],
+    "headline": "...",
+    "tool_name": "input",
+    "tool_args": {
+        "keyboard": "<ctrl+c>",
         "session": 0
     }
 }

--- a/python/tools/code_execution_tool.py
+++ b/python/tools/code_execution_tool.py
@@ -175,7 +175,14 @@ class CodeExecution(Tool):
     async def execute_terminal_command(
         self, session: int, command: str, reset: bool = False
     ):
-        prefix = ("bash>" if not runtime.is_windows() or self.agent.config.code_exec_ssh_enabled else "PS>") + self.format_command_for_output(command) + "\n\n"
+        if self.args.get("source") == "input":
+            label = "input>"
+        elif not runtime.is_windows() or self.agent.config.code_exec_ssh_enabled:
+            label = "bash>"
+        else:
+            label = "PS>"
+        display_command = self.args.get("display_code", command)
+        prefix = label + self.format_command_for_output(display_command) + "\n\n"
         return await self.terminal_session(session, command, reset, prefix)
 
     async def terminal_session(

--- a/python/tools/input.py
+++ b/python/tools/input.py
@@ -14,6 +14,7 @@ class Input(Tool):
     async def execute(self, keyboard="", **kwargs):
         # normalize keyboard input
         keyboard = keyboard.rstrip()
+        display_code = keyboard
         keyboard = resolve_control_chars(keyboard)
         # keyboard += "\n" # no need to, code_exec does that
         
@@ -21,8 +22,17 @@ class Input(Tool):
         session = int(self.args.get("session", 0))
 
         # forward keyboard input to code execution tool
-        args = {"runtime": "terminal", "code": keyboard, "session": session, "allow_running": True}
-        cet = CodeExecution(self.agent, "code_execution_tool", "", args, self.message, self.loop_data)
+        args = {
+            "runtime": "terminal",
+            "code": keyboard,
+            "session": session,
+            "allow_running": True,
+            "source": "input",
+            "display_code": display_code,
+        }
+        cet = CodeExecution(
+            self.agent, "code_execution_tool", "", args, self.message, self.loop_data
+        )
         cet.log = self.log
         return await cet.execute(**args)
 


### PR DESCRIPTION
- Allows the agent to interrupt hung processes and send EOF to terminal sessions
- Add `<ctrl+c>` (SIGINT) and `<ctrl+d>` (EOF) control signal support for the `input` tool
- Fix PTY controlling terminal setup so Ctrl+C is properly delivered to child processes
- Show `input>` prefix in terminal logs when called from the Input tool instead of `bash>`