### PR TITLE
fix(security): harden login redirect with origin validation

### DIFF
--- a/webui/js/api.js
+++ b/webui/js/api.js
@@ -129,8 +129,11 @@ export async function fetchApi(url, request) {
       csrfToken = null;
       return await _wrap(false);
     } else if (finalResponse.redirected && finalResponse.url.endsWith("/login")) {
-      // redirect to login
-      window.location.href = finalResponse.url;
+      // redirect to login (origin check prevents open redirect)
+      const _redirectUrl = new URL(finalResponse.url);
+      if (_redirectUrl.origin === window.location.origin) {
+        window.location.href = finalResponse.url;
+      }
       return;
     }
 
@@ -218,8 +221,11 @@ export async function getCsrfToken() {
     }
 
     if (response.redirected && response.url.endsWith("/login")) {
-      // redirect to login
-      window.location.href = response.url;
+      // redirect to login (origin check prevents open redirect)
+      const _redirectUrl = new URL(response.url);
+      if (_redirectUrl.origin === window.location.origin) {
+        window.location.href = response.url;
+      }
       return;
     }
     const json = await response.json();


### PR DESCRIPTION
## Summary

Adds origin validation before following server-issued login redirects — a defense-in-depth measure to ensure the client never leaves the current origin, even if a future server-side change or misconfigured reverse proxy produces an unexpected redirect target.

## What changed

Two locations in `webui/js/api.js` where `response.redirected && response.url.endsWith("/login")` triggers a `window.location.href` assignment:

- `fetchApi()` redirect handler
- `getCsrfToken()` redirect handler

Both now validate `new URL(response.url).origin === window.location.origin` before following.

## Context

Today, these redirects originate from the Agent Zero backend and target the same origin. The origin check is **not** patching an active vulnerability — it is a client-side guardrail that:

- Prevents any future server-side open redirect from propagating to the client
- Protects against misconfigured reverse proxies rewriting Location headers
- Follows the defense-in-depth principle (validate at every layer)

## Severity

Low (hardening — no known active exploit path)

## Testing

- Normal login redirect flow: unaffected (same-origin redirects pass validation)
- Cross-origin redirect (simulated): blocked as expected
- No redirect scenario: unaffected (code path not reached)