### PR TITLE
Update-check: send "fork" when repo is not agent0ai/agent-zero

### DIFF
--- a/python/helpers/git.py
+++ b/python/helpers/git.py
@@ -74,6 +74,23 @@ def get_version():
         return "unknown"
 
 
+def is_official_agent_zero_repo() -> bool:
+    """Return True when origin points to agent0ai/agent-zero."""
+    try:
+        repo = Repo(files.get_base_dir())
+        if not repo.remotes:
+            return False
+
+        remote_url = strip_auth_from_url(repo.remotes.origin.url).lower().rstrip("/")
+
+        if remote_url.endswith(".git"):
+            remote_url = remote_url[:-4]
+
+        return remote_url.endswith("github.com/agent0ai/agent-zero") or remote_url.endswith("github.com:agent0ai/agent-zero")
+    except Exception:
+        return False
+
+
 def clone_repo(url: str, dest: str, token: str | None = None):
     """Clone a git repository. Uses http.extraHeader for token auth (never stored in URL/config)."""
     cmd = ['git']

--- a/python/helpers/update_check.py
+++ b/python/helpers/update_check.py
@@ -1,12 +1,16 @@
 from python.helpers import git, runtime
 import hashlib
 
+
 async def check_version():
     import httpx
 
     current_version = git.get_version()
+    if not git.is_official_agent_zero_repo():
+        current_version = "fork"
+
     anonymized_id = hashlib.sha256(runtime.get_persistent_id().encode()).hexdigest()[:20]
-    
+
     url = "https://api.agent-zero.ai/a0-update-check"
     payload = {"current_version": current_version, "anonymized_id": anonymized_id}
     async with httpx.AsyncClient() as client:


### PR DESCRIPTION
### Motivation
- Prevent leaking the repository version string for forks or other upstreams when performing the update check by recognizing non-official origins and reporting them as a generic `fork` version.

### Description
- Added `is_official_agent_zero_repo()` to `python/helpers/git.py` to detect whether `origin` points to `agent0ai/agent-zero`, normalizing auth-stripped URLs and `.git` suffixes.
- Updated `python/helpers/update_check.py` to set `current_version = "fork"` when `git.is_official_agent_zero_repo()` returns `False`, otherwise keep the existing git-derived version.
- The detection logic handles common HTTPS and SSH GitHub origin formats and avoids raising on errors by returning `False` for unknown/invalid remotes.

### Testing
- Ran `python -m py_compile python/helpers/git.py python/helpers/update_check.py` and the files compiled successfully.
- Static sanity checks (module import and function invocation) were validated via local script execution and produced no exceptions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999bf63d0488332b08f38e7ffc0783b)