### PR TITLE
Allow other supervisord configs to be added to Agent Zero

### DIFF
--- a/docker/run/fs/etc/supervisor/conf.d/supervisord.conf
+++ b/docker/run/fs/etc/supervisor/conf.d/supervisord.conf
@@ -1,22 +1,3 @@
-[supervisord]
-nodaemon=true
-user=root
-logfile=/dev/stdout
-logfile_maxbytes=0
-pidfile=/var/run/supervisord.pid
-exitcodes=0,2
-directory=/
-
-[unix_http_server]
-file=/var/run/supervisor.sock
-chmod=0777
-
-[rpcinterface:supervisor]
-supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
-
-[supervisorctl]
-serverurl=unix:///var/run/supervisor.sock
-
 [program:run_sshd]
 command=/usr/sbin/sshd -D
 environment=

--- a/docker/run/fs/etc/supervisor/supervisord.conf
+++ b/docker/run/fs/etc/supervisor/supervisord.conf
@@ -1,0 +1,21 @@
+[supervisord]
+nodaemon=true
+user=root
+logfile=/dev/stdout
+logfile_maxbytes=0
+pidfile=/var/run/supervisord.pid
+exitcodes=0,2
+directory=/
+
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0777
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
+[include]
+files = /etc/supervisor/conf.d/*.conf

--- a/docker/run/fs/exe/initialize.sh
+++ b/docker/run/fs/exe/initialize.sh
@@ -20,4 +20,4 @@ chmod 444 /root/.profile
 apt-get update > /dev/null 2>&1 &
 
 # let supervisord handle the services
-exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
Allow other supervisord configs to be added to Agent Zero when using the /per/* mount point and copy on container start the /per/* mount point and copy on container start.

By setting up the supervisord this way, all added /etc/supervisor/conf.d/*.conf files are included, ensuring that a container upgrade will not break an added supervisord config as the /per mount can be used to persist the addition supervisor *.conf files and have them used.

Example:
- add /per mount to the docker compose file:
     volumes:
      - $DIR/a0:/a0
      - $DIR/per:/per
- create $DIR/per/etc/supervisor/conf.d/telegram_bridge.conf
[program:telegram_bridge]
command=/opt/venv/bin/python /a0/usr/telegram/telegram_bridge.py
directory=/a0/usr/telegram
...
- Launch container with docker compose up
- /exe/initialize.sh launches
- This script will copy /per/*
     Line 13: cp -r --no-preserve=ownership,mode /per/* /
     So the telegram_bridge.conf is copied to /etc/supervisor/conf.d
- initialize.sh exec's:
    exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
- This conf contains the generic supervisord config from the original agent zero conf file + includes all /etc/supervisor/conf.d/*.conf available files
- /etc/supervisor/conf.d/supervisord.conf contains all the original agent zero content (expect for the generic parts)
- The telegram_bridge.conf will also be included and launches automatically
