### PR TITLE
fix: plugin prompts search path resolution

### DIFF
--- a/python/helpers/subagents.py
+++ b/python/helpers/subagents.py
@@ -400,7 +400,10 @@ def get_paths(
         from python.helpers import plugins
 
         for plugin in plugins.get_plugins_list():
-            path = files.get_abs_path(plugin, *subpaths)
+            plugin_dir = plugins.find_plugin_dir(plugin)
+            if not plugin_dir:
+                continue
+            path = os.path.join(plugin_dir, *subpaths)
             if (not must_exist_completely) or files.exists(path):
                 if path not in paths:
                     paths.append(path)


### PR DESCRIPTION
The `include_plugins` block in `subagents.get_paths()` used bare plugin names (e.g. `"memory"`) from `plugins.get_plugins_list()` and passed them directly to `files.get_abs_path(plugin, *subpaths)`, producing invalid paths like `{base}/memory/prompts` instead of the correct `{base}/plugins/memory/prompts`.

Fix: Use `plugins.find_plugin_dir(plugin)` to resolve the actual plugin directory (searching both plugins and usr/plugins) before joining subpaths.