### PR TITLE
feat: add skill argument to call_subordinate tool for enhanced task delegation

### DIFF
--- a/prompts/agent.system.tool.call_sub.md
+++ b/prompts/agent.system.tool.call_sub.md
@@ -8,6 +8,8 @@ delegate specific subtasks not entire task
 reset arg usage:
   "true": spawn new subordinate
   "false": continue existing subordinate
+skill arg usage:
+  optional name of a skill to load for the subordinate (e.g. "python-expert", "data-analysis")  
 if superior, orchestrate
 respond to existing subordinates using call_subordinate tool with reset false
 profile arg usage: select from available profiles for specialized subordinates, leave empty for default
@@ -22,6 +24,7 @@ example usage
     "tool_name": "call_subordinate",
     "tool_args": {
         "profile": "",
+        "skill": "python-expert",
         "message": "...",
         "reset": "true"
     }

--- a/tools/call_subordinate.py
+++ b/tools/call_subordinate.py
@@ -1,12 +1,13 @@
 from agent import Agent, UserMessage
 from helpers.tool import Tool, Response
+from helpers import skills
 from initialize import initialize_agent
 from extensions.python.hist_add_tool_result import _90_save_tool_call_file as save_tool_call_file
 
 
 class Delegation(Tool):
 
-    async def execute(self, message="", reset="", **kwargs):
+    async def execute(self, message="", reset="", skill="", **kwargs):
         # create subordinate agent using the data object on this agent and set superior agent to his data object
         if (
             self.agent.get_data(Agent.DATA_NAME_SUBORDINATE) is None
@@ -26,9 +27,18 @@ class Delegation(Tool):
             sub.set_data(Agent.DATA_NAME_SUPERIOR, self.agent)
             self.agent.set_data(Agent.DATA_NAME_SUBORDINATE, sub)
 
+        # Load skill content if provided
+        system_messages = []
+        if skill:
+            skill_data = skills.load_skill_for_agent(skill_name=skill, agent=self.agent)
+            if skill_data:
+                system_messages.append(skill_data)
+
         # add user message to subordinate agent
         subordinate: Agent = self.agent.get_data(Agent.DATA_NAME_SUBORDINATE)  # type: ignore
-        subordinate.hist_add_user_message(UserMessage(message=message, attachments=[]))
+        subordinate.hist_add_user_message(
+            UserMessage(message=message, attachments=[], system_message=system_messages)
+        )
 
         # run subordinate monologue
         result = await subordinate.monologue()


### PR DESCRIPTION
- Introduced a new optional 'skill' argument in the call_subordinate tool to specify a skill for the subordinate agent (e.g., "python-expert").
- Updated documentation to reflect the new 'skill' argument usage.
- Modified the execution method to load skill content if provided, enhancing the functionality of subordinate agents.