### PR TITLE
plugins: toggle polish, intentional scope rules

### DIFF
--- a/plugins/example_agent/plugin.yaml
+++ b/plugins/example_agent/plugin.yaml
@@ -4,3 +4,4 @@ version: 1.0.0
 settings_sections: []
 per_project_config: true
 per_agent_config: false
+always_enabled: true

--- a/python/api/plugins.py
+++ b/python/api/plugins.py
@@ -51,6 +51,54 @@ class Plugins(ApiHandler):
                 "data": settings,
             }
 
+        if action == "get_toggle_status":
+            plugin_name = input.get("plugin_name", "")
+            project_name = input.get("project_name", "")
+            agent_profile = input.get("agent_profile", "")
+            if not plugin_name:
+                return Response(status=400, response="Missing plugin_name")
+
+            meta = plugins.get_plugin_meta(plugin_name)
+            if not meta:
+                return Response(status=404, response="Plugin not found")
+
+            if meta.always_enabled:
+                return {
+                    "ok": True,
+                    "status": "enabled",
+                    "loaded_project_name": project_name,
+                    "loaded_agent_profile": agent_profile,
+                    "loaded_path": "",
+                }
+
+            result = plugins.find_plugin_assets(
+                plugins.TOGGLE_FILE_PATTERN,
+                plugin_name=plugin_name,
+                project_name=project_name,
+                agent_profile=agent_profile,
+                only_first=True,
+            )
+
+            if result:
+                entry = result[0]
+                path = entry.get("path", "")
+                status = "enabled" if path.endswith(plugins.ENABLED_FILE_NAME) else "disabled"
+                return {
+                    "ok": True,
+                    "status": status,
+                    "loaded_project_name": entry.get("project_name", ""),
+                    "loaded_agent_profile": entry.get("agent_profile", ""),
+                    "loaded_path": path,
+                }
+
+            return {
+                "ok": True,
+                "status": "enabled",
+                "loaded_project_name": "",
+                "loaded_agent_profile": "",
+                "loaded_path": "",
+            }
+
         if action == "list_configs":
             plugin_name = input.get("plugin_name", "")
             asset_type = input.get("asset_type", "config")

--- a/webui/components/plugins/list/plugin-list.html
+++ b/webui/components/plugins/list/plugin-list.html
@@ -116,16 +116,26 @@
                             
                             <div class="plugin-footer-row">
                                 <div class="plugin-description" x-text="plugin.description || 'No description provided.'"></div>
-                                <select class="plugin-status-select"
-                                    @change="$store.pluginListStore.updateToggle(plugin, $event.target.value)"
-                                    @click.stop
-                                    :disabled="plugin.always_enabled">
-                                    <option value="enabled" :selected="plugin.toggle_state === 'enabled'">ON</option>
-                                    <option value="disabled" :selected="plugin.toggle_state === 'disabled'">OFF</option>
-                                    <template x-if="plugin.per_project_config || plugin.per_agent_config">
-                                        <option value="advanced" :selected="plugin.toggle_state === 'advanced'">Advanced</option>
+                                <div class="plugin-status-group">
+                                    <template x-if="plugin.toggle_state === 'advanced'">
+                                        <button type="button" 
+                                                class="button icon-button" 
+                                                title="Open Advanced"
+                                                @click="$store.pluginListStore.openPluginAdvancedToggle(plugin)">
+                                            <span class="icon material-symbols-outlined">rule_settings</span>
+                                        </button>
                                     </template>
-                                </select>
+                                    <select class="plugin-status-select"
+                                        @change="$store.pluginListStore.updateToggle(plugin, $event.target.value)"
+                                        @click.stop
+                                        :disabled="plugin.always_enabled">
+                                        <option value="enabled" :selected="plugin.toggle_state === 'enabled'">ON</option>
+                                        <option value="disabled" :selected="plugin.toggle_state === 'disabled'">OFF</option>
+                                        <template x-if="plugin.per_project_config || plugin.per_agent_config">
+                                            <option value="advanced" :selected="plugin.toggle_state === 'advanced'">Advanced</option>
+                                        </template>
+                                    </select>
+                                </div>
                             </div>
                         </div>
                     </template>
@@ -238,6 +248,25 @@
             justify-content: space-between;
             gap: 1rem;
             margin-top: 0.5rem;
+        }
+
+        .plugin-status-group {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            flex: 0 0 auto;
+        }
+
+        .plugin-status-group .button {
+            padding: 0.3rem 0.5rem;
+            height: 2.2rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .plugin-status-group .button .icon {
+            font-size: 1.1rem;
         }
 
         .plugin-status-select {

--- a/webui/components/plugins/list/plugin-list.html
+++ b/webui/components/plugins/list/plugin-list.html
@@ -169,7 +169,7 @@
             color: var(--color-text-primary);
             border-color: var(--color-border);
             border-bottom-color: transparent;
-            background: var(--color-bg-primary);
+            background: var(--color-background);
         }
 
         .plugins-toolbar {
@@ -195,7 +195,7 @@
             border-radius: 4px;
             padding: 0.75rem;
             margin-top: 0.75rem;
-            background: var(--color-bg-primary);
+            background: var(--color-background);
         }
 
         .plugin-header {
@@ -274,7 +274,7 @@
             font-size: 0.9rem;
             border: 1px solid var(--color-border);
             border-radius: 4px;
-            background: var(--color-bg-primary);
+            background: var(--color-background);
             color: var(--color-text-primary);
             cursor: pointer;
             height: 2.2rem;

--- a/webui/components/plugins/plugin-settings-store.js
+++ b/webui/components/plugins/plugin-settings-store.js
@@ -58,7 +58,7 @@ const model = {
         if (toggleStore) {
             toggleStore.projectName = nextProject;
             toggleStore.agentProfileKey = nextProfile;
-            toggleStore.calculateStatus();
+            await toggleStore.loadToggleStatus();
         }
     },
 

--- a/webui/components/plugins/plugin-settings.html
+++ b/webui/components/plugins/plugin-settings.html
@@ -9,7 +9,7 @@
     <div x-data>
         <template x-if="$store.pluginSettings">
             <div x-create="$store.pluginSettings.onModalOpen()"
-                 x-destroy="$store.pluginSettings.cleanup(); $dispatch('plugin-modal-closed')">
+                 x-destroy="$store.pluginSettings.cleanup(); window.dispatchEvent(new Event('plugin-modal-closed'))">
 
                 <!-- Context toolbar: Project + Agent profile (only when at least one scope is configurable) -->
                 <div class="plugin-settings-scope-section"

--- a/webui/components/plugins/toggle/plugin-toggle-advanced.html
+++ b/webui/components/plugins/toggle/plugin-toggle-advanced.html
@@ -60,18 +60,10 @@
                                 </label>
 
                                 <div class="plugin-settings-toolbar-item plugin-status-toggle-item">
-                                    <template x-if="!$store.pluginToggle.hasExplicitRuleForScope && !$store.pluginToggle.alwaysEnabled">
-                                        <button type="button" 
-                                                class="button icon-button" 
-                                                title="Add explicit rule for this scope"
-                                                @click="$store.pluginToggle.addRule()">
-                                            <span class="icon material-symbols-outlined">add</span>
-                                        </button>
-                                    </template>
                                     <label class="toggle" :class="{ 'disabled-appearance': !$store.pluginToggle.hasExplicitRuleForScope && !$store.pluginToggle.alwaysEnabled }">
                                         <input type="checkbox"
                                                :checked="$store.pluginToggle.status === 'enabled'"
-                                               :disabled="$store.pluginToggle.alwaysEnabled || $store.pluginToggle.isSaving || !$store.pluginToggle.hasExplicitRuleForScope"
+                                               :disabled="$store.pluginToggle.alwaysEnabled || $store.pluginToggle.isSaving"
                                                @change="$store.pluginToggle.setEnabled($event.target.checked)">
                                         <span class="toggler"></span>
                                     </label>
@@ -189,11 +181,6 @@
             font-size: var(--font-size-small);
         }
 
-        .plugin-settings-body {
-            padding: 1rem;
-            min-height: 4rem;
-        }
-
         @media (max-width: 640px) {
             .plugin-settings-toolbar-item {
                 flex-basis: 100%;
@@ -236,18 +223,6 @@
             align-items: center;
             gap: 0.75rem;
             flex: 0 0 auto;
-        }
-
-        .plugin-status-toggle-item .button {
-            padding: 0.3rem 0.5rem;
-            height: 2.2rem;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .plugin-status-toggle-item .button .icon {
-            font-size: 1.1rem;
         }
 
         .disabled-appearance {

--- a/webui/components/plugins/toggle/plugin-toggle-advanced.html
+++ b/webui/components/plugins/toggle/plugin-toggle-advanced.html
@@ -60,10 +60,18 @@
                                 </label>
 
                                 <div class="plugin-settings-toolbar-item plugin-status-toggle-item">
-                                    <label class="toggle">
+                                    <template x-if="!$store.pluginToggle.hasExplicitRuleForScope && !$store.pluginToggle.alwaysEnabled">
+                                        <button type="button" 
+                                                class="button icon-button" 
+                                                title="Add explicit rule for this scope"
+                                                @click="$store.pluginToggle.addRule()">
+                                            <span class="icon material-symbols-outlined">add</span>
+                                        </button>
+                                    </template>
+                                    <label class="toggle" :class="{ 'disabled-appearance': !$store.pluginToggle.hasExplicitRuleForScope && !$store.pluginToggle.alwaysEnabled }">
                                         <input type="checkbox"
                                                :checked="$store.pluginToggle.status === 'enabled'"
-                                               :disabled="$store.pluginToggle.alwaysEnabled || $store.pluginToggle.isSaving"
+                                               :disabled="$store.pluginToggle.alwaysEnabled || $store.pluginToggle.isSaving || !$store.pluginToggle.hasExplicitRuleForScope"
                                                @change="$store.pluginToggle.setEnabled($event.target.checked)">
                                         <span class="toggler"></span>
                                     </label>
@@ -91,10 +99,12 @@
 
     <!-- Footer -->
     <div class="modal-footer" data-modal-footer>
-        <button type="button" class="btn btn-ok footer-btn-left" @click="$store.pluginToggle.openConfigWithScope()">
-            <span class="icon material-symbols-outlined">settings</span>
-            Configure Plugin
-        </button>
+        <template x-if="$store.pluginToggle.hasConfigScreen">
+            <button type="button" class="btn btn-ok footer-btn-left" @click="$store.pluginToggle.openConfigWithScope()">
+                <span class="icon material-symbols-outlined">settings</span>
+                Configure Plugin
+            </button>
+        </template>
         <button class="btn btn-cancel" @click="window.closeModal?.()">
             Close
         </button>
@@ -226,6 +236,22 @@
             align-items: center;
             gap: 0.75rem;
             flex: 0 0 auto;
+        }
+
+        .plugin-status-toggle-item .button {
+            padding: 0.3rem 0.5rem;
+            height: 2.2rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .plugin-status-toggle-item .button .icon {
+            font-size: 1.1rem;
+        }
+
+        .disabled-appearance {
+            opacity: 0.6;
         }
 
         .plugin-toggle-status-text {

--- a/webui/components/plugins/toggle/plugin-toggle-advanced.html
+++ b/webui/components/plugins/toggle/plugin-toggle-advanced.html
@@ -9,7 +9,7 @@
     <div x-data>
         <template x-if="$store.pluginToggle">
             <div x-create="$store.pluginToggle.open($store.pluginListStore?.selectedPlugin || '')"
-                 x-destroy="$store.pluginToggle.cleanup(); $dispatch('plugin-modal-closed')">
+                 x-destroy="$store.pluginToggle.cleanup(); window.dispatchEvent(new Event('plugin-modal-closed'))">
 
                 <!-- Error -->
                 <div x-show="$store.pluginToggle.error" class="plugin-settings-error">

--- a/webui/components/plugins/toggle/plugin-toggle-store.js
+++ b/webui/components/plugins/toggle/plugin-toggle-store.js
@@ -23,6 +23,7 @@ const model = {
     perProjectConfig: true,
     perAgentConfig: true,
     hasExplicitRuleForScope: false,
+    hasConfigScreen: false,
 
     // Where the effective toggle was actually resolved (mirrors plugin-settings-store loadedXxx fields)
     loadedPath: "",
@@ -39,6 +40,8 @@ const model = {
         this.projectName = "";
         this.agentProfileKey = "";
         this.configs = [];
+        this.status = 'enabled';
+        this.hasExplicitRuleForScope = false;
         this.loadedPath = "";
         this.loadedProjectName = "";
         this.loadedAgentProfile = "";
@@ -72,6 +75,8 @@ const model = {
         this.loadedPath = "";
         this.loadedProjectName = "";
         this.loadedAgentProfile = "";
+        this.isLoading = false;
+        this.isSaving = false;
     },
 
     async loadProjects() {
@@ -176,27 +181,20 @@ const model = {
             });
         } else {
             // Same plugin — push current scope explicitly.
-            // onScopeChanged() syncs on @change events, but if the user never touched
-            // the scope selectors after the modal opened the settings store may still
-            // hold a stale scope from a prior session.
             settingsStore.projectName = this.projectName || "";
             settingsStore.agentProfileKey = this.agentProfileKey || "";
         }
-        await window.openModal?.("components/plugins/plugin-settings.html");
+        await window.openModal?.("/components/plugins/plugin-settings.html");
     },
 
     async openConfigListModal() {
         await window.openModal?.("/components/plugins/toggle/plugin-toggles.html");
     },
 
-    async loadConfigList() {
-        await this.loadConfigs();
-    },
-
     async switchToConfig(projectName, agentProfile) {
         this.projectName = projectName || "";
         this.agentProfileKey = agentProfile || "";
-        this.onScopeChanged();
+        await this.onScopeChanged();
         await window.closeModal?.();
     },
 
@@ -256,10 +254,6 @@ const model = {
         settingsStore.projectName = this.projectName || "";
         settingsStore.agentProfileKey = this.agentProfileKey || "";
         await settingsStore.loadSettings();
-    },
-
-    async addRule() {
-        await this.setEnabled(this.status === 'enabled');
     },
 
     projectLabel(key) {

--- a/webui/components/settings/plugins/plugins-subsection.html
+++ b/webui/components/settings/plugins/plugins-subsection.html
@@ -100,7 +100,7 @@
             border-radius: 4px;
             padding: 0.75rem;
             margin-top: 0.75rem;
-            background: var(--color-bg-primary);
+            background: var(--color-background);
         }
 
         .plugin-header {

--- a/webui/css/settings.css
+++ b/webui/css/settings.css
@@ -136,6 +136,11 @@ input:checked + .toggler:before {
 /* Select Styles */
 select {
   cursor: pointer;
+  color-scheme: dark;
+}
+
+.light-mode select {
+  color-scheme: light;
 }
 
 select:disabled {


### PR DESCRIPTION
- Added a shortcut "Open Advanced"  icon next to the dropdown (visible only in Advanced mode) to quickly open the Switch modal.
- Fixed the Switch modal so the "Configure Plugin" button only appears if the plugin actually has settings.
- Redesigned scope rule creation in the Switch modal: switching project/agent profiles no longer auto-creates .toggle-1 files silently.
- Matched plugins toggle handling with config handling.