### PR TITLE
Force stdlib asyncio event loop to fix MCP tool crashes with uvloop

### DIFF
--- a/run_ui.py
+++ b/run_ui.py
@@ -436,6 +436,7 @@ def run():
         log_level="info",
         access_log=_settings.get("uvicorn_access_logs_enabled", False),
         ws="wsproto",
+        loop="asyncio",
     )
     server = uvicorn.Server(config)
 


### PR DESCRIPTION
Fixes #1170

## Summary

MCP server tool calls (`send_message`, `finish_chat`) crash with `RuntimeError: this event loop is already running` when uvloop is the event loop implementation.

## Problem

Uvicorn auto-detects and uses uvloop when available. `nest_asyncio.apply()` patches CPython's `BaseEventLoop`, but **uvloop implements `run_until_complete` in C** (Cython) — the Python-level monkey-patch has no effect.

When MCP tool handlers (FastMCP) invoke `Agent.__init__` which calls `asyncio.run(self.call_extensions("agent_init"))` from within an already-running uvloop, the nested call is rejected:

```
fastmcp/tools/tool.py:333 in run
  → extension.py:141 in _inner_sync
    → agent.py:96 in __init__  (AgentContext creates Agent)
      → agent.py:387 in __init__  (asyncio.run → nest_asyncio → uvloop.run_until_complete → RuntimeError)
```

**Impact:** All MCP tool calls fail — external MCP clients cannot communicate with Agent Zero.

## Fix

Force uvicorn to use the stdlib asyncio event loop (`loop="asyncio"` in `uvicorn.Config`) where `nest_asyncio` patches work correctly.

## Changes

| File | Change |
|------|--------|
| `run_ui.py` | Add `loop="asyncio"` to `uvicorn.Config()` |

## Related

- #1166 / PR #1167 — fixes the `@extensible` decorator path but does not cover direct `asyncio.run()` calls in `Agent.__init__`

## Testing

- Verified MCP tool calls work after fix (uvicorn uses stdlib asyncio, nest_asyncio patches apply correctly)
- No regression on standard `python run_ui.py` startup