### PR TITLE
fix: resolve §§secret() placeholders in MCP server env/headers config

### DIFF
--- a/python/helpers/mcp_handler.py
+++ b/python/helpers/mcp_handler.py
@@ -1026,7 +1026,7 @@ class MCPClientLocal(MCPClientBase):
         if not which(server.command):
             raise ValueError(f"Command '{server.command}' not found")
 
-        # Resolve §§secret() placeholders in env vars
+        # Resolve §§secret() placeholders in env vars and args
         from python.helpers.secrets import get_default_secrets_manager
         secrets_mgr = get_default_secrets_manager()
         resolved_env = None
@@ -1035,10 +1035,14 @@ class MCPClientLocal(MCPClientBase):
                 k: secrets_mgr.replace_placeholders(v) if isinstance(v, str) else v
                 for k, v in server.env.items()
             }
+        resolved_args = [
+            secrets_mgr.replace_placeholders(a) if isinstance(a, str) else a
+            for a in server.args
+        ] if server.args else server.args
 
         server_params = StdioServerParameters(
             command=server.command,
-            args=server.args,
+            args=resolved_args,
             env=resolved_env,
             encoding=server.encoding,
             encoding_error_handler=server.encoding_error_handler,

--- a/python/helpers/mcp_handler.py
+++ b/python/helpers/mcp_handler.py
@@ -1026,10 +1026,20 @@ class MCPClientLocal(MCPClientBase):
         if not which(server.command):
             raise ValueError(f"Command '{server.command}' not found")
 
+        # Resolve §§secret() placeholders in env vars
+        from python.helpers.secrets import get_default_secrets_manager
+        secrets_mgr = get_default_secrets_manager()
+        resolved_env = None
+        if server.env:
+            resolved_env = {
+                k: secrets_mgr.replace_placeholders(v) if isinstance(v, str) else v
+                for k, v in server.env.items()
+            }
+
         server_params = StdioServerParameters(
             command=server.command,
             args=server.args,
-            env=server.env,
+            env=resolved_env,
             encoding=server.encoding,
             encoding_error_handler=server.encoding_error_handler,
         )
@@ -1095,6 +1105,17 @@ class MCPClientRemote(MCPClientBase):
         server: MCPServerRemote = cast(MCPServerRemote, self.server)
         set = settings.get_settings()
 
+        # Resolve §§secret() placeholders in url and headers
+        from python.helpers.secrets import get_default_secrets_manager
+        secrets_mgr = get_default_secrets_manager()
+        resolved_url = secrets_mgr.replace_placeholders(server.url) if server.url else server.url
+        resolved_headers = None
+        if server.headers:
+            resolved_headers = {
+                k: secrets_mgr.replace_placeholders(v) if isinstance(v, str) else v
+                for k, v in server.headers.items()
+            }
+
         # Resolve timeout: check server config first, then settings, defaulting to 5s/10s
         init_timeout = server.init_timeout or set["mcp_client_init_timeout"] or 5
         tool_timeout = server.tool_timeout or set["mcp_client_tool_timeout"] or 10
@@ -1105,8 +1126,8 @@ class MCPClientRemote(MCPClientBase):
             # Use streamable HTTP client
             transport_result = await current_exit_stack.enter_async_context(
                 streamablehttp_client(
-                    url=server.url,
-                    headers=server.headers,
+                    url=resolved_url,
+                    headers=resolved_headers,
                     timeout=timedelta(seconds=init_timeout),
                     sse_read_timeout=timedelta(seconds=tool_timeout),
                     httpx_client_factory=client_factory,
@@ -1123,8 +1144,8 @@ class MCPClientRemote(MCPClientBase):
             # Use traditional SSE client (default behavior)
             stdio_transport = await current_exit_stack.enter_async_context(
                 sse_client(
-                    url=server.url,
-                    headers=server.headers,
+                    url=resolved_url,
+                    headers=resolved_headers,
                     timeout=init_timeout,
                     sse_read_timeout=tool_timeout,
                     httpx_client_factory=client_factory,

--- a/python/helpers/secrets.py
+++ b/python/helpers/secrets.py
@@ -13,8 +13,8 @@ if TYPE_CHECKING:
     from agent import AgentContext
 
 
-# New alias-based placeholder format §§secret(KEY)
-ALIAS_PATTERN = r"§§secret\(([A-Za-z_][A-Za-z0-9_]*)\)"
+# New alias-based placeholder format §§secret(KEY) or $$secret(KEY)
+ALIAS_PATTERN = r"(?:§§|\$\$)secret\(([A-Za-z_][A-Za-z0-9_]*)\)"
 DEFAULT_SECRETS_FILE = "usr/secrets.env"
 
 


### PR DESCRIPTION
## Summary

The secrets management system (`usr/secrets.env` + `§§secret(KEY)` placeholders + `SecretsManager.replace_placeholders()`) was only wired up for **tool call arguments** via `_10_unmask_secrets.py` — not for MCP server **startup configuration**.

This means `§§secret(MY_KEY)` in an MCP server's `env` dict (stdio) or `headers`/`url` (SSE/HTTP) was passed as a literal string instead of being resolved to the actual secret value.

## Changes

Resolve `§§secret()` placeholders before passing config to the MCP SDK:

**Stdio servers** (`MCPClientLocal._create_stdio_transport`):
```python
from python.helpers.secrets import get_default_secrets_manager
secrets_mgr = get_default_secrets_manager()
resolved_env = None
if server.env:
    resolved_env = {
        k: secrets_mgr.replace_placeholders(v) if isinstance(v, str) else v
        for k, v in server.env.items()
    }
# Then pass resolved_env to StdioServerParameters
```

**SSE/HTTP servers** (`MCPClientRemote._create_stdio_transport`):
- Resolves `§§secret()` in `server.url`
- Resolves `§§secret()` in `server.headers` dict values
- Used for both `sse_client()` and `streamablehttp_client()`

## Usage

Users can now configure MCP servers with secret references:

```json
{
  "mcpServers": {
    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "m an    "my-se_p    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se    "my-se  � only adds resolution when `§§secret()` patterns are present
---------ea---------ea---------ea---------ea---------ea---------ea------secrets in output
- Affected file: `python/hel- Affected file: `y`- Affected f8