### PR TITLE
fix(skills): Prevent duplicate namespace in project skill import path

### DIFF
--- a/python/api/skills_import.py
+++ b/python/api/skills_import.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from python.helpers.api import ApiHandler, Request, Response
 from python.helpers import files
-from python.helpers.skills_import import import_skills
+from python.helpers.skills_import import import_skills, resolve_display_destination
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
 
@@ -62,7 +62,12 @@ class SkillsImport(ApiHandler):
 
             imported = [files.deabsolute_path(str(p)) for p in result.imported]
             skipped = [files.deabsolute_path(str(p)) for p in result.skipped]
-            dest_root = files.deabsolute_path(str(result.destination_root / result.namespace))
+
+            display_destination = resolve_display_destination(
+                result.destination_root,
+                result.namespace,
+            )
+            dest_root = files.deabsolute_path(str(display_destination))
 
             return {
                 "success": True,

--- a/python/api/skills_import_preview.py
+++ b/python/api/skills_import_preview.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from python.helpers.api import ApiHandler, Request, Response
 from python.helpers import files
-from python.helpers.skills_import import import_skills
+from python.helpers.skills_import import import_skills, resolve_display_destination
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
 
@@ -62,7 +62,12 @@ class SkillsImportPreview(ApiHandler):
 
             imported = [files.deabsolute_path(str(p)) for p in result.imported]
             skipped = [files.deabsolute_path(str(p)) for p in result.skipped]
-            dest_root = files.deabsolute_path(str(result.destination_root / result.namespace))
+
+            display_destination = resolve_display_destination(
+                result.destination_root,
+                result.namespace,
+            )
+            dest_root = files.deabsolute_path(str(display_destination))
 
             return {
                 "success": True,

--- a/python/helpers/skills_import.py
+++ b/python/helpers/skills_import.py
@@ -118,7 +118,11 @@ def build_import_plan(
     roots = _candidate_skill_roots(source_dir)
     plan: List[ImportPlanItem] = []
     ns = (namespace or _derive_namespace(source)).strip()
-    dest_ns_root = dest_root / ns
+    # Avoid duplicating the same trailing folder segment, e.g. "/skills/skills".
+    if ns and dest_root.name.lower() == ns.lower():
+        dest_ns_root = dest_root
+    else:
+        dest_ns_root = dest_root / ns
 
     for root in roots:
         for skill_md in discover_skill_md_files(root):
@@ -196,6 +200,13 @@ def resolve_skills_destination_root(
     if agent_profile:
         return get_agent_profile_skills_folder(agent_profile)
     return Path(files.get_abs_path("usr", "skills"))
+
+
+def resolve_display_destination(destination_root: Path, namespace: str) -> Path:
+    """Build display path for API responses without duplicating terminal folder segment."""
+    if namespace and destination_root.name.lower() != namespace.lower():
+        return destination_root / namespace
+    return destination_root
 
 
 def import_skills(

--- a/tests/test_skills_import_project_paths.py
+++ b/tests/test_skills_import_project_paths.py
@@ -106,3 +106,10 @@ def test_resolve_display_destination_does_not_duplicate_terminal_namespace(tmp_p
 def test_resolve_display_destination_appends_distinct_namespace(tmp_path: Path):
     destination_root = tmp_path / "usr" / "skills"
     assert resolve_display_destination(destination_root, "my-pack") == destination_root / "my-pack"
+
+
+def test_resolve_display_destination_is_case_insensitive_for_terminal_namespace(tmp_path: Path):
+    # destination_root ends with "Skills" (capital S), but namespace is "skills" (lowercase)
+    # The deduplication logic should treat these as equal and not append another "skills" segment.
+    destination_root = tmp_path / "usr" / "projects" / "demo" / ".a0proj" / "Skills"
+    assert resolve_display_destination(destination_root, "skills") == destination_root

--- a/tests/test_skills_import_project_paths.py
+++ b/tests/test_skills_import_project_paths.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from python.helpers import projects
+from python.helpers.skills_import import (
+    build_import_plan,
+    import_skills,
+    resolve_display_destination,
+)
+
+
+def _write_skill(root: Path, skill_name: str = "demo-skill") -> Path:
+    skill_dir = root / "skills" / skill_name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo\ndescription: demo\n---\n\n# Demo\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _mock_get_project_meta_factory(base_dir: Path):
+    def _mock_get_project_meta(project_name: str, *sub_dirs: str) -> str:
+        return str(base_dir / "usr" / "projects" / project_name / ".a0proj" / Path(*sub_dirs))
+
+    return _mock_get_project_meta
+
+
+def test_build_import_plan_does_not_duplicate_skills_segment_for_project_destination(tmp_path: Path):
+    source_root = tmp_path / "source"
+    _write_skill(source_root)
+
+    project_skills_root = tmp_path / "usr" / "projects" / "demo" / ".a0proj" / "skills"
+
+    plan, _ = build_import_plan(source_root, project_skills_root, namespace="skills")
+
+    assert len(plan) == 1
+    assert plan[0].dest_skill_dir == project_skills_root / "demo-skill"
+    assert "/skills/skills/" not in str(plan[0].dest_skill_dir).replace("\\", "/")
+
+
+def test_import_skills_project_scope_does_not_produce_skills_skills_path(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(projects, "get_project_meta", _mock_get_project_meta_factory(tmp_path))
+
+    source_root = tmp_path / "source"
+    _write_skill(source_root)
+
+    result = import_skills(
+        str(source_root),
+        namespace="skills",
+        dry_run=True,
+        project_name="demo",
+    )
+
+    expected_destination_root = tmp_path / "usr" / "projects" / "demo" / ".a0proj" / "skills"
+
+    assert result.destination_root == expected_destination_root
+    assert result.imported
+    assert result.imported[0] == expected_destination_root / "demo-skill"
+    assert "/skills/skills/" not in str(result.imported[0]).replace("\\", "/")
+
+
+def test_import_zip_named_skills_defaults_namespace_but_does_not_duplicate_segment(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.setattr(projects, "get_project_meta", _mock_get_project_meta_factory(tmp_path))
+
+    source_root = tmp_path / "source"
+    _write_skill(source_root)
+
+    zip_path = tmp_path / "skills.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for path in source_root.rglob("*"):
+            if path.is_file():
+                zf.write(path, path.relative_to(source_root))
+
+    result = import_skills(
+        str(zip_path),
+        namespace=None,
+        dry_run=True,
+        project_name="demo",
+    )
+
+    expected_destination_root = tmp_path / "usr" / "projects" / "demo" / ".a0proj" / "skills"
+
+    assert result.namespace == "skills"
+    assert result.destination_root == expected_destination_root
+    assert result.imported
+    assert result.imported[0] == expected_destination_root / "demo-skill"
+    assert "/skills/skills/" not in str(result.imported[0]).replace("\\", "/")
+
+
+def test_resolve_display_destination_does_not_duplicate_terminal_namespace(tmp_path: Path):
+    destination_root = tmp_path / "usr" / "projects" / "demo" / ".a0proj" / "skills"
+    assert resolve_display_destination(destination_root, "skills") == destination_root
+
+
+def test_resolve_display_destination_appends_distinct_namespace(tmp_path: Path):
+    destination_root = tmp_path / "usr" / "skills"
+    assert resolve_display_destination(destination_root, "my-pack") == destination_root / "my-pack"


### PR DESCRIPTION
# Summary
Resolves issue where the skills namespace ends up in paths twice while importing skills into projects (a0/usr/projects/projectName/skills/skills/SKILL.md)

# Unit Tests
Added unit tests in tests/test_skills_import_project_paths.py