### PR TITLE
Fix null reference error when sending custom welcome message

### DIFF
--- a/webui/index.js
+++ b/webui/index.js
@@ -57,7 +57,7 @@ export async function sendMessage() {
 
     if (message || hasAttachments) {
       // Check if agent is busy - queue instead of sending
-      if (chatsStore.selectedContext.running || messageQueueStore.hasQueue) {
+      if (chatsStore.selectedContext?.running || messageQueueStore.hasQueue) {
         const success = messageQueueStore.addToQueue(message, attachmentsWithUrls);
         // no await for the queue
         // if (success) {


### PR DESCRIPTION
Fixes #1164

## Summary

Fixes `Cannot read properties of undefined (reading 'running')` error that occurs when a custom welcome message is configured. The auto-send triggers before `selectedContext` is initialized in the Alpine.js store.

## Change

**`webui/index.js` line 60**: Add optional chaining operator (`?.`) on `selectedContext.running`.

```diff
- if (chatsStore.selectedContext.running || messageQueueStore.hasQueue) {
+ if (chatsStore.selectedContext?.running || messageQueueStore.hasQueue) {
```

This matches the existing pattern already used in `webui/js/input-store.js` line 15:
```javascript
const running = !!chatsStore.selectedContext?.running;
```

## Testing

One-line defensive fix. The optional chaining safely returns `undefined` (falsy) when `selectedContext` is null, allowing the send to proceed normally once the context initializes.