### PR TITLE
Fix KeyError when loading first skill in skills_tool

### DIFF
--- a/python/tools/skills_tool.py
+++ b/python/tools/skills_tool.py
@@ -123,7 +123,7 @@ class SkillsTool(Tool):
             return f"Error: skill not found: {skill_name!r}. Try skills_tool method=list or method=search."
 
         # Store skill name for fresh loading each turn
-        if not self.agent.data[DATA_NAME_LOADED_SKILLS]:
+        if not self.agent.data.get(DATA_NAME_LOADED_SKILLS):
             self.agent.data[DATA_NAME_LOADED_SKILLS] = []
         loaded = self.agent.data[DATA_NAME_LOADED_SKILLS]
         if skill.name in loaded:


### PR DESCRIPTION
### Motivation
- Prevent a `KeyError: 'loaded_skills'` when calling `skills_tool` load for the first time in a fresh session by handling a missing key safely.

### Description
- Use `self.agent.data.get(DATA_NAME_LOADED_SKILLS)` instead of direct indexing and initialize the list when the key is absent so the skill can be recorded without error.

### Testing
- Ran `python -m py_compile python/tools/skills_tool.py` successfully; attempted `pytest tests/test_skills_tool.py` but collection failed due to missing optional runtime dependencies in the test environment, so the pytest run did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d3486d658833290fa012cceffdb98)