### PR TITLE
feat: concurrent requests limit

### DIFF
--- a/initialize.py
+++ b/initialize.py
@@ -38,6 +38,7 @@ def initialize_agent(override_settings: dict | None = None):
         limit_requests=current_settings["chat_model_rl_requests"],
         limit_input=current_settings["chat_model_rl_input"],
         limit_output=current_settings["chat_model_rl_output"],
+        limit_concurrent=current_settings["chat_model_rl_concurrent"],
         kwargs=_normalize_model_kwargs(current_settings["chat_model_kwargs"]),
     )
 
@@ -51,6 +52,7 @@ def initialize_agent(override_settings: dict | None = None):
         limit_requests=current_settings["util_model_rl_requests"],
         limit_input=current_settings["util_model_rl_input"],
         limit_output=current_settings["util_model_rl_output"],
+        limit_concurrent=current_settings["util_model_rl_concurrent"],
         kwargs=_normalize_model_kwargs(current_settings["util_model_kwargs"]),
     )
     # embedding model from user settings
@@ -60,6 +62,8 @@ def initialize_agent(override_settings: dict | None = None):
         name=current_settings["embed_model_name"],
         api_base=current_settings["embed_model_api_base"],
         limit_requests=current_settings["embed_model_rl_requests"],
+        limit_input=current_settings["embed_model_rl_input"],
+        limit_concurrent=current_settings["embed_model_rl_concurrent"],
         kwargs=_normalize_model_kwargs(current_settings["embed_model_kwargs"]),
     )
     # browser model from user settings
@@ -69,6 +73,10 @@ def initialize_agent(override_settings: dict | None = None):
         name=current_settings["browser_model_name"],
         api_base=current_settings["browser_model_api_base"],
         vision=current_settings["browser_model_vision"],
+        limit_requests=current_settings["browser_model_rl_requests"],
+        limit_input=current_settings["browser_model_rl_input"],
+        limit_output=current_settings["browser_model_rl_output"],
+        limit_concurrent=current_settings["browser_model_rl_concurrent"],
         kwargs=_normalize_model_kwargs(current_settings["browser_model_kwargs"]),
     )
     # agent configuration

--- a/models.py
+++ b/models.py
@@ -76,6 +76,7 @@ class ModelConfig:
     limit_requests: int = 0
     limit_input: int = 0
     limit_output: int = 0
+    limit_concurrent: int = 0
     vision: bool = False
     kwargs: dict = field(default_factory=dict)
 
@@ -215,13 +216,14 @@ def get_api_key(service: str) -> str:
 
 
 def get_rate_limiter(
-    provider: str, name: str, requests: int, input: int, output: int
+    provider: str, name: str, requests: int, input: int, output: int, concurrent: int = 0
 ) -> RateLimiter:
     key = f"{provider}\\{name}"
     rate_limiters[key] = limiter = rate_limiters.get(key, RateLimiter(seconds=60))
     limiter.limits["requests"] = requests or 0
     limiter.limits["input"] = input or 0
     limiter.limits["output"] = output or 0
+    limiter.set_concurrent_limit(concurrent or 0)
     return limiter
 
 
@@ -265,10 +267,12 @@ async def apply_rate_limiter(
         model_config.limit_requests,
         model_config.limit_input,
         model_config.limit_output,
+        model_config.limit_concurrent,
     )
     limiter.add(input=approximate_tokens(input_text))
     limiter.add(requests=1)
     await limiter.wait(rate_limiter_callback)
+    await limiter.acquire(rate_limiter_callback)
     return limiter
 
 
@@ -490,10 +494,6 @@ class LiteLLMChatWrapper(SimpleChatModel):
         # convert to litellm format
         msgs_conv = self._convert_messages(messages, explicit_caching=explicit_caching)
 
-        # Apply rate limiting if configured
-        limiter = await apply_rate_limiter(
-            self.a0_model_conf, str(msgs_conv), rate_limiter_callback
-        )
 
         # Prepare call kwargs and retry config (strip A0-only params before calling LiteLLM)
         call_kwargs: dict[str, Any] = {**self.kwargs, **kwargs}
@@ -506,6 +506,10 @@ class LiteLLMChatWrapper(SimpleChatModel):
 
         attempt = 0
         while True:
+            # Apply rate limiting if configured
+            limiter = await apply_rate_limiter(
+                self.a0_model_conf, str(msgs_conv), rate_limiter_callback
+            )
             got_any_chunk = False
             try:
                 # call model
@@ -570,6 +574,9 @@ class LiteLLMChatWrapper(SimpleChatModel):
                     raise
                 attempt += 1
                 await asyncio.sleep(retry_delay_s)
+            finally:
+                if limiter:
+                    limiter.release()
 
 
 class AsyncAIChatReplacement:
@@ -625,7 +632,7 @@ class BrowserCompatibleChatWrapper(ChatOpenRouter):
         **kwargs: Any,
     ):
         # Apply rate limiting if configured
-        apply_rate_limiter_sync(self._wrapper.a0_model_conf, str(messages))
+        limiter = apply_rate_limiter_sync(self._wrapper.a0_model_conf, str(messages))
 
         # Call the model
         try:
@@ -655,6 +662,9 @@ class BrowserCompatibleChatWrapper(ChatOpenRouter):
 
         except Exception as e:
             raise e
+        finally:
+            if limiter:
+                limiter.release()
 
         # another hack for browser-use post process invalid jsons
         try:
@@ -685,21 +695,27 @@ class LiteLLMEmbeddingWrapper(Embeddings):
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         # Apply rate limiting if configured
-        apply_rate_limiter_sync(self.a0_model_conf, " ".join(texts))
-
-        resp = embedding(model=self.model_name, input=texts, **self.kwargs)
-        return [
-            item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
-            for item in resp.data  # type: ignore
-        ]
+        limiter = apply_rate_limiter_sync(self.a0_model_conf, " ".join(texts))
+        try:
+            resp = embedding(model=self.model_name, input=texts, **self.kwargs)
+            return [
+                item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
+                for item in resp.data  # type: ignore
+            ]
+        finally:
+            if limiter:
+                limiter.release()
 
     def embed_query(self, text: str) -> List[float]:
         # Apply rate limiting if configured
-        apply_rate_limiter_sync(self.a0_model_conf, text)
-
-        resp = embedding(model=self.model_name, input=[text], **self.kwargs)
-        item = resp.data[0]  # type: ignore
-        return item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
+        limiter = apply_rate_limiter_sync(self.a0_model_conf, text)
+        try:
+            resp = embedding(model=self.model_name, input=[text], **self.kwargs)
+            item = resp.data[0]  # type: ignore
+            return item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
+        finally:
+            if limiter:
+                limiter.release()
 
 
 class LocalSentenceTransformerWrapper(Embeddings):

--- a/models.py
+++ b/models.py
@@ -14,7 +14,7 @@ from typing import (
     TypedDict,
 )
 
-from litellm import completion, acompletion, embedding
+from litellm import EmbeddingResponse, completion, acompletion, embedding
 import litellm
 import openai
 from litellm.types.utils import ModelResponse
@@ -260,7 +260,7 @@ async def apply_rate_limiter(
     ) = None,
 ):
     if not model_config:
-        return
+        return None, None
     limiter = get_rate_limiter(
         model_config.provider,
         model_config.name,
@@ -272,8 +272,8 @@ async def apply_rate_limiter(
     limiter.add(input=approximate_tokens(input_text))
     limiter.add(requests=1)
     await limiter.wait(rate_limiter_callback)
-    await limiter.acquire(rate_limiter_callback)
-    return limiter
+    semaphore = await limiter.acquire(rate_limiter_callback)
+    return limiter, semaphore
 
 
 def apply_rate_limiter_sync(
@@ -284,7 +284,7 @@ def apply_rate_limiter_sync(
     ) = None,
 ):
     if not model_config:
-        return
+        return None, None
     import asyncio, nest_asyncio
 
     nest_asyncio.apply()
@@ -389,17 +389,21 @@ class LiteLLMChatWrapper(SimpleChatModel):
         msgs = self._convert_messages(messages)
 
         # Apply rate limiting if configured
-        apply_rate_limiter_sync(self.a0_model_conf, str(msgs))
+        limiter, semaphore = apply_rate_limiter_sync(self.a0_model_conf, str(msgs))
 
-        # Call the model
-        resp = completion(
-            model=self.model_name, messages=msgs, stop=stop, **{**self.kwargs, **kwargs}
-        )
+        try:
+            # Call the model
+            resp = completion(
+                model=self.model_name, messages=msgs, stop=stop, **{**self.kwargs, **kwargs}
+            )
 
-        # Parse output
-        parsed = _parse_chunk(resp)
-        output = ChatGenerationResult(parsed).output()
-        return output["response_delta"]
+            # Parse output
+            parsed = _parse_chunk(resp)
+            output = ChatGenerationResult(parsed).output()
+            return output["response_delta"]
+        finally:
+            if limiter:
+                limiter.release(semaphore)
 
     def _stream(
         self,
@@ -413,26 +417,30 @@ class LiteLLMChatWrapper(SimpleChatModel):
         msgs = self._convert_messages(messages)
 
         # Apply rate limiting if configured
-        apply_rate_limiter_sync(self.a0_model_conf, str(msgs))
+        limiter, semaphore = apply_rate_limiter_sync(self.a0_model_conf, str(msgs))
 
-        result = ChatGenerationResult()
+        try:
+            result = ChatGenerationResult()
 
-        for chunk in completion(
-            model=self.model_name,
-            messages=msgs,
-            stream=True,
-            stop=stop,
-            **{**self.kwargs, **kwargs},
-        ):
-            # parse chunk
-            parsed = _parse_chunk(chunk) # chunk parsing
-            output = result.add_chunk(parsed) # chunk processing
+            for chunk in completion(
+                model=self.model_name,
+                messages=msgs,
+                stream=True,
+                stop=stop,
+                **{**self.kwargs, **kwargs},
+            ):
+                # parse chunk
+                parsed = _parse_chunk(chunk) # chunk parsing
+                output = result.add_chunk(parsed) # chunk processing
 
-            # Only yield chunks with non-None content
-            if output["response_delta"]:
-                yield ChatGenerationChunk(
-                    message=AIMessageChunk(content=output["response_delta"])
-                )
+                # Only yield chunks with non-None content
+                if output["response_delta"]:
+                    yield ChatGenerationChunk(
+                        message=AIMessageChunk(content=output["response_delta"])
+                    )
+        finally:
+            if limiter:
+                limiter.release(semaphore)
 
     async def _astream(
         self,
@@ -444,27 +452,31 @@ class LiteLLMChatWrapper(SimpleChatModel):
         msgs = self._convert_messages(messages)
 
         # Apply rate limiting if configured
-        await apply_rate_limiter(self.a0_model_conf, str(msgs))
+        limiter, semaphore = await apply_rate_limiter(self.a0_model_conf, str(msgs))
 
-        result = ChatGenerationResult()
+        try:
+            result = ChatGenerationResult()
 
-        response = await acompletion(
-            model=self.model_name,
-            messages=msgs,
-            stream=True,
-            stop=stop,
-            **{**self.kwargs, **kwargs},
-        )
-        async for chunk in response:  # type: ignore
-            # parse chunk
-            parsed = _parse_chunk(chunk) # chunk parsing
-            output = result.add_chunk(parsed) # chunk processing
+            response = await acompletion(
+                model=self.model_name,
+                messages=msgs,
+                stream=True,
+                stop=stop,
+                **{**self.kwargs, **kwargs},
+            )
+            async for chunk in response:  # type: ignore
+                # parse chunk
+                parsed = _parse_chunk(chunk) # chunk parsing
+                output = result.add_chunk(parsed) # chunk processing
 
-            # Only yield chunks with non-None content
-            if output["response_delta"]:
-                yield ChatGenerationChunk(
-                    message=AIMessageChunk(content=output["response_delta"])
-                )
+                # Only yield chunks with non-None content
+                if output["response_delta"]:
+                    yield ChatGenerationChunk(
+                        message=AIMessageChunk(content=output["response_delta"])
+                    )
+        finally:
+            if limiter:
+                limiter.release(semaphore)
 
     async def unified_call(
         self,
@@ -507,7 +519,7 @@ class LiteLLMChatWrapper(SimpleChatModel):
         attempt = 0
         while True:
             # Apply rate limiting if configured
-            limiter = await apply_rate_limiter(
+            limiter, semaphore = await apply_rate_limiter(
                 self.a0_model_conf, str(msgs_conv), rate_limiter_callback
             )
             got_any_chunk = False
@@ -576,7 +588,7 @@ class LiteLLMChatWrapper(SimpleChatModel):
                 await asyncio.sleep(retry_delay_s)
             finally:
                 if limiter:
-                    limiter.release()
+                    limiter.release(semaphore)
 
 
 class AsyncAIChatReplacement:
@@ -632,7 +644,7 @@ class BrowserCompatibleChatWrapper(ChatOpenRouter):
         **kwargs: Any,
     ):
         # Apply rate limiting if configured
-        limiter = apply_rate_limiter_sync(self._wrapper.a0_model_conf, str(messages))
+        limiter, semaphore = await apply_rate_limiter(self._wrapper.a0_model_conf, str(messages))
 
         # Call the model
         try:
@@ -664,7 +676,7 @@ class BrowserCompatibleChatWrapper(ChatOpenRouter):
             raise e
         finally:
             if limiter:
-                limiter.release()
+                limiter.release(semaphore)
 
         # another hack for browser-use post process invalid jsons
         try:
@@ -695,27 +707,27 @@ class LiteLLMEmbeddingWrapper(Embeddings):
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         # Apply rate limiting if configured
-        limiter = apply_rate_limiter_sync(self.a0_model_conf, " ".join(texts))
+        limiter, semaphore = apply_rate_limiter_sync(self.a0_model_conf, " ".join(texts))
         try:
-            resp = embedding(model=self.model_name, input=texts, **self.kwargs)
+            resp: EmbeddingResponse = embedding(model=self.model_name, input=texts, **self.kwargs)
             return [
                 item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
                 for item in resp.data  # type: ignore
             ]
         finally:
             if limiter:
-                limiter.release()
+                limiter.release(semaphore)
 
     def embed_query(self, text: str) -> List[float]:
         # Apply rate limiting if configured
-        limiter = apply_rate_limiter_sync(self.a0_model_conf, text)
+        limiter, semaphore = apply_rate_limiter_sync(self.a0_model_conf, text)
         try:
-            resp = embedding(model=self.model_name, input=[text], **self.kwargs)
-            item = resp.data[0]  # type: ignore
+            resp: EmbeddingResponse = embedding(model=self.model_name, input=[text], **self.kwargs)
+            item = resp.data[0]
             return item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
         finally:
             if limiter:
-                limiter.release()
+                limiter.release(semaphore)
 
 
 class LocalSentenceTransformerWrapper(Embeddings):
@@ -752,20 +764,28 @@ class LocalSentenceTransformerWrapper(Embeddings):
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         # Apply rate limiting if configured
-        apply_rate_limiter_sync(self.a0_model_conf, " ".join(texts))
+        limiter, semaphore = apply_rate_limiter_sync(self.a0_model_conf, " ".join(texts))
 
-        embeddings = self.model.encode(texts, convert_to_tensor=False)  # type: ignore
-        return embeddings.tolist() if hasattr(embeddings, "tolist") else embeddings  # type: ignore
+        try:
+            embeddings = self.model.encode(texts, convert_to_tensor=False)  # type: ignore
+            return embeddings.tolist() if hasattr(embeddings, "tolist") else embeddings  # type: ignore
+        finally:
+            if limiter:
+                limiter.release(semaphore)
 
     def embed_query(self, text: str) -> List[float]:
         # Apply rate limiting if configured
-        apply_rate_limiter_sync(self.a0_model_conf, text)
+        limiter, semaphore = apply_rate_limiter_sync(self.a0_model_conf, text)
 
-        embedding = self.model.encode([text], convert_to_tensor=False)  # type: ignore
-        result = (
-            embedding[0].tolist() if hasattr(embedding[0], "tolist") else embedding[0]
-        )
-        return result  # type: ignore
+        try:
+            embedding = self.model.encode([text], convert_to_tensor=False)  # type: ignore
+            result = (
+                embedding[0].tolist() if hasattr(embedding[0], "tolist") else embedding[0]
+            )
+            return result  # type: ignore
+        finally:
+            if limiter:
+                limiter.release(semaphore)
 
 
 def _get_litellm_chat(

--- a/python/helpers/rate_limiter.py
+++ b/python/helpers/rate_limiter.py
@@ -9,6 +9,48 @@ class RateLimiter:
         self.limits = {key: value if isinstance(value, (int, float)) else 0 for key, value in (limits or {}).items()}
         self.values = {key: [] for key in self.limits.keys()}
         self._lock = asyncio.Lock()
+        self._concurrent_limit = 0
+        self._semaphore: asyncio.Semaphore | None = None
+        self._semaphore_loop_id: int | None = None
+
+    def _get_current_loop_id(self) -> int:
+        """Get ID of the current running event loop."""
+        return id(asyncio.get_running_loop())
+
+    def _ensure_semaphore(self) -> asyncio.Semaphore | None:
+        """Ensure we have a Semaphore bound to the current event loop."""
+        if self._concurrent_limit <= 0:
+            return None
+        loop_id = self._get_current_loop_id()
+        if self._semaphore_loop_id != loop_id:
+            self._semaphore = asyncio.Semaphore(self._concurrent_limit)
+            self._semaphore_loop_id = loop_id
+        return self._semaphore
+
+    def set_concurrent_limit(self, limit: int):
+        """Set the maximum number of concurrent requests allowed."""
+        if limit != self._concurrent_limit:
+            self._concurrent_limit = limit
+            self._semaphore = None  # Reset to be recreated lazily
+
+    async def acquire(self, callback: Callable[[str, str, int, int], Awaitable[bool]] | None = None):
+        """Acquire a semaphore slot, waiting if concurrent limit is reached."""
+        semaphore = self._ensure_semaphore()
+        if semaphore:
+            if semaphore._value == 0 and callback:
+                total = self._concurrent_limit - semaphore._value
+                msg = f"Concurrent request limit reached ({total}/{self._concurrent_limit}), waiting..."
+                await callback(msg, "concurrent", total, self._concurrent_limit)
+            await semaphore.acquire()
+
+    def release(self):
+        """Release a semaphore slot, allowing another request to proceed."""
+        semaphore = self._semaphore  # Use cached, don't create new
+        if semaphore:
+            try:
+                semaphore.release()
+            except ValueError:
+                pass
 
     def add(self, **kwargs: int):
         now = time.time()

--- a/python/helpers/rate_limiter.py
+++ b/python/helpers/rate_limiter.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 import time
 from typing import Callable, Awaitable
 
@@ -10,42 +11,28 @@ class RateLimiter:
         self.values = {key: [] for key in self.limits.keys()}
         self._lock = asyncio.Lock()
         self._concurrent_limit = 0
-        self._semaphore: asyncio.Semaphore | None = None
-        self._semaphore_loop_id: int | None = None
-
-    def _get_current_loop_id(self) -> int:
-        """Get ID of the current running event loop."""
-        return id(asyncio.get_running_loop())
-
-    def _ensure_semaphore(self) -> asyncio.Semaphore | None:
-        """Ensure we have a Semaphore bound to the current event loop."""
-        if self._concurrent_limit <= 0:
-            return None
-        loop_id = self._get_current_loop_id()
-        if self._semaphore_loop_id != loop_id:
-            self._semaphore = asyncio.Semaphore(self._concurrent_limit)
-            self._semaphore_loop_id = loop_id
-        return self._semaphore
+        self._semaphore = threading.Semaphore(0)
 
     def set_concurrent_limit(self, limit: int):
         """Set the maximum number of concurrent requests allowed."""
         if limit != self._concurrent_limit:
             self._concurrent_limit = limit
-            self._semaphore = None  # Reset to be recreated lazily
+            self._semaphore = threading.Semaphore(self._concurrent_limit)
 
-    async def acquire(self, callback: Callable[[str, str, int, int], Awaitable[bool]] | None = None):
-        """Acquire a semaphore slot, waiting if concurrent limit is reached."""
-        semaphore = self._ensure_semaphore()
-        if semaphore:
-            if semaphore._value == 0 and callback:
-                total = self._concurrent_limit - semaphore._value
-                msg = f"Concurrent request limit reached ({total}/{self._concurrent_limit}), waiting..."
-                await callback(msg, "concurrent", total, self._concurrent_limit)
-            await semaphore.acquire()
+    async def acquire(self, callback: Callable[[str, str, int, int], Awaitable[bool]] | None = None) -> threading.Semaphore | None:
+        """Acquire a semaphore slot, waiting if concurrent limit is reached. Returns the semaphore for release."""
+        if self._concurrent_limit <= 0:
+            return None
+        semaphore = self._semaphore
+        if semaphore._value == 0 and callback:
+            total = self._concurrent_limit - semaphore._value
+            msg = f"Concurrent request limit reached ({total}/{self._concurrent_limit}), waiting..."
+            await callback(msg, "concurrent", total, self._concurrent_limit)
+        await asyncio.to_thread(semaphore.acquire)
+        return semaphore
 
-    def release(self):
-        """Release a semaphore slot, allowing another request to proceed."""
-        semaphore = self._semaphore  # Use cached, don't create new
+    def release(self, semaphore: threading.Semaphore | None):
+        """Release a semaphore slot on the specific semaphore that was acquired."""
         if semaphore:
             try:
                 semaphore.release()

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -63,6 +63,7 @@ class Settings(TypedDict):
     chat_model_rl_requests: int
     chat_model_rl_input: int
     chat_model_rl_output: int
+    chat_model_rl_concurrent: int
 
     util_model_provider: str
     util_model_name: str
@@ -73,6 +74,7 @@ class Settings(TypedDict):
     util_model_rl_requests: int
     util_model_rl_input: int
     util_model_rl_output: int
+    util_model_rl_concurrent: int
 
     embed_model_provider: str
     embed_model_name: str
@@ -80,6 +82,7 @@ class Settings(TypedDict):
     embed_model_kwargs: dict[str, Any]
     embed_model_rl_requests: int
     embed_model_rl_input: int
+    embed_model_rl_concurrent: int
 
     browser_model_provider: str
     browser_model_name: str
@@ -88,6 +91,7 @@ class Settings(TypedDict):
     browser_model_rl_requests: int
     browser_model_rl_input: int
     browser_model_rl_output: int
+    browser_model_rl_concurrent: int
     browser_model_kwargs: dict[str, Any]
     browser_http_headers: dict[str, Any]
 
@@ -523,6 +527,7 @@ def get_default_settings() -> Settings:
         chat_model_rl_requests=get_default_value("chat_model_rl_requests", 0),
         chat_model_rl_input=get_default_value("chat_model_rl_input", 0),
         chat_model_rl_output=get_default_value("chat_model_rl_output", 0),
+        chat_model_rl_concurrent=get_default_value("chat_model_rl_concurrent", 0),
         util_model_provider=get_default_value("util_model_provider", "openrouter"),
         util_model_name=get_default_value("util_model_name", "google/gemini-3-flash-preview"),
         util_model_api_base=get_default_value("util_model_api_base", ""),
@@ -532,12 +537,14 @@ def get_default_settings() -> Settings:
         util_model_rl_requests=get_default_value("util_model_rl_requests", 0),
         util_model_rl_input=get_default_value("util_model_rl_input", 0),
         util_model_rl_output=get_default_value("util_model_rl_output", 0),
+        util_model_rl_concurrent=get_default_value("util_model_rl_concurrent", 0),
         embed_model_provider=get_default_value("embed_model_provider", "huggingface"),
         embed_model_name=get_default_value("embed_model_name", "sentence-transformers/all-MiniLM-L6-v2"),
         embed_model_api_base=get_default_value("embed_model_api_base", ""),
         embed_model_kwargs=get_default_value("embed_model_kwargs", {}),
         embed_model_rl_requests=get_default_value("embed_model_rl_requests", 0),
         embed_model_rl_input=get_default_value("embed_model_rl_input", 0),
+        embed_model_rl_concurrent=get_default_value("embed_model_rl_concurrent", 0),
         browser_model_provider=get_default_value("browser_model_provider", "openrouter"),
         browser_model_name=get_default_value("browser_model_name", "google/gemini-3-pro-preview"),
         browser_model_api_base=get_default_value("browser_model_api_base", ""),
@@ -545,6 +552,7 @@ def get_default_settings() -> Settings:
         browser_model_rl_requests=get_default_value("browser_model_rl_requests", 0),
         browser_model_rl_input=get_default_value("browser_model_rl_input", 0),
         browser_model_rl_output=get_default_value("browser_model_rl_output", 0),
+        browser_model_rl_concurrent=get_default_value("browser_model_rl_concurrent", 0),
         browser_model_kwargs=get_default_value("browser_model_kwargs", {}),
         browser_http_headers=get_default_value("browser_http_headers", {}),
         memory_recall_enabled=get_default_value("memory_recall_enabled", True),

--- a/webui/components/settings/agent/browser_model.html
+++ b/webui/components/settings/agent/browser_model.html
@@ -113,6 +113,18 @@
             </div>
           </div>
 
+          <div class="field">
+            <div class="field-label">
+              <div class="field-title">Concurrent requests limit</div>
+              <div class="field-description">
+                Maximum number of simultaneous in-flight requests. Additional requests will wait until a slot is available. Set to 0 to disable.
+              </div>
+            </div>
+            <div class="field-control">
+              <input type="number" x-model.number="$store.settings.settings.browser_model_rl_concurrent" />
+            </div>
+          </div>
+
           <div class="field field-full">
             <div class="field-label">
               <div class="field-title">Web browser model additional parameters</div>

--- a/webui/components/settings/agent/chat_model.html
+++ b/webui/components/settings/agent/chat_model.html
@@ -144,6 +144,18 @@
             </div>
           </div>
 
+          <div class="field">
+            <div class="field-label">
+              <div class="field-title">Concurrent requests limit</div>
+              <div class="field-description">
+                Maximum number of simultaneous in-flight requests. Additional requests will wait until a slot is available. Set to 0 to disable.
+              </div>
+            </div>
+            <div class="field-control">
+              <input type="number" x-model.number="$store.settings.settings.chat_model_rl_concurrent" />
+            </div>
+          </div>
+
           <div class="field field-full">
             <div class="field-label">
               <div class="field-title">Chat model additional parameters</div>

--- a/webui/components/settings/agent/embed_model.html
+++ b/webui/components/settings/agent/embed_model.html
@@ -86,6 +86,18 @@
             </div>
           </div>
 
+          <div class="field">
+            <div class="field-label">
+              <div class="field-title">Concurrent requests limit</div>
+              <div class="field-description">
+                Maximum number of simultaneous in-flight requests. Additional requests will wait until a slot is available. Set to 0 to disable.
+              </div>
+            </div>
+            <div class="field-control">
+              <input type="number" x-model.number="$store.settings.settings.embed_model_rl_concurrent" />
+            </div>
+          </div>
+
           <div class="field field-full">
             <div class="field-label">
               <div class="field-title">Embedding model additional parameters</div>

--- a/webui/components/settings/agent/util_model.html
+++ b/webui/components/settings/agent/util_model.html
@@ -98,6 +98,18 @@
             </div>
           </div>
 
+          <div class="field">
+            <div class="field-label">
+              <div class="field-title">Concurrent requests limit</div>
+              <div class="field-description">
+                Maximum number of simultaneous in-flight requests. Additional requests will wait until a slot is available. Set to 0 to disable.
+              </div>
+            </div>
+            <div class="field-control">
+              <input type="number" x-model.number="$store.settings.settings.util_model_rl_concurrent" />
+            </div>
+          </div>
+
           <div class="field field-full">
             <div class="field-label">
               <div class="field-title">Utility model additional parameters</div>


### PR DESCRIPTION
Adds concurrent request limiting via semaphores, allowing to cap how many requests can run simultaneously per model type. This is useful when running multiple chats in parallel (and using #1030) to avoid overwhelming the API or the local model.

Also fixes missing rate limit settings for browser and embedding models in initialize.py.