### PR TITLE
fix(security): add Secure flag to CSRF cookie on HTTPS

### DIFF
--- a/webui/js/api.js
+++ b/webui/js/api.js
@@ -165,7 +165,8 @@ export async function getCsrfToken() {
           : null;
       const cookieRuntimeId = runtimeId || injectedRuntimeId;
       if (cookieRuntimeId) {
-        document.cookie = `csrf_token_${cookieRuntimeId}=${csrfToken}; SameSite=Strict; Path=/`;
+        const _secureFlag = window.location.protocol === 'https:' ? '; Secure' : '';
+        document.cookie = `csrf_token_${cookieRuntimeId}=${csrfToken}; SameSite=Strict; Path=/${_secureFlag}`;
       } else {
         console.warn("CSRF runtime id missing; skipping cookie name binding.");
       }


### PR DESCRIPTION
## Vulnerability

The CSRF token cookie is set without the `Secure` flag. On HTTPS deployments, the cookie could be transmitted over plain HTTP if a mixed-content scenario occurs, potentially exposing the CSRF token.

## Fix

Conditionally add the `Secure` flag to the CSRF cookie when the page is served over HTTPS (`window.location.protocol === 'https:'`).

- On HTTPS: cookie includes `; Secure`
- On HTTP: flag is omitted (no change in behaviour for HTTP-only deployments)

## Impact / Severity

**Low-Medium** — exploitation requires a mixed-content scenario on an HTTPS deployment, but the fix is trivial and has zero downside.

## How to test

1. Deploy on HTTPS — verify the CSRF cookie includes the `Secure` flag (browser DevTools → Application → Cookies)
2. Deploy on HTTP — verify the cookie does NOT include `Secure` (behaviour unchanged)
3. Verify CSRF protection still works in both scenarios