### PR TITLE
fix: handle structuredContent in MCP tool responses

### DIFF
--- a/python/helpers/mcp_handler.py
+++ b/python/helpers/mcp_handler.py
@@ -118,6 +118,14 @@ class MCPTool(Tool):
             message = "\n\n".join(
                 [item.text for item in response.content if item.type == "text"]
             )
+            # Include structuredContent if available (some MCP servers
+            # return their actual payload here, e.g. Splunk MCP)
+            if getattr(response, "structuredContent", None):
+                structured_str = json.dumps(response.structuredContent, indent=2)
+                if message:
+                    message = message + "\n\n" + structured_str
+                else:
+                    message = structured_str
             if response.isError:
                 error = message
         except Exception as e:


### PR DESCRIPTION
## Summary

`MCPTool.execute()` now includes `structuredContent` JSON in the tool response message when present.

Some MCP servers (e.g. Splunk MCP) return their actual payload data exclusively in `structuredContent`, while the `content` text blocks contain only a brief summary like "Tool executed successfully (100 results)." The result is that Agent Zero sees only the summary and never receives the actual data.

## Changes

In `MCPTool.execute()`, after joining text content blocks, check if `response.structuredContent` is present and non-None. If so, serialize it to JSON and append it to the message.

```python
if getattr(response, "structuredContent", None):
    structured_str = json.dumps(response.structuredContent, indent=2)
    if message:
        message = message + "\n\n" + structured_str
    else:
        message = structured_str
```

## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C##ny]## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## C## Cler.py`

Fixes #1147