### PR TITLE
Fix extensible decorator crash when called from async context (uvloop)

### DIFF
--- a/python/helpers/extension.py
+++ b/python/helpers/extension.py
@@ -131,7 +131,14 @@ def extensible(func):
 
     @wraps(func)
     def _inner_sync(*args, **kwargs):
-        return asyncio.run(_inner_async(*args, **kwargs))
+        try:
+            asyncio.get_running_loop()
+            # Already inside an async event loop (e.g. uvloop) —
+            # asyncio.run() would raise "this event loop is already running".
+            # Fall back to calling the original function directly.
+            return func(*args, **kwargs)
+        except RuntimeError:
+            return asyncio.run(_inner_async(*args, **kwargs))
 
     return _inner_sync
 


### PR DESCRIPTION
## Summary

Fixes `RuntimeError: this event loop is already running` when a sync function decorated with `@extensible` is called from within an already-running async event loop (e.g. uvloop).

Fixes #1166

## Problem

The `extensible` decorator wraps sync functions with `asyncio.run()` to invoke the async extension pipeline. When a decorated sync function (e.g. `ctx.output()`) is called from within an already-running event loop (uvloop + nest_asyncio in production), `asyncio.run()` raises because uvloop does not support nested event loops — even with nest_asyncio patching.

**Traceback:**
```
File "python/helpers/state_snapshot.py", line 247, in build_snapshot_from_request
    context_data = ctx.output()
File "python/helpers/extension.py", line 136, in _inner_sync
    return asyncio.run(_inner_async(*args, **kwargs))
RuntimeError: this event loop is already running.
```

**Impact:** WebSocket state snapshots fail, causing the UI to not load chats (sidebar empty, no chat data rendered). The data is intact on disk but the app cannot serve it.

## Fix

Detect whether an async event loop is already running via `asyncio.get_running_loop()`. If so, fall back to calling the original function directly (bypassing the async extension pipeline). If no loop is running, proceed with `asyncio.run()` as before.

## Changes

- `python/helpers/extension.py`: Updated `_inner_sync` wrapper in the `extensible` decorator to handle already-running event loops gracefully.

## Testing

- Verified on Kubernetes deployment (uvicorn + uvloop) — UI loads correctly, chats are visible.
- No regression on standard `python run_ui.py` startup (no event loop running at call time → `asyncio.run()` path still used).