### PR TITLE
fix: image attachment 404 on message display

### DIFF
--- a/webui/components/chat/attachments/attachmentsStore.js
+++ b/webui/components/chat/attachments/attachmentsStore.js
@@ -260,7 +260,7 @@ const model = {
 
   // Generate server-side API URL for file (for device sync)
   getServerImgUrl(filename) {
-    return `/image_get?path=/a0/usr/uploads/${encodeURIComponent(filename)}`;
+    return `/api/image_get?path=/a0/usr/uploads/${encodeURIComponent(filename)}`;
   },
 
   getServerFileUrl(filename) {

--- a/webui/components/chat/message-queue/message-queue-store.js
+++ b/webui/components/chat/message-queue/message-queue-store.js
@@ -237,7 +237,7 @@ const model = {
   },
 
   getAttachmentUrl(filename) {
-    return `/image_get?path=/a0/usr/uploads/${encodeURIComponent(filename)}`;
+    return `/api/image_get?path=/a0/usr/uploads/${encodeURIComponent(filename)}`;
   },
 };
 

--- a/webui/js/messages.js
+++ b/webui/js/messages.js
@@ -1723,7 +1723,7 @@ function drawKvpsIncremental(container, kvps, latex) {
       if (typeof value === "string" && value.startsWith("img://")) {
         const imgElement = document.createElement("img");
         imgElement.classList.add("kvps-img");
-        imgElement.src = value.replace("img://", "/image_get?path=");
+        imgElement.src = value.replace("img://", "/api/image_get?path=");
         imgElement.alt = "Image Attachment";
         tdiv.appendChild(imgElement);
 
@@ -1789,7 +1789,7 @@ function convertHTML(str) {
 }
 
 function convertImgFilePaths(str) {
-  return str.replace(/img:\/\//g, "/image_get?path=");
+  return str.replace(/img:\/\//g, "/api/image_get?path=");
 }
 
 function convertFilePaths(str) {


### PR DESCRIPTION
Fix: Updated all frontend image URL builders to use the correct `/api/image_get?path=` prefix.