### PR TITLE
fix: add missing litellm dependency, remove duplicate crontab

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ flaredantic==0.1.5
 GitPython==3.1.43
 inputimeout==1.0.4
 kokoro>=0.9.2
+litellm>=1.78.7
 simpleeval==1.0.3
 langchain-core==0.3.49
 langchain-community==0.3.19
@@ -38,7 +39,6 @@ pydantic==2.11.7
 pymupdf==1.25.3
 pytesseract==0.3.13
 pdf2image==1.17.0
-crontab==1.0.1
 pathspec>=0.12.1
 psutil>=7.0.0
 soundfile==0.13.1


### PR DESCRIPTION
## Problem

`models.py` imports `litellm` on lines 17–18 and uses it extensively throughout the file, but `litellm` is not declared in `requirements.txt`. Fresh installs fail with `ImportError` unless `litellm` is installed manually or happens to be pulled in as a transitive dependency.

## Changes

- Add `litellm>=1.78.7` to `requirements.txt`
- Remove duplicate `crontab==1.0.1` entry (was listed twice, lines 35 and 41)

## Dependency Conflict Note

`litellm>=1.78.7` requires `openai>=1.99.5`, which conflicts with `browser-use==0.5.11`'s exact pin of `openai==1.99.2`. In testing, `openai==1.99.5` works fine with `browser-use` (3 patch versions apart, no API breaks between them). A separate `openai>=1.99.5` pin or updated `browser-use` version may be warranted — leaving that decision to maintainers.