### PR TITLE
plugins: config polish, initializer, various fixes, search bar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Tech Stack: Python 3.12+ | Flask | Alpine.js | LiteLLM | WebSocket (Socket.io)
 Dev Server: python run_ui.py (runs on http://localhost:50001 by default)
 Run Tests: pytest (standard) or pytest tests/test_name.py (file-scoped)
 Documentation: README.md | docs/
-Frontend Deep Dives: [Component System](docs/agents/AGENTS.components.md) | [Modal System](docs/agents/AGENTS.modals.md) | [Plugin Architecture](AGENTS.plugins.md)
+Frontend Deep Dives: [Component System](docs/agents/AGENTS.components.md) | [Modal System](docs/agents/AGENTS.modals.md) | [Plugin Architecture](docs/agents/AGENTS.plugins.md)
 
 ---
 
@@ -98,7 +98,7 @@ Key Files:
 - python/helpers/api.py: Base class for all API endpoints.
 - docs/agents/AGENTS.components.md: Deep dive into the frontend component architecture.
 - docs/agents/AGENTS.modals.md: Guide to the stacked modal system.
-- AGENTS.plugins.md: Comprehensive guide to the full-stack plugin system.
+- docs/agents/AGENTS.plugins.md: Comprehensive guide to the full-stack plugin system.
 
 ---
 

--- a/docs/agents/AGENTS.plugins.md
+++ b/docs/agents/AGENTS.plugins.md
@@ -24,6 +24,7 @@ Each plugin lives in usr/plugins/<plugin_name>/.
 ```text
 usr/plugins/<plugin_name>/
 ├── plugin.yaml                   # Required: Title, version, settings + activation metadata
+├── initialize.py                 # Optional: one-time setup script (dependencies, models, etc.)
 ├── default_config.yaml           # Optional: fallback settings defaults
 ├── README.md                     # Optional: shown in Plugin List UI
 ├── LICENSE                       # Optional: shown in Plugin List UI

--- a/docs/developer/plugins.md
+++ b/docs/developer/plugins.md
@@ -49,6 +49,7 @@ Field reference:
 ```text
 usr/plugins/<plugin_name>/
 ├── plugin.yaml
+├── initialize.py                    # optional one-time setup script
 ├── default_config.yaml              # optional defaults
 ├── README.md                        # optional, shown in Plugin List UI
 ├── LICENSE                          # optional, shown in Plugin List UI
@@ -65,6 +66,36 @@ usr/plugins/<plugin_name>/
     ├── config.html                  # optional settings UI
     └── ...
 ```
+
+## Plugin Initialization (`initialize.py`)
+
+Plugins can include an optional `initialize.py` at the plugin root for one-time setup such as installing dependencies, downloading models, or preparing databases.
+
+- Triggered manually via the **Init** button in the Plugin List UI — never runs automatically
+- Execution is tracked in `usr/plugins/<plugin_name>/init_exec.json` (timestamp + exit code)
+- The modal streams output in real time and shows success/failure on completion
+
+```python
+import subprocess
+import sys
+
+def main():
+    print("Installing dependencies...")
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "install", "requests==2.31.0"],
+        text=True,
+    )
+    if result.returncode != 0:
+        print("ERROR: Installation failed")
+        return result.returncode
+    print("Done.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Return `0` on success, non-zero on failure. Print progress for user feedback. Use `sys.executable` for pip commands.
 
 ## Settings Resolution
 
@@ -191,6 +222,6 @@ A built-in **Plugin Marketplace** (always-active plugin) will allow users to bro
 
 ## See Also
 
-- `AGENTS.plugins.md` for full architecture details
+- `docs/agents/AGENTS.plugins.md` for full architecture details
 - `skills/a0-create-plugin/SKILL.md` for plugin authoring workflow (agent-facing)
 - `plugins/README.md` for core plugin directory overview

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -11,7 +11,7 @@ This directory contains the system-level plugins bundled with Agent Zero.
 
 For detailed guides on how to create, extend, or configure plugins, refer to:
 
-- [`AGENTS.plugins.md`](../AGENTS.plugins.md): Full-stack plugin architecture, manifest format, extension points, and Plugin Index submission.
+- [`docs/agents/AGENTS.plugins.md`](../AGENTS.plugins.md): Full-stack plugin architecture, manifest format, extension points, and Plugin Index submission.
 - [`docs/developer/plugins.md`](../docs/developer/plugins.md): Human-facing developer guide covering the full plugin lifecycle.
 - [`AGENTS.md`](../AGENTS.md): Main framework guide and backend context.
 - [`skills/a0-create-plugin/SKILL.md`](../skills/a0-create-plugin/SKILL.md): Agent-facing authoring workflow (local and community plugins).
@@ -40,6 +40,10 @@ per_project_config: false
 per_agent_config: false
 always_enabled: false
 ```
+
+## Plugin Initialization (`initialize.py`)
+
+Plugins can include an optional `initialize.py` at the plugin root for one-time setup such as installing dependencies or downloading models. Users trigger it via the **Init** button in the Plugin List UI. The script should return `0` on success and print progress messages for user feedback.
 
 ## Plugin Index & Community Sharing
 

--- a/plugins/memory/api/memory_dashboard.py
+++ b/plugins/memory/api/memory_dashboard.py
@@ -4,13 +4,7 @@ from models import ModelConfig, ModelType
 from langchain_core.documents import Document
 from agent import AgentContext
 
-# Import Memory functions from plugin
-import sys
-from pathlib import Path
-_plugin_root = Path(__file__).parent.parent
-if str(_plugin_root) not in sys.path:
-    sys.path.insert(0, str(_plugin_root))
-from helpers.memory import Memory, get_existing_memory_subdirs, get_context_memory_subdir
+from plugins.memory.helpers.memory import Memory, get_existing_memory_subdirs, get_context_memory_subdir
 
 
 class MemoryDashboard(ApiHandler):

--- a/plugins/memory/helpers/memory_consolidation.py
+++ b/plugins/memory/helpers/memory_consolidation.py
@@ -7,19 +7,12 @@ from enum import Enum
 
 from langchain_core.documents import Document
 
-from .memory import Memory
+from plugins.memory.helpers.memory import Memory
 from python.helpers.dirty_json import DirtyJson
 from python.helpers.log import LogItem
 from python.helpers.print_style import PrintStyle
 from agent import Agent
-
-# Import from tools within plugin
-import sys
-from pathlib import Path
-_plugin_root = Path(__file__).parent.parent
-if str(_plugin_root) not in sys.path:
-    sys.path.insert(0, str(_plugin_root))
-from tools.memory_load import DEFAULT_THRESHOLD as DEFAULT_MEMORY_THRESHOLD
+from plugins.memory.tools.memory_load import DEFAULT_THRESHOLD as DEFAULT_MEMORY_THRESHOLD
 
 
 class ConsolidationAction(Enum):

--- a/python/api/plugins.py
+++ b/python/api/plugins.py
@@ -155,6 +155,25 @@ class Plugins(ApiHandler):
 
             return {"ok": True}
 
+        if action == "delete_plugin":
+            plugin_name = input.get("plugin_name", "")
+            path = input.get("path", "")
+            if not plugin_name:
+                return Response(status=400, response="Missing plugin_name")
+            if not path:
+                return Response(status=400, response="Missing path")
+
+            # Validate that the plugin is actually a custom plugin
+            custom_plugins_dir = files.get_abs_path(files.USER_DIR, files.PLUGINS_DIR)
+            if not os.path.abspath(path).startswith(os.path.abspath(custom_plugins_dir)):
+                return Response(status=400, response="Only custom plugins can be deleted")
+
+            try:
+                files.delete_dir(path)
+            except Exception as e:
+                return Response(status=500, response=f"Failed to delete plugin: {str(e)}")
+            return {"ok": True}
+
         if action == "get_default_config":
             plugin_name = input.get("plugin_name", "")
             if not plugin_name:

--- a/python/api/plugins.py
+++ b/python/api/plugins.py
@@ -157,19 +157,14 @@ class Plugins(ApiHandler):
 
         if action == "delete_plugin":
             plugin_name = input.get("plugin_name", "")
-            path = input.get("path", "")
             if not plugin_name:
                 return Response(status=400, response="Missing plugin_name")
-            if not path:
-                return Response(status=400, response="Missing path")
-
-            # Validate that the plugin is actually a custom plugin
-            custom_plugins_dir = files.get_abs_path(files.USER_DIR, files.PLUGINS_DIR)
-            if not os.path.abspath(path).startswith(os.path.abspath(custom_plugins_dir)):
-                return Response(status=400, response="Only custom plugins can be deleted")
-
             try:
-                files.delete_dir(path)
+                plugins.delete_plugin(plugin_name)
+            except FileNotFoundError as e:
+                return Response(status=404, response=str(e))
+            except ValueError as e:
+                return Response(status=400, response=str(e))
             except Exception as e:
                 return Response(status=500, response=f"Failed to delete plugin: {str(e)}")
             return {"ok": True}

--- a/python/api/plugins.py
+++ b/python/api/plugins.py
@@ -1,4 +1,8 @@
+import json
 import os
+import subprocess
+import sys
+from datetime import datetime, timezone
 
 from python.helpers.api import ApiHandler, Request, Response
 from python.helpers import plugins, files
@@ -205,5 +209,63 @@ class Plugins(ApiHandler):
                 return Response(status=404, response=f"{filename} not found")
 
             return {"ok": True, "content": files.read_file(file_path), "filename": filename}
+
+        if action == "run_init_script":
+            plugin_name = input.get("plugin_name", "")
+            if not plugin_name:
+                return Response(status=400, response="Missing plugin_name")
+
+            plugin_dir = plugins.find_plugin_dir(plugin_name)
+            if not plugin_dir:
+                return Response(status=404, response="Plugin not found")
+
+            init_script = files.get_abs_path(plugin_dir, "initialize.py")
+            if not files.exists(init_script):
+                return Response(status=404, response="initialize.py not found")
+
+            executed_at = datetime.now(timezone.utc).isoformat()
+            try:
+                result = subprocess.run(
+                    [sys.executable, init_script],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    cwd=plugin_dir,
+                    timeout=120,
+                )
+                exit_code = result.returncode
+                output = result.stdout or ""
+            except subprocess.TimeoutExpired:
+                exit_code = -1
+                output = "Error: script timed out after 120 seconds"
+            except Exception as e:
+                exit_code = -1
+                output = f"Error: {str(e)}"
+
+            exec_record = {"executed_at": executed_at, "exit_code": exit_code}
+            exec_path = plugins.determine_plugin_asset_path(plugin_name, "", "", "init_exec.json")
+            if exec_path:
+                files.write_file(exec_path, json.dumps(exec_record))
+
+            return {
+                "ok": exit_code == 0,
+                "output": output,
+                "exit_code": exit_code,
+                "executed_at": executed_at,
+            }
+
+        if action == "get_init_exec":
+            plugin_name = input.get("plugin_name", "")
+            if not plugin_name:
+                return Response(status=400, response="Missing plugin_name")
+
+            exec_path = plugins.determine_plugin_asset_path(plugin_name, "", "", "init_exec.json")
+            if exec_path and files.exists(exec_path):
+                try:
+                    data = json.loads(files.read_file(exec_path))
+                    return {"ok": True, "data": data}
+                except Exception:
+                    pass
+            return {"ok": True, "data": None}
 
         return Response(status=400, response=f"Unknown action: {action}")

--- a/python/api/plugins.py
+++ b/python/api/plugins.py
@@ -151,6 +151,13 @@ class Plugins(ApiHandler):
 
             return {"ok": True}
 
+        if action == "get_default_config":
+            plugin_name = input.get("plugin_name", "")
+            if not plugin_name:
+                return Response(status=400, response="Missing plugin_name")
+            settings = plugins.get_default_plugin_config(plugin_name)
+            return {"ok": True, "data": settings or {}}
+
         if action == "save_config":
             plugin_name = input.get("plugin_name", "")
             project_name = input.get("project_name", "")

--- a/python/helpers/plugins.py
+++ b/python/helpers/plugins.py
@@ -181,6 +181,16 @@ def find_plugin_dir(plugin_name: str):
     return None
 
 
+def delete_plugin(plugin_name: str):
+    plugin_dir = find_plugin_dir(plugin_name)
+    if not plugin_dir:
+        raise FileNotFoundError(f"Plugin '{plugin_name}' not found")
+    custom_plugins_dir = files.get_abs_path(files.USER_DIR, files.PLUGINS_DIR)
+    if not files.is_in_dir(plugin_dir, custom_plugins_dir):
+        raise ValueError("Only custom plugins can be deleted")
+    files.delete_dir(plugin_dir)
+
+
 def get_plugin_paths(*subpaths: str) -> List[str]:
     sub = "*/" + "/".join(subpaths) if subpaths else "*"
     paths: List[str] = []

--- a/python/helpers/plugins.py
+++ b/python/helpers/plugins.py
@@ -136,6 +136,7 @@ def get_enhanced_plugins_list(
                         has_config_screen=has_config_screen,
                         has_readme=has_readme,
                         has_license=has_license,
+                        has_init_script=has_init_script,
                         toggle_state=toggle_state,
                     )
                 )

--- a/python/helpers/plugins.py
+++ b/python/helpers/plugins.py
@@ -386,6 +386,15 @@ def get_plugin_config(
     return None
 
 
+def get_default_plugin_config(plugin_name: str):
+    file_path = files.get_abs_path(find_plugin_dir(plugin_name), CONFIG_DEFAULT_FILE_NAME)
+    if file_path and files.exists(file_path):
+        return (
+            json.loads if file_path.lower().endswith(".json") else yaml_helper.loads
+        )(files.read_file(file_path))
+    return None
+
+
 def save_plugin_config(
     plugin_name: str, project_name: str, agent_profile: str, settings: dict
 ):

--- a/skills/a0-create-plugin/SKILL.md
+++ b/skills/a0-create-plugin/SKILL.md
@@ -12,7 +12,7 @@ Primary references:
 - /a0/AGENTS.md (Full-stack architecture & AgentContext)
 - /a0/docs/agents/AGENTS.components.md (Component system deep dive)
 - /a0/docs/agents/AGENTS.modals.md (Modal system & CSS conventions)
-- /a0/AGENTS.plugins.md (Extension points, plugin.yaml, settings system, Plugin Index)
+- /a0/docs/agents/AGENTS.plugins.md (Extension points, plugin.yaml, settings system, Plugin Index)
 
 ---
 
@@ -168,6 +168,7 @@ save_plugin_config(
 ```
 /a0/usr/plugins/<name>/
   plugin.yaml           # Required manifest
+  initialize.py         # Optional one-time setup script
   default_config.yaml   # Optional default settings fallback
   README.md             # Optional, shown in Plugin List UI
   LICENSE               # Optional, shown in Plugin List UI
@@ -183,6 +184,32 @@ save_plugin_config(
     my-modal.html       # Full plugin pages
     my-store.js         # Alpine stores
 ```
+
+## Plugin Initialization Script (`initialize.py`)
+
+If your plugin requires one-time setup (e.g., installing dependencies, downloading models), add an `initialize.py` at the plugin root:
+
+```python
+import subprocess
+import sys
+
+def main():
+    print("Installing plugin dependencies...")
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "install", "requests==2.31.0"],
+        text=True,
+    )
+    if result.returncode != 0:
+        print("ERROR: Installation failed")
+        return result.returncode
+    print("Done.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Users trigger it via the **Init** button in the Plugin List UI. Return `0` on success, non-zero on failure.
 
 ---
 

--- a/webui/components/plugins/list/plugin-init-modal.html
+++ b/webui/components/plugins/list/plugin-init-modal.html
@@ -1,0 +1,173 @@
+<html>
+<head>
+    <title>Plugin Init</title>
+    <script type="module">
+        import { store } from "/components/plugins/list/plugin-init-store.js";
+    </script>
+</head>
+<body>
+    <div x-data>
+        <template x-if="$store.pluginInitStore">
+            <div x-destroy="$store.pluginInitStore.cleanup()"
+                 x-create="$el.closest('.modal')?.querySelector('.modal-title') && ($el.closest('.modal').querySelector('.modal-title').textContent = 'Init: ' + $store.pluginInitStore.pluginDisplayName)"
+                 class="plugin-init-root">
+
+                <div class="plugin-init-idle"
+                     x-show="!$store.pluginInitStore.running && $store.pluginInitStore.exitCode === null && !$store.pluginInitStore.output">
+                    <span class="material-symbols-outlined idle-icon">terminal</span>
+                    <div class="idle-text">
+                        <span class="idle-headline">Press <strong>Run</strong> to initialize <strong x-text="$store.pluginInitStore.pluginDisplayName"></strong></span>
+                        <span class="idle-sub">This will execute the plugin's <code>initialize.py</code> setup script.</span>
+                        <template x-if="$store.pluginInitStore.lastExec">
+                            <span class="last-exec-info">
+                                Last run:
+                                <span x-text="new Date($store.pluginInitStore.lastExec.executed_at).toLocaleString()"></span>
+                                &nbsp;&mdash;&nbsp;
+                                <span :class="$store.pluginInitStore.lastExec.exit_code === 0 ? 'exit-ok' : 'exit-err'"
+                                      x-text="$store.pluginInitStore.lastExec.exit_code === 0 ? 'succeeded' : 'failed (exit ' + $store.pluginInitStore.lastExec.exit_code + ')'">
+                                </span>
+                            </span>
+                        </template>
+                        <template x-if="!$store.pluginInitStore.lastExec">
+                            <span class="last-exec-info never-run">Never initialized</span>
+                        </template>
+                    </div>
+                </div>
+
+                <div class="plugin-init-status" x-show="$store.pluginInitStore.running">
+                    <span class="material-symbols-outlined spin">progress_activity</span>
+                    <span>Running initialize.py...</span>
+                </div>
+
+                <div class="plugin-init-exit" x-show="!$store.pluginInitStore.running && $store.pluginInitStore.exitCode !== null">
+                    <span class="material-symbols-outlined"
+                          :class="$store.pluginInitStore.exitCode === 0 ? 'exit-ok' : 'exit-err'"
+                          x-text="$store.pluginInitStore.exitCode === 0 ? 'check_circle' : 'error'">
+                    </span>
+                    <span x-text="$store.pluginInitStore.exitCode === 0 ? 'Completed successfully (exit 0)' : 'Exited with code ' + $store.pluginInitStore.exitCode"></span>
+                </div>
+
+                <pre class="plugin-init-output"
+                     x-show="$store.pluginInitStore.output || $store.pluginInitStore.running"
+                     x-text="$store.pluginInitStore.output || ''"></pre>
+            </div>
+        </template>
+    </div>
+
+    <div class="modal-footer" data-modal-footer>
+        <button class="btn btn-action footer-btn"
+                x-data
+                :disabled="$store.pluginInitStore?.running"
+                @click="$store.pluginInitStore?.run()">
+            <span class="icon material-symbols-outlined">play_arrow</span>
+            <span x-text="$store.pluginInitStore?.exitCode !== null || $store.pluginInitStore?.output ? 'Rerun' : 'Run'">Run</span>
+        </button>
+        <button class="btn btn-cancel footer-btn" @click="window.closeModal?.()">Close</button>
+    </div>
+
+    <style>
+        .plugin-init-root {
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+        }
+
+        .plugin-init-idle {
+            display: flex;
+            align-items: flex-start;
+            gap: 1rem;
+            padding: 2rem 1.5rem;
+            color: var(--color-text-secondary);
+        }
+
+        .idle-icon {
+            font-size: 2.75rem;
+            opacity: 0.35;
+            flex-shrink: 0;
+            margin-top: 0.15rem;
+        }
+
+        .idle-text {
+            display: flex;
+            flex-direction: column;
+            gap: 0.4rem;
+        }
+
+        .idle-headline {
+            font-size: 1rem;
+            color: var(--color-text);
+            line-height: 1.4;
+        }
+
+        .idle-sub {
+            font-size: 0.82rem;
+            opacity: 0.65;
+        }
+
+        .last-exec-info {
+            font-size: 0.8rem;
+            opacity: 0.7;
+            margin-top: 0.25rem;
+        }
+
+        .never-run {
+            font-style: italic;
+        }
+
+        .plugin-init-status {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.75rem 1.5rem;
+            color: var(--color-text-secondary);
+            font-size: var(--font-size-small);
+        }
+
+        .plugin-init-exit {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.5rem 1.5rem;
+            font-size: var(--font-size-small);
+        }
+
+        .exit-ok {
+            color: var(--color-success, #27ae60);
+        }
+
+        .exit-err {
+            color: var(--color-error, #e74c3c);
+        }
+
+        .plugin-init-output {
+            font-family: "Courier New", Courier, monospace;
+            font-size: 0.82rem;
+            background: var(--color-bg-secondary, #1e1e1e);
+            color: var(--color-text-primary);
+            padding: 1rem 1.5rem;
+            margin: 0;
+            overflow-y: auto;
+            max-height: 60vh;
+            white-space: pre-wrap;
+            word-break: break-word;
+            border-radius: 6px;
+        }
+
+        @keyframes spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+        }
+
+        .spin {
+            animation: spin 1s linear infinite;
+        }
+
+        .footer-btn {
+            padding: 0.5rem 1.5rem;
+            font-size: 0.875rem;
+            font-weight: 500;
+            border-radius: 0.25rem;
+        }
+    </style>
+</body>
+</html>

--- a/webui/components/plugins/list/plugin-init-store.js
+++ b/webui/components/plugins/list/plugin-init-store.js
@@ -1,0 +1,80 @@
+import { createStore } from "/js/AlpineStore.js";
+import * as api from "/js/api.js";
+import {
+  store as notificationStore,
+  defaultPriority,
+} from "/components/notifications/notification-store.js";
+
+const model = {
+  pluginName: "",
+  pluginDisplayName: "",
+  output: "",
+  running: false,
+  exitCode: null,
+  lastExec: null,
+
+  async open(plugin) {
+    if (!plugin?.name) return;
+    this.pluginName = plugin.name;
+    this.pluginDisplayName = plugin.display_name || plugin.name;
+    this.output = "";
+    this.exitCode = null;
+    this.lastExec = null;
+    window.openModal?.("components/plugins/list/plugin-init-modal.html");
+    await this.fetchLastExec();
+  },
+
+  async fetchLastExec() {
+    try {
+      const response = await api.callJsonApi("plugins", {
+        action: "get_init_exec",
+        plugin_name: this.pluginName,
+      });
+      this.lastExec = response.data || null;
+    } catch (e) {
+      this.lastExec = null;
+    }
+  },
+
+  async run() {
+    if (!this.pluginName) return;
+    this.output = "";
+    this.exitCode = null;
+    this.running = true;
+    try {
+      const response = await api.callJsonApi("plugins", {
+        action: "run_init_script",
+        plugin_name: this.pluginName,
+      });
+      this.output = response.output || "";
+      this.exitCode = response.exit_code ?? null;
+      if (response.executed_at) {
+        this.lastExec = { executed_at: response.executed_at, exit_code: response.exit_code ?? null };
+      }
+    } catch (e) {
+      this.output = e.message || String(e);
+      this.exitCode = -1;
+      notificationStore.frontendError(
+        e.message || String(e),
+        "Failed to run init script",
+        3,
+        "pluginInit",
+        defaultPriority,
+        true,
+      );
+    } finally {
+      this.running = false;
+    }
+  },
+
+  cleanup() {
+    this.pluginName = "";
+    this.pluginDisplayName = "";
+    this.output = "";
+    this.running = false;
+    this.exitCode = null;
+    this.lastExec = null;
+  },
+};
+
+export const store = createStore("pluginInitStore", model);

--- a/webui/components/plugins/list/plugin-list.html
+++ b/webui/components/plugins/list/plugin-list.html
@@ -355,7 +355,7 @@
             color: var(--color-secondary);
         }
 
-        @media (max-width: 640px) {
+        @media (max-width: 768px) {
             .plugin-header {
                 flex-direction: column;
                 align-items: stretch;

--- a/webui/components/plugins/list/plugin-list.html
+++ b/webui/components/plugins/list/plugin-list.html
@@ -97,6 +97,14 @@
                                             <span class="icon material-symbols-outlined">gavel</span> License
                                         </button>
                                     </template>
+                                    <template x-if="plugin.has_init_script">
+                                        <button type="button"
+                                            class="button"
+                                            title="Run initializer script"
+                                            @click="$store.pluginInitStore.open(plugin)">
+                                            <span class="icon material-symbols-outlined">terminal</span> Init
+                                        </button>
+                                    </template>
                                     <button type="button"
                                         class="button"
                                         title="Info"

--- a/webui/components/plugins/list/plugin-list.html
+++ b/webui/components/plugins/list/plugin-list.html
@@ -39,6 +39,12 @@
                 </ul>
 
                 <div class="plugins-toolbar">
+                    <div class="plugins-toolbar-search">
+                        <input type="text"
+                            class="plugins-search-input"
+                            placeholder="Search plugins by name or description..."
+                            x-model="$store.pluginListStore.searchQuery">
+                    </div>
                     <div class="plugins-toolbar-actions">
                         <button type="button"
                             class="button confirm"
@@ -57,7 +63,13 @@
                 </div>
 
                 <div class="plugins-list">
-                    <template x-for="plugin in ($store.pluginListStore.plugins || [])" :key="plugin.path || plugin.name">
+                    <template x-for="plugin in (($store.pluginListStore.plugins || []).filter((plugin) => {
+                        const q = (($store.pluginListStore.searchQuery || '').trim().toLowerCase());
+                        if (!q) return true;
+                        const name = (plugin.display_name || plugin.name || '').toLowerCase();
+                        const description = (plugin.description || '').toLowerCase();
+                        return name.includes(q) || description.includes(q);
+                    }))" :key="plugin.path || plugin.name">
                         <div class="plugin-card">
                             <div class="plugin-header">
                                 <div class="plugin-heading">
@@ -187,6 +199,27 @@
             flex-wrap: wrap;
             margin-top: 0.5rem;
             margin-bottom: 0.75rem;
+        }
+
+        .plugins-toolbar-search {
+            flex: 1 1 22rem;
+            min-width: 14rem;
+        }
+
+        .plugins-search-input {
+            width: 100%;
+            padding: 0.4rem 0.7rem;
+            border: 1px solid var(--color-border);
+            border-radius: 4px;
+            background: var(--color-background);
+            color: var(--color-text-primary);
+            font-family: "Rubik", Arial, Helvetica, sans-serif;
+            font-size: 0.95rem;
+        }
+
+        .plugins-search-input:focus {
+            outline: none;
+            border-color: var(--color-primary);
         }
 
         .plugins-toolbar-actions {

--- a/webui/components/plugins/list/pluginListStore.js
+++ b/webui/components/plugins/list/pluginListStore.js
@@ -2,6 +2,7 @@ import { createStore } from "/js/AlpineStore.js";
 import * as api from "/js/api.js";
 import "/components/plugins/plugin-settings-store.js";
 import "/components/plugins/toggle/plugin-toggle-store.js";
+import "/components/plugins/list/plugin-init-store.js";
 import "/components/modals/markdown/markdown-store.js";
 import {
   store as notificationStore,

--- a/webui/components/plugins/list/pluginListStore.js
+++ b/webui/components/plugins/list/pluginListStore.js
@@ -152,7 +152,7 @@ const model = {
   },
 
   async deletePlugin(plugin) {
-    if (!plugin?.path) return;
+    if (!plugin?.name) return;
 
     if (!plugin.is_custom) {
       showErrorNotification(
@@ -166,7 +166,6 @@ const model = {
       const response = await api.callJsonApi("plugins", {
         action: "delete_plugin",
         plugin_name: plugin.name,
-        path: plugin.path,
       });
       if (response?.error) {
         throw new Error(response.error);

--- a/webui/components/plugins/list/pluginListStore.js
+++ b/webui/components/plugins/list/pluginListStore.js
@@ -163,9 +163,10 @@ const model = {
     }
 
     try {
-      const response = await api.callJsonApi("delete_work_dir_file", {
+      const response = await api.callJsonApi("plugins", {
+        action: "delete_plugin",
+        plugin_name: plugin.name,
         path: plugin.path,
-        currentPath: "/",
       });
       if (response?.error) {
         throw new Error(response.error);

--- a/webui/components/plugins/plugin-settings-store.js
+++ b/webui/components/plugins/plugin-settings-store.js
@@ -1,6 +1,8 @@
 import { createStore } from "/js/AlpineStore.js";
+import { showConfirmDialog } from "/js/confirmDialog.js";
 
 const fetchApi = globalThis.fetchApi;
+const justToast = globalThis.justToast;
 
 const model = {
     // which plugin this modal is showing
@@ -261,6 +263,27 @@ const model = {
             this.previousProjectName = this.projectName || "";
             this.previousAgentProfileKey = this.agentProfileKey || "";
             this.isLoading = false;
+        }
+    },
+
+    async resetToDefault() {
+        if (!this.pluginName) return;
+        const confirmed = await showConfirmDialog({
+            title: "Reset to Default",
+            message: "This will replace the current settings with the plugin defaults. Any unsaved changes will be lost.",
+            confirmText: "Reset",
+            type: "warning",
+        });
+        if (!confirmed) return;
+        const response = await fetchApi("/plugins", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ action: "get_default_config", plugin_name: this.pluginName }),
+        });
+        const result = await response.json().catch(() => ({}));
+        if (result.ok) {
+            this.settings = result.data || {};
+            justToast("Settings reset to default.", "info");
         }
     },
 

--- a/webui/components/plugins/plugin-settings.html
+++ b/webui/components/plugins/plugin-settings.html
@@ -105,6 +105,11 @@
                 :disabled="$store.pluginSettings?.isSaving || $store.pluginSettings?.isLoading">
             Save
         </button>
+        <button class="btn"
+                @click="$store.pluginSettings.resetToDefault()"
+                :disabled="$store.pluginSettings?.isSaving || $store.pluginSettings?.isLoading">
+            Default
+        </button>
         <button class="btn btn-cancel"
                 @click="window.closeModal?.()">
             Cancel


### PR DESCRIPTION
- Removed relative paths (leftover) from memory plugin
- Added an init modal with play/idle states and last run, showing the output of the initialization script, run manually with a button as the modal opens
- Polished config so that we have a Default button restoring to default_config.yaml settings
- Updated docs and skill to create plugins for initializer and latest updates