### PR TITLE
feat(projects): add UI-driven plugin symlink management

### DIFF
--- a/api/projects.py
+++ b/api/projects.py
@@ -32,6 +32,10 @@ class Projects(ApiHandler):
                 data = self.deactivate_project(ctxid)
             elif action == "file_structure":
                 data = self.get_file_structure(input.get("name", None), input.get("settings"))
+            elif action == "symlink_plugin":
+                data = self.symlink_plugin(input.get("name"), input.get("plugin_dir"))
+            elif action == "unsymlink_plugin":
+                data = self.unsymlink_plugin(input.get("name"))
             else:
                 raise Exception("Invalid action")
 
@@ -146,3 +150,15 @@ class Projects(ApiHandler):
             basic_data["file_structure"] = settings # type: ignore
         # get structure
         return projects.get_file_structure(name, basic_data)
+
+    def symlink_plugin(self, name, plugin_dir):
+        if not name:
+            raise Exception("Project name is required")
+        if not plugin_dir:
+            raise Exception("plugin_dir is required")
+        return projects.create_plugin_symlink(name, plugin_dir)
+
+    def unsymlink_plugin(self, name):
+        if not name:
+            raise Exception("Project name is required")
+        return projects.remove_plugin_symlink(name)

--- a/helpers/projects.py
+++ b/helpers/projects.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import Literal, TypedDict, TYPE_CHECKING, cast
 
 from helpers import files, dirty_json, persist_chat, file_tree
@@ -34,6 +35,7 @@ class BasicProjectData(TypedDict):
     instructions: str
     color: str
     git_url: str
+    plugin_dir: str
     file_structure: FileStructureInjectionSettings
 
 class GitStatusData(TypedDict, total=False):
@@ -45,6 +47,13 @@ class GitStatusData(TypedDict, total=False):
     last_commit: dict
     error: str
 
+class PluginSymlinkStatus(TypedDict, total=False):
+    has_plugin_yaml: bool
+    plugin_dir: str
+    is_linked: bool
+    symlink_path: str
+    default_plugin_dir: str
+
 class EditProjectData(BasicProjectData):
     name: str
     instruction_files_count: int
@@ -53,6 +62,7 @@ class EditProjectData(BasicProjectData):
     secrets: str
     subagents: dict[str, SubAgentSettings]
     git_status: GitStatusData
+    plugin_symlink_status: PluginSymlinkStatus
 
 
 
@@ -155,6 +165,7 @@ def _normalizeBasicData(data: BasicProjectData) -> BasicProjectData:
         "instructions": data.get("instructions", ""),
         "color": data.get("color", ""),
         "git_url": data.get("git_url", ""),
+        "plugin_dir": data.get("plugin_dir", ""),
         "file_structure": data.get(
             "file_structure",
             _default_file_structure_settings(),
@@ -180,6 +191,7 @@ def _normalizeEditData(data: EditProjectData) -> EditProjectData:
             _default_file_structure_settings(),
         ),
         "subagents": data.get("subagents", {}),
+        "plugin_symlink_status": data.get("plugin_symlink_status", {"has_plugin_yaml": False}),
     }
     return normalized
 
@@ -200,6 +212,7 @@ def _basic_data_to_edit_data(data: BasicProjectData) -> EditProjectData:
             "secrets": "",
             "subagents": {},
             "git_status": {"is_git_repo": False},
+            "plugin_symlink_status": {"has_plugin_yaml": False},
         },
     )
     return _normalizeEditData(base)
@@ -240,6 +253,7 @@ def load_edit_project_data(name: str) -> EditProjectData:
     subagents = load_project_subagents(name)
     knowledge_files_count = get_knowledge_files_count(name)
     git_status = cast(GitStatusData, git.get_repo_status(get_project_folder(name)))
+    plugin_symlink_status = get_plugin_symlink_status(name)
     
     data = cast(
         EditProjectData,
@@ -252,6 +266,7 @@ def load_edit_project_data(name: str) -> EditProjectData:
             "secrets": secrets,
             "subagents": subagents,
             "git_status": git_status,
+            "plugin_symlink_status": plugin_symlink_status,
         },
     )
     data = _normalizeEditData(data)
@@ -492,3 +507,119 @@ def get_file_structure(name: str, basic_data: BasicProjectData|None=None) -> str
         tree += "\n # Empty"
 
     return tree
+
+
+def get_plugin_symlink_status(name: str) -> PluginSymlinkStatus:
+    """Get the current plugin symlink status for a project."""
+    project_folder = get_project_folder(name)
+    has_plugin_yaml = os.path.exists(os.path.join(project_folder, 'plugin.yaml'))
+
+    # load plugin_dir from project header
+    try:
+        header = load_project_header(name)
+        plugin_dir = header.get('plugin_dir', '') or ''
+    except Exception:
+        plugin_dir = ''
+
+    # determine default plugin_dir suggestion
+    default_plugin_dir = _get_default_plugin_dir(name)
+
+    # check if symlink exists and points to this project
+    is_linked = False
+    symlink_path = ''
+    if plugin_dir:
+        symlink_path = files.get_abs_path('usr/plugins', plugin_dir)
+        if os.path.islink(symlink_path):
+            link_target = os.path.realpath(symlink_path)
+            project_real = os.path.realpath(project_folder)
+            is_linked = (link_target == project_real)
+
+    return PluginSymlinkStatus(
+        has_plugin_yaml=has_plugin_yaml,
+        plugin_dir=plugin_dir,
+        is_linked=is_linked,
+        symlink_path=symlink_path,
+        default_plugin_dir=default_plugin_dir,
+    )
+
+
+def _get_default_plugin_dir(name: str) -> str:
+    """Suggest a plugin_dir name from plugin.yaml name field or project folder name."""
+    project_folder = get_project_folder(name)
+    plugin_yaml_path = os.path.join(project_folder, 'plugin.yaml')
+    if os.path.exists(plugin_yaml_path):
+        try:
+            import yaml
+            with open(plugin_yaml_path) as f:
+                data = yaml.safe_load(f)
+            yaml_name = data.get('name', '') if data else ''
+            if yaml_name and re.match(r'^[a-z0-9_-]+$', str(yaml_name).strip()):
+                return str(yaml_name).strip()
+        except Exception:
+            pass
+    return name
+
+
+def create_plugin_symlink(name: str, plugin_dir: str) -> PluginSymlinkStatus:
+    """Create symlink /a0/usr/plugins/<plugin_dir> -> project folder."""
+    if not plugin_dir or not re.match(r'^[a-z0-9_-]+$', plugin_dir):
+        raise ValueError('plugin_dir must be lowercase letters, numbers, hyphens, underscores only')
+
+    project_folder = get_project_folder(name)
+    plugins_dir = files.get_abs_path('usr/plugins')
+    symlink_path = os.path.join(plugins_dir, plugin_dir)
+
+    if os.path.islink(symlink_path):
+        os.unlink(symlink_path)
+    elif os.path.exists(symlink_path):
+        raise ValueError(f'Target {symlink_path} exists and is not a symlink — remove it manually first')
+
+    os.makedirs(plugins_dir, exist_ok=True)
+    os.symlink(project_folder, symlink_path)
+    _save_plugin_dir(name, plugin_dir)
+
+    try:
+        from helpers import plugins as _plugins
+        _plugins.invalidate_plugin_cache()
+    except Exception:
+        pass
+
+    return get_plugin_symlink_status(name)
+
+
+def remove_plugin_symlink(name: str) -> PluginSymlinkStatus:
+    """Remove the plugin symlink for this project."""
+    try:
+        header = load_project_header(name)
+        plugin_dir = header.get('plugin_dir', '') or ''
+    except Exception:
+        plugin_dir = ''
+
+    if plugin_dir:
+        symlink_path = files.get_abs_path('usr/plugins', plugin_dir)
+        if os.path.islink(symlink_path):
+            link_target = os.path.realpath(symlink_path)
+            project_real = os.path.realpath(get_project_folder(name))
+            if link_target == project_real:
+                os.unlink(symlink_path)
+
+    _save_plugin_dir(name, '')
+
+    try:
+        from helpers import plugins as _plugins
+        _plugins.invalidate_plugin_cache()
+    except Exception:
+        pass
+
+    return get_plugin_symlink_status(name)
+
+
+def _save_plugin_dir(name: str, plugin_dir: str):
+    """Save plugin_dir field to project.json."""
+    try:
+        abs_path = files.get_abs_path(PROJECTS_PARENT_DIR, name, PROJECT_META_DIR, PROJECT_HEADER_FILE)
+        current = dirty_json.parse(files.read_file(abs_path)) or {}
+        current['plugin_dir'] = plugin_dir
+        files.write_file(abs_path, dirty_json.stringify(current))
+    except Exception as e:
+        PrintStyle.error(f'Error saving plugin_dir: {e}')

--- a/webui/components/projects/project-edit-basic-data.html
+++ b/webui/components/projects/project-edit-basic-data.html
@@ -134,6 +134,56 @@
                         </div>
                     </div>
                 </template>
+
+                <!-- Plugin Section -->
+                <template x-if="!$store.projects.selectedProject._meta.creating && $store.projects.selectedProject.plugin_symlink_status?.has_plugin_yaml">
+                    <div class="projects-form-group plugin-status-section">
+                        <label class="projects-form-label">
+                            <span class="material-symbols-outlined" style="vertical-align:middle;font-size:1.1em;">extension</span>
+                            Plugin
+                        </label>
+                        <div class="git-status-card">
+                            <div class="git-status-row">
+                                <span class="git-status-label">Plugin Dir</span>
+                                <input class="projects-form-input" style="flex:1;"
+                                    x-model="$store.projects.selectedProject.plugin_symlink_status.plugin_dir"
+                                    :placeholder="$store.projects.selectedProject.plugin_symlink_status?.default_plugin_dir"
+                                />
+                            </div>
+                            <div class="git-status-row">
+                                <span class="git-status-label">Symlink</span>
+                                <span class="git-status-value">
+                                    <template x-if="$store.projects.selectedProject.plugin_symlink_status?.is_linked">
+                                        <span class="plugin-linked">&#10003; Linked</span>
+                                    </template>
+                                    <template x-if="!$store.projects.selectedProject.plugin_symlink_status?.is_linked">
+                                        <span class="plugin-unlinked">Not linked</span>
+                                    </template>
+                                </span>
+                            </div>
+                            <template x-if="$store.projects.selectedProject.plugin_symlink_status?.is_linked">
+                                <div class="git-status-row">
+                                    <span class="git-status-label">Path</span>
+                                    <span class="git-status-value git-url" x-text="$store.projects.selectedProject.plugin_symlink_status?.symlink_path"></span>
+                                </div>
+                            </template>
+                            <div class="git-status-row">
+                                <span class="git-status-label"></span>
+                                <div style="display:flex;gap:0.5em;">
+                                    <template x-if="!$store.projects.selectedProject.plugin_symlink_status?.is_linked">
+                                        <button class="btn btn-primary btn-sm" @click="$store.projects.linkPlugin()">Link as Plugin</button>
+                                    </template>
+                                    <template x-if="$store.projects.selectedProject.plugin_symlink_status?.is_linked">
+                                        <div style="display:flex;gap:0.5em;">
+                                            <button class="btn btn-secondary btn-sm" @click="$store.projects.unlinkPlugin()">Unlink</button>
+                                            <button class="btn btn-primary btn-sm" disabled>&#10003; Linked</button>
+                                        </div>
+                                    </template>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </template>
             </div>
 
 

--- a/webui/components/projects/projects-store.js
+++ b/webui/components/projects/projects-store.js
@@ -99,7 +99,7 @@ const model = {
   },
 
   async openEditModal(name) {
-    this.selectedProject = await this._createEditProjectData(name);
+    this.selectedProject = await this._createEditProjectData(name)
     await modals.openModal(editModal);
     this.selectedProject = null;
   },
@@ -522,6 +522,100 @@ const model = {
         message: "Error testing file structure",
         priority: shortcuts.NotificationPriority.NORMAL,
         displayTime: 3,
+        frontendOnly: true,
+      });
+    }
+  },
+
+  async linkPlugin() {
+    const project = this.selectedProject;
+    if (!project) return;
+    const pluginDir = project.plugin_symlink_status?.plugin_dir
+      || project.plugin_symlink_status?.default_plugin_dir;
+    if (!pluginDir) {
+      shortcuts.frontendNotification({
+        type: shortcuts.NotificationType.ERROR,
+        message: "Plugin dir name is required",
+        priority: shortcuts.NotificationPriority.NORMAL,
+        displayTime: 3,
+        group: "plugin_link",
+        frontendOnly: true,
+      });
+      return;
+    }
+    try {
+      const response = await api.callJsonApi("projects", {
+        action: "symlink_plugin",
+        name: project.name,
+        plugin_dir: pluginDir,
+      });
+      if (response?.ok) {
+        project.plugin_symlink_status = response.data;
+        shortcuts.frontendNotification({
+          type: shortcuts.NotificationType.SUCCESS,
+          message: "Plugin linked successfully",
+          priority: shortcuts.NotificationPriority.NORMAL,
+          displayTime: 3,
+          group: "plugin_link",
+          frontendOnly: true,
+        });
+      } else {
+        shortcuts.frontendNotification({
+          type: shortcuts.NotificationType.ERROR,
+          message: response?.error || "Failed to link plugin",
+          priority: shortcuts.NotificationPriority.NORMAL,
+          displayTime: 5,
+          group: "plugin_link",
+          frontendOnly: true,
+        });
+      }
+    } catch (error) {
+      shortcuts.frontendNotification({
+        type: shortcuts.NotificationType.ERROR,
+        message: "Error linking plugin: " + error,
+        priority: shortcuts.NotificationPriority.NORMAL,
+        displayTime: 5,
+        group: "plugin_link",
+        frontendOnly: true,
+      });
+    }
+  },
+
+  async unlinkPlugin() {
+    const project = this.selectedProject;
+    if (!project) return;
+    try {
+      const response = await api.callJsonApi("projects", {
+        action: "unsymlink_plugin",
+        name: project.name,
+      });
+      if (response?.ok) {
+        project.plugin_symlink_status = response.data;
+        shortcuts.frontendNotification({
+          type: shortcuts.NotificationType.SUCCESS,
+          message: "Plugin unlinked successfully",
+          priority: shortcuts.NotificationPriority.NORMAL,
+          displayTime: 3,
+          group: "plugin_link",
+          frontendOnly: true,
+        });
+      } else {
+        shortcuts.frontendNotification({
+          type: shortcuts.NotificationType.ERROR,
+          message: response?.error || "Failed to unlink plugin",
+          priority: shortcuts.NotificationPriority.NORMAL,
+          displayTime: 5,
+          group: "plugin_link",
+          frontendOnly: true,
+        });
+      }
+    } catch (error) {
+      shortcuts.frontendNotification({
+        type: shortcuts.NotificationType.ERROR,
+        message: "Error unlinking plugin: " + error,
+        priority: shortcuts.NotificationPriority.NORMAL,
+        displayTime: 5,
+        group: "plugin_link",
         frontendOnly: true,
       });
     }


### PR DESCRIPTION
Projects that contain a plugin.yaml can now be linked and unlinked as A0 plugins directly from the Project edit UI, without needing manual terminal symlink operations.

Changes:
- helpers/projects.py: PluginSymlinkStatus TypedDict, get/create/remove symlink helpers, plugin_dir persistence in project.json, plugin cache invalidation on link/unlink
- api/projects.py: symlink_plugin and unsymlink_plugin actions on the existing /api/projects dispatcher
- api/__init__.py: add empty init to make api/ a proper Python package
- project-edit-basic-data.html: Plugin section auto-shown when project has plugin.yaml — displays dir input, linked/unlinked status, path
- projects-store.js: linkPlugin() and unlinkPlugin() store methods with success/error notifications