### PR TITLE
Add util_model_call_after extension hook

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -788,6 +788,10 @@ class Agent:
             ),
         )
 
+        await extension.call_extensions_async(
+            "util_model_call_after", self, call_data=call_data, response=response
+        )
+
         return response
 
     @extension.extensible


### PR DESCRIPTION
## Summary
- Adds `util_model_call_after` extension hook to `call_utility_model()` in `agent.py`
- Symmetric counterpart to the existing `util_model_call_before` hook
- Passes `call_data` and `response` to allow plugins to capture utility model output

## Motivation
The `util_model_call_before` hook exists but has no matching "after" hook. This makes it impossible for observability plugins (e.g. Langfuse tracing) to capture the utility model's response for cost tracking, span finalization, and output logging.

This is a 4-line addition with no behavioral change to existing code — extensions that don't listen for this hook are unaffected.

## Test plan
- [ ] Verify existing `util_model_call_before` extensions still fire correctly
- [ ] Verify new `util_model_call_after` fires after utility model completes with correct `response` value
- [ ] Confirm no regressions in agent monologue flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)