### PR TITLE
Provider settings per agent

### DIFF
--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -374,9 +374,46 @@ def set_runtime_settings_snapshot(settings: Settings) -> None:
     _runtime_settings_snapshot = settings.copy()
 
 
+def get_profile_settings(profile_name: str) -> dict | None:
+    """Load settings.json from an agent profile directory.
+    
+    Searches in order: usr/agents/{profile}/settings.json, agents/{profile}/settings.json
+    Returns merged settings dict or None if no settings file found.
+    """
+    if not profile_name:
+        return None
+    
+    settings_override: dict = {}
+    
+    profile_paths = [
+        files.get_abs_path("usr/agents", profile_name, "settings.json"),
+        files.get_abs_path("agents", profile_name, "settings.json"),
+    ]
+    
+    for settings_path in profile_paths:
+        if files.exists(settings_path):
+            try:
+                override_settings_str = files.read_file(settings_path)
+                override_settings = dirty_json.try_parse(override_settings_str)
+                if isinstance(override_settings, dict):
+                    settings_override.update(override_settings)
+            except Exception:
+                pass
+    
+    return settings_override if settings_override else None
+
+
 def set_settings(settings: Settings, apply: bool = True):
     global _settings
     previous = _settings
+    
+    if previous and settings.get("agent_profile") != previous.get("agent_profile"):
+        profile_settings = get_profile_settings(settings.get("agent_profile", ""))
+        if profile_settings:
+            for key, value in profile_settings.items():
+                if key in settings or key in previous:
+                    settings[key] = value
+    
     _settings = normalize_settings(settings)
     _write_settings_file(_settings)
     if apply:


### PR DESCRIPTION
## Summary
This pull request introduces enhancements to how agent profile-specific settings are loaded and applied in the `python/helpers/settings.py` module. The primary change is the addition of a mechanism to load and merge settings from agent profile directories when the active profile changes.

Profile settings loading and merging:

* Added the `get_profile_settings` function to load and merge settings from `usr/agents/{profile}/settings.json` and `agents/{profile}/settings.json`, returning a merged dictionary or `None` if no settings file is found.
* Updated the `set_settings` function to check if the `agent_profile` has changed, and if so, load and merge profile-specific settings into the active settings before normalization and saving.

This way, if you want to use an expensive model, or even completely different provider for one agent, and a cheaper model for another agent you can quickly switch by just switching agents.

### Examples
Simply create a settings.json file in the agent directory and set the provider and model settings.

/a0/agents/developer/settings.json:
```json
{
  "chat_model_provider": "anthropic",
  "chat_model_name": "claude-sonnet-4",
  "util_model_provider": "anthropic",
  "util_model_name": "claude-3-5-haiku-latest"
}
```
/a0/agents/researcher/settings.json:
```json
{
  "chat_model_provider": "openai",
  "chat_model_name": "gpt-4o",
  "util_model_provider": "openai",
  "util_model_name": "gpt-4o-mini"
}
```