### PR TITLE
ui: enhance chat input vertical expansion and auto-resize

### DIFF
--- a/webui/components/chat/input/chat-bar-input.html
+++ b/webui/components/chat/input/chat-bar-input.html
@@ -84,8 +84,9 @@
     font-optical-sizing: auto;
     -webkit-font-optical-sizing: auto;
     font-size: 0.9rem;
-    max-height: 7rem;
+    max-height: clamp(7rem, 40vh, 20rem);
     min-height: 3.05rem;
+    field-sizing: content;
     width: 100%;
     padding: 0.48rem 40px var(--spacing-sm) var(--spacing-sm);
     margin-right: var(--spacing-xs);

--- a/webui/components/chat/input/chat-bar.html
+++ b/webui/components/chat/input/chat-bar.html
@@ -39,6 +39,8 @@
       align-items: start;
       place-items: normal;
       flex-shrink: 0;
+      max-height: 60vh;
+      overflow: visible;
       z-index: 1001;
     }
 

--- a/webui/components/chat/input/input-store.js
+++ b/webui/components/chat/input/input-store.js
@@ -64,6 +64,7 @@ const model = {
   adjustTextareaHeight() {
     const chatInput = document.getElementById("chat-input");
     if (chatInput) {
+      if (!this.message) chatInput.value = "";
       chatInput.style.height = "auto";
       chatInput.style.height = chatInput.scrollHeight + "px";
     }

--- a/webui/components/modals/full-screen-input/full-screen-input.html
+++ b/webui/components/modals/full-screen-input/full-screen-input.html
@@ -94,7 +94,7 @@
     width: 100%;
     height: calc(100% - 50px);
     border: none;
-    background-color: transparent;
+    background-color: var(--color-background);
     color: var(--color-text);
     font-family: "Roboto Mono", monospace;
     font-optical-sizing: auto;

--- a/webui/css/modals.css
+++ b/webui/css/modals.css
@@ -315,12 +315,6 @@ some classes like modal-header are shared between the old and the new system */
   align-items: center;
   gap: 1rem;
   padding: 0.5rem 1rem;
-  border-radius: 6px;
-  background-color: rgba(30, 30, 30, 0.95);
-  border-bottom: 1px solid var(--color-border);
-}
-.light-mode .editor-toolbar {
-  background-color: rgba(240, 240, 240, 0.95);
 }
 .toolbar-group {
   display: flex;

--- a/webui/index.js
+++ b/webui/index.js
@@ -62,6 +62,7 @@ export async function sendMessage() {
         // no await for the queue
         // if (success) {
           inputStore.reset();
+          adjustTextareaHeight();
         // }
         return;
       }
@@ -73,8 +74,9 @@ export async function sendMessage() {
       let response;
       const messageId = generateGUID();
 
-      // Clear input and attachments
-      inputStore.reset();
+    // Clear input and attachments
+    inputStore.reset();
+    adjustTextareaHeight();
 
       // Include attachments in the user message
       if (hasAttachments) {
@@ -229,6 +231,7 @@ globalThis.loadKnowledge = async function () {
 function adjustTextareaHeight() {
   const chatInputEl = document.getElementById("chat-input");
   if (chatInputEl) {
+    if (!inputStore.message) chatInputEl.value = "";
     chatInputEl.style.height = "auto";
     chatInputEl.style.height = chatInputEl.scrollHeight + "px";
   }


### PR DESCRIPTION
- Switched chat-input to use `clamp()` for vertical expansion (up to 20rem, 12 lines of text vs. previous 5 lines).
- Added `field-sizing: content` for modern browser auto-resize support.
- Removed layout constraints on `#input-section` by allowing overflow.
- Fixed an issue where the textarea wouldn't shrink after sending messages.