### PR TITLE
Fix MCP call_tool ignoring per-server tool_timeout

### DIFF
--- a/helpers/mcp_handler.py
+++ b/helpers/mcp_handler.py
@@ -968,11 +968,13 @@ class MCPClientBase(ABC):
 
         async def call_tool_op(current_session: ClientSession):
             set = settings.get_settings()
+            # Resolve timeout: per-server override takes precedence over global default
+            tool_timeout = self.server.tool_timeout or set["mcp_client_tool_timeout"]
             # PrintStyle(font_color="cyan").print(f"MCPClientBase ({self.server.name}): Executing 'call_tool' for '{tool_name}' via MCP session...")
             response: CallToolResult = await current_session.call_tool(
                 tool_name,
                 input_data,
-                read_timeout_seconds=timedelta(seconds=set["mcp_client_tool_timeout"]),
+                read_timeout_seconds=timedelta(seconds=tool_timeout),
             )
             # PrintStyle(font_color="green").print(f"MCPClientBase ({self.server.name}): Tool '{tool_name}' call successful via session.")
             return response


### PR DESCRIPTION
Fixes #1431

## Summary

- `call_tool` in `MCPClientBase` always used the global `mcp_client_tool_timeout` setting, ignoring the per-server `tool_timeout` override
- This caused tools with long execution times (e.g., Perplexity deep research at 5-20 min) to timeout prematurely at the global default (120s), even when the server config specified a higher timeout
- Applied the same resolution pattern already used for SSE/HTTP transport connections (line ~1110): prefer per-server `tool_timeout`, fall back to global setting

## The Bug

```python
# BEFORE (line 984) - always uses global timeout
read_timeout_seconds=timedelta(seconds=set["mcp_client_tool_timeout"])

# AFTER - per-server override takes precedence
tool_timeout = self.server.tool_timeout or set["mcp_client_tool_timeout"]
read_timeout_seconds=timedelta(seconds=tool_timeout)
```

The per-server `tool_timeout` was already being used for the transport-level SSE read timeout, but not for the actual MCP protocol `call_tool` operation. This one-line fix makes them consistent.

## Impact

Any MCP server with a custom `tool_timeout` in its config was silently having that value ignored during tool execution. Only the transport connection respected it.

## Testing

- Verified the fix resolves Perplexity deep research timeouts (configured `tool_timeout: 1200` for 20-minute research queries)
- No changes to behavior for servers without a custom `tool_timeout` (falls back to global as before)