### PR TITLE
feat: setting to inherit active project on new chat

### DIFF
--- a/python/api/chat_create.py
+++ b/python/api/chat_create.py
@@ -1,7 +1,7 @@
 from python.helpers.api import ApiHandler, Input, Output, Request, Response
 
 
-from python.helpers import projects, guids
+from python.helpers import settings, projects, guids
 from agent import AgentContext
 
 
@@ -17,14 +17,13 @@ class CreateChat(ApiHandler):
         new_context = self.use_context(new_ctxid)
 
         # copy selected data from current to new context
-        # do not create new chats in the same project anymore, it can be annoying
-        # if current_context:
-            # current_data_1 = current_context.get_data(projects.CONTEXT_DATA_KEY_PROJECT)
-            # if current_data_1:
-            #     new_context.set_data(projects.CONTEXT_DATA_KEY_PROJECT, current_data_1)
-            # current_data_2 = current_context.get_output_data(projects.CONTEXT_DATA_KEY_PROJECT)
-            # if current_data_2:
-            #     new_context.set_output_data(projects.CONTEXT_DATA_KEY_PROJECT, current_data_2)
+        if current_context and settings.get_settings().get("chat_inherit_project", True):
+            current_data_1 = current_context.get_data(projects.CONTEXT_DATA_KEY_PROJECT)
+            if current_data_1:
+                new_context.set_data(projects.CONTEXT_DATA_KEY_PROJECT, current_data_1)
+            current_data_2 = current_context.get_output_data(projects.CONTEXT_DATA_KEY_PROJECT)
+            if current_data_2:
+                new_context.set_output_data(projects.CONTEXT_DATA_KEY_PROJECT, current_data_2)
 
         # New context should appear in other tabs' chat lists via state_push.
         from python.helpers.state_monitor_integration import mark_dirty_all

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -157,6 +157,7 @@ class Settings(TypedDict):
     litellm_global_kwargs: dict[str, Any]
 
     update_check_enabled: bool
+    chat_inherit_project: bool
 
 
 class PartialSettings(Settings, total=False):
@@ -599,6 +600,7 @@ def get_default_settings() -> Settings:
         secrets="",
         litellm_global_kwargs=get_default_value("litellm_global_kwargs", {}),
         update_check_enabled=get_default_value("update_check_enabled", True),
+        chat_inherit_project=get_default_value("chat_inherit_project", True),
     )
 
 

--- a/webui/components/settings/agent/agent.html
+++ b/webui/components/settings/agent/agent.html
@@ -43,6 +43,21 @@
               </select>
             </div>
           </div>
+
+          <div class="field">
+            <div class="field-label">
+              <div class="field-title">Inherit active project</div>
+              <div class="field-description">
+                When creating a new chat, automatically inherit the active project from the current chat.
+              </div>
+            </div>
+            <div class="field-control">
+              <label class="toggle">
+                <input type="checkbox" x-model="$store.settings.settings.chat_inherit_project">
+                <span class="toggler"> </span>
+              </label>
+            </div>
+          </div>
         </div>
       </template>
     </div>


### PR DESCRIPTION
Restores project inheritance for new chats and adds a user setting in Agent Config.

- Add chat_inherit_project boolean
- When enabled, new chats copy the active project from current chat
- Toggle added under Agent Config in settings modal