### PR TITLE
fix: use .get() to avoid KeyError in skills_tool _load()

### DIFF
--- a/python/tools/skills_tool.py
+++ b/python/tools/skills_tool.py
@@ -123,7 +123,7 @@ class SkillsTool(Tool):
             return f"Error: skill not found: {skill_name!r}. Try skills_tool method=list or method=search."
 
         # Store skill name for fresh loading each turn
-        if not self.agent.data[DATA_NAME_LOADED_SKILLS]:
+        if not self.agent.data.get(DATA_NAME_LOADED_SKILLS):
             self.agent.data[DATA_NAME_LOADED_SKILLS] = []
         loaded = self.agent.data[DATA_NAME_LOADED_SKILLS]
         if skill.name in loaded:


### PR DESCRIPTION
When skills_tool:load is called for the first time in a fresh agent session, the "loaded_skills" key does not yet exist in agent.data. Direct dict access (agent.data[key]) raises KeyError which is caught and returned as "Error in skills_tool: loaded_skills".

Fix: replace with agent.data.get(key) which safely returns None, matching the pattern already used correctly in the companion extension _65_include_loaded_skills.py.