### PR TITLE
Allow §§secret() placeholders in MCP server config

### DIFF
--- a/initialize.py
+++ b/initialize.py
@@ -129,7 +129,9 @@ def initialize_mcp():
     set = settings.get_settings()
     async def initialize_mcp_async():
         from python.helpers.mcp_handler import initialize_mcp as _initialize_mcp
-        return _initialize_mcp(set["mcp_servers"])
+        from python.helpers.secrets import get_default_secrets_manager
+        resolved = get_default_secrets_manager().replace_placeholders(set["mcp_servers"])
+        return _initialize_mcp(resolved)
     return defer.DeferredTask().start_task(initialize_mcp_async)
 
 def initialize_job_loop():

--- a/python/helpers/secrets.py
+++ b/python/helpers/secrets.py
@@ -259,7 +259,12 @@ class SecretsManager:
         return StreamingSecretsFilter(self.load_secrets())
 
     def replace_placeholders(self, text: str) -> str:
-        """Replace secret placeholders with actual values"""
+        """Replace secret placeholders with actual values.
+
+        Handles both literal §§secret(KEY) and JSON-escaped variants
+        (\\u00a7\\u00a7secret(KEY)) that appear when the placeholder is
+        inside a JSON-encoded string value stored in settings.
+        """
         if not text:
             return text
 
@@ -277,7 +282,14 @@ class SecretsManager:
 
                 raise RepairableException(error_msg)
 
-        return re.sub(self.PLACEHOLDER_PATTERN, replacer, text)
+        # First try the standard pattern with literal § characters
+        result = re.sub(self.PLACEHOLDER_PATTERN, replacer, text)
+        # Also handle JSON-escaped Unicode variants: \u00a7\u00a7secret(KEY)
+        # This occurs when §§secret() placeholders are inside JSON string values
+        # that are themselves stored as a JSON-encoded string in settings.
+        escaped_pattern = r"\\u00a7\\u00a7secret\(([A-Za-z_][A-Za-z0-9_]*)\)"
+        result = re.sub(escaped_pattern, replacer, result)
+        return result
 
     def change_placeholders(self, text: str, new_format: str) -> str:
         """Substitute secret placeholders with a different placeholder format"""

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -651,6 +651,11 @@ def _apply_settings(previous: Settings | None):
 
                 mcp_config = MCPConfig.get_instance()
                 try:
+                    # Resolve §§secret(KEY) placeholders in MCP server config before parsing.
+                    # This allows API keys for external MCP servers to be stored securely
+                    # in secrets.env rather than hardcoded in the MCP config JSON.
+                    from python.helpers.secrets import get_default_secrets_manager
+                    mcp_servers = get_default_secrets_manager().replace_placeholders(mcp_servers)
                     MCPConfig.update(mcp_servers)
                 except Exception as e:
                     


### PR DESCRIPTION
## Problem

API keys for external MCP servers (e.g. Firecrawl, GitHub) must currently be hardcoded directly in the MCP config JSON in settings. Agent Zero's `§§secret(KEY)` placeholder system — used everywhere else in the codebase (prompts, tools, etc.) — was never wired up to MCP config parsing.

Worse, even adding a `replace_placeholders()` call isn't enough on its own. The MCP config is stored as a **JSON string within JSON** in `settings.json`. When `mask_values()` writes `§§secret(KEY)` (with real `§` = U+00A7 characters), `json.dump()` encodes them as `\u00a7`. On read-back, `json.load()` only decodes the outer JSON layer, leaving the inner `\u00a7` as literal backslash text. The regex pattern `§§secret(...)` never matches `\u00a7\u00a7secret(...)`, so placeholders silently pass through as literal strings — causing "Unauthorized: Invalid token" errors from external APIs like Firecrawl.

## Fix

Three changes across three files:

| File | Change |
|------|--------|
| `python/helpers/secrets.py` | `replace_placeholders()` now runs a second regex pass for the JSON-escaped `\u00a7\u00a7secret(KEY)` variant |
| `initialize.py` | Resolve placeholders at **startup** before passing config to `MCPConfig.update()` |
| `python/helpers/settings.py` | Resolve placeholders on **runtime settings changes** (web UI) before passing config to `MCPConfig.update()` |

Users can now store MCP API keys securely in `secrets.env` and reference them via `§§secret(KEY)` in the MCP config:

```json
"env": {
    "FIRECRAWL_API_KEY": "§§secret(FIRECRAWL_API_KEY)"
}
```

## Notes

- Since MCP servers are configured globally (`settings.json`), resolving against the global `usr/secrets.env` via `get_default_secrets_manager()` is the correct scope
- If per-project MCP server config is ever introduced, this should be updated to use `get_secrets_manager()` with the appropriate project context
- The double-encoding issue is inherent to how `settings.json` stores MCP config as a JSON string — any Unicode character outside ASCII in a placeholder would hit the same problem

## Tested

Verified with Firecrawl MCP — secret resolves correctly at startup and on settings update, all 8 tools load successfully, scrape operations return results with no API token errors.