### PR TITLE
fix: KeyError on first skills_tool:load call

### DIFF
--- a/python/tools/skills_tool.py
+++ b/python/tools/skills_tool.py
@@ -123,7 +123,7 @@ class SkillsTool(Tool):
             return f"Error: skill not found: {skill_name!r}. Try skills_tool method=list or method=search."
 
         # Store skill name for fresh loading each turn
-        if not self.agent.data[DATA_NAME_LOADED_SKILLS]:
+        if not self.agent.data.get(DATA_NAME_LOADED_SKILLS):
             self.agent.data[DATA_NAME_LOADED_SKILLS] = []
         loaded = self.agent.data[DATA_NAME_LOADED_SKILLS]
         if skill.name in loaded:


### PR DESCRIPTION
## Problem

`skills_tool._load()` raises `KeyError: 'loaded_skills'` on **every call in every session** because `agent.data` is a plain dict and the key has never been initialized.

```python
# Line 126 — throws KeyError because key doesn't exist yet:
if not self.agent.data[DATA_NAME_LOADED_SKILLS]:
    self.agent.data[DATA_NAME_LOADED_SKILLS] = []   # never reached
```

The initialization on line 127 is the **only place** in the codebase where `loaded_skills` is created — but it's guarded by line 126, which throws before it can execute. This means the key is never set, and the error repeats on every subsequent call in the same session. It never self-heals.

The `except` block in `execute()` catches the `KeyError` and returns it to the agent as:
```
Error in skills_tool: 'loaded_skills'
```

This makes `skills_tool:load` **completely non-functional** in all deployments. No agent can load detailed skill instructions (SKILL.md content) through the intended mechanism.

### Why it's hard to notice

Skills still *appear* to work because:
- Skill **descriptions** are injected into the system prompt separately (not through `skills_tool:load`)
- Agents can still **list** skills (`method=list` doesn't touch this code path)
- Agents fall back to reading skill files directly via `code_execution_tool`
- The error message `"Error in skills_tool: 'loaded_skills'"` looks like a bad skill name, not a missing dict key

## Fix

Use `.get()` instead of direct dict access — returns `None` (falsy) when the key is missing, allowing the initialization on the next line to proceed normally.

```python
- if not self.agent.data[DATA_NAME_LOADED_SKILLS]:
+ if not self.agent.data.get(DATA_NAME_LOADED_SKILLS):
```

Lines 128 and 132 (`loaded = self.agent.data[DATA_NAME_LOADED_SKILLS]`) are safe — they only execute after line 127 has guaranteed the key exists.

## Testing

Verified in a live Agent Zero session: `skills_tool:load` now succeeds on every call with no errors, and loaded skill content is correctly injected into the agent's EXTRAS context.