### PR TITLE
feat: add Tensorix provider for chat and embedding

### DIFF
--- a/conf/model_providers.yaml
+++ b/conf/model_providers.yaml
@@ -81,6 +81,11 @@ chat:
   sambanova:
     name: Sambanova
     litellm_provider: sambanova
+  tensorix:
+    name: Tensorix
+    litellm_provider: openai
+    kwargs:
+      api_base: https://api.tensorix.ai/v1
   venice:
     name: Venice.ai
     litellm_provider: openai
@@ -139,6 +144,11 @@ embedding:
       extra_headers:
         "HTTP-Referer": "https://agent-zero.ai/"
         "X-Title": "Agent Zero"
+  tensorix:
+    name: Tensorix
+    litellm_provider: openai
+    kwargs:
+      api_base: https://api.tensorix.ai/v1
   other:
     name: Other OpenAI compatible
     litellm_provider: openai


### PR DESCRIPTION
## Summary

Adds [Tensorix](https://tensorix.ai) as a provider option in both the `chat` and `embedding` sections of `conf/model_providers.yaml`.

## What is Tensorix?

Tensorix is an OpenAI-compatible API gateway providing 50+ open-source models with:
- **EU-hosted inference** (Frankfurt data center)
- **Zero data retention** — prompts and completions are never stored
- **OpenAI-compatible API** at `https://api.tensorix.ai/v1`

Popular models available through Tensorix:
| Model | Context |
|-------|---------|
| `z-ai/glm-5` | 203K |
| `deepseek/deepseek-chat-v3.1` | 164K |
| `deepseek/deepseek-r1-0528` | 164K |
| `minimax/minimax-m2.5` | 197K |
| `moonshotai/kimi-k2.5` | 262K |

## Changes

- `conf/model_providers.yaml`: Added `tensorix` entry under both `chat:` and `embedding:` sections

## Implementation

Uses `litellm_provider: openai` with `api_base: https://api.tensorix.ai/v1`, following the same pattern as existing providers like Venice.ai and Z.AI.

Users authenticate by setting `TENSORIX_API_KEY` in their environment, which is automatically constructed from the provider ID per the existing convention.