### PR TITLE
fix plugin toggle signature, sync UI, and update docs

### DIFF
--- a/AGENTS.plugins.md
+++ b/AGENTS.plugins.md
@@ -23,7 +23,10 @@ Each plugin lives in usr/plugins/<plugin_name>/.
 
 ```text
 usr/plugins/<plugin_name>/
-├── plugin.yaml                   # Required: Name, version, settings + activation metadata
+├── plugin.yaml                   # Required: Title, version, settings + activation metadata
+├── default_config.yaml           # Optional: fallback settings defaults
+├── README.md                     # Optional: shown in Plugin List UI
+├── LICENSE                       # Optional: shown in Plugin List UI
 ├── api/                          # API handlers (ApiHandler subclasses)
 ├── tools/                        # Agent tools (Tool subclasses)
 ├── helpers/                      # Shared Python logic
@@ -37,7 +40,10 @@ usr/plugins/<plugin_name>/
     └── ...                       # Full plugin pages/components
 ```
 
-### plugin.yaml format
+### plugin.yaml (runtime manifest)
+
+This is the manifest file that lives inside your plugin directory and drives runtime behavior. It is distinct from the index manifest used when publishing to the Plugin Index (see Section 7).
+
 ```yaml
 title: My Plugin
 description: What this plugin does.
@@ -49,7 +55,15 @@ per_agent_config: false
 # Optional: lock plugin permanently ON in UI/back-end
 always_enabled: false
 ```
-settings_sections values: agent, external, mcp, developer, backup.
+
+Field reference:
+- `title`: UI display name
+- `description`: Short plugin summary
+- `version`: Plugin version string
+- `settings_sections`: Which Settings tabs show a subsection for this plugin. Valid values: `agent`, `external`, `mcp`, `developer`, `backup`. Use `[]` for no subsection.
+- `per_project_config`: Enables project-scoped settings and toggle rules
+- `per_agent_config`: Enables agent-profile-scoped settings and toggle rules
+- `always_enabled`: Forces ON and disables toggle controls in the UI (reserved for framework use)
 
 ---
 
@@ -96,7 +110,79 @@ Place *.js files in extensions/webui/<extension_point>/ and export a default asy
 |---|---|
 | GET /plugins/<name>/<path> | Serve static assets |
 | POST /api/plugins/<name>/<handler> | Call plugin API |
-| POST /api/plugins | Management (actions: get_config, save_config, list_configs, delete_config, toggle_plugin) |
+| POST /api/plugins | Management (actions: get_config, save_config, list_configs, delete_config, toggle_plugin, get_doc) |
+
+---
+
+## 7. Plugin Index & Community Sharing
+
+The **Plugin Index** is a community-maintained repository at https://github.com/agent0ai/a0-plugins that lists plugins available to the Agent Zero community. Plugins listed there can be discovered and installed by other users.
+
+### Two Distinct plugin.yaml Files
+
+There are two completely different `plugin.yaml` schemas used at different stages. They must not be confused:
+
+**Runtime manifest** (inside your plugin repo/directory, drives Agent Zero behavior):
+```yaml
+title: My Plugin
+description: What this plugin does.
+version: 1.0.0
+settings_sections:
+  - agent
+per_project_config: false
+per_agent_config: false
+always_enabled: false
+```
+
+**Index manifest** (submitted to the `a0-plugins` repo under `plugins/<your-plugin-name>/`, drives discoverability only):
+```yaml
+title: My Plugin
+description: What this plugin does.
+github: https://github.com/yourname/your-plugin-repo
+tags:
+  - tools
+  - example
+```
+
+The index manifest contains only four fields (`title`, `description`, `github`, `tags`) and must not include runtime fields. The `github` field must point to the root of a GitHub repository that itself contains a runtime `plugin.yaml` at the repository root.
+
+### Repository Structure for Community Plugins
+
+When creating a plugin intended for the community, the plugin should be a standalone GitHub repository where the plugin directory contents live at the repo root:
+
+```text
+your-plugin-repo/          ← GitHub repository root
+├── plugin.yaml            ← runtime manifest (title, description, version, ...)
+├── default_config.yaml
+├── README.md
+├── LICENSE
+├── api/
+├── tools/
+├── extensions/
+└── webui/
+```
+
+Users install it locally by cloning (or downloading) the repo contents into `/a0/usr/plugins/<plugin_name>/`.
+
+### Submitting to the Plugin Index
+
+1. Create a GitHub repository for your plugin with the runtime `plugin.yaml` at the repo root.
+2. Fork `https://github.com/agent0ai/a0-plugins`.
+3. Create a folder `plugins/<your-plugin-name>/` containing only an index `plugin.yaml` (and optionally a square thumbnail image ≤ 20 KB).
+4. Open a Pull Request with exactly one new plugin folder.
+5. CI validates the submission automatically. A maintainer reviews and merges.
+
+Index submission rules:
+- One plugin per PR
+- Folder name must be unique, stable, lowercase, kebab-case
+- Folders starting with `_` are reserved for internal use
+- `github` must point to a public repo that contains `plugin.yaml` at its root
+- `title` max 50 characters, `description` max 500 characters
+- `tags`: optional, up to 5, use recommended tags from https://github.com/agent0ai/a0-plugins/blob/main/TAGS.md
+
+### Plugin Marketplace (Coming Soon)
+
+A built-in **Plugin Marketplace** plugin (always active) will allow users to browse the Plugin Index and install or update community plugins directly from the Agent Zero UI. This section will be updated once the marketplace plugin is released.
 
 ---
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,23 +1,67 @@
 # Agent Zero - Core Plugins
 
-This directory contains the system-level plugins for Agent Zero.
+This directory contains the system-level plugins bundled with Agent Zero.
 
 ## Directory Structure
 
-- plugins/: Core system plugins (reserved for framework updates).
-- usr/plugins/: Recommended location for user-developed plugins.
+- `plugins/`: Core system plugins. Reserved for framework updates — do not place custom plugins here.
+- `usr/plugins/`: The correct location for all user-developed and custom plugins. This directory is gitignored.
 
 ## Documentation
 
-For detailed guides on how to create, extend, or configure plugins, please refer to:
+For detailed guides on how to create, extend, or configure plugins, refer to:
 
-- AGENTS.plugins.md: Full-stack plugin architecture, manifest format, and extension points.
-- AGENTS.md: Main framework guide and backend context overview.
+- [`AGENTS.plugins.md`](../AGENTS.plugins.md): Full-stack plugin architecture, manifest format, extension points, and Plugin Index submission.
+- [`docs/developer/plugins.md`](../docs/developer/plugins.md): Human-facing developer guide covering the full plugin lifecycle.
+- [`AGENTS.md`](../AGENTS.md): Main framework guide and backend context.
+- [`skills/a0-create-plugin/SKILL.md`](../skills/a0-create-plugin/SKILL.md): Agent-facing authoring workflow (local and community plugins).
 
-## Usage
+## What a Plugin Can Provide
 
-Plugins are automatically discovered based on the presence of a plugin.yaml file. Each plugin can contribute:
-- Backend: APIs, Tools, Helpers, and Lifecycle Extensions.
-- Frontend: HTML/JS UI contributions via core breakpoints.
-- Config: Isolated settings scoped per-project and per-agent profile.
-- Activation: Global/scoped ON-OFF rules via `.toggle-1` and `.toggle-0` files, including advanced per-scope switching in WebUI.
+Plugins are automatically discovered based on the presence of a `plugin.yaml` file. Each plugin can contribute:
+
+- **Backend**: API handlers, tools, helpers, and lifecycle extensions
+- **Frontend**: HTML/JS UI contributions via core extension breakpoints
+- **Settings**: Isolated configuration scoped per-project and per-agent profile
+- **Activation**: Global and scoped ON/OFF rules via `.toggle-1` and `.toggle-0` files, including advanced per-scope switching in the WebUI
+- **Agent profiles**: Plugin-distributed subagent definitions under `agents/<profile>/agent.yaml`
+
+## Plugin Manifest
+
+Every plugin requires a `plugin.yaml` at its root:
+
+```yaml
+title: My Plugin
+description: What this plugin does.
+version: 1.0.0
+settings_sections:
+  - agent
+per_project_config: false
+per_agent_config: false
+always_enabled: false
+```
+
+## Plugin Index & Community Sharing
+
+The **Plugin Index** at https://github.com/agent0ai/a0-plugins is the community-maintained registry of plugins available to all Agent Zero users.
+
+To share a plugin with the community:
+
+1. Create a standalone GitHub repository with the plugin contents at the repo root and the runtime `plugin.yaml` there.
+2. Fork `https://github.com/agent0ai/a0-plugins` and add a folder `plugins/<your-plugin-name>/` containing a separate index `plugin.yaml`:
+
+```yaml
+title: My Plugin
+description: What this plugin does.
+github: https://github.com/yourname/your-plugin-repo
+tags:
+  - tools
+```
+
+3. Open a Pull Request. CI validates the submission; a maintainer reviews and merges.
+
+Note: The index `plugin.yaml` is a **different schema** from the runtime manifest — it contains only `title`, `description`, `github`, and optional `tags`. Do not mix them up.
+
+## Plugin Marketplace (Coming Soon)
+
+A built-in **Plugin Marketplace** (always-active plugin) is planned and will allow users to browse the Plugin Index and install community plugins directly from the Agent Zero UI.

--- a/python/helpers/plugins.py
+++ b/python/helpers/plugins.py
@@ -305,8 +305,23 @@ def get_toggle_state(plugin_name: str) -> ToggleState:
 
 
 def toggle_plugin(
-    plugin_name: str, enabled: bool, project_name: str = "", agent_profile: str = ""
+    plugin_name: str,
+    enabled: bool,
+    project_name: str = "",
+    agent_profile: str = "",
+    clear_overrides: bool = False,
 ):
+    if clear_overrides:
+        all_toggles = find_plugin_assets(
+            TOGGLE_FILE_PATTERN,
+            plugin_name=plugin_name,
+            project_name="*",
+            agent_profile="*",
+            only_first=False,
+        )
+        for toggle in all_toggles:
+            files.delete_file(toggle["path"])
+
     enabled_file = determine_plugin_asset_path(
         plugin_name, project_name, agent_profile, ENABLED_FILE_NAME
     )

--- a/skills/a0-create-plugin/SKILL.md
+++ b/skills/a0-create-plugin/SKILL.md
@@ -6,17 +6,30 @@ description: Create, extend, or modify Agent Zero plugins. Follows strict full-s
 # Agent Zero Plugin Development
 
 > [!IMPORTANT]
-> Always create new plugins in usr/plugins/<plugin_name>/. The root /plugins directory is reserved for core system plugins.
+> Always create new plugins in `/a0/usr/plugins/<plugin_name>/`. The `/a0/plugins/` directory is reserved for core system plugins.
 
 Primary references:
 - /a0/AGENTS.md (Full-stack architecture & AgentContext)
 - /a0/docs/agents/AGENTS.components.md (Component system deep dive)
 - /a0/docs/agents/AGENTS.modals.md (Modal system & CSS conventions)
-- /a0/AGENTS.plugins.md (Extension points, plugin.yaml, settings system)
+- /a0/AGENTS.plugins.md (Extension points, plugin.yaml, settings system, Plugin Index)
+
+---
+
+## Step 0: Ask First — Local or Community Plugin?
+
+Before starting, ask the user one question:
+
+> "Should this plugin be **local only** (stays in your Agent Zero installation) or a **community plugin** (published to the Plugin Index so others can install it)?"
+
+- **Local plugin**: Create it in `/a0/usr/plugins/<plugin_name>/`. No repository needed. Skip to the manifest section below.
+- **Community plugin**: The plugin must live in its own GitHub repository (runtime manifest at the repo root), and then a separate index submission PR is made to https://github.com/agent0ai/a0-plugins. Guide the user through both steps.
+
+---
 
 ## Plugin Manifest (plugin.yaml)
 
-Every plugin must have a plugin.yaml or it will not be discovered:
+Every plugin must have a `plugin.yaml` or it will not be discovered.
 
 ```yaml
 title: My Plugin
@@ -28,8 +41,11 @@ per_project_config: false
 per_agent_config: false
 ```
 
-settings_sections controls which Settings tabs show a subsection for this plugin. Valid values: agent, external, mcp, developer, backup. Use [] for no subsection.
+`settings_sections` controls which Settings tabs show a subsection for this plugin. Valid values: `agent`, `external`, `mcp`, `developer`, `backup`. Use `[]` for no subsection.
+
 Activation defaults to ON when no toggle rule exists. Set `per_project_config` and/or `per_agent_config` to enable advanced per-scope switching. Core system plugins may also use `always_enabled: true` to lock the plugin permanently ON (reserved for framework use).
+
+---
 
 ## Mandatory Frontend Patterns
 
@@ -64,13 +80,15 @@ Import it in the HTML <head>:
 </head>
 ```
 
+---
+
 ## Plugin Settings
 
-If your plugin needs user-configurable settings, add webui/config.html. The system detects it automatically and shows a Settings button in the relevant tabs (per settings_sections in plugin.yaml).
+If your plugin needs user-configurable settings, add `webui/config.html`. The system detects it automatically and shows a Settings button in the relevant tabs (per `settings_sections` in `plugin.yaml`).
 
 ### Settings modal contract
 
-The modal provides Project + Agent profile context selectors. Your config.html binds to $store.pluginSettings.settings:
+The modal provides Project + Agent profile context selectors. Your config.html binds to `$store.pluginSettings.settings`:
 
 ```html
 <html>
@@ -89,11 +107,11 @@ The modal provides Project + Agent profile context selectors. Your config.html b
 </html>
 ```
 
-The modal's Save button persists $store.pluginSettings.settings to config.json in the correct scope (project/agent/global).
+The modal's Save button persists `$store.pluginSettings.settings` to `config.json` in the correct scope (project/agent/global).
 
 ### Surfacing core settings (e.g. memory pattern)
 
-If your plugin exposes existing core settings rather than plugin-specific ones, set saveMode = 'core' so Save delegates to the core settings API:
+If your plugin exposes existing core settings rather than plugin-specific ones, set `saveMode = 'core'` so Save delegates to the core settings API:
 
 ```html
 <div x-data x-init="
@@ -105,16 +123,18 @@ If your plugin exposes existing core settings rather than plugin-specific ones, 
 ```
 
 ### Sidebar Button (sidebar entry point)
-- Extension point: sidebar-quick-actions-main-start
-- Class: class="config-button"
-- Placement: x-move-after=".config-button#dashboard"
-- Action: @click="openModal('/plugins/<plugin_name>/webui/my-modal.html')"
+- Extension point: `sidebar-quick-actions-main-start`
+- Class: `class="config-button"`
+- Placement: `x-move-after=".config-button#dashboard"`
+- Action: `@click="openModal('/plugins/<plugin_name>/webui/my-modal.html')"`
+
+---
 
 ## Backend API & Context
 
 ### Import Paths
-- Correct: from agent import AgentContext, AgentContextType
-- Correct: from initialize import initialize_agent
+- Correct: `from agent import AgentContext, AgentContextType`
+- Correct: `from initialize import initialize_agent`
 
 ### Sending Messages Proactively
 ```python
@@ -142,11 +162,15 @@ save_plugin_config(
 )
 ```
 
+---
+
 ## Directory Layout
 ```
-usr/plugins/<name>/
+/a0/usr/plugins/<name>/
   plugin.yaml           # Required manifest
   default_config.yaml   # Optional default settings fallback
+  README.md             # Optional, shown in Plugin List UI
+  LICENSE               # Optional, shown in Plugin List UI
   agents/
     <profile>/agent.yaml # Optional plugin-distributed agent profile
   api/                  # API Handlers (ApiHandler base class)
@@ -159,3 +183,65 @@ usr/plugins/<name>/
     my-modal.html       # Full plugin pages
     my-store.js         # Alpine stores
 ```
+
+---
+
+## Community Plugin: GitHub Repo + Plugin Index Submission
+
+If the user chose a **community plugin**, follow these additional steps after building and testing the plugin locally.
+
+### 1. Repository Structure
+
+The plugin must live in its own GitHub repository with the plugin contents at the **repository root** (not inside a subfolder):
+
+```text
+your-plugin-repo/          ← GitHub repository root
+├── plugin.yaml            ← runtime manifest (title, description, version, ...)
+├── default_config.yaml
+├── README.md
+├── LICENSE
+├── api/
+├── tools/
+├── extensions/
+└── webui/
+```
+
+Help the user create this repository and push the plugin files to it.
+
+### 2. Index manifest (different from runtime manifest)
+
+The Plugin Index (`https://github.com/agent0ai/a0-plugins`) uses a **separate, simpler `plugin.yaml`** that only describes discoverability — it is NOT the same as the runtime manifest:
+
+```yaml
+title: My Plugin
+description: What this plugin does.
+github: https://github.com/yourname/your-plugin-repo
+tags:
+  - tools
+  - example
+```
+
+Only four fields: `title`, `description`, `github` (required), and `tags` (optional, up to 5). See the recommended tag list at https://github.com/agent0ai/a0-plugins/blob/main/TAGS.md.
+
+### 3. Submission steps
+
+1. Fork `https://github.com/agent0ai/a0-plugins`.
+2. Create the folder `plugins/<your-plugin-name>/` in the fork.
+3. Add the index `plugin.yaml` inside it (and optionally a square thumbnail ≤ 20 KB named `thumbnail.png`, `thumbnail.jpg`, or `thumbnail.webp`).
+4. Open a Pull Request. The PR must add exactly one new plugin folder.
+5. CI will validate automatically. A maintainer reviews and merges.
+
+Submission constraints:
+- Folder name: unique, stable, lowercase, kebab-case
+- Folders starting with `_` are reserved for internal use
+- `title` max 50 characters, `description` max 500 characters
+
+Help the user prepare the fork, the index manifest, and draft the PR.
+
+---
+
+## Plugin Index & Marketplace
+
+The **Plugin Index** is the community hub at https://github.com/agent0ai/a0-plugins.
+
+A **Plugin Marketplace** (a built-in always-active plugin) is planned and will allow users to browse, install, and update indexed plugins directly from the Agent Zero UI. When available, this skill will be updated to guide users through marketplace-based installation as well.

--- a/webui/components/plugins/list/plugin-list.html
+++ b/webui/components/plugins/list/plugin-list.html
@@ -7,7 +7,7 @@
 </head>
 
 <body>
-    <div x-data>
+    <div x-data x-on:plugin-modal-closed.window="$store.pluginListStore.refresh()">
         <template x-if="$store.pluginListStore">
             <div x-init="$store.pluginListStore.init && $store.pluginListStore.init()">
 

--- a/webui/components/plugins/list/plugin-list.html
+++ b/webui/components/plugins/list/plugin-list.html
@@ -114,7 +114,8 @@
                                 </div>
                             </div>
                             
-                            <div class="plugin-controls-row">
+                            <div class="plugin-footer-row">
+                                <div class="plugin-description" x-text="plugin.description || 'No description provided.'"></div>
                                 <select class="plugin-status-select"
                                     @change="$store.pluginListStore.updateToggle(plugin, $event.target.value)"
                                     @click.stop
@@ -126,8 +127,6 @@
                                     </template>
                                 </select>
                             </div>
-
-                            <div class="plugin-description" x-text="plugin.description || 'No description provided.'"></div>
                         </div>
                     </template>
                 </div>
@@ -233,11 +232,12 @@
             font-size: 1.1rem;
         }
 
-        .plugin-controls-row {
-            margin-top: 0.5rem;
+        .plugin-footer-row {
             display: flex;
             align-items: center;
-            justify-content: flex-end;
+            justify-content: space-between;
+            gap: 1rem;
+            margin-top: 0.5rem;
         }
 
         .plugin-status-select {
@@ -249,6 +249,8 @@
             color: var(--color-text-primary);
             cursor: pointer;
             height: 2.2rem;
+            width: 8rem;
+            flex: 0 0 8rem;
         }
         
         .plugin-status-select:disabled {
@@ -258,9 +260,10 @@
         }
 
         .plugin-description {
-            margin-top: 0.35rem;
             color: var(--color-text-secondary);
             font-size: var(--font-size-small);
+            flex: 1 1 auto;
+            min-width: 0;
         }
 
         .plugin-path {

--- a/webui/components/plugins/plugin-settings.html
+++ b/webui/components/plugins/plugin-settings.html
@@ -9,7 +9,7 @@
     <div x-data>
         <template x-if="$store.pluginSettings">
             <div x-create="$store.pluginSettings.onModalOpen()"
-                 x-destroy="$store.pluginSettings.cleanup()">
+                 x-destroy="$store.pluginSettings.cleanup(); $dispatch('plugin-modal-closed')">
 
                 <!-- Context toolbar: Project + Agent profile (only when at least one scope is configurable) -->
                 <div class="plugin-settings-scope-section"

--- a/webui/components/plugins/toggle/plugin-toggle-advanced.html
+++ b/webui/components/plugins/toggle/plugin-toggle-advanced.html
@@ -9,7 +9,7 @@
     <div x-data>
         <template x-if="$store.pluginToggle">
             <div x-create="$store.pluginToggle.open($store.pluginListStore?.selectedPlugin || '')"
-                 x-destroy="$store.pluginToggle.cleanup()">
+                 x-destroy="$store.pluginToggle.cleanup(); $dispatch('plugin-modal-closed')">
 
                 <!-- Error -->
                 <div x-show="$store.pluginToggle.error" class="plugin-settings-error">


### PR DESCRIPTION
Backend: Update toggle_plugin signature to match API
Frontend: use x-on:modal-closed in the Plugin List to auto-refresh state, ensuring the "Advanced" dropdown status updates immediately without manual store calls

Documentation: added mentions of the Plugin Index repo to both human and agent-facing docs.