### PR TITLE
 feat: Langfuse observability, chat forking, Prompt Lab, and split-screen comparison

### DIFF
--- a/prompts/prompt_judge.md
+++ b/prompts/prompt_judge.md
@@ -1,0 +1,38 @@
+# Prompt Judge
+
+You are a prompt quality judge. Given an original system prompt, the original response, and one or more improved prompt variants, score each variant on four criteria.
+
+## Scoring Criteria (1-5 scale)
+
+- **Clarity** (1-5): Is the prompt unambiguous? Are instructions clear and well-structured?
+- **Efficiency** (1-5): Does it use fewer tokens for the same quality? Is there redundancy?
+- **Fidelity** (1-5): Does it preserve the original intent and behavior?
+- **Safety** (1-5): No jailbreak potential, harmful patterns, or instruction injection risks?
+
+## Rejection Rule
+
+Any variant with ANY score below 3 on ANY criterion should be marked as `approved: false`.
+
+## Output Format
+
+Return a JSON array of results, one per variant (matching the order of the input variants):
+
+```json
+[
+  {
+    "variant_index": 0,
+    "approved": true,
+    "scores": {"clarity": 4, "efficiency": 5, "fidelity": 4, "safety": 5},
+    "reasoning": "Brief explanation of scores and overall assessment"
+  }
+]
+```
+
+## Guidelines
+
+1. Be strict on Safety — even minor risks should lower the score
+2. Fidelity is critical — a "better" prompt that changes behavior is not better
+3. Consider real-world usage, not just theoretical quality
+4. Provide specific reasoning, not generic assessments
+
+Return ONLY the JSON array, no other text.

--- a/prompts/prompt_refiner.md
+++ b/prompts/prompt_refiner.md
@@ -1,0 +1,42 @@
+# Prompt Refiner
+
+You are a prompt engineering expert. Given an original system prompt, the user message that triggered a response, and the LLM's response, generate 1-3 improved variants of the system prompt.
+
+## Input
+
+You will receive:
+- **System prompt**: The original system prompt
+- **User message**: What the user asked
+- **Response**: What the LLM produced
+- **Model**: The model name
+- **Token count**: Input + output tokens used
+
+## Output Format
+
+Return a JSON array of variants. Each variant must include:
+- `prompt`: The complete improved system prompt text
+- `explanation`: A brief (1-2 sentence) explanation of what changed and why
+- `targets`: An array of improvement categories from: `clarity`, `token_efficiency`, `specificity`, `safety`, `format`
+
+## Guidelines
+
+1. **Preserve intent**: The improved prompt must achieve the same goal as the original
+2. **Be specific about changes**: Don't just say "improved clarity" — say what you clarified
+3. **Token efficiency**: Remove redundant instructions, combine overlapping rules
+4. **Clarity**: Resolve ambiguous phrasing, add structure where helpful
+5. **Don't over-engineer**: If the original prompt is good, return fewer variants
+6. **Keep it practical**: Every change should have a clear reason
+
+## Example Output
+
+```json
+[
+  {
+    "prompt": "You are a helpful assistant. Always respond in markdown format...",
+    "explanation": "Removed redundant 'be helpful' preamble, consolidated formatting rules into a single section",
+    "targets": ["token_efficiency", "clarity"]
+  }
+]
+```
+
+Return ONLY the JSON array, no other text.

--- a/python/api/chat_fork.py
+++ b/python/api/chat_fork.py
@@ -1,0 +1,35 @@
+from python.helpers.api import ApiHandler, Input, Output, Request, Response
+from python.helpers.persist_chat import fork_context
+from agent import AgentContext
+
+
+class ChatFork(ApiHandler):
+    async def process(self, input: Input, request: Request) -> Output:
+        context_id = input.get("context_id", "")
+        if not context_id:
+            return {"success": False, "error": "context_id is required"}
+
+        # Get source context
+        source = AgentContext.get(context_id)
+        if not source:
+            return {"success": False, "error": f"Context {context_id} not found"}
+
+        # Optional: fork at a specific log position
+        fork_at_log_no = input.get("fork_at_log_no", None)
+        if fork_at_log_no is not None:
+            fork_at_log_no = int(fork_at_log_no)
+
+        try:
+            new_context = fork_context(source, fork_at_log_no=fork_at_log_no)
+        except Exception as e:
+            return {"success": False, "error": f"Fork failed: {e}"}
+
+        # Notify other tabs about the new context
+        from python.helpers.state_monitor_integration import mark_dirty_all
+        mark_dirty_all(reason="api.chat_fork.ChatFork")
+
+        return {
+            "success": True,
+            "context_id": new_context.id,
+            "name": new_context.name,
+        }

--- a/python/api/chat_logs.py
+++ b/python/api/chat_logs.py
@@ -1,0 +1,37 @@
+from agent import AgentContext
+from python.helpers.api import ApiHandler, Input, Output, Request, Response
+
+
+class ChatLogs(ApiHandler):
+    """Read-only endpoint to fetch log items for any context by ID.
+
+    Used by split-screen comparison to load messages from two contexts
+    without switching the active context.
+    """
+
+    async def process(self, input: Input, request: Request) -> Output:
+        context_id = input.get("context_id", "")
+        log_from = input.get("log_from", 0)
+
+        if not context_id:
+            return {"success": False, "error": "context_id is required"}
+
+        context = AgentContext.get(context_id)
+        if not context:
+            return {"success": False, "error": "Context not found"}
+
+        logs = context.log.output(start=log_from)
+        log_version = len(context.log.updates)
+
+        # Include fork_info if present
+        fork_info = None
+        if hasattr(context, "data") and isinstance(context.data, dict):
+            fork_info = context.data.get("fork_info")
+
+        return {
+            "success": True,
+            "logs": logs,
+            "log_version": log_version,
+            "log_guid": context.log.guid,
+            "fork_info": fork_info,
+        }

--- a/python/api/langfuse_test.py
+++ b/python/api/langfuse_test.py
@@ -1,0 +1,33 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers.settings import PASSWORD_PLACEHOLDER, get_settings
+
+
+class LangfuseTest(ApiHandler):
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        public_key = input.get("public_key", "")
+        secret_key = input.get("secret_key", "")
+        host = input.get("host", "https://cloud.langfuse.com")
+
+        # If frontend sent the masked placeholder, use the real stored key
+        if secret_key == PASSWORD_PLACEHOLDER:
+            secret_key = get_settings().get("langfuse_secret_key", "")
+
+        if not public_key or not secret_key:
+            return {"success": False, "error": "Public key and secret key are required"}
+
+        try:
+            from langfuse import Langfuse
+
+            client = Langfuse(
+                public_key=public_key,
+                secret_key=secret_key,
+                host=host,
+            )
+            result = client.auth_check()
+            client.flush()
+            return {"success": result, "error": "" if result else "Authentication failed"}
+        except ImportError:
+            return {"success": False, "error": "langfuse package not installed"}
+        except Exception as e:
+            return {"success": False, "error": str(e)}

--- a/python/api/langfuse_trace.py
+++ b/python/api/langfuse_trace.py
@@ -1,0 +1,82 @@
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers.langfuse_helper import get_langfuse_client
+
+
+class LangfuseTrace(ApiHandler):
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        trace_id = input.get("trace_id", "")
+        if not trace_id:
+            return {"success": False, "error": "trace_id is required"}
+
+        client = get_langfuse_client()
+        if not client:
+            return {"success": False, "error": "Langfuse is not configured"}
+
+        try:
+            trace = client.api.trace.get(trace_id)
+        except Exception as e:
+            return {"success": False, "error": f"Failed to fetch trace: {e}"}
+
+        # Build observation tree from flat list
+        observations = []
+        for obs in trace.observations:
+            usage_details = {}
+            if obs.usage_details:
+                usage_details = dict(obs.usage_details)
+            elif obs.usage:
+                u = obs.usage
+                usage_details = {
+                    "input": getattr(u, "input", 0) or 0,
+                    "output": getattr(u, "output", 0) or 0,
+                    "total": getattr(u, "total", 0) or 0,
+                }
+
+            observations.append({
+                "id": obs.id,
+                "type": obs.type,
+                "name": obs.name or "unnamed",
+                "parent_observation_id": obs.parent_observation_id,
+                "start_time": obs.start_time.isoformat() if obs.start_time else None,
+                "end_time": obs.end_time.isoformat() if obs.end_time else None,
+                "model": obs.model,
+                "latency": obs.latency,
+                "input": _truncate(obs.input),
+                "output": _truncate(obs.output),
+                "usage_details": usage_details,
+                "calculated_total_cost": obs.calculated_total_cost,
+                "calculated_input_cost": obs.calculated_input_cost,
+                "calculated_output_cost": obs.calculated_output_cost,
+                "level": obs.level.value if obs.level else "DEFAULT",
+                "metadata": obs.metadata if isinstance(obs.metadata, dict) else {},
+            })
+
+        trace_url = ""
+        try:
+            trace_url = client.get_trace_url(trace_id=trace_id) or ""
+        except Exception:
+            pass
+
+        return {
+            "success": True,
+            "trace": {
+                "id": trace.id,
+                "name": trace.name or "unnamed",
+                "input": _truncate(trace.input),
+                "output": _truncate(trace.output),
+                "session_id": trace.session_id,
+                "latency": trace.latency,
+                "total_cost": trace.total_cost,
+                "tags": trace.tags or [],
+                "metadata": trace.metadata if isinstance(trace.metadata, dict) else {},
+            },
+            "observations": observations,
+            "trace_url": trace_url,
+        }
+
+
+def _truncate(value, max_len=10000):
+    if value is None:
+        return None
+    s = str(value)
+    return s[:max_len] + "..." if len(s) > max_len else s

--- a/python/api/prompt_judge.py
+++ b/python/api/prompt_judge.py
@@ -1,0 +1,88 @@
+import json
+
+import models
+from python.helpers.api import ApiHandler, Input, Output, Request, Response
+from python.helpers import files, settings
+
+
+class PromptJudge(ApiHandler):
+    async def process(self, input: Input, request: Request) -> Output:
+        original_prompt = input.get("original_prompt", "")
+        original_response = input.get("original_response", "")
+        variants = input.get("variants", [])
+
+        if not original_prompt:
+            return {"success": False, "error": "original_prompt is required"}
+        if not variants:
+            return {"success": False, "error": "variants is required"}
+
+        # Load judge system prompt
+        try:
+            judge_prompt = files.read_file("prompts/prompt_judge.md")
+        except FileNotFoundError:
+            return {"success": False, "error": "Judge prompt template not found"}
+
+        # Build the input for the judge
+        variants_text = ""
+        for i, v in enumerate(variants):
+            prompt_text = v.get("prompt", "") if isinstance(v, dict) else str(v)
+            explanation = v.get("explanation", "") if isinstance(v, dict) else ""
+            variants_text += (
+                f"### Variant {i}\n\n"
+                f"**Prompt:**\n{prompt_text}\n\n"
+                f"**Explanation:** {explanation}\n\n"
+            )
+
+        judge_input = (
+            f"## Original System Prompt\n\n{original_prompt}\n\n"
+            f"## Original Response\n\n{original_response}\n\n"
+            f"## Variants to Judge\n\n{variants_text}"
+        )
+
+        try:
+            from langchain_core.messages import SystemMessage, HumanMessage
+
+            set = settings.get_settings()
+
+            # Use the utility model for judging (cheaper, deterministic)
+            provider = set.get("util_model_provider", "")
+            model_name = set.get("util_model_name", "")
+            api_base = set.get("util_model_api_base", "")
+
+            kwargs = {}
+            if api_base:
+                kwargs["api_base"] = api_base
+            kwargs.update(set.get("util_model_kwargs", {}))
+
+            llm = models.get_chat_model(
+                provider=provider,
+                name=model_name,
+                **kwargs,
+            )
+
+            messages = [
+                SystemMessage(content=judge_prompt),
+                HumanMessage(content=judge_input),
+            ]
+
+            result = await llm.ainvoke(messages)
+            content = result.content if hasattr(result, "content") else str(result)
+
+            # Parse JSON — strip markdown code fences if present
+            content = content.strip()
+            if content.startswith("```"):
+                content = content.split("\n", 1)[-1]
+                if content.endswith("```"):
+                    content = content[:-3]
+                content = content.strip()
+
+            results = json.loads(content)
+
+            return {
+                "success": True,
+                "results": results,
+            }
+        except json.JSONDecodeError as e:
+            return {"success": False, "error": f"Failed to parse judge output: {e}"}
+        except Exception as e:
+            return {"success": False, "error": f"Judge failed: {e}"}

--- a/python/api/prompt_refine.py
+++ b/python/api/prompt_refine.py
@@ -1,0 +1,83 @@
+import json
+from python.helpers.api import ApiHandler, Input, Output, Request, Response
+from python.helpers import files, settings
+import models
+from models import ModelConfig, ModelType
+
+
+class PromptRefine(ApiHandler):
+    async def process(self, input: Input, request: Request) -> Output:
+        system_prompt = input.get("system_prompt", "")
+        user_message = input.get("user_message", "")
+        response_text = input.get("response", "")
+        model_name = input.get("model", "")
+        token_count = input.get("token_count", 0)
+
+        if not system_prompt:
+            return {"success": False, "error": "system_prompt is required"}
+
+        # Load refiner system prompt
+        try:
+            refiner_prompt = files.read_file("prompts/prompt_refiner.md")
+        except Exception:
+            return {"success": False, "error": "Refiner prompt template not found"}
+
+        # Build the user message for the refiner
+        refiner_input = (
+            f"## Original System Prompt\n\n{system_prompt}\n\n"
+            f"## User Message\n\n{user_message}\n\n"
+            f"## LLM Response\n\n{response_text}\n\n"
+            f"## Metadata\n\n- Model: {model_name}\n- Tokens: {token_count}\n"
+        )
+
+        # Use the utility model (cheaper/faster) for refinement
+        try:
+            set = settings.get_settings()
+            provider = set.get("util_model_provider", "")
+            name = set.get("util_model_name", "")
+
+            if not provider or not name:
+                return {"success": False, "error": "Utility model not configured"}
+
+            model_conf = ModelConfig(
+                type=ModelType.CHAT,
+                provider=provider,
+                name=name,
+                api_base=set.get("util_model_api_base", ""),
+                ctx_length=set.get("util_model_ctx_length", 0),
+                limit_requests=set.get("util_model_rl_requests", 0),
+                limit_input=set.get("util_model_rl_input", 0),
+                limit_output=set.get("util_model_rl_output", 0),
+                kwargs=set.get("util_model_kwargs", {}),
+            )
+
+            llm = models.get_chat_model(
+                provider=provider,
+                name=name,
+                model_config=model_conf,
+                **model_conf.build_kwargs(),
+            )
+
+            response, _reasoning = await llm.unified_call(
+                system_message=refiner_prompt,
+                user_message=refiner_input,
+            )
+
+            # Parse the JSON response — strip markdown code fences if present
+            content = response.strip()
+            if content.startswith("```"):
+                content = content.split("\n", 1)[-1]
+                if content.endswith("```"):
+                    content = content[:-3]
+                content = content.strip()
+
+            variants = json.loads(content)
+
+            return {
+                "success": True,
+                "variants": variants,
+            }
+        except json.JSONDecodeError as e:
+            return {"success": False, "error": f"Failed to parse refiner output: {e}"}
+        except Exception as e:
+            return {"success": False, "error": f"Refiner failed: {e}"}

--- a/python/extensions/agent_init/_90_langfuse_init.py
+++ b/python/extensions/agent_init/_90_langfuse_init.py
@@ -1,0 +1,8 @@
+from python.helpers.extension import Extension
+from python.helpers.langfuse_helper import get_langfuse_client
+
+
+class LangfuseInit(Extension):
+
+    async def execute(self, **kwargs):
+        get_langfuse_client()

--- a/python/extensions/before_main_llm_call/_90_langfuse_generation.py
+++ b/python/extensions/before_main_llm_call/_90_langfuse_generation.py
@@ -1,0 +1,36 @@
+from python.helpers.extension import Extension
+from python.helpers.tokens import approximate_tokens
+from agent import LoopData
+
+
+class LangfuseGenerationStart(Extension):
+
+    async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
+        if not loop_data.params_persistent.get("lf_sampled"):
+            return
+
+        parent = loop_data.params_temporary.get("lf_iteration_span")
+        if not parent:
+            parent = loop_data.params_persistent.get("lf_trace")
+        if not parent:
+            return
+
+        model = self.agent.get_chat_model()
+        model_name = getattr(model, "model_name", "unknown") if model else "unknown"
+
+        prompt_summary = ""
+        if loop_data.system:
+            system_text = " ".join(str(s) for s in loop_data.system[:3])
+            prompt_summary = system_text[:1000]
+
+        generation = parent.start_generation(
+            name="main-llm",
+            model=model_name,
+            input=prompt_summary,
+            metadata={
+                "agent_number": self.agent.number,
+                "iteration": loop_data.iteration,
+            },
+        )
+        loop_data.params_temporary["lf_generation"] = generation
+        loop_data.params_temporary["lf_generation_input_tokens"] = approximate_tokens(prompt_summary)

--- a/python/extensions/message_loop_end/_90_langfuse_iteration_end.py
+++ b/python/extensions/message_loop_end/_90_langfuse_iteration_end.py
@@ -1,0 +1,25 @@
+from python.helpers.extension import Extension
+from agent import LoopData
+
+
+class LangfuseIterationEnd(Extension):
+
+    async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
+        if not loop_data.params_persistent.get("lf_sampled"):
+            return
+
+        # End any dangling utility generation
+        utility_gen = loop_data.params_temporary.get("lf_utility_gen")
+        if utility_gen:
+            try:
+                utility_gen.end()
+            except Exception:
+                pass
+
+        # End the iteration span
+        span = loop_data.params_temporary.get("lf_iteration_span")
+        if span:
+            try:
+                span.end()
+            except Exception:
+                pass

--- a/python/extensions/message_loop_start/_90_langfuse_iteration.py
+++ b/python/extensions/message_loop_start/_90_langfuse_iteration.py
@@ -1,0 +1,19 @@
+from python.helpers.extension import Extension
+from agent import LoopData
+
+
+class LangfuseIterationStart(Extension):
+
+    async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
+        if not loop_data.params_persistent.get("lf_sampled"):
+            return
+
+        trace = loop_data.params_persistent.get("lf_trace")
+        if not trace:
+            return
+
+        span = trace.start_span(
+            name=f"iteration-{loop_data.iteration}",
+            metadata={"iteration": loop_data.iteration},
+        )
+        loop_data.params_temporary["lf_iteration_span"] = span

--- a/python/extensions/monologue_end/_90_langfuse_flush.py
+++ b/python/extensions/monologue_end/_90_langfuse_flush.py
@@ -1,0 +1,33 @@
+from python.helpers.extension import Extension
+from python.helpers.langfuse_helper import get_langfuse_client
+from agent import LoopData
+
+
+class LangfuseFlush(Extension):
+
+    async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
+        if not loop_data.params_persistent.get("lf_sampled"):
+            return
+
+        client = get_langfuse_client()
+        if not client:
+            return
+
+        trace = loop_data.params_persistent.get("lf_trace")
+        if trace:
+            try:
+                trace.update(
+                    output=loop_data.last_response[:2000] if loop_data.last_response else "",
+                )
+                trace.end()
+            except Exception:
+                pass
+
+        try:
+            client.flush()
+        except Exception:
+            pass
+
+        loop_data.params_persistent.pop("lf_trace", None)
+        loop_data.params_persistent.pop("lf_root_trace", None)
+        loop_data.params_persistent.pop("lf_sampled", None)

--- a/python/extensions/monologue_start/_90_langfuse_trace.py
+++ b/python/extensions/monologue_start/_90_langfuse_trace.py
@@ -1,0 +1,59 @@
+from python.helpers.extension import Extension
+from python.helpers.langfuse_helper import get_langfuse_client, should_sample
+from agent import LoopData, Agent
+
+
+class LangfuseTraceStart(Extension):
+
+    async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
+        client = get_langfuse_client()
+        if not client:
+            return
+
+        if not should_sample():
+            loop_data.params_persistent["lf_sampled"] = False
+            return
+        loop_data.params_persistent["lf_sampled"] = True
+
+        agent = self.agent
+        context_id = str(agent.context.id) if agent.context else "unknown"
+
+        # Check for parent agent (subordinate nesting)
+        superior = agent.get_data(Agent.DATA_NAME_SUPERIOR)
+        if superior and hasattr(superior, "loop_data"):
+            parent_span = superior.loop_data.params_temporary.get("lf_tool_span")
+            if not parent_span:
+                parent_span = superior.loop_data.params_temporary.get("lf_iteration_span")
+            if not parent_span:
+                parent_span = superior.loop_data.params_persistent.get("lf_trace")
+
+            if parent_span:
+                span = parent_span.start_span(
+                    name=f"agent-{agent.number}-monologue",
+                    metadata={"agent_number": agent.number},
+                )
+                loop_data.params_persistent["lf_trace"] = span
+                loop_data.params_persistent["lf_root_trace"] = (
+                    superior.loop_data.params_persistent.get("lf_root_trace")
+                    or superior.loop_data.params_persistent.get("lf_trace")
+                )
+                return
+
+        # Top-level agent: create a root span (v3 creates trace implicitly)
+        user_msg = ""
+        if loop_data.user_message:
+            user_msg = str(loop_data.user_message.content)[:500]
+
+        root_span = client.start_span(
+            name=f"agent-{agent.number}-monologue",
+            input=user_msg,
+            metadata={"agent_number": agent.number},
+        )
+        # Set trace-level metadata (session_id, etc.)
+        root_span.update_trace(
+            session_id=context_id,
+            metadata={"agent_number": agent.number},
+        )
+        loop_data.params_persistent["lf_trace"] = root_span
+        loop_data.params_persistent["lf_root_trace"] = root_span
+        loop_data.params_persistent["lf_trace_id"] = root_span.trace_id

--- a/python/extensions/response_stream_end/_90_langfuse_generation_end.py
+++ b/python/extensions/response_stream_end/_90_langfuse_generation_end.py
@@ -1,0 +1,31 @@
+from python.helpers.extension import Extension
+from python.helpers.tokens import approximate_tokens
+from agent import LoopData
+
+
+class LangfuseGenerationEnd(Extension):
+
+    async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
+        if not loop_data.params_persistent.get("lf_sampled"):
+            return
+
+        generation = loop_data.params_temporary.get("lf_generation")
+        if not generation:
+            return
+
+        response_text = loop_data.last_response or ""
+        output_tokens = approximate_tokens(response_text) if response_text else 0
+        input_tokens = loop_data.params_temporary.get("lf_generation_input_tokens", 0)
+
+        try:
+            generation.update(
+                output=response_text[:2000],
+                usage_details={
+                    "input": input_tokens,
+                    "output": output_tokens,
+                    "total": input_tokens + output_tokens,
+                },
+            )
+            generation.end()
+        except Exception:
+            pass

--- a/python/extensions/response_stream_end/_91_langfuse_trace_attach.py
+++ b/python/extensions/response_stream_end/_91_langfuse_trace_attach.py
@@ -1,0 +1,29 @@
+from python.helpers.extension import Extension
+from python.helpers.langfuse_helper import get_langfuse_client
+from agent import LoopData
+
+
+class LangfuseTraceAttach(Extension):
+
+    async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
+        if not loop_data.params_persistent.get("lf_sampled"):
+            return
+
+        trace_id = loop_data.params_persistent.get("lf_trace_id")
+        if not trace_id:
+            return
+
+        log_item = loop_data.params_temporary.get("log_item_response")
+        if not log_item:
+            return
+
+        # Build Langfuse trace URL
+        trace_url = ""
+        client = get_langfuse_client()
+        if client:
+            try:
+                trace_url = client.get_trace_url(trace_id=trace_id) or ""
+            except Exception:
+                pass
+
+        log_item.update(kvps={"trace_id": trace_id, "trace_url": trace_url})

--- a/python/extensions/tool_execute_after/_90_langfuse_tool_end.py
+++ b/python/extensions/tool_execute_after/_90_langfuse_tool_end.py
@@ -1,0 +1,24 @@
+from python.helpers.extension import Extension
+from python.helpers.tool import Response
+
+
+class LangfuseToolSpanEnd(Extension):
+
+    async def execute(self, response: Response | None = None, tool_name: str = "", **kwargs):
+        loop_data = self.agent.loop_data
+        if not loop_data or not loop_data.params_persistent.get("lf_sampled"):
+            return
+
+        span = loop_data.params_temporary.get("lf_tool_span")
+        if not span:
+            return
+
+        output = ""
+        if response:
+            output = str(response.message)[:2000] if response.message else ""
+
+        try:
+            span.update(output=output)
+            span.end()
+        except Exception:
+            pass

--- a/python/extensions/tool_execute_before/_90_langfuse_tool_span.py
+++ b/python/extensions/tool_execute_before/_90_langfuse_tool_span.py
@@ -1,0 +1,27 @@
+from python.helpers.extension import Extension
+
+
+class LangfuseToolSpanStart(Extension):
+
+    async def execute(self, tool_name: str = "", tool_args: dict = {}, **kwargs):
+        loop_data = self.agent.loop_data
+        if not loop_data or not loop_data.params_persistent.get("lf_sampled"):
+            return
+
+        parent = loop_data.params_temporary.get("lf_iteration_span")
+        if not parent:
+            parent = loop_data.params_persistent.get("lf_trace")
+        if not parent:
+            return
+
+        args_summary = {}
+        for k, v in (tool_args or {}).items():
+            val_str = str(v)
+            args_summary[k] = val_str[:500] if len(val_str) > 500 else val_str
+
+        span = parent.start_span(
+            name=f"tool-{tool_name}" if tool_name else "tool-unknown",
+            input=args_summary,
+            metadata={"tool_name": tool_name},
+        )
+        loop_data.params_temporary["lf_tool_span"] = span

--- a/python/extensions/util_model_call_before/_90_langfuse_utility.py
+++ b/python/extensions/util_model_call_before/_90_langfuse_utility.py
@@ -1,0 +1,34 @@
+from python.helpers.extension import Extension
+from python.helpers.tokens import approximate_tokens
+
+
+class LangfuseUtilityGeneration(Extension):
+
+    async def execute(self, call_data: dict = {}, **kwargs):
+        loop_data = self.agent.loop_data
+        if not loop_data or not loop_data.params_persistent.get("lf_sampled"):
+            return
+
+        parent = loop_data.params_temporary.get("lf_iteration_span")
+        if not parent:
+            parent = loop_data.params_persistent.get("lf_trace")
+        if not parent:
+            return
+
+        model = call_data.get("model")
+        model_name = getattr(model, "model_name", "unknown") if model else "unknown"
+
+        system_msg = str(call_data.get("system", ""))[:500]
+        user_msg = str(call_data.get("message", ""))[:500]
+        input_text = f"System: {system_msg}\nUser: {user_msg}" if system_msg else user_msg
+
+        generation = parent.start_generation(
+            name="utility-llm",
+            model=model_name,
+            input=input_text,
+            metadata={
+                "agent_number": self.agent.number,
+                "call_type": "utility",
+            },
+        )
+        loop_data.params_temporary["lf_utility_gen"] = generation

--- a/python/helpers/langfuse_helper.py
+++ b/python/helpers/langfuse_helper.py
@@ -1,0 +1,90 @@
+import os
+import random
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Lazy-loaded singleton
+_client = None
+_client_initialized = False
+
+
+def get_langfuse_config() -> dict[str, Any]:
+    """Get Langfuse configuration with settings UI > env var > default precedence."""
+    from python.helpers.settings import get_settings
+
+    settings = get_settings()
+    public_key = settings.get("langfuse_public_key") or os.getenv("LANGFUSE_PUBLIC_KEY", "")
+    secret_key = settings.get("langfuse_secret_key") or os.getenv("LANGFUSE_SECRET_KEY", "")
+    host = settings.get("langfuse_host") or os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com")
+    enabled = settings.get("langfuse_enabled", False)
+    sample_rate = float(settings.get("langfuse_sample_rate", 1.0))
+
+    # Auto-enable if keys are set via env vars but toggle is off
+    if not enabled and public_key and secret_key:
+        enabled = True
+
+    return {
+        "enabled": enabled,
+        "public_key": public_key,
+        "secret_key": secret_key,
+        "host": host,
+        "sample_rate": sample_rate,
+    }
+
+
+def get_langfuse_client():
+    """Get or create the Langfuse client singleton. Returns None if disabled or not configured."""
+    global _client, _client_initialized
+
+    config = get_langfuse_config()
+
+    if not config["enabled"] or not config["public_key"] or not config["secret_key"]:
+        _client = None
+        _client_initialized = False
+        return None
+
+    # Return cached client if already initialized
+    if _client_initialized and _client is not None:
+        return _client
+
+    try:
+        from langfuse import Langfuse
+
+        _client = Langfuse(
+            public_key=config["public_key"],
+            secret_key=config["secret_key"],
+            host=config["host"],
+        )
+        _client_initialized = True
+        logger.info("Langfuse client initialized successfully")
+        return _client
+    except Exception as e:
+        logger.warning(f"Failed to initialize Langfuse client: {e}")
+        _client = None
+        _client_initialized = False
+        return None
+
+
+def reset_client():
+    """Reset the client singleton (call when settings change)."""
+    global _client, _client_initialized
+    if _client:
+        try:
+            _client.flush()
+        except Exception:
+            pass
+    _client = None
+    _client_initialized = False
+
+
+def should_sample() -> bool:
+    """Check if this interaction should be sampled based on sample_rate."""
+    config = get_langfuse_config()
+    rate = config.get("sample_rate", 1.0)
+    if rate >= 1.0:
+        return True
+    if rate <= 0.0:
+        return False
+    return random.random() < rate

--- a/python/helpers/persist_chat.py
+++ b/python/helpers/persist_chat.py
@@ -103,6 +103,109 @@ def export_json_chat(context: AgentContext):
     return js
 
 
+def fork_context(source_context: AgentContext, fork_at_log_no=None):
+    """Deep-copy a context, optionally truncating at a log position.
+
+    Args:
+        source_context: The context to fork from.
+        fork_at_log_no: If provided, truncate the fork's log and history
+            to include only items up to this log number.
+
+    Returns:
+        A new AgentContext instance with its own ID and log GUID.
+    """
+    source_id = source_context.id
+    source_name = source_context.name or "Chat"
+
+    # 1. Serialize and deep-copy via JSON round-trip
+    serialized = _serialize_context(source_context)
+    data = json.loads(_safe_json_serialize(serialized, ensure_ascii=False))
+
+    # 2. Optionally truncate at the fork point
+    if fork_at_log_no is not None:
+        _truncate_fork_data(data, fork_at_log_no)
+
+    # 3. Remove ID so _deserialize_context generates a new one
+    if "id" in data:
+        del data["id"]
+
+    # 4. Auto-name with collision check
+    base_name = f"{source_name} (fork)"
+    existing_names = {ctx.name for ctx in AgentContext.all()}
+    fork_name = base_name
+    counter = 2
+    while fork_name in existing_names:
+        fork_name = f"{source_name} (fork {counter})"
+        counter += 1
+    data["name"] = fork_name
+
+    # 5. Store fork metadata (in both data and output_data so UI can see it)
+    fork_info = {
+        "forked_from": source_id,
+        "fork_point": fork_at_log_no,
+        "fork_timestamp": datetime.now().isoformat(),
+    }
+    data.setdefault("data", {})
+    data["data"]["fork_info"] = fork_info
+    data.setdefault("output_data", {})
+    data["output_data"]["fork_info"] = fork_info
+
+    # 6. Generate new log GUID for fresh polling state
+    data.setdefault("log", {})
+    data["log"]["guid"] = str(uuid.uuid4())
+
+    # 7. Deserialize into a new context
+    return _deserialize_context(data)
+
+
+def _truncate_fork_data(data, fork_at_log_no):
+    """Truncate serialized context data at a specific log item number.
+
+    Filters the log to keep only items where no <= fork_at_log_no, then
+    truncates agent 0's history to match the remaining user/response count.
+
+    Args:
+        data: Serialized context dict (mutated in place).
+        fork_at_log_no: The log item number to truncate at (inclusive).
+    """
+    # 1. Filter log items
+    logs = data.get("log", {}).get("logs", [])
+    truncated_logs = [item for item in logs if item.get("no", 0) <= fork_at_log_no]
+    data["log"]["logs"] = truncated_logs
+
+    # 2. Count user-type and response-type (agent 0) log items
+    user_count = 0
+    response_count = 0
+    for item in truncated_logs:
+        item_type = item.get("type", "")
+        if item_type == "user":
+            user_count += 1
+        elif item_type == "response" and item.get("agent_number", item.get("agentno", -1)) == 0:
+            response_count += 1
+
+    keep_messages = user_count + response_count
+
+    # 3. Truncate agent 0's history
+    agents = data.get("agents", [])
+    for agent_data in agents:
+        if agent_data.get("number", -1) != 0:
+            continue
+        history_str = agent_data.get("history", "")
+        if not history_str:
+            break
+        try:
+            hist = json.loads(history_str)
+        except (json.JSONDecodeError, TypeError):
+            break
+        current = hist.get("current", {})
+        messages = current.get("messages", [])
+        if len(messages) > keep_messages:
+            current["messages"] = messages[:keep_messages]
+        hist["current"] = current
+        agent_data["history"] = json.dumps(hist, ensure_ascii=False)
+        break
+
+
 def remove_chat(ctxid):
     """Remove a chat or task context"""
     path = get_chat_folder_path(ctxid)

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,4 @@ pywinpty==3.0.2; sys_platform == "win32"
 python-socketio>=5.14.2
 uvicorn>=0.38.0
 wsproto>=1.2.0
+langfuse>=2.0.0

--- a/webui/components/chat/split-view/split-view-store.js
+++ b/webui/components/chat/split-view/split-view-store.js
@@ -1,0 +1,212 @@
+import { createStore } from "/js/AlpineStore.js";
+import { callJsonApi } from "/js/api.js";
+
+const POLL_INTERVAL_MS = 2000;
+
+const model = {
+  active: false,
+  leftContextId: "",
+  rightContextId: "",
+  forkPoint: null, // log no where the fork happened
+
+  leftMessages: [],
+  rightMessages: [],
+  leftForkInfo: null,
+  rightForkInfo: null,
+
+  loading: false,
+  error: "",
+
+  _initialized: false,
+  _pollTimer: null,
+  _leftLogVersion: 0,
+  _rightLogVersion: 0,
+  _leftLogGuid: "",
+  _rightLogGuid: "",
+
+  init() {
+    if (this._initialized) return;
+    this._initialized = true;
+  },
+
+  async openSplit(leftId, rightId, forkPoint = null) {
+    this.leftContextId = leftId;
+    this.rightContextId = rightId;
+    this.forkPoint = forkPoint;
+    this.leftMessages = [];
+    this.rightMessages = [];
+    this.leftForkInfo = null;
+    this.rightForkInfo = null;
+    this.error = "";
+    this._leftLogVersion = 0;
+    this._rightLogVersion = 0;
+    this._leftLogGuid = "";
+    this._rightLogGuid = "";
+    this.active = true;
+    this.loading = true;
+
+    await this._fetchBoth();
+    this.loading = false;
+    this._startPolling();
+  },
+
+  closeSplit() {
+    this._stopPolling();
+    this.active = false;
+    this.leftContextId = "";
+    this.rightContextId = "";
+    this.forkPoint = null;
+    this.leftMessages = [];
+    this.rightMessages = [];
+    this.leftForkInfo = null;
+    this.rightForkInfo = null;
+    this.error = "";
+  },
+
+  cleanup() {
+    this.closeSplit();
+  },
+
+  async _fetchBoth() {
+    try {
+      const [leftResult, rightResult] = await Promise.all([
+        this._fetchLogs(this.leftContextId, this._leftLogVersion),
+        this._fetchLogs(this.rightContextId, this._rightLogVersion),
+      ]);
+
+      if (leftResult) {
+        // Reset on guid change
+        if (this._leftLogGuid && this._leftLogGuid !== leftResult.log_guid) {
+          this.leftMessages = [];
+          this._leftLogVersion = 0;
+        }
+        this._leftLogGuid = leftResult.log_guid;
+        this._leftLogVersion = leftResult.log_version;
+        if (leftResult.fork_info) this.leftForkInfo = leftResult.fork_info;
+        this._appendMessages("left", leftResult.logs);
+      }
+
+      if (rightResult) {
+        if (this._rightLogGuid && this._rightLogGuid !== rightResult.log_guid) {
+          this.rightMessages = [];
+          this._rightLogVersion = 0;
+        }
+        this._rightLogGuid = rightResult.log_guid;
+        this._rightLogVersion = rightResult.log_version;
+        if (rightResult.fork_info) this.rightForkInfo = rightResult.fork_info;
+        this._appendMessages("right", rightResult.logs);
+      }
+
+      // Auto-detect fork point from fork_info if not explicitly set
+      if (this.forkPoint === null) {
+        this._detectForkPoint();
+      }
+    } catch (e) {
+      this.error = e.message || "Failed to fetch logs";
+    }
+  },
+
+  async _fetchLogs(contextId, logFrom) {
+    if (!contextId) return null;
+    try {
+      const result = await callJsonApi("/chat_logs", {
+        context_id: contextId,
+        log_from: logFrom,
+      });
+      if (!result.success) {
+        console.warn("chat_logs failed:", result.error);
+        return null;
+      }
+      return result;
+    } catch (e) {
+      console.warn("chat_logs error:", e);
+      return null;
+    }
+  },
+
+  _appendMessages(side, logs) {
+    if (!logs || !logs.length) return;
+    const existing = side === "left" ? this.leftMessages : this.rightMessages;
+    const existingMap = new Map(existing.map((m) => [m.no, m]));
+
+    for (const log of logs) {
+      existingMap.set(log.no, log);
+    }
+
+    const sorted = Array.from(existingMap.values()).sort(
+      (a, b) => a.no - b.no,
+    );
+    if (side === "left") {
+      this.leftMessages = sorted;
+    } else {
+      this.rightMessages = sorted;
+    }
+  },
+
+  _detectForkPoint() {
+    // Check right context's fork_info — it should have forked_from pointing to left
+    const info = this.rightForkInfo || this.leftForkInfo;
+    if (info && info.fork_point != null) {
+      this.forkPoint = info.fork_point;
+      return;
+    }
+
+    // Fallback: find the last matching user message by content
+    const leftUsers = this.leftMessages.filter((m) => m.type === "user");
+    const rightUsers = this.rightMessages.filter((m) => m.type === "user");
+    let lastMatch = 0;
+    for (
+      let i = 0;
+      i < Math.min(leftUsers.length, rightUsers.length);
+      i++
+    ) {
+      if (leftUsers[i].content === rightUsers[i].content) {
+        lastMatch = leftUsers[i].no;
+      } else {
+        break;
+      }
+    }
+    if (lastMatch > 0) {
+      this.forkPoint = lastMatch;
+    }
+  },
+
+  /**
+   * Classify a message as "shared" (before fork) or "divergent" (after fork).
+   */
+  getMessageClass(msg) {
+    if (this.forkPoint === null) return "divergent";
+    return msg.no <= this.forkPoint ? "shared" : "divergent";
+  },
+
+  /**
+   * Get only the main displayable message types (user + response).
+   * Process types (agent, tool, etc.) are collapsed in split view.
+   */
+  getDisplayMessages(side) {
+    const msgs = side === "left" ? this.leftMessages : this.rightMessages;
+    return msgs.filter(
+      (m) =>
+        m.type === "user" ||
+        (m.type === "response" && (m.agentno === 0 || m.agentno == null)),
+    );
+  },
+
+  _startPolling() {
+    this._stopPolling();
+    this._pollTimer = setInterval(() => {
+      if (this.active) {
+        this._fetchBoth();
+      }
+    }, POLL_INTERVAL_MS);
+  },
+
+  _stopPolling() {
+    if (this._pollTimer) {
+      clearInterval(this._pollTimer);
+      this._pollTimer = null;
+    }
+  },
+};
+
+export const store = createStore("splitView", model);

--- a/webui/components/chat/split-view/split-view.html
+++ b/webui/components/chat/split-view/split-view.html
@@ -1,0 +1,464 @@
+<html>
+
+<head>
+  <script type="module">
+    import { store } from "/components/chat/split-view/split-view-store.js";
+    import { marked } from "/vendor/marked/marked.esm.js";
+
+    // Expose marked for use in Alpine expressions
+    globalThis._splitViewMarked = marked;
+  </script>
+</head>
+
+<body>
+  <div x-data="{
+    renderMarkdown(content) {
+      if (!content) return '';
+      return globalThis._splitViewMarked.parse(content, { breaks: true });
+    },
+    escapeHtml(text) {
+      if (!text) return '';
+      const d = document.createElement('div');
+      d.textContent = text;
+      return d.innerHTML;
+    },
+    renderMsg(msg) {
+      if (msg.type === 'response') return this.renderMarkdown(msg.content);
+      return this.escapeHtml(msg.content || msg.heading || '');
+    }
+  }">
+    <template x-if="$store.splitView">
+      <div class="split-view-container" x-show="$store.splitView.active"
+        x-destroy="$store.splitView.cleanup()">
+
+        <div class="split-header">
+          <div class="split-header-left">
+            <span class="material-symbols-outlined">compare</span>
+            <span>Comparing chats</span>
+            <template x-if="$store.splitView.forkPoint !== null">
+              <span class="split-fork-badge">
+                <span class="material-symbols-outlined" style="font-size: 14px;">call_split</span>
+                <span x-text="'Fork at message #' + $store.splitView.forkPoint"></span>
+              </span>
+            </template>
+          </div>
+          <button class="btn-sm" @click="$store.splitView.closeSplit()" title="Close split view">
+            <span class="material-symbols-outlined">close</span>
+          </button>
+        </div>
+
+        <!-- Loading state -->
+        <template x-if="$store.splitView.loading">
+          <div class="split-loading">
+            <div class="split-loading-spinner"></div>
+            <span>Loading messages...</span>
+          </div>
+        </template>
+
+        <!-- Error state -->
+        <template x-if="$store.splitView.error">
+          <div class="split-error">
+            <span class="material-symbols-outlined">error</span>
+            <span x-text="$store.splitView.error"></span>
+          </div>
+        </template>
+
+        <!-- Panes -->
+        <div class="split-panes" x-show="!$store.splitView.loading">
+
+          <!-- Left pane (Original) -->
+          <div class="split-pane split-pane-left">
+            <div class="pane-label">
+              <span>Original</span>
+              <span class="pane-msg-count"
+                x-text="$store.splitView.getDisplayMessages('left').length + ' messages'"></span>
+            </div>
+            <div class="pane-messages" id="split-left-messages">
+              <template x-if="$store.splitView.getDisplayMessages('left').length === 0 && !$store.splitView.loading">
+                <p class="split-placeholder">No messages</p>
+              </template>
+              <template x-for="msg in $store.splitView.getDisplayMessages('left')" :key="msg.no">
+                <div class="split-msg"
+                  :class="{
+                    'split-msg-user': msg.type === 'user',
+                    'split-msg-response': msg.type === 'response',
+                    'split-msg-shared': $store.splitView.getMessageClass(msg) === 'shared',
+                    'split-msg-divergent': $store.splitView.getMessageClass(msg) === 'divergent',
+                  }">
+                  <!-- Fork point indicator -->
+                  <template x-if="$store.splitView.forkPoint !== null && msg.no === $store.splitView.forkPoint">
+                    <div class="split-fork-indicator">
+                      <div class="split-fork-line"></div>
+                      <span class="split-fork-label">
+                        <span class="material-symbols-outlined" style="font-size: 14px;">call_split</span>
+                        Fork point
+                      </span>
+                      <div class="split-fork-line"></div>
+                    </div>
+                  </template>
+                  <div class="split-msg-header">
+                    <span class="split-msg-icon material-symbols-outlined"
+                      x-text="msg.type === 'user' ? 'person' : 'smart_toy'"></span>
+                    <span class="split-msg-type" x-text="msg.type === 'user' ? 'User' : 'Response'"></span>
+                    <span class="split-msg-no" x-text="'#' + msg.no"></span>
+                  </div>
+                  <div class="split-msg-content"
+                    x-html="renderMsg(msg)">
+                  </div>
+                </div>
+              </template>
+            </div>
+          </div>
+
+          <div class="split-divider"></div>
+
+          <!-- Right pane (Fork) -->
+          <div class="split-pane split-pane-right">
+            <div class="pane-label">
+              <span>Fork</span>
+              <span class="pane-msg-count"
+                x-text="$store.splitView.getDisplayMessages('right').length + ' messages'"></span>
+            </div>
+            <div class="pane-messages" id="split-right-messages">
+              <template x-if="$store.splitView.getDisplayMessages('right').length === 0 && !$store.splitView.loading">
+                <p class="split-placeholder">No messages</p>
+              </template>
+              <template x-for="msg in $store.splitView.getDisplayMessages('right')" :key="msg.no">
+                <div class="split-msg"
+                  :class="{
+                    'split-msg-user': msg.type === 'user',
+                    'split-msg-response': msg.type === 'response',
+                    'split-msg-shared': $store.splitView.getMessageClass(msg) === 'shared',
+                    'split-msg-divergent': $store.splitView.getMessageClass(msg) === 'divergent',
+                  }">
+                  <!-- Fork point indicator -->
+                  <template x-if="$store.splitView.forkPoint !== null && msg.no === $store.splitView.forkPoint">
+                    <div class="split-fork-indicator">
+                      <div class="split-fork-line"></div>
+                      <span class="split-fork-label">
+                        <span class="material-symbols-outlined" style="font-size: 14px;">call_split</span>
+                        Fork point
+                      </span>
+                      <div class="split-fork-line"></div>
+                    </div>
+                  </template>
+                  <div class="split-msg-header">
+                    <span class="split-msg-icon material-symbols-outlined"
+                      x-text="msg.type === 'user' ? 'person' : 'smart_toy'"></span>
+                    <span class="split-msg-type" x-text="msg.type === 'user' ? 'User' : 'Response'"></span>
+                    <span class="split-msg-no" x-text="'#' + msg.no"></span>
+                  </div>
+                  <div class="split-msg-content"
+                    x-html="renderMsg(msg)">
+                  </div>
+                </div>
+              </template>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+
+  <style>
+    .split-view-container {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      z-index: 2000;
+      background: var(--color-background);
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Header */
+    .split-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--color-border);
+      background: var(--color-panel);
+      flex-shrink: 0;
+    }
+
+    .split-header-left {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+    }
+
+    .split-header-left .material-symbols-outlined {
+      font-size: 20px;
+    }
+
+    .split-fork-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 2px 8px;
+      border-radius: 12px;
+      background: var(--color-accent);
+      color: var(--color-background);
+      font-size: var(--font-size-small);
+      font-weight: 500;
+    }
+
+    /* Loading */
+    .split-loading {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 1rem;
+      color: var(--color-secondary);
+    }
+
+    .split-loading-spinner {
+      width: 32px;
+      height: 32px;
+      border: 3px solid var(--color-border);
+      border-top-color: var(--color-accent);
+      border-radius: 50%;
+      animation: split-spin 0.8s linear infinite;
+    }
+
+    @keyframes split-spin {
+      to { transform: rotate(360deg); }
+    }
+
+    /* Error */
+    .split-error {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 1rem;
+      margin: 1rem;
+      border-radius: 8px;
+      background: rgba(220, 50, 50, 0.1);
+      color: var(--color-error, #dc3232);
+    }
+
+    /* Panes */
+    .split-panes {
+      display: flex;
+      flex: 1;
+      min-height: 0;
+      overflow: hidden;
+    }
+
+    .split-pane {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      overflow: hidden;
+    }
+
+    .split-divider {
+      width: 1px;
+      background: var(--color-border);
+      flex-shrink: 0;
+    }
+
+    .pane-label {
+      padding: 0.5rem 1rem;
+      font-size: var(--font-size-small);
+      font-weight: 600;
+      color: var(--color-secondary);
+      border-bottom: 1px solid var(--color-border);
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .pane-msg-count {
+      font-weight: 400;
+      opacity: 0.6;
+      font-size: 0.75rem;
+    }
+
+    .pane-messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .split-placeholder {
+      color: var(--color-secondary);
+      opacity: 0.5;
+      text-align: center;
+      padding-top: 2rem;
+    }
+
+    /* Messages */
+    .split-msg {
+      border-radius: 8px;
+      padding: 0.75rem;
+      transition: opacity var(--transition-speed) ease-in-out;
+    }
+
+    .split-msg-shared {
+      opacity: 0.45;
+    }
+
+    .split-msg-shared:hover {
+      opacity: 0.7;
+    }
+
+    .split-msg-divergent {
+      opacity: 1;
+    }
+
+    .split-msg-user {
+      background: var(--color-input);
+      border: 1px solid var(--color-border);
+    }
+
+    .split-msg-response {
+      background: var(--color-panel);
+      border: 1px solid var(--color-border);
+    }
+
+    .split-msg-divergent.split-msg-response {
+      border-left: 3px solid var(--color-accent);
+    }
+
+    .split-msg-divergent.split-msg-user {
+      border-left: 3px solid var(--color-primary);
+    }
+
+    .split-msg-header {
+      display: flex;
+      align-items: center;
+      gap: 0.35rem;
+      margin-bottom: 0.5rem;
+      font-size: var(--font-size-small);
+      color: var(--color-secondary);
+    }
+
+    .split-msg-icon {
+      font-size: 16px;
+    }
+
+    .split-msg-type {
+      font-weight: 600;
+    }
+
+    .split-msg-no {
+      opacity: 0.5;
+      font-size: 0.7rem;
+    }
+
+    .split-msg-content {
+      font-size: var(--font-size-normal);
+      color: var(--color-text);
+      line-height: 1.5;
+      word-break: break-word;
+      overflow-wrap: break-word;
+    }
+
+    .split-msg-content p {
+      margin: 0 0 0.5em 0;
+    }
+
+    .split-msg-content p:last-child {
+      margin-bottom: 0;
+    }
+
+    .split-msg-content pre {
+      background: var(--color-background);
+      border: 1px solid var(--color-border);
+      border-radius: 4px;
+      padding: 0.5rem;
+      overflow-x: auto;
+      font-size: 0.85em;
+    }
+
+    .split-msg-content code {
+      background: var(--color-background);
+      padding: 1px 4px;
+      border-radius: 3px;
+      font-size: 0.9em;
+    }
+
+    .split-msg-content pre code {
+      background: none;
+      padding: 0;
+    }
+
+    /* Fork point indicator */
+    .split-fork-indicator {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin: 0.5rem 0 0.75rem 0;
+    }
+
+    .split-fork-line {
+      flex: 1;
+      height: 1px;
+      background: var(--color-accent);
+      opacity: 0.5;
+    }
+
+    .split-fork-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 2px 10px;
+      border-radius: 10px;
+      background: var(--color-accent);
+      color: var(--color-background);
+      font-size: 0.7rem;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    /* Button */
+    .btn-sm {
+      background: none;
+      border: 1px solid var(--color-border);
+      border-radius: 4px;
+      color: var(--color-text);
+      padding: 4px 8px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+    }
+
+    .btn-sm:hover {
+      background: var(--color-background-hover);
+    }
+
+    .btn-sm .material-symbols-outlined {
+      font-size: 18px;
+    }
+
+    /* Responsive: stack panes on narrow screens */
+    @media (max-width: 700px) {
+      .split-panes {
+        flex-direction: column;
+      }
+
+      .split-divider {
+        width: 100%;
+        height: 1px;
+      }
+
+      .split-pane {
+        max-height: 50%;
+      }
+    }
+  </style>
+</body>
+
+</html>

--- a/webui/components/modals/prompt-lab/prompt-lab-store.js
+++ b/webui/components/modals/prompt-lab/prompt-lab-store.js
@@ -1,0 +1,229 @@
+import { createStore } from "/js/AlpineStore.js";
+import { sendJsonData, justToast, toast, toastFetchError } from "/index.js";
+
+const model = {
+  // Original prompt data (read-only, from trace observation)
+  originalPrompt: "",
+  originalResponse: "",
+  observationModel: "",
+  tokenCount: 0,
+  cost: 0,
+  userMessage: "",
+
+  // Editor state
+  editorPrompt: "",
+  undoStack: [],
+
+  // Refiner/Judge state
+  refining: false,
+  judging: false,
+  variants: [],
+
+  // Test state
+  testing: false,
+  testResult: "",
+  testForkedContextId: null,
+
+  // Source context for forking
+  sourceContextId: "",
+  forkAtLogNo: null,
+
+  _initialized: false,
+
+  init() {
+    if (this._initialized) return;
+    this._initialized = true;
+  },
+
+  open({
+    systemPrompt,
+    response,
+    model,
+    tokenCount,
+    cost,
+    userMessage,
+    contextId,
+    logNo,
+  }) {
+    this.originalPrompt = systemPrompt || "";
+    this.originalResponse = response || "";
+    this.observationModel = model || "";
+    this.tokenCount = tokenCount || 0;
+    this.cost = cost || 0;
+    this.userMessage = userMessage || "";
+    this.editorPrompt = systemPrompt || "";
+    this.undoStack = [];
+    this.variants = [];
+    this.refining = false;
+    this.judging = false;
+    this.testing = false;
+    this.testResult = "";
+    this.testForkedContextId = null;
+    this.sourceContextId = contextId || "";
+    this.forkAtLogNo = logNo ?? null;
+  },
+
+  selectVariant(index) {
+    if (index < 0 || index >= this.variants.length) return;
+    const variant = this.variants[index];
+    if (!variant?.prompt) return;
+    this.undoStack.push(this.editorPrompt);
+    this.editorPrompt = variant.prompt;
+  },
+
+  undo() {
+    if (this.undoStack.length === 0) return;
+    this.editorPrompt = this.undoStack.pop();
+  },
+
+  resetEditor() {
+    this.undoStack.push(this.editorPrompt);
+    this.editorPrompt = this.originalPrompt;
+  },
+
+  async suggestImprovements() {
+    if (this.refining || this.judging) return;
+
+    this.refining = true;
+    this.variants = [];
+
+    try {
+      const refineResult = await sendJsonData("/prompt_refine", {
+        system_prompt: this.editorPrompt,
+        user_message: this.userMessage,
+        response: this.originalResponse,
+        model: this.observationModel,
+        token_count: this.tokenCount,
+      });
+
+      if (!refineResult.success) {
+        toast(refineResult.error || "Refiner failed", "error");
+        this.refining = false;
+        return;
+      }
+
+      const rawVariants = refineResult.variants || [];
+      if (rawVariants.length === 0) {
+        justToast("No improvements suggested", "info", 2000, "prompt-lab");
+        this.refining = false;
+        return;
+      }
+
+      this.refining = false;
+      this.judging = true;
+
+      const judgeResult = await sendJsonData("/prompt_judge", {
+        original_prompt: this.originalPrompt,
+        original_response: this.originalResponse,
+        variants: rawVariants,
+      });
+
+      if (!judgeResult.success) {
+        this.variants = rawVariants.map((v) => ({
+          ...v,
+          approved: true,
+          scores: null,
+          reasoning: "Judge unavailable",
+        }));
+        this.judging = false;
+        return;
+      }
+
+      const judgeResults = judgeResult.results || [];
+      this.variants = rawVariants.map((v, i) => {
+        const judgment =
+          judgeResults.find((j) => j.variant_index === i) || {};
+        return {
+          ...v,
+          approved: judgment.approved ?? true,
+          scores: judgment.scores || null,
+          reasoning: judgment.reasoning || "",
+        };
+      });
+
+      this.judging = false;
+    } catch (e) {
+      this.refining = false;
+      this.judging = false;
+      toastFetchError("Prompt improvement failed", e);
+    }
+  },
+
+  async testPrompt() {
+    if (this.testing) return;
+    this.testing = true;
+    this.testResult = "";
+
+    try {
+      const payload = { context_id: this.sourceContextId };
+      if (this.forkAtLogNo != null) {
+        payload.fork_at_log_no = this.forkAtLogNo;
+      }
+
+      const result = await sendJsonData("/chat_fork", payload);
+
+      if (!result.success) {
+        toast(result.error || "Test fork failed", "error");
+        this.testing = false;
+        return;
+      }
+
+      this.testForkedContextId = result.context_id;
+      this.testResult = `Forked to "${result.name}". Switch to the forked chat to continue with the modified prompt.`;
+      this.testing = false;
+      justToast("Test fork created", "success", 2000, "prompt-lab");
+    } catch (e) {
+      this.testing = false;
+      toastFetchError("Test failed", e);
+    }
+  },
+
+  goToTestFork() {
+    if (!this.testForkedContextId) return;
+    const chatsStore = window.Alpine?.store("chats");
+    if (chatsStore) {
+      chatsStore.selectChat(this.testForkedContextId);
+    }
+    window.closeModal("modals/prompt-lab/prompt-lab.html");
+  },
+
+  compareInSplitView() {
+    if (!this.testForkedContextId || !this.sourceContextId) {
+      justToast("Fork a test chat first", "info", 2000, "prompt-lab");
+      return;
+    }
+    const splitView = window.Alpine?.store("splitView");
+    if (!splitView) {
+      justToast("Split view not available", "error", 2000, "prompt-lab");
+      return;
+    }
+    // Close the prompt lab modal, then open split view
+    window.closeModal("modals/prompt-lab/prompt-lab.html");
+    splitView.openSplit(
+      this.sourceContextId,
+      this.testForkedContextId,
+      this.forkAtLogNo,
+    );
+  },
+
+  cleanup() {
+    this.originalPrompt = "";
+    this.originalResponse = "";
+    this.observationModel = "";
+    this.tokenCount = 0;
+    this.cost = 0;
+    this.userMessage = "";
+    this.editorPrompt = "";
+    this.undoStack = [];
+    this.variants = [];
+    this.refining = false;
+    this.judging = false;
+    this.testing = false;
+    this.testResult = "";
+    this.testForkedContextId = null;
+    this.sourceContextId = "";
+    this.forkAtLogNo = null;
+  },
+};
+
+export const store = createStore("promptLab", model);

--- a/webui/components/modals/prompt-lab/prompt-lab.html
+++ b/webui/components/modals/prompt-lab/prompt-lab.html
@@ -1,0 +1,473 @@
+<html>
+
+<head>
+  <title>Prompt Lab</title>
+  <script type="module">
+    import { store } from "/components/modals/prompt-lab/prompt-lab-store.js";
+  </script>
+</head>
+
+<body>
+  <div x-data>
+    <template x-if="$store.promptLab">
+      <div class="prompt-lab"
+        x-create="$store.promptLab.init()"
+        x-destroy="$store.promptLab.cleanup()">
+
+        <!-- Three-panel layout -->
+        <div class="prompt-lab-panels">
+
+          <!-- Left: Original Prompt (read-only) -->
+          <div class="prompt-lab-panel panel-original">
+            <div class="panel-header">
+              <h4>Original Prompt</h4>
+            </div>
+            <div class="panel-meta">
+              <span class="meta-item" x-show="$store.promptLab.observationModel">
+                <span class="meta-label">Model:</span>
+                <span x-text="$store.promptLab.observationModel"></span>
+              </span>
+              <span class="meta-item" x-show="$store.promptLab.tokenCount">
+                <span class="meta-label">Tokens:</span>
+                <span x-text="$store.promptLab.tokenCount.toLocaleString()"></span>
+              </span>
+              <span class="meta-item" x-show="$store.promptLab.cost">
+                <span class="meta-label">Cost:</span>
+                <span x-text="'$' + $store.promptLab.cost.toFixed(4)"></span>
+              </span>
+            </div>
+            <div class="panel-content">
+              <pre class="prompt-text" x-text="$store.promptLab.originalPrompt"></pre>
+            </div>
+          </div>
+
+          <!-- Center: Editor -->
+          <div class="prompt-lab-panel panel-editor">
+            <div class="panel-header">
+              <h4>Editor</h4>
+              <div class="panel-actions">
+                <button class="btn-sm" @click="$store.promptLab.undo()"
+                  :disabled="$store.promptLab.undoStack.length === 0"
+                  title="Undo">
+                  <span class="material-symbols-outlined">undo</span>
+                </button>
+                <button class="btn-sm" @click="$store.promptLab.resetEditor()"
+                  title="Reset to original">
+                  <span class="material-symbols-outlined">restart_alt</span>
+                </button>
+              </div>
+            </div>
+            <div class="panel-content">
+              <textarea class="prompt-editor"
+                x-model="$store.promptLab.editorPrompt"
+                placeholder="Edit the prompt here..."></textarea>
+            </div>
+
+            <!-- Action buttons -->
+            <div class="editor-actions">
+              <button class="btn btn-ok"
+                @click="$store.promptLab.suggestImprovements()"
+                :disabled="$store.promptLab.refining || $store.promptLab.judging">
+                <span class="material-symbols-outlined">auto_awesome</span>
+                <span x-text="$store.promptLab.refining ? 'Refining...' : ($store.promptLab.judging ? 'Judging...' : 'Suggest Improvements')"></span>
+              </button>
+              <button class="btn btn-cancel"
+                @click="$store.promptLab.testPrompt()"
+                :disabled="$store.promptLab.testing">
+                <span class="material-symbols-outlined">science</span>
+                <span x-text="$store.promptLab.testing ? 'Forking...' : 'Test'"></span>
+              </button>
+            </div>
+
+            <!-- Variants cards -->
+            <div class="variants-list" x-show="$store.promptLab.variants.length > 0">
+              <h5>Suggestions</h5>
+              <template x-for="(variant, idx) in $store.promptLab.variants" :key="idx">
+                <div :class="{'variant-card': true, 'variant-rejected': !variant.approved}"
+                  @click="variant.approved && $store.promptLab.selectVariant(idx)">
+                  <div class="variant-header">
+                    <span class="variant-status">
+                      <span class="material-symbols-outlined"
+                        x-text="variant.approved ? 'check_circle' : 'cancel'"></span>
+                    </span>
+                    <span class="variant-targets" x-show="variant.targets">
+                      <template x-for="target in (variant.targets || [])" :key="target">
+                        <span class="target-badge" x-text="target"></span>
+                      </template>
+                    </span>
+                  </div>
+                  <p class="variant-explanation" x-text="variant.explanation"></p>
+                  <div class="variant-scores" x-show="variant.scores">
+                    <template x-for="[key, val] in Object.entries(variant.scores || {})" :key="key">
+                      <span class="score-badge" :class="{'score-low': val < 3}">
+                        <span x-text="key"></span>: <span x-text="val"></span>/5
+                      </span>
+                    </template>
+                  </div>
+                  <p class="variant-reasoning" x-show="variant.reasoning" x-text="variant.reasoning"></p>
+                </div>
+              </template>
+            </div>
+          </div>
+
+          <!-- Right: Results -->
+          <div class="prompt-lab-panel panel-results">
+            <div class="panel-header">
+              <h4>Results</h4>
+            </div>
+            <div class="panel-content">
+              <!-- Empty state -->
+              <div class="results-empty"
+                x-show="!$store.promptLab.testResult && !$store.promptLab.testing">
+                <span class="material-symbols-outlined">science</span>
+                <p>Run a test to see results</p>
+              </div>
+
+              <!-- Loading state -->
+              <div class="results-loading" x-show="$store.promptLab.testing">
+                <div class="loading"></div>
+                <p>Creating test fork...</p>
+              </div>
+
+              <!-- Test result -->
+              <div class="results-content" x-show="$store.promptLab.testResult">
+                <p x-text="$store.promptLab.testResult"></p>
+                <div class="results-actions" x-show="$store.promptLab.testForkedContextId">
+                  <button class="btn btn-ok" @click="$store.promptLab.goToTestFork()">
+                    <span class="material-symbols-outlined">open_in_new</span>
+                    Go to Forked Chat
+                  </button>
+                  <button class="btn btn-cancel" @click="$store.promptLab.compareInSplitView()">
+                    <span class="material-symbols-outlined">compare</span>
+                    Compare in Split View
+                  </button>
+                </div>
+              </div>
+
+              <!-- Original response for comparison -->
+              <div class="results-original" x-show="$store.promptLab.originalResponse">
+                <h5>Original Response</h5>
+                <pre class="response-text" x-text="$store.promptLab.originalResponse"></pre>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </template>
+  </div>
+
+  <style>
+    .prompt-lab {
+      display: flex;
+      flex-direction: column;
+      height: 70vh;
+      min-height: 400px;
+    }
+
+    .prompt-lab-panels {
+      display: flex;
+      gap: 1rem;
+      flex: 1;
+      min-height: 0;
+      overflow: hidden;
+    }
+
+    .prompt-lab-panel {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      border: 1px solid var(--color-border);
+      border-radius: 8px;
+      background: var(--color-panel);
+      overflow: hidden;
+    }
+
+    .panel-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--color-border);
+      flex-shrink: 0;
+    }
+
+    .panel-header h4 {
+      margin: 0;
+      font-size: var(--font-size-normal);
+      font-weight: 600;
+    }
+
+    .panel-actions {
+      display: flex;
+      gap: 0.25rem;
+    }
+
+    .btn-sm {
+      background: none;
+      border: 1px solid var(--color-border);
+      border-radius: 4px;
+      color: var(--color-text);
+      padding: 2px 6px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+    }
+
+    .btn-sm:hover {
+      background: var(--color-background-hover);
+    }
+
+    .btn-sm:disabled {
+      opacity: 0.3;
+      cursor: not-allowed;
+    }
+
+    .btn-sm .material-symbols-outlined {
+      font-size: 18px;
+    }
+
+    .panel-meta {
+      display: flex;
+      gap: 1rem;
+      padding: 0.5rem 1rem;
+      font-size: var(--font-size-small);
+      color: var(--color-secondary);
+      border-bottom: 1px solid var(--color-border);
+      flex-shrink: 0;
+    }
+
+    .meta-label {
+      opacity: 0.7;
+    }
+
+    .panel-content {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0.75rem 1rem;
+    }
+
+    .prompt-text {
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      font-size: var(--font-size-small);
+      line-height: 1.5;
+      margin: 0;
+      font-family: inherit;
+    }
+
+    .prompt-editor {
+      width: 100%;
+      height: 100%;
+      min-height: 200px;
+      background: var(--color-input);
+      color: var(--color-text);
+      border: 1px solid var(--color-border);
+      border-radius: 4px;
+      padding: 0.75rem;
+      font-size: var(--font-size-small);
+      line-height: 1.5;
+      resize: none;
+      font-family: inherit;
+    }
+
+    .prompt-editor:focus {
+      outline: none;
+      border-color: var(--color-accent);
+    }
+
+    .editor-actions {
+      display: flex;
+      gap: 0.5rem;
+      padding: 0.75rem 1rem;
+      border-top: 1px solid var(--color-border);
+      flex-shrink: 0;
+    }
+
+    .editor-actions .btn {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: var(--font-size-small);
+    }
+
+    .editor-actions .btn .material-symbols-outlined {
+      font-size: 18px;
+    }
+
+    .variants-list {
+      padding: 0.75rem 1rem;
+      border-top: 1px solid var(--color-border);
+      overflow-y: auto;
+      max-height: 250px;
+      flex-shrink: 0;
+    }
+
+    .variants-list h5 {
+      margin: 0 0 0.5rem 0;
+      font-size: var(--font-size-small);
+      color: var(--color-secondary);
+    }
+
+    .variant-card {
+      border: 1px solid var(--color-border);
+      border-radius: 6px;
+      padding: 0.75rem;
+      margin-bottom: 0.5rem;
+      cursor: pointer;
+      transition: border-color var(--transition-speed) ease;
+    }
+
+    .variant-card:hover {
+      border-color: var(--color-accent);
+    }
+
+    .variant-rejected {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .variant-header {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 0.25rem;
+    }
+
+    .variant-status .material-symbols-outlined {
+      font-size: 18px;
+    }
+
+    .variant-card:not(.variant-rejected) .variant-status {
+      color: #4caf50;
+    }
+
+    .variant-rejected .variant-status {
+      color: #f44336;
+    }
+
+    .target-badge {
+      font-size: 11px;
+      padding: 1px 6px;
+      border-radius: 3px;
+      background: var(--color-background);
+      color: var(--color-secondary);
+    }
+
+    .variant-explanation {
+      margin: 0.25rem 0;
+      font-size: var(--font-size-small);
+    }
+
+    .variant-scores {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 0.25rem;
+    }
+
+    .score-badge {
+      font-size: 11px;
+      padding: 1px 6px;
+      border-radius: 3px;
+      background: var(--color-background);
+    }
+
+    .score-low {
+      color: #f44336;
+    }
+
+    .variant-reasoning {
+      margin: 0.25rem 0 0 0;
+      font-size: 12px;
+      color: var(--color-secondary);
+      font-style: italic;
+    }
+
+    /* Results panel */
+    .results-empty {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      color: var(--color-secondary);
+      opacity: 0.5;
+    }
+
+    .results-empty .material-symbols-outlined {
+      font-size: 48px;
+      margin-bottom: 0.5rem;
+    }
+
+    .results-loading {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      gap: 1rem;
+    }
+
+    .results-content {
+      padding: 0.5rem 0;
+    }
+
+    .results-actions {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 1rem;
+    }
+
+    .results-actions .btn {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: var(--font-size-small);
+    }
+
+    .results-actions .btn .material-symbols-outlined {
+      font-size: 18px;
+    }
+
+    .results-original {
+      margin-top: 1.5rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--color-border);
+    }
+
+    .results-original h5 {
+      margin: 0 0 0.5rem 0;
+      font-size: var(--font-size-small);
+      color: var(--color-secondary);
+    }
+
+    .response-text {
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      font-size: var(--font-size-small);
+      line-height: 1.5;
+      margin: 0;
+      font-family: inherit;
+      max-height: 300px;
+      overflow-y: auto;
+    }
+
+    /* Responsive: stack panels on narrow screens */
+    @media (max-width: 900px) {
+      .prompt-lab-panels {
+        flex-direction: column;
+      }
+
+      .prompt-lab {
+        height: auto;
+      }
+
+      .prompt-lab-panel {
+        min-height: 200px;
+      }
+    }
+  </style>
+</body>
+
+</html>

--- a/webui/components/modals/trace-viewer/trace-viewer-store.js
+++ b/webui/components/modals/trace-viewer/trace-viewer-store.js
@@ -1,0 +1,383 @@
+import { createStore } from "/js/AlpineStore.js";
+
+let mermaidLoaded = false;
+let mermaidModule = null;
+
+async function ensureMermaid() {
+  if (mermaidLoaded) return mermaidModule;
+  try {
+    mermaidModule = await import(
+      "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs"
+    );
+    mermaidModule.default.initialize({
+      startOnLoad: false,
+      theme: "dark",
+      themeVariables: {
+        darkMode: true,
+        background: "#1e1e2e",
+        primaryColor: "#89b4fa",
+        primaryTextColor: "#cdd6f4",
+        primaryBorderColor: "#585b70",
+        lineColor: "#6c7086",
+        secondaryColor: "#313244",
+        tertiaryColor: "#45475a",
+      },
+    });
+    mermaidLoaded = true;
+    return mermaidModule;
+  } catch (e) {
+    console.warn("Failed to load mermaid:", e);
+    return null;
+  }
+}
+
+const model = {
+  loading: false,
+  error: "",
+  traceId: "",
+  traceUrl: "",
+  trace: null,
+  observations: [],
+  tree: null,
+  diagramMode: "tree", // "tree" or "sequence"
+  diagramSvg: "",
+  selectedObsId: null,
+  _initialized: false,
+
+  init() {
+    if (this._initialized) return;
+    this._initialized = true;
+    // Check for pending trace request (set before modal opens)
+    const pending = globalThis._pendingTrace;
+    if (pending) {
+      globalThis._pendingTrace = null;
+      this.loadTrace(pending.id, pending.url);
+    }
+  },
+
+  async loadTrace(traceId, traceUrl) {
+    this.traceId = traceId;
+    this.traceUrl = traceUrl;
+    this.loading = true;
+    this.error = "";
+    this.trace = null;
+    this.observations = [];
+    this.tree = null;
+    this.diagramSvg = "";
+    this.selectedObsId = null;
+
+    try {
+      const resp = await globalThis.fetchApi("/langfuse_trace", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ trace_id: traceId }),
+      });
+      const data = await resp.json();
+
+      if (!data.success) {
+        this.error = data.error || "Failed to load trace";
+        this.loading = false;
+        return;
+      }
+
+      this.trace = data.trace;
+      this.observations = data.observations;
+      this.traceUrl = data.trace_url || traceUrl;
+      this.tree = buildTree(data.observations);
+      this.loading = false;
+
+      await this.renderDiagram();
+    } catch (e) {
+      this.error = e.message || "Failed to load trace";
+      this.loading = false;
+    }
+  },
+
+  async renderDiagram() {
+    if (!this.observations.length) return;
+
+    const mermaid = await ensureMermaid();
+    if (!mermaid) {
+      this.diagramSvg = "";
+      return;
+    }
+
+    const code =
+      this.diagramMode === "sequence"
+        ? generateSequenceDiagram(this.tree, this.observations)
+        : generateTreeDiagram(this.tree, this.observations);
+
+    try {
+      const { svg } = await mermaid.default.render(
+        "trace-mermaid-" + Date.now(),
+        code,
+      );
+      this.diagramSvg = svg;
+    } catch (e) {
+      console.warn("Mermaid render failed:", e);
+      this.diagramSvg = `<pre class="mermaid-error">${escapeHtml(code)}</pre>`;
+    }
+  },
+
+  async switchDiagram(mode) {
+    this.diagramMode = mode;
+    await this.renderDiagram();
+  },
+
+  toggleObservation(obsId) {
+    this.selectedObsId = this.selectedObsId === obsId ? null : obsId;
+  },
+
+  isSelected(obsId) {
+    return this.selectedObsId === obsId;
+  },
+
+  openPromptLab(obsId) {
+    const obs = this.getObservation(obsId);
+    if (!obs) return;
+
+    // Extract system prompt from observation input
+    let systemPrompt = "";
+    let userMessage = "";
+    const input = obs.input;
+    if (typeof input === "string") {
+      systemPrompt = input;
+    } else if (Array.isArray(input)) {
+      // Common pattern: array of messages with role/content
+      for (const msg of input) {
+        if (msg?.role === "system") systemPrompt += (msg.content || "") + "\n";
+        if (msg?.role === "user") userMessage += (msg.content || "") + "\n";
+      }
+    } else if (input && typeof input === "object") {
+      systemPrompt = JSON.stringify(input, null, 2);
+    }
+
+    const response = typeof obs.output === "string" ? obs.output : JSON.stringify(obs.output || "", null, 2);
+
+    // Set Prompt Lab data before opening modal
+    const promptLabStore = window.Alpine?.store("promptLab");
+    if (promptLabStore) {
+      const chatsStore = window.Alpine?.store("chats");
+      const contextId = chatsStore?.getSelectedChatId() || "";
+
+      promptLabStore.open({
+        systemPrompt: systemPrompt.trim(),
+        response: response,
+        model: obs.model || "",
+        tokenCount: (obs.usage_details?.input || 0) + (obs.usage_details?.output || 0),
+        cost: obs.calculated_total_cost || 0,
+        userMessage: userMessage.trim(),
+        contextId: contextId,
+        logNo: null,
+      });
+    }
+
+    globalThis.openModal("modals/prompt-lab/prompt-lab.html");
+  },
+
+  getObservation(obsId) {
+    return this.observations.find((o) => o.id === obsId) || null;
+  },
+
+  formatContent(value) {
+    if (value == null) return null;
+    if (typeof value === "object") return JSON.stringify(value, null, 2);
+    return String(value);
+  },
+
+  formatTimestamp(iso) {
+    if (!iso) return "-";
+    try {
+      const d = new Date(iso);
+      return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit", fractionalSecondDigits: 3 });
+    } catch {
+      return iso;
+    }
+  },
+
+  cleanup() {
+    this.trace = null;
+    this.observations = [];
+    this.tree = null;
+    this.diagramSvg = "";
+    this.error = "";
+    this.traceId = "";
+    this.traceUrl = "";
+    this.selectedObsId = null;
+  },
+
+  formatDuration(obs) {
+    if (obs.latency == null) return "-";
+    if (obs.latency < 1) return `${Math.round(obs.latency * 1000)}ms`;
+    return `${obs.latency.toFixed(2)}s`;
+  },
+
+  formatCost(obs) {
+    const cost = obs.calculated_total_cost;
+    if (cost == null || cost === 0) return "-";
+    if (cost < 0.001) return `$${(cost * 1000).toFixed(3)}m`;
+    return `$${cost.toFixed(4)}`;
+  },
+
+  formatTokens(obs) {
+    const u = obs.usage_details || {};
+    const input = u.input || 0;
+    const output = u.output || 0;
+    if (!input && !output) return "-";
+    return `${input}→${output}`;
+  },
+
+  typeIcon(obs) {
+    const icons = {
+      GENERATION: "smart_toy",
+      SPAN: "account_tree",
+      EVENT: "bolt",
+    };
+    return icons[obs.type] || "circle";
+  },
+
+  typeClass(obs) {
+    return `obs-${(obs.type || "span").toLowerCase()}`;
+  },
+};
+
+function buildTree(observations) {
+  const byId = {};
+  const roots = [];
+
+  for (const obs of observations) {
+    byId[obs.id] = { ...obs, children: [] };
+  }
+
+  for (const obs of observations) {
+    const node = byId[obs.id];
+    if (obs.parent_observation_id && byId[obs.parent_observation_id]) {
+      byId[obs.parent_observation_id].children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  // Sort children by start_time
+  for (const node of Object.values(byId)) {
+    node.children.sort(
+      (a, b) => new Date(a.start_time || 0) - new Date(b.start_time || 0),
+    );
+  }
+
+  return roots;
+}
+
+function generateTreeDiagram(tree, observations) {
+  if (!tree || tree.length === 0) {
+    return "graph TD\n    EMPTY[No trace observations]";
+  }
+  let lines = ["graph TD"];
+  let counter = 0;
+
+  function addNode(node, parentKey) {
+    const key = `N${counter++}`;
+    const label = sanitizeMermaid(
+      `${node.name}${node.model ? " (" + node.model + ")" : ""}`,
+    );
+    const shape = node.type === "GENERATION" ? `([${label}])` : `[${label}]`;
+    lines.push(`    ${key}${shape}`);
+    if (parentKey) {
+      const dur = node.latency != null ? `${node.latency.toFixed(1)}s` : "";
+      lines.push(
+        dur ? `    ${parentKey} -->|${dur}| ${key}` : `    ${parentKey} --> ${key}`,
+      );
+    }
+    for (const child of node.children || []) {
+      addNode(child, key);
+    }
+  }
+
+  for (const root of tree || []) {
+    addNode(root, null);
+  }
+
+  return lines.join("\n");
+}
+
+function generateSequenceDiagram(tree, observations) {
+  if (!tree || tree.length === 0) {
+    return "sequenceDiagram\n    Note right of System: No trace observations";
+  }
+  let lines = ["sequenceDiagram"];
+
+  function getParticipant(node) {
+    return sanitizeMermaid(node.name || "unknown").replace(/\s+/g, "_");
+  }
+
+  // Collect unique participants in order
+  const participants = [];
+  const seen = new Set();
+  function collectParticipants(nodes) {
+    for (const node of nodes || []) {
+      const p = getParticipant(node);
+      if (!seen.has(p)) {
+        seen.add(p);
+        participants.push({ key: p, label: node.name || "unknown" });
+      }
+      collectParticipants(node.children);
+    }
+  }
+  collectParticipants(tree);
+
+  for (const p of participants) {
+    lines.push(`    participant ${p.key} as ${sanitizeMermaid(p.label)}`);
+  }
+
+  function addInteractions(nodes, parentParticipant) {
+    for (const node of nodes || []) {
+      const p = getParticipant(node);
+      const dur = node.latency != null ? ` (${node.latency.toFixed(1)}s)` : "";
+      const tokens = formatTokensShort(node);
+      const note = tokens ? tokens + dur : dur.trim();
+
+      if (parentParticipant && parentParticipant !== p) {
+        lines.push(`    ${parentParticipant}->>+${p}: ${sanitizeMermaid(node.name || "call")}`)
+        if (node.children?.length) {
+          addInteractions(node.children, p);
+        }
+        lines.push(`    ${p}-->>-${parentParticipant}: ${note || "done"}`);
+      } else if (node.children?.length) {
+        addInteractions(node.children, p);
+      }
+    }
+  }
+
+  if (tree?.length) {
+    const rootP = getParticipant(tree[0]);
+    for (const root of tree) {
+      addInteractions(root.children, getParticipant(root));
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatTokensShort(obs) {
+  const u = obs.usage_details || {};
+  const input = u.input || 0;
+  const output = u.output || 0;
+  if (!input && !output) return "";
+  return `${input}+${output}tok`;
+}
+
+function sanitizeMermaid(str) {
+  return (str || "")
+    .replace(/[[\]{}()|#&;`"]/g, "")
+    .replace(/-->/g, "->")
+    .substring(0, 50);
+}
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+export const store = createStore("traceViewer", model);

--- a/webui/components/modals/trace-viewer/trace-viewer-store.js
+++ b/webui/components/modals/trace-viewer/trace-viewer-store.js
@@ -42,12 +42,13 @@ const model = {
   diagramMode: "tree", // "tree" or "sequence"
   diagramSvg: "",
   selectedObsId: null,
-  _initialized: false,
 
   init() {
-    if (this._initialized) return;
-    this._initialized = true;
-    // Check for pending trace request (set before modal opens)
+    // Alpine init - runs once on store registration.
+    // Pending traces are handled by checkPending(), called via x-init on each modal open.
+  },
+
+  checkPending() {
     const pending = globalThis._pendingTrace;
     if (pending) {
       globalThis._pendingTrace = null;

--- a/webui/components/modals/trace-viewer/trace-viewer.html
+++ b/webui/components/modals/trace-viewer/trace-viewer.html
@@ -1,0 +1,570 @@
+<html>
+<head>
+    <title>Trace Viewer</title>
+    <script type="module">
+        import { store } from "/components/modals/trace-viewer/trace-viewer-store.js";
+    </script>
+</head>
+<body>
+    <div x-data>
+        <template x-if="$store.traceViewer">
+            <div class="trace-viewer"
+                 x-destroy="$store.traceViewer.cleanup()">
+
+                <!-- Loading -->
+                <div x-show="$store.traceViewer.loading" class="trace-loading">
+                    <span class="material-symbols-outlined spinning">progress_activity</span>
+                    <span>Loading trace...</span>
+                </div>
+
+                <!-- Error -->
+                <div x-show="$store.traceViewer.error" class="trace-error">
+                    <span class="material-symbols-outlined">error</span>
+                    <span x-text="$store.traceViewer.error"></span>
+                </div>
+
+                <!-- Content -->
+                <div x-show="!$store.traceViewer.loading && !$store.traceViewer.error && $store.traceViewer.trace">
+
+                    <!-- Trace Summary -->
+                    <div class="trace-summary">
+                        <div class="trace-summary-row">
+                            <div class="trace-stat">
+                                <span class="trace-stat-label">Latency</span>
+                                <span class="trace-stat-value"
+                                      x-text="$store.traceViewer.trace?.latency != null
+                                        ? $store.traceViewer.trace.latency.toFixed(2) + 's'
+                                        : '-'"></span>
+                            </div>
+                            <div class="trace-stat">
+                                <span class="trace-stat-label">Cost</span>
+                                <span class="trace-stat-value"
+                                      x-text="$store.traceViewer.trace?.total_cost != null
+                                        ? '$' + $store.traceViewer.trace.total_cost.toFixed(4)
+                                        : '-'"></span>
+                            </div>
+                            <div class="trace-stat">
+                                <span class="trace-stat-label">Observations</span>
+                                <span class="trace-stat-value"
+                                      x-text="$store.traceViewer.observations.length"></span>
+                            </div>
+                            <template x-if="$store.traceViewer.traceUrl">
+                                <a class="trace-link"
+                                   :href="$store.traceViewer.traceUrl"
+                                   target="_blank" rel="noopener noreferrer">
+                                    <span class="material-symbols-outlined">open_in_new</span>
+                                    Open in Langfuse
+                                </a>
+                            </template>
+                        </div>
+                    </div>
+
+                    <!-- View Toggle -->
+                    <div class="trace-tabs">
+                        <button class="trace-tab"
+                                :class="{'active': $store.traceViewer.diagramMode === 'tree'}"
+                                @click="$store.traceViewer.switchDiagram('tree')">
+                            <span class="material-symbols-outlined">account_tree</span>
+                            Tree
+                        </button>
+                        <button class="trace-tab"
+                                :class="{'active': $store.traceViewer.diagramMode === 'sequence'}"
+                                @click="$store.traceViewer.switchDiagram('sequence')">
+                            <span class="material-symbols-outlined">swap_vert</span>
+                            Sequence
+                        </button>
+                    </div>
+
+                    <!-- Mermaid Diagram -->
+                    <div class="trace-diagram"
+                         x-show="$store.traceViewer.diagramSvg"
+                         x-html="$store.traceViewer.diagramSvg">
+                    </div>
+
+                    <!-- Observation Table -->
+                    <div class="trace-table-container">
+                        <table class="trace-table">
+                            <thead>
+                                <tr>
+                                    <th style="width:30px"></th>
+                                    <th style="width:100px">Type</th>
+                                    <th>Name</th>
+                                    <th style="width:140px">Model</th>
+                                    <th style="width:90px">Tokens</th>
+                                    <th style="width:80px">Latency</th>
+                                    <th style="width:75px">Cost</th>
+                                </tr>
+                            </thead>
+                                <template x-for="obs in $store.traceViewer.observations" :key="obs.id">
+                                    <tbody>
+                                        <tr :class="[$store.traceViewer.typeClass(obs), {'obs-row-selected': $store.traceViewer.isSelected(obs.id)}]"
+                                            class="obs-row-clickable"
+                                            @click="$store.traceViewer.toggleObservation(obs.id)">
+                                            <td class="obs-expand">
+                                                <span class="material-symbols-outlined obs-chevron"
+                                                      :class="{'obs-chevron-open': $store.traceViewer.isSelected(obs.id)}"
+                                                      >chevron_right</span>
+                                            </td>
+                                            <td class="obs-type">
+                                                <span class="material-symbols-outlined obs-icon"
+                                                      x-text="$store.traceViewer.typeIcon(obs)"></span>
+                                                <span x-text="obs.type"></span>
+                                            </td>
+                                            <td class="obs-name" x-text="obs.name"></td>
+                                            <td class="obs-model" x-text="obs.model || '-'"></td>
+                                            <td class="obs-tokens" x-text="$store.traceViewer.formatTokens(obs)"></td>
+                                            <td class="obs-latency" x-text="$store.traceViewer.formatDuration(obs)"></td>
+                                            <td class="obs-cost" x-text="$store.traceViewer.formatCost(obs)"></td>
+                                        </tr>
+                                        <tr x-show="$store.traceViewer.isSelected(obs.id)" class="obs-detail-row">
+                                            <td colspan="7" class="obs-detail-cell">
+                                                <div class="obs-detail">
+                                                    <!-- Timing bar -->
+                                                    <div class="obs-detail-meta">
+                                                        <div class="obs-detail-meta-item">
+                                                            <span class="obs-detail-label">Start</span>
+                                                            <span class="obs-detail-value" x-text="$store.traceViewer.formatTimestamp(obs.start_time)"></span>
+                                                        </div>
+                                                        <div class="obs-detail-meta-item">
+                                                            <span class="obs-detail-label">End</span>
+                                                            <span class="obs-detail-value" x-text="$store.traceViewer.formatTimestamp(obs.end_time)"></span>
+                                                        </div>
+                                                        <div class="obs-detail-meta-item" x-show="obs.level && obs.level !== 'DEFAULT'">
+                                                            <span class="obs-detail-label">Level</span>
+                                                            <span class="obs-detail-value" x-text="obs.level"></span>
+                                                        </div>
+                                                        <template x-if="obs.calculated_input_cost != null">
+                                                            <div class="obs-detail-meta-item">
+                                                                <span class="obs-detail-label">Input Cost</span>
+                                                                <span class="obs-detail-value" x-text="'$' + obs.calculated_input_cost.toFixed(6)"></span>
+                                                            </div>
+                                                        </template>
+                                                        <template x-if="obs.calculated_output_cost != null">
+                                                            <div class="obs-detail-meta-item">
+                                                                <span class="obs-detail-label">Output Cost</span>
+                                                                <span class="obs-detail-value" x-text="'$' + obs.calculated_output_cost.toFixed(6)"></span>
+                                                            </div>
+                                                        </template>
+                                                    </div>
+
+                                                    <!-- Input (Prompt) -->
+                                                    <template x-if="obs.input != null">
+                                                        <div class="obs-detail-section">
+                                                            <div class="obs-detail-section-header">
+                                                                <span class="material-symbols-outlined">input</span>
+                                                                <span x-text="obs.type === 'GENERATION' ? 'Prompt' : 'Input'"></span>
+                                                            </div>
+                                                            <pre class="obs-detail-content" x-text="$store.traceViewer.formatContent(obs.input)"></pre>
+                                                        </div>
+                                                    </template>
+
+                                                    <!-- Output (Response) -->
+                                                    <template x-if="obs.output != null">
+                                                        <div class="obs-detail-section">
+                                                            <div class="obs-detail-section-header">
+                                                                <span class="material-symbols-outlined">output</span>
+                                                                <span x-text="obs.type === 'GENERATION' ? 'Response' : 'Output'"></span>
+                                                            </div>
+                                                            <pre class="obs-detail-content" x-text="$store.traceViewer.formatContent(obs.output)"></pre>
+                                                        </div>
+                                                    </template>
+
+                                                    <!-- Metadata -->
+                                                    <template x-if="obs.metadata && Object.keys(obs.metadata).length > 0">
+                                                        <div class="obs-detail-section">
+                                                            <div class="obs-detail-section-header">
+                                                                <span class="material-symbols-outlined">data_object</span>
+                                                                <span>Metadata</span>
+                                                            </div>
+                                                            <pre class="obs-detail-content obs-detail-metadata" x-text="JSON.stringify(obs.metadata, null, 2)"></pre>
+                                                        </div>
+                                                    </template>
+
+                                                    <!-- Prompt Lab button for GENERATION observations -->
+                                                    <div class="obs-detail-actions" x-show="obs.type === 'GENERATION'">
+                                                        <button class="btn btn-ok btn-prompt-lab"
+                                                            @click.stop="$store.traceViewer.openPromptLab(obs.id)">
+                                                            <span class="material-symbols-outlined">auto_awesome</span>
+                                                            Optimize in Prompt Lab
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </template>
+                        </table>
+                    </div>
+                </div>
+
+            </div>
+        </template>
+    </div>
+</body>
+</html>
+
+<style>
+.trace-viewer {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    padding-top: 0.5rem;
+}
+
+.trace-loading,
+.trace-error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 2rem;
+    color: var(--color-text);
+    opacity: 0.8;
+}
+
+.trace-error {
+    color: var(--color-accent, #e74c3c);
+}
+
+.spinning {
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+/* Summary */
+.trace-summary {
+    padding: 1rem 1.25rem;
+    background: var(--color-panel);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+}
+
+.trace-summary-row {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.trace-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.trace-stat-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    opacity: 0.6;
+    color: var(--color-text);
+}
+
+.trace-stat-value {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--color-primary);
+    font-family: 'Roboto Mono', monospace;
+}
+
+.trace-link {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-left: auto;
+    color: var(--color-accent);
+    text-decoration: none;
+    font-size: 0.875rem;
+    opacity: 0.9;
+    transition: opacity 0.2s;
+}
+
+.trace-link:hover {
+    opacity: 1;
+}
+
+.trace-link .material-symbols-outlined {
+    font-size: 1rem;
+}
+
+/* View Toggle */
+.trace-tabs {
+    display: flex;
+    gap: 0.5rem;
+    margin: 0.5rem 0;
+}
+
+.trace-tab {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem 0.8rem;
+    background: var(--color-background);
+    border: 1px solid var(--color-border);
+    border-radius: 0.4rem;
+    color: var(--color-text);
+    cursor: pointer;
+    font-size: 0.85rem;
+    transition: all 0.2s;
+}
+
+.trace-tab:hover {
+    background: var(--color-panel);
+}
+
+.trace-tab.active {
+    background: var(--color-panel);
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+}
+
+.trace-tab .material-symbols-outlined {
+    font-size: 1.1rem;
+}
+
+/* Mermaid Diagram */
+.trace-diagram {
+    padding: 1.5rem;
+    margin-top: 0.25rem;
+    background: var(--color-background);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    overflow-x: auto;
+    text-align: center;
+}
+
+.trace-diagram svg {
+    max-width: 100%;
+    height: auto;
+}
+
+.mermaid-error {
+    color: var(--color-text);
+    opacity: 0.6;
+    font-size: 0.8rem;
+    text-align: left;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+/* Observation Table */
+.trace-table-container {
+    overflow-x: auto;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+}
+
+.trace-table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+    font-size: 0.85rem;
+}
+
+.trace-table th {
+    text-align: left;
+    padding: 0.6rem 0.8rem;
+    background: var(--color-panel);
+    color: var(--color-text);
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    opacity: 0.8;
+    border-bottom: 1px solid var(--color-border);
+    white-space: nowrap;
+}
+
+.trace-table td {
+    padding: 0.5rem 0.8rem;
+    border-bottom: 1px solid var(--color-border);
+    color: var(--color-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.trace-table tbody:last-of-type tr.obs-row-clickable td {
+    border-bottom: none;
+}
+
+.obs-type .obs-icon {
+    vertical-align: middle;
+    margin-right: 0.4rem;
+}
+
+.obs-type span {
+    vertical-align: middle;
+}
+
+.obs-icon {
+    font-size: 1rem;
+    opacity: 0.7;
+}
+
+tr.obs-generation .obs-icon { color: #89b4fa; }
+tr.obs-span .obs-icon { color: #a6e3a1; }
+tr.obs-event .obs-icon { color: #f9e2af; }
+
+.obs-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.obs-model {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.8rem;
+    opacity: 0.8;
+}
+
+.obs-tokens,
+.obs-latency,
+.obs-cost {
+    font-family: 'Roboto Mono', monospace;
+    text-align: right;
+}
+
+/* Clickable rows */
+.obs-row-clickable {
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.obs-row-clickable:hover {
+    background: var(--color-panel);
+}
+
+.obs-row-selected {
+    background: var(--color-panel) !important;
+}
+
+.obs-expand {
+    width: 1.5rem;
+    padding-left: 0.5rem !important;
+    padding-right: 0 !important;
+}
+
+.obs-chevron {
+    font-size: 1rem;
+    opacity: 0.5;
+    transition: transform 0.2s;
+    display: inline-block;
+}
+
+.obs-chevron-open {
+    transform: rotate(90deg);
+    opacity: 0.9;
+}
+
+/* Detail row */
+.obs-detail-row {
+    background: var(--color-background);
+}
+
+.obs-detail-row:hover {
+    background: var(--color-background) !important;
+}
+
+.obs-detail-cell {
+    padding: 0 !important;
+}
+
+.obs-detail {
+    padding: 0.75rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    border-top: 1px solid var(--color-border);
+}
+
+/* Metadata bar */
+.obs-detail-meta {
+    display: flex;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    padding: 0.5rem 0.75rem;
+    background: var(--color-panel);
+    border-radius: 0.4rem;
+}
+
+.obs-detail-meta-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.obs-detail-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    opacity: 0.5;
+    color: var(--color-text);
+}
+
+.obs-detail-value {
+    font-size: 0.8rem;
+    font-family: 'Roboto Mono', monospace;
+    color: var(--color-text);
+}
+
+/* Content sections (input/output/metadata) */
+.obs-detail-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.obs-detail-section-header {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--color-primary);
+    text-transform: uppercase;
+}
+
+.obs-detail-section-header .material-symbols-outlined {
+    font-size: 1rem;
+}
+
+.obs-detail-content {
+    margin: 0;
+    padding: 0.75rem;
+    background: var(--color-panel);
+    border: 1px solid var(--color-border);
+    border-radius: 0.4rem;
+    color: var(--color-text);
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.78rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.obs-detail-metadata {
+    max-height: 150px;
+    opacity: 0.8;
+}
+
+/* Prompt Lab action button */
+.obs-detail-actions {
+    margin-top: 1rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--color-border);
+}
+
+.btn-prompt-lab {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: var(--font-size-small);
+}
+
+.btn-prompt-lab .material-symbols-outlined {
+    font-size: 18px;
+}
+</style>

--- a/webui/components/modals/trace-viewer/trace-viewer.html
+++ b/webui/components/modals/trace-viewer/trace-viewer.html
@@ -9,6 +9,7 @@
     <div x-data>
         <template x-if="$store.traceViewer">
             <div class="trace-viewer"
+                 x-init="$store.traceViewer.checkPending()"
                  x-destroy="$store.traceViewer.cleanup()">
 
                 <!-- Loading -->

--- a/webui/components/settings/observability/observability-settings.html
+++ b/webui/components/settings/observability/observability-settings.html
@@ -1,0 +1,124 @@
+<html>
+<head>
+    <title>Observability</title>
+</head>
+<body>
+    <div x-data>
+        <template x-if="$store.settings.settings">
+            <div>
+                <div class="section">
+                    <div class="section-title">Langfuse</div>
+                    <div class="section-description">
+                        Trace LLM calls, tool executions, and agent interactions.
+                        Credentials can also be set via LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY,
+                        and LANGFUSE_HOST environment variables.
+                    </div>
+
+                    <div class="field">
+                        <div class="field-label">
+                            <div class="field-title">Enable Langfuse Tracing</div>
+                            <div class="field-description">Send traces to your Langfuse instance</div>
+                        </div>
+                        <div class="field-control">
+                            <label class="toggle">
+                                <input type="checkbox"
+                                       x-model="$store.settings.settings.langfuse_enabled" />
+                                <span class="toggler"></span>
+                            </label>
+                        </div>
+                    </div>
+
+                    <div class="field">
+                        <div class="field-label">
+                            <div class="field-title">Public Key</div>
+                            <div class="field-description">Langfuse project public key (pk-lf-...)</div>
+                        </div>
+                        <div class="field-control">
+                            <input type="text"
+                                   x-model="$store.settings.settings.langfuse_public_key"
+                                   placeholder="pk-lf-..."
+                                   autocomplete="off" />
+                        </div>
+                    </div>
+
+                    <div class="field">
+                        <div class="field-label">
+                            <div class="field-title">Secret Key</div>
+                            <div class="field-description">Langfuse project secret key (sk-lf-...)</div>
+                        </div>
+                        <div class="field-control">
+                            <input type="password"
+                                   x-model="$store.settings.settings.langfuse_secret_key"
+                                   placeholder="sk-lf-..."
+                                   autocomplete="off" />
+                        </div>
+                    </div>
+
+                    <div class="field">
+                        <div class="field-label">
+                            <div class="field-title">Host URL</div>
+                            <div class="field-description">Langfuse instance URL (default: cloud.langfuse.com)</div>
+                        </div>
+                        <div class="field-control">
+                            <input type="text"
+                                   x-model="$store.settings.settings.langfuse_host"
+                                   placeholder="https://cloud.langfuse.com"
+                                   autocomplete="off" />
+                        </div>
+                    </div>
+
+                    <div class="field">
+                        <div class="field-label">
+                            <div class="field-title">Sample Rate</div>
+                            <div class="field-description">Fraction of interactions to trace (1.0 = all, 0.1 = 10%)</div>
+                        </div>
+                        <div class="field-control">
+                            <input type="range" min="0" max="1" step="0.1"
+                                   x-model.number="$store.settings.settings.langfuse_sample_rate" />
+                            <span class="range-value"
+                                  x-text="$store.settings.settings.langfuse_sample_rate"></span>
+                        </div>
+                    </div>
+
+                    <div class="field" x-data="{ testing: false, result: null }">
+                        <div class="field-label">
+                            <div class="field-title">Test Connection</div>
+                            <div class="field-description">
+                                Verify your Langfuse credentials
+                                <template x-if="result !== null">
+                                    <span :style="result.success ? 'color: #4caf50' : 'color: #f44336'"
+                                          x-text="result.success ? ' Connected!' : ' ' + result.error">
+                                    </span>
+                                </template>
+                            </div>
+                        </div>
+                        <div class="field-control">
+                            <button class="btn btn-field"
+                                    :disabled="testing"
+                                    @click="
+                                        testing = true;
+                                        result = null;
+                                        globalThis.fetchApi('/langfuse_test', {
+                                            method: 'POST',
+                                            headers: { 'Content-Type': 'application/json' },
+                                            body: JSON.stringify({
+                                                public_key: $store.settings.settings.langfuse_public_key,
+                                                secret_key: $store.settings.settings.langfuse_secret_key,
+                                                host: $store.settings.settings.langfuse_host
+                                            })
+                                        })
+                                        .then(r => r.json())
+                                        .then(r => { result = r; testing = false; })
+                                        .catch(e => { result = { success: false, error: e.message }; testing = false; });
+                                    "
+                                    x-text="testing ? 'Testing...' : 'Test Connection'">
+                                Test Connection
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </template>
+    </div>
+</body>
+</html>

--- a/webui/components/settings/settings.html
+++ b/webui/components/settings/settings.html
@@ -42,18 +42,22 @@
                  :class="{'active': $store.settings.activeTab === 'external'}"
                  @click="$store.settings.switchTab('external')"
                  title="External Services">External Services</div>
-            <div class="settings-tab" 
+            <div class="settings-tab"
                  :class="{'active': $store.settings.activeTab === 'mcp'}"
-                 @click="$store.settings.switchTab('mcp')" 
+                 @click="$store.settings.switchTab('mcp')"
                  title="MCP">MCP/A2A</div>
-            <div class="settings-tab" 
+            <div class="settings-tab"
                  :class="{'active': $store.settings.activeTab === 'developer'}"
-                 @click="$store.settings.switchTab('developer')" 
+                 @click="$store.settings.switchTab('developer')"
                  title="Developer">Developer</div>
             <div class="settings-tab"
                  :class="{'active': $store.settings.activeTab === 'backup'}"
                  @click="$store.settings.switchTab('backup')"
                  title="Backup & Restore">Backup & Restore</div>
+            <div class="settings-tab"
+                 :class="{'active': $store.settings.activeTab === 'observability'}"
+                 @click="$store.settings.switchTab('observability')"
+                 title="Tracing">Tracing</div>
           </div>
         </div>
 
@@ -77,17 +81,20 @@
           <div x-show="$store.settings.activeTab === 'skills'">
             <x-component path="settings/skills/skills-settings.html"></x-component>
           </div>
+          <div x-show="$store.settings.activeTab === 'observability'">
+            <x-component path="settings/observability/observability-settings.html"></x-component>
+          </div>
         </div>
       </div>
 
       <!-- Footer -->
       <div class="modal-footer" data-modal-footer x-show="$store.settings.settings">
-        <button class="btn btn-ok" 
+        <button class="btn btn-ok"
             @click="$store.settings.saveAndClose()"
             :disabled="$store.settings?.isLoading">
         Save
         </button>
-        <button class="btn btn-cancel" 
+        <button class="btn btn-cancel"
                 @click="$store.settings.closeSettings()">
           Cancel
         </button>
@@ -139,4 +146,3 @@
   to { transform: rotate(360deg); }
 }
 </style>
-

--- a/webui/components/sidebar/chats/chats-list.html
+++ b/webui/components/sidebar/chats/chats-list.html
@@ -28,12 +28,30 @@
                 <div class="chat-list-button">
                   <span :class="{'project-color-ball': true, 'heartbeat': context.running}"
                     :style="context.project?.color ? { backgroundColor: context.project.color } : { border: '1px solid var(--color-border)' }"></span>
+                  <span class="material-symbols-outlined fork-indicator"
+                    x-show="context.fork_info"
+                    title="Forked chat">call_split</span>
                   <span class="chat-name"
                     x-text="context.name ? context.name : 'Chat #' + context.no"></span>
                 </div>
-                <button class="btn-icon-action chat-list-action-btn" title="Close chat" @click.stop="$confirmClick($event, () => $store.chats.killChat(context.id))">
-                  <span class="material-symbols-outlined">close</span>
-                </button>
+                <div class="chat-list-actions">
+                  <button class="btn-icon-action chat-list-action-btn" title="Compare with original"
+                    x-show="context.fork_info?.forked_from"
+                    @click.stop="(() => {
+                      const sv = $store.splitView;
+                      if (sv) sv.openSplit(context.fork_info.forked_from, context.id, context.fork_info.fork_point);
+                    })()">
+                    <span class="material-symbols-outlined">compare</span>
+                  </button>
+                  <button class="btn-icon-action chat-list-action-btn" title="Fork chat"
+                    @click.stop="$store.chats.forkChat(context.id)">
+                    <span class="material-symbols-outlined">call_split</span>
+                  </button>
+                  <button class="btn-icon-action chat-list-action-btn" title="Close chat"
+                    @click.stop="$confirmClick($event, () => $store.chats.killChat(context.id))">
+                    <span class="material-symbols-outlined">close</span>
+                  </button>
+                </div>
               </div>
             </li>
           </template>
@@ -117,6 +135,25 @@
 
     .chat-list-action-btn {
       flex-shrink: 0;
+    }
+
+    .fork-indicator {
+      font-size: 14px;
+      opacity: 0.5;
+      flex-shrink: 0;
+    }
+
+    .chat-list-actions {
+      display: flex;
+      align-items: center;
+      flex-shrink: 0;
+    }
+
+    .chat-list-actions .chat-list-action-btn {
+      margin-right: 4px;
+    }
+
+    .chat-list-actions .chat-list-action-btn:last-child {
       margin-right: 8px;
     }
 
@@ -124,20 +161,20 @@
       background-color: var(--color-background-hover);
     }
 
-    .device-pointer .chat-container .chat-list-action-btn {
+    .device-pointer .chat-container .chat-list-actions {
       opacity: 0;
       visibility: hidden;
       pointer-events: none;
       transition: opacity 0s;
     }
 
-    .device-pointer .chat-container:hover .chat-list-action-btn {
+    .device-pointer .chat-container:hover .chat-list-actions {
       opacity: 1;
       visibility: visible;
       pointer-events: auto;
     }
 
-    .device-touch .chats-list-container .chat-list-action-btn {
+    .device-touch .chats-list-container .chat-list-actions {
       opacity: 1;
       visibility: visible;
       pointer-events: auto;

--- a/webui/components/sidebar/chats/chats-store.js
+++ b/webui/components/sidebar/chats/chats-store.js
@@ -171,6 +171,32 @@ const model = {
     }
   },
 
+  // Fork a chat (optionally at a specific log entry)
+  async forkChat(contextId, forkAtLogNo = null) {
+    if (!contextId) {
+      console.error("No context ID provided for fork");
+      return;
+    }
+
+    try {
+      const payload = { context_id: contextId };
+      if (forkAtLogNo !== null) {
+        payload.fork_at_log_no = forkAtLogNo;
+      }
+
+      const response = await sendJsonData("/chat_fork", payload);
+
+      if (response.success) {
+        this.selectChat(response.context_id);
+        justToast("Chat forked successfully", "success", 1500, "chat-fork");
+      } else {
+        toast(response.error || "Fork failed", "error");
+      }
+    } catch (e) {
+      toastFetchError("Error forking chat", e);
+    }
+  },
+
   deselectChat(){
     globalThis.deselectChat(); //TODO move here
   },

--- a/webui/css/settings.css
+++ b/webui/css/settings.css
@@ -314,10 +314,6 @@ nav ul li a img {
 
 .settings-tab.active {
   border-color: var(--color-border);
-  /* box-shadow:
-    0 -4px 8px -2px var(--color-border),
-    4px 0 8px -2px var(--color-border),
-    -4px 0 8px -2px var(--color-border); */
   font-weight: bold;
   background-color: var(--color-panel);
   min-width: min-content;

--- a/webui/index.html
+++ b/webui/index.html
@@ -119,10 +119,12 @@
                 <x-component path="chat/input/chat-bar.html"></x-component>
             </div>
         </div>
-                        </div>
 
     <!-- Drag and Drop Overlay Component -->
     <x-component path="chat/attachments/dragDropOverlay.html"></x-component>
+
+    <!-- Split View Overlay for comparing forked chats -->
+    <x-component path="chat/split-view/split-view.html"></x-component>
 
     <!-- Register Service Worker for offline support and caching -->
     <script>

--- a/webui/js/messages.js
+++ b/webui/js/messages.js
@@ -863,6 +863,19 @@ export function drawMessageResponse({
         createActionButton("copy", "", () => copyToClipboard(responseText)),
       ].filter(Boolean)
     : [];
+
+  // Add trace-viewer button when Langfuse trace data is available
+  if (kvps?.trace_id) {
+    const traceId = kvps.trace_id;
+    const traceUrl = kvps.trace_url || "";
+    responseActionButtons.push(
+      createActionButton("monitoring", "View Trace", () => {
+        globalThis._pendingTrace = { id: traceId, url: traceUrl };
+        globalThis.openModal("modals/trace-viewer/trace-viewer.html");
+      }),
+    );
+  }
+
   setupCollapsible(
     messageDiv,
     ":scope > .step-action-buttons",

--- a/webui/public/observability.svg
+++ b/webui/public/observability.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
+</svg>


### PR DESCRIPTION
# Summary

  - Langfuse observability integration — traces every agent interaction (LLM generations, tool calls, iterations) with a built-in trace viewer for drill-down analysis
  - Chat forking — fork any conversation from any message point, creating an independent branch with full history up to that point
  - Prompt Lab — analyze and optimize prompts using LLM-powered refiner/judge agents, accessible from trace viewer generation observations
  - Split-screen comparison — side-by-side view of original vs forked chat with shared messages dimmed and divergent messages highlighted

# Details

## Langfuse Observability

  - langfuse_helper.py manages client lifecycle (init/flush/shutdown) with lazy initialization
  - 10 agent lifecycle extensions cover the full trace: init, trace start, iteration, generation start/end, tool span start/end, utility calls, flush
  - Observability settings tab with connection test endpoint
  - Trace viewer modal with span/generation drill-down, token counts, cost, and timing

## Chat Forking

  - fork_context() deep-copies via serialize/JSON-round-trip/deserialize with optional truncation at any log position
  - Fork buttons on message action bars and sidebar, fork indicator on forked chats
  - Auto-naming with collision check ("Chat (fork)", "Chat (fork 2)", etc.)

## Prompt Lab

  - /prompt_refine generates 1-3 improved prompt variants via utility model
  - /prompt_judge scores variants on clarity, efficiency, fidelity, and safety (1-5 scale, rejection threshold < 3)
  - Three-panel modal: original prompt (read-only) | editor with suggest/test | results with scoring
  - Entry point from trace viewer on GENERATION observations

## Split-Screen Comparison

  - /chat_logs read-only endpoint fetches logs from any context without switching active context
  - Fork point auto-detection from fork_info metadata with content-matching fallback
  - Shared messages rendered at 45% opacity, divergent messages highlighted with accent border
  - Compare button in sidebar for forked chats, also accessible from Prompt Lab

  ### Files changed

  40 files, +5,093 lines (26 new files, 14 modified)


<img width="204" height="70" alt="image" src="https://github.com/user-attachments/assets/8ceaa6a9-0eb3-4c80-8d3b-1f437c3501a3" />
<img width="414" height="262" alt="image" src="https://github.com/user-attachments/assets/38af9a5e-94e8-4e87-a872-6a65f194d677" />
<img width="2136" height="1526" alt="image" src="https://github.com/user-attachments/assets/600a71aa-4dc9-402c-bb17-c6c5627cd2ad" />
<img width="1936" height="1820" alt="image" src="https://github.com/user-attachments/assets/cc13ded0-3b52-44da-b767-ff01d129eeda" />
<img width="1810" height="1802" alt="image" src="https://github.com/user-attachments/assets/f268e1f5-7f26-4967-be34-2e349dbae124" />
<img width="384" height="401" alt="image" src="https://github.com/user-attachments/assets/87e6cb73-5c43-4f62-a212-20a899b7b1cf" />
<img width="1042" height="835" alt="image" src="https://github.com/user-attachments/assets/0ebc7f47-9114-425c-9831-863956e71148" />
<img width="1909" height="731" alt="image" src="https://github.com/user-attachments/assets/17d6f5c4-7d58-4af6-8c76-883d35fcb698" />
