### PR TITLE
plugins: marketplace redesign, modal polish, and confirm-dialog extension hook

### DIFF
--- a/docs/agents/AGENTS.plugins.md
+++ b/docs/agents/AGENTS.plugins.md
@@ -80,6 +80,8 @@ To contribute:
 ### JS Hooks
 Place *.js files in extensions/webui/<extension_point>/ and export a default async function. They are called via callJsExtensions("<point>", context).
 
+Core JS hooks can also expose runtime UI surfaces when static HTML breakpoints are not a fit. For example, `confirm_dialog_after_render` runs after the shared confirm dialog is built and receives the rendered dialog/body/footer nodes plus any caller-provided `extensionContext`.
+
 ---
 
 ## 4. Plugin Settings

--- a/docs/developer/plugins.md
+++ b/docs/developer/plugins.md
@@ -225,3 +225,8 @@ A built-in **Plugin Marketplace** (always-active plugin) will allow users to bro
 - `docs/agents/AGENTS.plugins.md` for full architecture details
 - `skills/a0-create-plugin/SKILL.md` for plugin authoring workflow (agent-facing)
 - `plugins/README.md` for core plugin directory overview
+
+## Frontend Extension Notes
+
+- HTML breakpoints are preferred when the core template already exposes an `x-extension` anchor.
+- JS hooks are the right fit for runtime-built UI surfaces. For example, `confirm_dialog_after_render` can extend the shared confirm dialog using the supplied DOM nodes and caller `extensionContext`.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -11,7 +11,7 @@ This directory contains the system-level plugins bundled with Agent Zero.
 
 For detailed guides on how to create, extend, or configure plugins, refer to:
 
-- [`docs/agents/AGENTS.plugins.md`](../AGENTS.plugins.md): Full-stack plugin architecture, manifest format, extension points, and Plugin Index submission.
+- [`docs/agents/AGENTS.plugins.md`](../docs/agents/AGENTS.plugins.md): Full-stack plugin architecture, manifest format, extension points, and Plugin Index submission.
 - [`docs/developer/plugins.md`](../docs/developer/plugins.md): Human-facing developer guide covering the full plugin lifecycle.
 - [`AGENTS.md`](../AGENTS.md): Main framework guide and backend context.
 - [`skills/a0-create-plugin/SKILL.md`](../skills/a0-create-plugin/SKILL.md): Agent-facing authoring workflow (local and community plugins).

--- a/plugins/memory/webui/memory-dashboard.html
+++ b/plugins/memory/webui/memory-dashboard.html
@@ -373,7 +373,7 @@
             display: grid;
             grid-template-columns: 35% 25% 10% auto;
             grid-template-rows: auto auto;
-            margin: 1rem 0;
+            margin: 0 0 1rem 0;
         }
 
         /* Grid positioning for desktop - 2 rows */

--- a/plugins/plugin_installer/api/plugin_install.py
+++ b/plugins/plugin_installer/api/plugin_install.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
+import logging
 import time
+import urllib.request
 import uuid
 from pathlib import Path
 
@@ -8,7 +11,6 @@ from helpers.api import ApiHandler, Input, Request, Output
 from helpers import files
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
-
 
 class PluginInstall(ApiHandler):
     """Plugin installation API. Handles ZIP upload, Git clone, and index fetch."""
@@ -64,10 +66,45 @@ class PluginInstall(ApiHandler):
     def _fetch_index(self, input: dict) -> dict:
         from plugins.plugin_installer.helpers.install import fetch_plugin_index
         from helpers.plugins import get_plugins_list
+
         index_data = fetch_plugin_index()
-        installed = get_plugins_list()
-        return {
-            "success": True,
-            "index": index_data,
-            "installed_plugins": installed,
-        }
+        plugins = index_data.get("plugins", {})
+        installed_dirs = set(get_plugins_list())
+
+        def _dir_name(github: str) -> str:
+            seg = (github or "").rstrip("/").split("/")[-1]
+            return seg[:-4] if seg.endswith(".git") else seg
+
+        installed_keys = [
+            key for key, p in plugins.items()
+            if _dir_name(p.get("github", "")) in installed_dirs
+        ]
+
+        if all(plugin.get("discussion") for plugin in plugins.values()):
+            return {"success": True, "index": index_data, "installed_plugins": installed_keys}
+
+        try:
+            req = urllib.request.Request(
+                "https://api.github.com/repos/agent0ai/a0-plugins/discussions?per_page=100",
+                headers={
+                    "User-Agent": "AgentZero",
+                    "Accept": "application/vnd.github+json",
+                },
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                discussions = json.loads(resp.read().decode())
+
+            for discussion in discussions:
+                title = discussion.get("title", "")
+                if not title.startswith("Plugin: "):
+                    continue
+
+                key = title[len("Plugin: "):]
+                if key in plugins and not plugins[key].get("discussion"):
+                    plugins[key]["discussion"] = discussion["html_url"]
+        except Exception as e:
+            logging.getLogger(__name__).warning(
+                "Failed to augment plugin index discussions: %s", e
+            )
+
+        return {"success": True, "index": index_data, "installed_plugins": installed_keys}

--- a/plugins/plugin_installer/api/plugin_install.py
+++ b/plugins/plugin_installer/api/plugin_install.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import time
-import uuid
-from pathlib import Path
-
-from helpers.api import ApiHandler, Input, Request, Output
-from helpers import files
+from helpers.api import ApiHandler, Input, Output, Request
 from werkzeug.datastructures import FileStorage
-from werkzeug.utils import secure_filename
+
+from plugins.plugin_installer.helpers.install import (
+    get_marketplace_index,
+    install_from_git,
+    install_uploaded_zip,
+)
 
 class PluginInstall(ApiHandler):
     """Plugin installation API. Handles ZIP upload, Git clone, and index fetch."""
@@ -37,19 +37,7 @@ class PluginInstall(ApiHandler):
         if not plugin_file.filename:
             return {"success": False, "error": "No file selected"}
 
-        # Save upload to temp
-        tmp_dir = Path(files.get_abs_path("tmp", "plugin_uploads"))
-        tmp_dir.mkdir(parents=True, exist_ok=True)
-        base = secure_filename(plugin_file.filename)
-        if not base.lower().endswith(".zip"):
-            base = f"{base}.zip"
-        unique = uuid.uuid4().hex[:8]
-        stamp = time.strftime("%Y%m%d_%H%M%S")
-        tmp_path = str(tmp_dir / f"plugin_{stamp}_{unique}_{base}")
-        plugin_file.save(tmp_path)
-
-        from plugins.plugin_installer.helpers.install import install_from_zip
-        return install_from_zip(tmp_path)
+        return install_uploaded_zip(plugin_file)
 
     def _install_git(self, input: dict) -> dict:
         git_url = (input.get("git_url", "") or "").strip()
@@ -57,24 +45,7 @@ class PluginInstall(ApiHandler):
         if not git_url:
             return {"success": False, "error": "Git URL is required"}
 
-        from plugins.plugin_installer.helpers.install import install_from_git
         return install_from_git(git_url, git_token)
 
     def _fetch_index(self, input: dict) -> dict:
-        from plugins.plugin_installer.helpers.install import fetch_plugin_index
-        from helpers.plugins import get_plugins_list
-
-        index_data = fetch_plugin_index()
-        plugins = index_data.get("plugins", {})
-        installed_dirs = set(get_plugins_list())
-
-        def _dir_name(github: str) -> str:
-            seg = (github or "").rstrip("/").split("/")[-1]
-            return seg[:-4] if seg.endswith(".git") else seg
-
-        installed_keys = [
-            key for key, p in plugins.items()
-            if _dir_name(p.get("github", "")) in installed_dirs
-        ]
-
-        return {"success": True, "index": index_data, "installed_plugins": installed_keys}
+        return {"success": True, **get_marketplace_index()}

--- a/plugins/plugin_installer/api/plugin_install.py
+++ b/plugins/plugin_installer/api/plugin_install.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import json
-import logging
 import time
-import urllib.request
 import uuid
 from pathlib import Path
 
@@ -79,32 +76,5 @@ class PluginInstall(ApiHandler):
             key for key, p in plugins.items()
             if _dir_name(p.get("github", "")) in installed_dirs
         ]
-
-        if all(plugin.get("discussion") for plugin in plugins.values()):
-            return {"success": True, "index": index_data, "installed_plugins": installed_keys}
-
-        try:
-            req = urllib.request.Request(
-                "https://api.github.com/repos/agent0ai/a0-plugins/discussions?per_page=100",
-                headers={
-                    "User-Agent": "AgentZero",
-                    "Accept": "application/vnd.github+json",
-                },
-            )
-            with urllib.request.urlopen(req, timeout=10) as resp:
-                discussions = json.loads(resp.read().decode())
-
-            for discussion in discussions:
-                title = discussion.get("title", "")
-                if not title.startswith("Plugin: "):
-                    continue
-
-                key = title[len("Plugin: "):]
-                if key in plugins and not plugins[key].get("discussion"):
-                    plugins[key]["discussion"] = discussion["html_url"]
-        except Exception as e:
-            logging.getLogger(__name__).warning(
-                "Failed to augment plugin index discussions: %s", e
-            )
 
         return {"success": True, "index": index_data, "installed_plugins": installed_keys}

--- a/plugins/plugin_installer/helpers/install.py
+++ b/plugins/plugin_installer/helpers/install.py
@@ -1,23 +1,53 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import time
+import urllib.request
+import uuid
 import zipfile
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from helpers import files
+from helpers import yaml as yaml_helper
 from helpers.plugins import (
     META_FILE_NAME,
     PluginMetadata,
+    get_plugins_list,
     invalidate_plugin_cache,
 )
-from helpers import yaml as yaml_helper
+from werkzeug.datastructures import FileStorage
+from werkzeug.utils import secure_filename
 
 def _get_user_plugins_dir() -> str:
     """Return absolute path to usr/plugins/."""
     return files.get_abs_path(files.USER_DIR, files.PLUGINS_DIR)
+
+
+def _derive_git_plugin_name(url: str) -> str:
+    """Derive the canonical plugin ID from a Git repository URL."""
+    repo_name = url.rstrip("/").split("/")[-1]
+    if repo_name.endswith(".git"):
+        repo_name = repo_name[:-4]
+    if not repo_name:
+        raise ValueError("Could not derive plugin name from URL")
+    return repo_name
+
+
+def _derive_zip_plugin_name(
+    plugin_root: str, extract_dir: str, original_filename: str | None
+) -> str:
+    """Resolve the plugin ID for an uploaded ZIP archive."""
+    if plugin_root != extract_dir:
+        return os.path.basename(plugin_root)
+
+    upload_name = Path((original_filename or "").strip()).name
+    plugin_name = Path(upload_name).stem
+    if not plugin_name:
+        raise ValueError("Could not derive plugin name from uploaded filename")
+    return plugin_name
 
 
 def validate_plugin_dir(path: str) -> PluginMetadata:
@@ -48,7 +78,28 @@ def _find_plugin_root(extracted_dir: str) -> str:
     raise ValueError(f"No {META_FILE_NAME} found in the uploaded archive")
 
 
-def install_from_zip(zip_path: str) -> dict:
+def install_uploaded_zip(plugin_file: FileStorage) -> dict:
+    """Persist an uploaded ZIP temporarily and install it."""
+    original_filename = Path((plugin_file.filename or "").strip()).name
+    if not original_filename:
+        raise ValueError("No file selected")
+
+    tmp_dir = Path(files.get_abs_path("tmp", "plugin_uploads"))
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    temp_name = secure_filename(original_filename) or "plugin.zip"
+    if not temp_name.lower().endswith(".zip"):
+        temp_name = f"{temp_name}.zip"
+
+    unique = uuid.uuid4().hex[:8]
+    stamp = time.strftime("%Y%m%d_%H%M%S")
+    tmp_path = str(tmp_dir / f"plugin_{stamp}_{unique}_{temp_name}")
+    plugin_file.save(tmp_path)
+
+    return install_from_zip(tmp_path, original_filename=original_filename)
+
+
+def install_from_zip(zip_path: str, original_filename: str | None = None) -> dict:
     """Extract ZIP, find plugin.yaml, move its parent to usr/plugins/.
     Returns dict with plugin name and metadata.
     Cleans up tmp files regardless of outcome."""
@@ -74,13 +125,7 @@ def install_from_zip(zip_path: str) -> dict:
         # Find plugin.yaml
         plugin_root = _find_plugin_root(extract_dir)
         meta = validate_plugin_dir(plugin_root)
-        plugin_name = os.path.basename(plugin_root)
-
-        # If the zip only has one top-level dir that IS the plugin root,
-        # use that dir's name. Otherwise use the zip's stem.
-        if plugin_root == extract_dir:
-            # plugin.yaml at root of extraction — use zip filename stem
-            plugin_name = Path(zip_path).stem
+        plugin_name = _derive_zip_plugin_name(plugin_root, extract_dir, original_filename)
 
         check_plugin_conflict(plugin_name)
 
@@ -110,12 +155,7 @@ def install_from_git(url: str, token: Optional[str] = None) -> dict:
     Returns dict with plugin name and metadata."""
     from helpers.git import clone_repo
 
-    # Derive plugin name from URL
-    repo_name = url.rstrip("/").split("/")[-1]
-    if repo_name.endswith(".git"):
-        repo_name = repo_name[:-4]
-    if not repo_name:
-        raise ValueError("Could not derive plugin name from URL")
+    repo_name = _derive_git_plugin_name(url)
 
     check_plugin_conflict(repo_name)
 
@@ -146,11 +186,34 @@ def install_from_git(url: str, token: Optional[str] = None) -> dict:
     }
 
 
+def get_marketplace_index() -> dict[str, Any]:
+    """Return the plugin index plus installed marketplace keys."""
+    index_data = fetch_plugin_index()
+    if not isinstance(index_data, dict):
+        raise ValueError("Plugin index response was not a JSON object")
+
+    plugins = index_data.get("plugins")
+    if not isinstance(plugins, dict):
+        raise ValueError("Plugin index payload is missing a valid 'plugins' map")
+
+    installed_dirs = set(get_plugins_list())
+    installed_keys: list[str] = []
+    for key, plugin_data in plugins.items():
+        if not isinstance(plugin_data, dict):
+            continue
+        github_url = plugin_data.get("github", "")
+        try:
+            plugin_name = _derive_git_plugin_name(github_url)
+        except ValueError:
+            continue
+        if plugin_name in installed_dirs:
+            installed_keys.append(key)
+
+    return {"index": index_data, "installed_plugins": installed_keys}
+
+
 def fetch_plugin_index() -> dict:
     """Download the plugin index from GitHub releases."""
-    import urllib.request
-    import json
-
     index_url = "https://github.com/agent0ai/a0-plugins/releases/download/generated-index/index.json"
     req = urllib.request.Request(index_url, headers={"User-Agent": "AgentZero"})
     with urllib.request.urlopen(req, timeout=30) as resp:

--- a/plugins/plugin_installer/helpers/install.py
+++ b/plugins/plugin_installer/helpers/install.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import re
 import shutil
 import time
 import zipfile
@@ -16,26 +15,9 @@ from helpers.plugins import (
 )
 from helpers import yaml as yaml_helper
 
-_SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_]*$")
-
-
 def _get_user_plugins_dir() -> str:
     """Return absolute path to usr/plugins/."""
     return files.get_abs_path(files.USER_DIR, files.PLUGINS_DIR)
-
-
-def _sanitize_plugin_name(name: str) -> str:
-    """Validate and sanitize a plugin directory name.
-    Converts dots and dashes to underscores for Python import compatibility.
-    Raises ValueError if the name is unsafe for filesystem use."""
-    name = name.strip().strip(".")
-    name = re.sub(r"[-.]", "_", name)
-    if not name or not _SAFE_NAME_RE.match(name):
-        raise ValueError(
-            f"Invalid plugin name: '{name}'. "
-            "Names must start with a letter or digit and contain only letters, digits, or underscores."
-        )
-    return name
 
 
 def validate_plugin_dir(path: str) -> PluginMetadata:
@@ -100,7 +82,6 @@ def install_from_zip(zip_path: str) -> dict:
             # plugin.yaml at root of extraction — use zip filename stem
             plugin_name = Path(zip_path).stem
 
-        plugin_name = _sanitize_plugin_name(plugin_name)
         check_plugin_conflict(plugin_name)
 
         # Move to usr/plugins/
@@ -136,7 +117,6 @@ def install_from_git(url: str, token: Optional[str] = None) -> dict:
     if not repo_name:
         raise ValueError("Could not derive plugin name from URL")
 
-    repo_name = _sanitize_plugin_name(repo_name)
     check_plugin_conflict(repo_name)
 
     dest = os.path.join(_get_user_plugins_dir(), repo_name)

--- a/plugins/plugin_installer/webui/install-detail.html
+++ b/plugins/plugin_installer/webui/install-detail.html
@@ -28,41 +28,35 @@
                                 <div class="pi-hero-manage">
                                     <template x-if="$store.pluginInstallStore.installedPluginInfo.has_main_screen">
                                         <button type="button" class="button"
-                                            title="Open"
                                             @click="$store.pluginInstallStore.manageOpenPlugin()">
                                             <span class="icon material-symbols-outlined">dashboard</span> Open
                                         </button>
                                     </template>
                                     <template x-if="$store.pluginInstallStore.installedPluginInfo.has_config_screen">
                                         <button type="button" class="button"
-                                            title="Config"
                                             @click="$store.pluginInstallStore.manageOpenConfig()">
                                             <span class="icon material-symbols-outlined">settings</span> Config
                                         </button>
                                     </template>
                                     <template x-if="$store.pluginInstallStore.installedPluginInfo.has_readme">
                                         <button type="button" class="button"
-                                            title="README"
                                             @click="$store.pluginInstallStore.manageOpenDoc('readme')">
                                             <span class="icon material-symbols-outlined">description</span> README
                                         </button>
                                     </template>
                                     <template x-if="$store.pluginInstallStore.installedPluginInfo.has_license">
                                         <button type="button" class="button"
-                                            title="LICENSE"
                                             @click="$store.pluginInstallStore.manageOpenDoc('license')">
                                             <span class="icon material-symbols-outlined">gavel</span> License
                                         </button>
                                     </template>
                                     <template x-if="$store.pluginInstallStore.installedPluginInfo.has_init_script">
                                         <button type="button" class="button"
-                                            title="Run initializer script"
                                             @click="$store.pluginInstallStore.manageOpenInit()">
                                             <span class="icon material-symbols-outlined">terminal</span> Init
                                         </button>
                                     </template>
                                     <button type="button" class="button"
-                                        title="Info"
                                         @click="$store.pluginInstallStore.manageOpenInfo()">
                                         <span class="icon material-symbols-outlined">info</span> Info
                                     </button>
@@ -323,12 +317,8 @@
         }
 
         .pi-tag {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.4rem;
-        }
-
-        .pi-tag {
+            display: inline-flex;
+            align-items: center;
             font-size: 0.8rem;
             padding: 0.25rem 0.6rem;
             border-radius: 4px;

--- a/plugins/plugin_installer/webui/install-detail.html
+++ b/plugins/plugin_installer/webui/install-detail.html
@@ -8,24 +8,86 @@
 <body>
     <div x-data>
         <template x-if="$store.pluginInstallStore?.selectedPlugin">
-            <div>
-                <div class="pi-detail-header">
-                    <div class="pi-detail-thumb">
-                        <template x-if="$store.pluginInstallStore.selectedPlugin.thumbnail">
-                            <img :src="$store.pluginInstallStore.selectedPlugin.thumbnail"
-                                :alt="$store.pluginInstallStore.selectedPlugin.title">
+            <div class="pi-detail-container"
+                 x-destroy="$store.pluginInstallStore.refreshPluginList()">
+                <div class="pi-hero">
+                    <div class="pi-hero-thumb">
+                        <template x-if="$store.pluginInstallStore.getDetailThumbnailUrl()">
+                            <img :src="$store.pluginInstallStore.getDetailThumbnailUrl()"
+                                :alt="$store.pluginInstallStore.selectedPlugin.title"
+                                @error="$store.pluginInstallStore.nextDetailThumbnail()">
                         </template>
-                        <template x-if="!$store.pluginInstallStore.selectedPlugin.thumbnail">
-                            <span class="material-symbols-outlined pi-detail-placeholder">extension</span>
+                        <template x-if="!$store.pluginInstallStore.getDetailThumbnailUrl()">
+                            <span class="material-symbols-outlined pi-hero-placeholder">extension</span>
                         </template>
                     </div>
-                    <div class="pi-detail-info">
-                        <h3 class="pi-detail-title" x-text="$store.pluginInstallStore.selectedPlugin.title || $store.pluginInstallStore.selectedPlugin.key"></h3>
-                        <div class="pi-detail-stars">
-                            <span class="material-symbols-outlined" style="font-size:1rem">star</span>
-                            <span x-text="($store.pluginInstallStore.selectedPlugin.stars || 0) + ' stars'"></span>
+                    <div class="pi-hero-info">
+                        <div class="pi-hero-title-row">
+                            <h2 class="pi-hero-title" x-text="$store.pluginInstallStore.selectedPlugin.title || $store.pluginInstallStore.selectedPlugin.key"></h2>
+                            <template x-if="$store.pluginInstallStore.selectedPlugin.installed && $store.pluginInstallStore.installedPluginInfo">
+                                <div class="pi-hero-manage">
+                                    <template x-if="$store.pluginInstallStore.installedPluginInfo.has_main_screen">
+                                        <button type="button" class="button"
+                                            title="Open"
+                                            @click="$store.pluginInstallStore.manageOpenPlugin()">
+                                            <span class="icon material-symbols-outlined">dashboard</span> Open
+                                        </button>
+                                    </template>
+                                    <template x-if="$store.pluginInstallStore.installedPluginInfo.has_config_screen">
+                                        <button type="button" class="button"
+                                            title="Config"
+                                            @click="$store.pluginInstallStore.manageOpenConfig()">
+                                            <span class="icon material-symbols-outlined">settings</span> Config
+                                        </button>
+                                    </template>
+                                    <template x-if="$store.pluginInstallStore.installedPluginInfo.has_readme">
+                                        <button type="button" class="button"
+                                            title="README"
+                                            @click="$store.pluginInstallStore.manageOpenDoc('readme')">
+                                            <span class="icon material-symbols-outlined">description</span> README
+                                        </button>
+                                    </template>
+                                    <template x-if="$store.pluginInstallStore.installedPluginInfo.has_license">
+                                        <button type="button" class="button"
+                                            title="LICENSE"
+                                            @click="$store.pluginInstallStore.manageOpenDoc('license')">
+                                            <span class="icon material-symbols-outlined">gavel</span> License
+                                        </button>
+                                    </template>
+                                    <template x-if="$store.pluginInstallStore.installedPluginInfo.has_init_script">
+                                        <button type="button" class="button"
+                                            title="Run initializer script"
+                                            @click="$store.pluginInstallStore.manageOpenInit()">
+                                            <span class="icon material-symbols-outlined">terminal</span> Init
+                                        </button>
+                                    </template>
+                                    <button type="button" class="button"
+                                        title="Info"
+                                        @click="$store.pluginInstallStore.manageOpenInfo()">
+                                        <span class="icon material-symbols-outlined">info</span> Info
+                                    </button>
+                                </div>
+                            </template>
                         </div>
-                        <div class="pi-detail-tags" x-show="$store.pluginInstallStore.selectedPlugin.tags?.length">
+                        <template x-if="$store.pluginInstallStore.selectedPlugin.installed">
+                            <div class="pi-installed-badge-simple">
+                                <span class="material-symbols-outlined">check_circle</span>
+                                <span>Installed</span>
+                            </div>
+                        </template>
+                        <div class="pi-hero-meta">
+                            <template x-if="$store.pluginInstallStore.selectedPlugin.author">
+                                <span class="pi-hero-author">
+                                    <span class="pi-hero-label">Author</span>
+                                    <span x-text="$store.pluginInstallStore.selectedPlugin.author"></span>
+                                </span>
+                            </template>
+                            <span class="pi-hero-stars">
+                                <span class="material-symbols-outlined">star</span>
+                                <span x-text="($store.pluginInstallStore.selectedPlugin.stars || 0)"></span>
+                            </span>
+                        </div>
+                        <div class="pi-hero-tags" x-show="$store.pluginInstallStore.selectedPlugin.tags?.length">
                             <template x-for="tag in $store.pluginInstallStore.selectedPlugin.tags || []" :key="tag">
                                 <span class="pi-tag" x-text="tag"></span>
                             </template>
@@ -33,105 +95,94 @@
                     </div>
                 </div>
 
-                <div class="pi-detail-desc" x-text="$store.pluginInstallStore.selectedPlugin.description || 'No description available.'"></div>
-
-                <div class="pi-detail-links">
-                    <template x-if="$store.pluginInstallStore.selectedPlugin.github">
-                        <a :href="$store.pluginInstallStore.selectedPlugin.github" target="_blank" class="pi-link">
-                            <span class="material-symbols-outlined pi-link-icon">code</span>
-                            <span class="pi-link-text">GitHub Repository</span>
-                        </a>
-                    </template>
-                    <template x-if="$store.pluginInstallStore.selectedPlugin.discussion">
-                        <a :href="$store.pluginInstallStore.selectedPlugin.discussion" target="_blank" class="pi-link">
-                            <span class="material-symbols-outlined pi-link-icon">forum</span>
-                            <span class="pi-link-text">Discussion</span>
-                        </a>
-                    </template>
+                <div class="pi-screenshots-section"
+                     x-show="$store.pluginInstallStore.selectedPlugin.screenshots?.length">
+                    <div class="pi-screenshots-header">Screenshots</div>
+                    <div class="pi-screenshots-grid">
+                        <template x-for="(url, i) in ($store.pluginInstallStore.selectedPlugin.screenshots || [])" :key="i">
+                            <img class="pi-screenshot-thumb"
+                                 :src="url"
+                                 :alt="$store.pluginInstallStore.selectedPlugin.title + ' screenshot ' + (i + 1)"
+                                 @click="$store.imageViewer.open(url, { name: $store.pluginInstallStore.selectedPlugin.title })">
+                        </template>
+                    </div>
                 </div>
 
-                <div class="pi-detail-actions">
-                    <template x-if="$store.pluginInstallStore.selectedPlugin.installed">
-                        <div>
-                            <div class="pi-installed-badge-row">
-                                <span class="material-symbols-outlined pi-installed-check">check_circle</span>
-                                <span class="pi-installed-label">Installed</span>
-                            </div>
+                <div class="pi-description" x-text="$store.pluginInstallStore.selectedPlugin.description || 'No description available.'"></div>
 
-                            <div x-show="$store.pluginInstallStore.installedPluginInfoLoading" class="pi-loading-inline">
-                                Loading plugin info...
-                            </div>
-
-                            <template x-if="$store.pluginInstallStore.installedPluginInfo">
-                                <div class="pi-manage-actions">
-                                    <template x-if="$store.pluginInstallStore.installedPluginInfo.has_main_screen">
-                                        <button type="button" class="button"
-                                            @click="$store.pluginInstallStore.manageOpenPlugin()">
-                                            <span class="icon material-symbols-outlined">dashboard</span> Open
-                                        </button>
-                                    </template>
-                                    <template x-if="$store.pluginInstallStore.installedPluginInfo.has_config_screen">
-                                        <button type="button" class="button"
-                                            @click="$store.pluginInstallStore.manageOpenConfig()">
-                                            <span class="icon material-symbols-outlined">settings</span> Config
-                                        </button>
-                                    </template>
-                                    <template x-if="$store.pluginInstallStore.installedPluginInfo.has_readme">
-                                        <button type="button" class="button"
-                                            @click="$store.pluginInstallStore.manageOpenDoc('readme')">
-                                            <span class="icon material-symbols-outlined">description</span> README
-                                        </button>
-                                    </template>
-                                    <template x-if="$store.pluginInstallStore.installedPluginInfo.has_license">
-                                        <button type="button" class="button"
-                                            @click="$store.pluginInstallStore.manageOpenDoc('license')">
-                                            <span class="icon material-symbols-outlined">gavel</span> License
-                                        </button>
-                                    </template>
-                                    <button type="button" class="button"
-                                        @click="$store.pluginInstallStore.manageOpenInfo()">
-                                        <span class="icon material-symbols-outlined">info</span> Info
-                                    </button>
-                                    <template x-if="$store.pluginInstallStore.installedPluginInfo.is_custom">
-                                        <button type="button" class="button cancel"
-                                            @click="$confirmClick($event, () => $store.pluginInstallStore.manageDeletePlugin())">
-                                            <span class="icon material-symbols-outlined">delete</span> Delete
-                                        </button>
-                                    </template>
-                                </div>
-                            </template>
-                        </div>
-                    </template>
+                <div class="pi-actions-primary">
                     <template x-if="!$store.pluginInstallStore.selectedPlugin.installed">
-                        <button class="button confirm"
+                        <button class="pi-btn-install"
                             @click="$store.pluginInstallStore.installFromIndex($store.pluginInstallStore.selectedPlugin)"
                             :disabled="$store.pluginInstallStore.loading">
                             <template x-if="$store.pluginInstallStore.loading">
-                                <span class="pi-button-loading">
+                                <span class="pi-btn-loading">
                                     <span class="spinner"></span>
                                     <span x-text="$store.pluginInstallStore.loadingMessage || 'Installing...'"></span>
                                 </span>
                             </template>
                             <template x-if="!$store.pluginInstallStore.loading">
-                                <span>
-                                    <span class="icon material-symbols-outlined">download</span> Install Plugin
-                                </span>
+                                <span class="material-symbols-outlined">download</span>
+                            </template>
+                            <template x-if="!$store.pluginInstallStore.loading">
+                                <span>Install</span>
                             </template>
                         </button>
                     </template>
+                    <template x-if="$store.pluginInstallStore.selectedPlugin.installed && $store.pluginInstallStore.installedPluginInfo?.is_custom">
+                        <button type="button" class="pi-btn-uninstall"
+                            @click="$confirmClick($event, () => $store.pluginInstallStore.manageDeletePlugin())">
+                            <span class="material-symbols-outlined">delete</span>
+                            <span>Uninstall</span>
+                        </button>
+                    </template>
+                    <template x-if="$store.pluginInstallStore.selectedPlugin.discussion">
+                        <a :href="$store.pluginInstallStore.selectedPlugin.discussion" target="_blank" class="pi-btn-discussion">
+                            <span class="material-symbols-outlined">forum</span>
+                            <span>Join Discussion</span>
+                        </a>
+                    </template>
                 </div>
 
-                <div x-show="$store.pluginInstallStore.error" class="pi-error">
+                <div x-show="$store.pluginInstallStore.error" class="pi-message pi-message-error">
                     <span x-text="$store.pluginInstallStore.error"></span>
                 </div>
 
-                <div x-show="$store.pluginInstallStore.result" class="pi-result">
-                    <div class="pi-result-icon">
-                        <span class="material-symbols-outlined">check_circle</span>
+                <div class="pi-readme-section" x-show="$store.pluginInstallStore.readmeContent || $store.pluginInstallStore.readmeLoading">
+                    <div class="pi-readme-header">Readme</div>
+                    <div x-show="$store.pluginInstallStore.readmeLoading" class="pi-loading-text">
+                        Loading readme...
                     </div>
-                    <div class="pi-result-text">
-                        <strong>Plugin installed successfully!</strong>
-                        <div class="pi-result-path" x-text="$store.pluginInstallStore.result?.path || ''"></div>
+                    <div x-show="$store.pluginInstallStore.readmeContent && !$store.pluginInstallStore.readmeLoading"
+                         class="pi-readme-content" x-html="$store.pluginInstallStore.readmeContent"></div>
+                </div>
+
+                <div class="pi-developer-section">
+                    <div class="pi-developer-header">Plugin Code</div>
+                    <div class="pi-developer-links">
+                        <template x-if="$store.pluginInstallStore.selectedPlugin.github">
+                            <a :href="$store.pluginInstallStore.selectedPlugin.github" target="_blank" class="pi-dev-link">
+                                <span class="material-symbols-outlined">code</span>
+                                <span>GitHub Repository</span>
+                            </a>
+                        </template>
+                        <template x-if="$store.pluginInstallStore.selectedPlugin.key">
+                            <a :href="$store.pluginInstallStore.getIndexUrl($store.pluginInstallStore.selectedPlugin.key)" target="_blank" class="pi-dev-link">
+                                <span class="material-symbols-outlined">inventory_2</span>
+                                <span>Plugin Index</span>
+                            </a>
+                        </template>
+                    </div>
+                </div>
+            </div>
+        </template>
+
+        <template x-if="$store.pluginInstallStore?.selectedPlugin">
+            <div class="modal-footer pi-footer" data-modal-footer>
+                <div class="buttons-container">
+                    <div class="buttons-left"></div>
+                    <div class="buttons-right">
+                        <button class="btn btn-cancel" @click="window.closeModal?.()">Close</button>
                     </div>
                 </div>
             </div>
@@ -139,190 +190,522 @@
     </div>
 
     <style>
-        .pi-detail-header {
-            display: flex;
-            gap: 1rem;
-            margin-bottom: 1rem;
+        .pi-detail-container {
+            padding: 1rem;
+            margin: 0 auto;
         }
 
-        .pi-detail-thumb {
-            width: 100px;
-            height: 100px;
-            border-radius: 8px;
+        .pi-hero {
+            display: flex;
+            align-items: flex-start;
+            gap: 1.5rem;
+            margin-bottom: 1.25rem;
+        }
+
+        .pi-hero-thumb {
+            width: 120px;
+            height: 120px;
+            border-radius: 12px;
             overflow: hidden;
             flex-shrink: 0;
             display: flex;
             align-items: center;
             justify-content: center;
             background: var(--color-panel);
-        }
-
-        .pi-detail-thumb img {
-            width: 100%;
-            height: 100%;
-            object-fit: contain;
-        }
-
-        .pi-detail-placeholder {
-            font-size: 4rem;
-            color: var(--color-text-muted);
-        }
-
-        .pi-detail-info {
-            flex: 1;
-        }
-
-        .pi-detail-title {
-            margin: 0 0 0.3rem 0;
-            font-size: 1.2rem;
-        }
-
-        .pi-detail-stars {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.25rem;
-            font-size: 0.9rem;
-            color: var(--color-text-secondary);
-            margin-bottom: 0.4rem;
-        }
-
-        .pi-detail-tags {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.3rem;
-        }
-
-        .pi-tag {
-            font-size: 0.75rem;
-            padding: 0.15rem 0.5rem;
-            border-radius: 3px;
-            background: var(--color-panel);
-            color: var(--color-text-secondary);
             border: 1px solid var(--color-border);
         }
 
-        .pi-detail-desc {
-            color: var(--color-text-primary);
-            font-size: 0.95rem;
-            line-height: 1.5;
-            margin-bottom: 1rem;
+        .pi-hero-thumb img {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+            padding: 0.5rem;
         }
 
-        .pi-detail-links {
+        .pi-hero-placeholder {
+            font-size: 5rem;
+            color: var(--color-text-muted);
+        }
+
+        .pi-hero-info {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .pi-hero-title-row {
             display: flex;
-            gap: 1rem;
-            margin-bottom: 1rem;
-        }
-
-        .pi-link {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.3rem;
-            text-decoration: none;
-            font-size: 0.9rem;
-        }
-
-        .pi-link-icon {
-            color: var(--color-highlight);
-            display: inline-block;
-            font-size: 1.1rem;
-            flex-shrink: 0;
-        }
-
-        .pi-link-text {
-            color: var(--color-highlight);
-        }
-
-        .pi-link:hover .pi-link-text {
-            text-decoration: underline;
-            text-underline-offset: 2px;
-        }
-
-        .pi-detail-actions {
-            margin: 1rem 0;
-        }
-
-        .pi-button-loading {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
-
-        .pi-error {
-            color: var(--color-error);
-            padding: 0.75rem;
-            background: var(--color-error-bg, rgba(239,68,68,0.1));
-            border-radius: 4px;
-            margin-top: 0.75rem;
-        }
-
-        .pi-result {
-            display: flex;
-            align-items: center;
+            align-items: flex-start;
+            justify-content: space-between;
             gap: 0.75rem;
-            padding: 0.75rem;
-            background: rgba(34,197,94,0.1);
-            border: 1px solid rgba(34,197,94,0.3);
-            border-radius: 4px;
-            margin-top: 0.75rem;
+            margin-bottom: 0.5rem;
         }
 
-        .pi-result-icon .material-symbols-outlined {
-            font-size: 2rem;
-            color: #22c55e;
+        .pi-hero-title {
+            margin: 0;
+            font-size: 1.75rem;
+            font-weight: 600;
+            line-height: 1.2;
+            color: var(--color-text-primary);
         }
 
-        .pi-result-path {
-            font-size: 0.85rem;
-            color: var(--color-text-secondary);
-            margin-top: 0.25rem;
-            font-family: var(--font-family-code);
-        }
-
-        .pi-installed-badge-row {
+        .pi-hero-manage {
             display: flex;
             align-items: center;
-            gap: 0.4rem;
-            margin-bottom: 0.75rem;
-        }
-
-        .pi-installed-check {
-            font-size: 1.3rem;
-            color: #22c55e;
-        }
-
-        .pi-installed-label {
-            font-weight: 600;
-            font-size: 0.95rem;
-            color: #22c55e;
-        }
-
-        .pi-manage-actions {
-            display: flex;
-            flex-wrap: wrap;
             gap: 0.5rem;
+            flex-wrap: wrap;
+            flex-shrink: 0;
+            justify-content: flex-end;
         }
 
-        .pi-manage-actions .button {
+        .pi-hero-manage .button {
             padding: 0.3rem 0.6rem;
             font-size: 0.9rem;
         }
 
-        .pi-manage-actions .button .icon {
+        .pi-hero-manage .button .icon {
             font-size: 1.1rem;
         }
 
-        .pi-loading-inline {
-            font-size: 0.85rem;
-            color: var(--color-text-secondary);
-            padding: 0.5rem 0;
+        .pi-hero-meta {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            flex-wrap: wrap;
+            margin-bottom: 0.5rem;
         }
 
-        @media (max-width: 500px) {
-            .pi-detail-header {
+        .pi-hero-label {
+            font-size: 0.8rem;
+            color: var(--color-text-muted);
+            margin-right: 0.2rem;
+        }
+
+        .pi-hero-author {
+            font-size: 1rem;
+            color: var(--color-text-secondary);
+            font-weight: 500;
+            display: inline-flex;
+            align-items: baseline;
+            gap: 0.15rem;
+        }
+
+        .pi-hero-stars {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.3rem;
+            font-size: 0.95rem;
+            color: var(--color-text-secondary);
+        }
+
+        .pi-hero-stars .material-symbols-outlined {
+            font-size: 1.1rem;
+            color: #fbbf24;
+        }
+
+        .pi-hero-tags {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.4rem;
+        }
+
+        .pi-installed-badge-simple {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            font-size: 0.9rem;
+            font-weight: 600;
+            color: #22c55e;
+            margin-bottom: 0.35rem;
+        }
+
+        .pi-installed-badge-simple .material-symbols-outlined {
+            font-size: 1.1rem;
+        }
+
+        .pi-tag {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.4rem;
+        }
+
+        .pi-tag {
+            font-size: 0.8rem;
+            padding: 0.25rem 0.6rem;
+            border-radius: 4px;
+            background: var(--color-panel);
+            color: var(--color-text-secondary);
+            border: 1px solid var(--color-border);
+            font-weight: 500;
+        }
+
+        .pi-description {
+            font-size: 1rem;
+            line-height: 1.6;
+            color: var(--color-text-primary);
+            margin-bottom: 1.5rem;
+        }
+
+        .pi-actions-primary {
+            display: flex;
+            gap: 0.75rem;
+            margin-bottom: 1.5rem;
+            flex-wrap: wrap;
+        }
+
+        .pi-btn-install {
+            flex: 1;
+            min-width: 200px;
+            padding: 0.85rem 1.5rem;
+            border: none;
+            border-radius: 8px;
+            background: var(--color-highlight);
+            color: #fff;
+            font-family: 'Rubik';
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+        }
+
+        .pi-btn-install:hover:not(:disabled) {
+            opacity: 0.9;
+            transform: translateY(-1px);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+        }
+
+        .pi-btn-install:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+        }
+
+        .pi-btn-install .material-symbols-outlined {
+            font-size: 1.3rem;
+        }
+
+        .pi-btn-uninstall {
+            flex: 1;
+            min-width: 200px;
+            padding: 0.85rem 1.5rem;
+            border: 2px solid var(--color-accent);
+            border-radius: 8px;
+            background: transparent;
+            color: var(--color-accent);
+            font-family: 'Rubik';
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+        }
+
+        .pi-btn-uninstall:hover {
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+            background: var(--color-accent);
+            color: #fff;
+        }
+
+        .pi-btn-uninstall .material-symbols-outlined {
+            font-size: 1.3rem;
+        }
+
+        .pi-btn-discussion {
+            flex: 1;
+            min-width: 200px;
+            padding: 0.85rem 1.5rem;
+            border: 2px solid var(--color-highlight);
+            border-radius: 8px;
+            background: transparent;
+            color: var(--color-highlight);
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            text-decoration: none;
+        }
+
+        .pi-btn-discussion:hover {
+            background: var(--color-highlight);
+            color: #fff;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+        }
+
+        .pi-btn-discussion .material-symbols-outlined {
+            font-size: 1.3rem;
+        }
+
+        .pi-btn-loading {
+            display: flex;
+            align-items: center;
+            gap: 0.6rem;
+        }
+
+        .pi-loading-text {
+            font-size: 0.9rem;
+            color: var(--color-text-secondary);
+            padding: 0.75rem 0;
+        }
+
+        .pi-message {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            padding: 1rem;
+            border-radius: 8px;
+            margin-bottom: 1rem;
+        }
+
+        .pi-message-error {
+            background: rgba(239,68,68,0.1);
+            border: 1px solid rgba(239,68,68,0.3);
+            color: var(--color-error);
+        }
+
+        .pi-screenshots-section {
+            margin-top: 1.5rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--color-border);
+        }
+
+        .pi-screenshots-header {
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: var(--color-text-muted);
+            margin-bottom: 0.75rem;
+        }
+
+        .pi-screenshots-grid {
+            display: flex;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .pi-screenshot-thumb {
+            height: 120px;
+            flex: 1;
+            min-width: 0;
+            object-fit: cover;
+            border-radius: 8px;
+            cursor: pointer;
+            border: 1px solid var(--color-border);
+            transition: opacity 0.15s;
+        }
+
+        .pi-screenshot-thumb:hover {
+            opacity: 0.8;
+        }
+
+        .pi-readme-section {
+            margin-top: 2rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--color-border);
+        }
+
+        .pi-readme-header {
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: var(--color-text-muted);
+            margin-bottom: 0.75rem;
+        }
+
+        .pi-readme-content {
+            font-size: 0.95rem;
+            line-height: 1.6;
+            color: var(--color-text-primary);
+            overflow-y: auto;
+            padding-right: 0.5rem;
+            scrollbar-width: none;
+            -ms-overflow-style: none;
+        }
+        .pi-readme-content::-webkit-scrollbar {
+            display: none;
+        }
+
+        .pi-readme-content h1,
+        .pi-readme-content h2,
+        .pi-readme-content h3,
+        .pi-readme-content h4 {
+            margin-top: 1rem;
+            margin-bottom: 0.5rem;
+            color: var(--color-text-primary);
+        }
+
+        .pi-readme-content h1 { font-size: 1.5rem; }
+        .pi-readme-content h2 { font-size: 1.25rem; }
+        .pi-readme-content h3 { font-size: 1.1rem; }
+        .pi-readme-content h4 { font-size: 1rem; }
+
+        .pi-readme-content p {
+            margin-bottom: 0.75rem;
+        }
+
+        .pi-readme-content code {
+            background: var(--color-panel);
+            padding: 0.15rem 0.35rem;
+            border-radius: 4px;
+            font-family: var(--font-family-code);
+            font-size: 0.85em;
+        }
+
+        .pi-readme-content pre {
+            background: var(--color-panel);
+            padding: 1rem;
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+
+        .pi-readme-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .pi-readme-content ul,
+        .pi-readme-content ol {
+            margin-bottom: 0.75rem;
+            padding-left: 1.5rem;
+        }
+
+        .pi-readme-content li {
+            margin-bottom: 0.25rem;
+        }
+
+        .pi-readme-content a {
+            color: var(--color-highlight);
+            text-decoration: none;
+        }
+
+        .pi-readme-content a:hover {
+            text-decoration: underline;
+        }
+
+        .pi-readme-content img {
+            max-width: 100%;
+            border-radius: 8px;
+            margin: 0.5rem 0;
+        }
+
+        .pi-readme-content blockquote {
+            border-left: 3px solid var(--color-border);
+            padding-left: 1rem;
+            margin-left: 0;
+            color: var(--color-text-secondary);
+        }
+
+        .pi-readme-content table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 1rem;
+        }
+
+        .pi-readme-content th,
+        .pi-readme-content td {
+            border: 1px solid var(--color-border);
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .pi-readme-content th {
+            background: var(--color-panel);
+        }
+
+        .pi-developer-section {
+            margin-top: 2rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--color-border);
+        }
+
+        .pi-developer-header {
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: var(--color-text-muted);
+            margin-bottom: 0.75rem;
+        }
+
+        .pi-developer-links {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .pi-dev-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.5rem 0;
+            text-decoration: none;
+            font-size: 0.9rem;
+            color: var(--color-text-secondary);
+            transition: color 0.15s;
+        }
+
+        .pi-dev-link:hover {
+            color: var(--color-highlight);
+        }
+
+        .pi-dev-link .material-symbols-outlined {
+            font-size: 1.1rem;
+            color: var(--color-text-muted);
+        }
+
+        .pi-dev-link:hover .material-symbols-outlined {
+            color: var(--color-highlight);
+        }
+
+        .pi-footer .buttons-container {
+            width: 100%;
+        }
+
+        @media (max-width: 600px) {
+            .pi-hero {
                 flex-direction: column;
                 align-items: center;
                 text-align: center;
+            }
+
+            .pi-hero-thumb {
+                width: 100px;
+                height: 100px;
+            }
+
+            .pi-hero-title {
+                font-size: 1.5rem;
+            }
+
+            .pi-hero-title-row {
+                flex-direction: column;
+                align-items: center;
+            }
+
+            .pi-hero-manage {
+                justify-content: center;
+            }
+
+            .pi-hero-meta {
+                justify-content: center;
+            }
+
+            .pi-hero-tags {
+                justify-content: center;
+            }
+
+            .pi-actions-primary {
+                flex-direction: column;
+            }
+
+            .pi-btn-install,
+            .pi-btn-discussion {
+                min-width: 100%;
             }
         }
     </style>

--- a/plugins/plugin_installer/webui/install-git.html
+++ b/plugins/plugin_installer/webui/install-git.html
@@ -8,7 +8,8 @@
 <body>
     <div x-data>
         <template x-if="$store.pluginInstallStore">
-            <div x-init="$store.pluginInstallStore.resetGit()">
+            <div x-init="$store.pluginInstallStore.resetGit()"
+                 x-destroy="$store.pluginInstallStore.refreshPluginList()">
 
                 <div class="pi-form-group">
                     <label class="pi-label">Git Repository URL</label>

--- a/plugins/plugin_installer/webui/install-index.html
+++ b/plugins/plugin_installer/webui/install-index.html
@@ -204,7 +204,7 @@
             flex-shrink: 0;
             padding: 0.6rem 0.85rem;
             border: 1px solid var(--color-border);
-            border-radius: 999px;
+            border-radius: 0.5rem;
             background: var(--color-panel);
             font-size: 0.85rem;
             font-weight: 600;
@@ -286,7 +286,7 @@
             gap: 0.45rem;
             padding: 0.45rem 0.75rem;
             border: 1px solid var(--color-border);
-            border-radius: 999px;
+            border-radius: 0.5rem;
             background: var(--color-panel);
             color: var(--color-text-secondary);
             font-size: 0.85rem;
@@ -308,7 +308,7 @@
 
         .pi-filter-count {
             padding: 0.12rem 0.4rem;
-            border-radius: 999px;
+            border-radius: 0.5rem;
             background: rgba(255, 255, 255, 0.06);
             color: var(--color-text-muted);
             font-size: 0.75rem;
@@ -409,7 +409,7 @@
             top: 0.75rem;
             right: 0.75rem;
             padding: 0.24rem 0.5rem;
-            border-radius: 999px;
+            border-radius: 0.5rem;
             background: rgba(34, 197, 94, 0.15);
             color: #4ade80;
             font-size: 0.72rem;
@@ -487,7 +487,7 @@
 
         .pi-card-tag {
             padding: 0.22rem 0.55rem;
-            border-radius: 999px;
+            border-radius: 0.5rem;
             font-size: 0.75rem;
             font-weight: 600;
             background: var(--color-panel);

--- a/plugins/plugin_installer/webui/install-index.html
+++ b/plugins/plugin_installer/webui/install-index.html
@@ -8,35 +8,73 @@
 <body>
     <div x-data>
         <template x-if="$store.pluginInstallStore">
-            <div x-init="$store.pluginInstallStore.resetIndex(); $store.pluginInstallStore.fetchIndex()">
+            <div class="pi-browse-shell"
+                 x-init="$store.pluginInstallStore.resetIndex(); $store.pluginInstallStore.fetchIndex()"
+                 x-destroy="$store.pluginInstallStore.refreshPluginList()">
 
-                <!-- Search & Sort Bar -->
+                <section class="pi-browse-hero">
+                    <div class="pi-browse-copy">
+                        <div class="pi-browse-eyebrow">Community Marketplace</div>
+                        <h2 class="pi-browse-title">Discover plugins for Agent Zero</h2>
+                        <p class="pi-browse-description">
+                            Browse community plugins, filter by what you already have installed, and open each listing for screenshots, README, and install actions.
+                        </p>
+                    </div>
+                    <div class="pi-browse-summary" x-text="$store.pluginInstallStore.browseResultsSummary"></div>
+                </section>
+
                 <div class="pi-index-toolbar">
-                    <input type="text" class="pi-search-input"
-                        x-model="$store.pluginInstallStore.search"
-                        @input="$store.pluginInstallStore.page = 1"
-                        placeholder="Search plugins...">
-                    <select class="pi-sort-select"
-                        x-model="$store.pluginInstallStore.sortBy">
-                        <option value="stars">Stars</option>
-                        <option value="name">Name</option>
-                    </select>
+                    <label class="pi-search-field">
+                        <span class="material-symbols-outlined">search</span>
+                        <input type="text"
+                            class="pi-search-input"
+                            x-model="$store.pluginInstallStore.search"
+                            @input="$store.pluginInstallStore.page = 1"
+                            placeholder="Search plugins, authors, or tags...">
+                    </label>
+
+                    <label class="pi-sort-field">
+                        <span class="pi-field-label">Sort</span>
+                        <select class="pi-sort-select"
+                            x-model="$store.pluginInstallStore.sortBy">
+                            <option value="stars">Stars</option>
+                            <option value="name">Name</option>
+                        </select>
+                    </label>
                 </div>
 
-                <!-- Loading -->
-                <div x-show="$store.pluginInstallStore.loading" class="pi-loading">
-                    <span x-text="$store.pluginInstallStore.loadingMessage || 'Loading...'"></span>
+                <div class="pi-filter-row" x-show="$store.pluginInstallStore.browseFilters.length > 1">
+                    <template x-for="filter in $store.pluginInstallStore.browseFilters" :key="filter.key">
+                        <button type="button"
+                            class="pi-filter-chip"
+                            :class="{ active: $store.pluginInstallStore.browseFilter === filter.key }"
+                            @click="$store.pluginInstallStore.setBrowseFilter(filter.key)">
+                            <span x-text="filter.label"></span>
+                            <span class="pi-filter-count" x-text="filter.count"></span>
+                        </button>
+                    </template>
                 </div>
 
-                <!-- Error -->
-                <div x-show="$store.pluginInstallStore.error && !$store.pluginInstallStore.loading" class="pi-error">
-                    <span x-text="$store.pluginInstallStore.error"></span>
+                <div x-show="$store.pluginInstallStore.loading" class="pi-state-card pi-state-loading">
+                    <span class="material-symbols-outlined">progress_activity</span>
+                    <div>
+                        <div class="pi-state-title">Loading marketplace</div>
+                        <div class="pi-state-text" x-text="$store.pluginInstallStore.loadingMessage || 'Loading plugins...'"></div>
+                    </div>
                 </div>
 
-                <!-- Plugin Grid -->
-                <div x-show="$store.pluginInstallStore.index && !$store.pluginInstallStore.loading" class="pi-grid">
+                <div x-show="$store.pluginInstallStore.error && !$store.pluginInstallStore.loading" class="pi-state-card pi-state-error">
+                    <span class="material-symbols-outlined">error</span>
+                    <div>
+                        <div class="pi-state-title">Marketplace unavailable</div>
+                        <div class="pi-state-text" x-text="$store.pluginInstallStore.error"></div>
+                    </div>
+                </div>
+
+                <div x-show="$store.pluginInstallStore.index && !$store.pluginInstallStore.loading && $store.pluginInstallStore.filteredPlugins.length > 0"
+                    class="pi-grid">
                     <template x-for="plugin in $store.pluginInstallStore.paginatedPlugins" :key="plugin.key">
-                        <div class="pi-card" @click="$store.pluginInstallStore.openDetail(plugin)">
+                        <button type="button" class="pi-card" @click="$store.pluginInstallStore.openDetail(plugin)">
                             <div class="pi-card-thumb">
                                 <template x-if="plugin.thumbnail">
                                     <img :src="plugin.thumbnail" :alt="plugin.title" loading="lazy">
@@ -44,33 +82,55 @@
                                 <template x-if="!plugin.thumbnail">
                                     <span class="material-symbols-outlined pi-card-placeholder">extension</span>
                                 </template>
-                                <div class="pi-card-thumb-overlay">
-                                    <span class="pi-card-thumb-title" x-text="plugin.title || plugin.key"></span>
-                                    <template x-if="plugin.installed">
-                                        <span class="pi-badge-installed">Installed</span>
-                                    </template>
+
+                                <template x-if="plugin.installed">
+                                    <span class="pi-card-installed-pill">Installed</span>
+                                </template>
+                            </div>
+
+                            <div class="pi-card-body">
+                                <div class="pi-card-head">
+                                    <div class="pi-card-heading">
+                                        <h3 class="pi-card-title" x-text="plugin.title || plugin.key"></h3>
+                                        <div class="pi-card-subtitle"
+                                            x-text="$store.pluginInstallStore.getBrowseSubtitle(plugin)">
+                                        </div>
+                                    </div>
+                                    <span class="material-symbols-outlined pi-card-arrow">arrow_outward</span>
+                                </div>
+
+                                <div class="pi-card-desc"
+                                    x-text="$store.pluginInstallStore.truncate(plugin.description, 110)">
                                 </div>
                             </div>
-                            <div class="pi-card-body">
-                                <div class="pi-card-desc" x-text="$store.pluginInstallStore.truncate(plugin.description, 100)"></div>
-                            </div>
+
                             <div class="pi-card-footer">
-                                <span class="pi-stars">
-                                    <span class="material-symbols-outlined" style="font-size:0.9rem">star</span>
+                                <span class="pi-card-stars">
+                                    <span class="material-symbols-outlined">star</span>
                                     <span x-text="plugin.stars || 0"></span>
                                 </span>
+
+                                <template x-if="$store.pluginInstallStore.getBrowsePrimaryTag(plugin)">
+                                    <span class="pi-card-tag"
+                                        x-text="$store.pluginInstallStore.getBrowsePrimaryTag(plugin)">
+                                    </span>
+                                </template>
                             </div>
-                        </div>
+                        </button>
                     </template>
                 </div>
 
-                <!-- Empty state -->
                 <div x-show="$store.pluginInstallStore.index && !$store.pluginInstallStore.loading && $store.pluginInstallStore.filteredPlugins.length === 0"
-                    class="pi-empty">
-                    No plugins found matching your search.
+                    class="pi-state-card pi-state-empty">
+                    <span class="material-symbols-outlined">search_off</span>
+                    <div>
+                        <div class="pi-state-title">No plugins match this view</div>
+                        <div class="pi-state-text">
+                            Try a different search or switch to another marketplace filter.
+                        </div>
+                    </div>
                 </div>
 
-                <!-- Pagination -->
                 <div x-show="$store.pluginInstallStore.totalPages > 1" class="pi-pagination">
                     <button class="button"
                         :disabled="$store.pluginInstallStore.page <= 1"
@@ -78,7 +138,7 @@
                         <span class="material-symbols-outlined">chevron_left</span>
                     </button>
                     <span class="pi-page-info"
-                        x-text="$store.pluginInstallStore.page + ' / ' + $store.pluginInstallStore.totalPages">
+                        x-text="'Page ' + $store.pluginInstallStore.page + ' of ' + $store.pluginInstallStore.totalPages">
                     </span>
                     <button class="button"
                         :disabled="$store.pluginInstallStore.page >= $store.pluginInstallStore.totalPages"
@@ -86,140 +146,353 @@
                         <span class="material-symbols-outlined">chevron_right</span>
                     </button>
                 </div>
-
             </div>
         </template>
     </div>
 
     <style>
+        .pi-browse-shell {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            font-family: "Rubik", Arial, Helvetica, sans-serif;
+        }
+
+        .pi-browse-shell button,
+        .pi-browse-shell input,
+        .pi-browse-shell select {
+            font-family: inherit;
+        }
+
+        .pi-browse-hero {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 1rem;
+            padding: 0.25rem 0 0.35rem;
+        }
+
+        .pi-browse-copy {
+            max-width: 44rem;
+        }
+
+        .pi-browse-eyebrow {
+            margin-bottom: 0.4rem;
+            font-size: 0.78rem;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--color-highlight);
+        }
+
+        .pi-browse-title {
+            margin: 0;
+            font-size: 1.6rem;
+            line-height: 1.15;
+            color: var(--color-text-primary);
+        }
+
+        .pi-browse-description {
+            margin: 0.5rem 0 0;
+            max-width: 38rem;
+            font-size: 0.95rem;
+            line-height: 1.55;
+            color: var(--color-text-secondary);
+        }
+
+        .pi-browse-summary {
+            flex-shrink: 0;
+            padding: 0.6rem 0.85rem;
+            border: 1px solid var(--color-border);
+            border-radius: 999px;
+            background: var(--color-panel);
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: var(--color-text-primary);
+        }
+
         .pi-index-toolbar {
             display: flex;
-            gap: 0.5rem;
-            margin-bottom: 1rem;
+            gap: 0.75rem;
+            align-items: stretch;
+        }
+
+        .pi-search-field,
+        .pi-sort-field {
+            display: flex;
+            align-items: center;
+            gap: 0.55rem;
+            padding: 0.55rem 0;
+            border: 0;
+            border-bottom: 1px solid var(--color-border);
+            border-radius: 0;
+            background: transparent;
+        }
+
+        .pi-search-field {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .pi-search-field .material-symbols-outlined {
+            font-size: 1.15rem;
+            color: var(--color-text-muted);
         }
 
         .pi-search-input {
-            flex: 1;
+            width: 100%;
             min-width: 0;
-            padding: 0.5rem 0.75rem;
-            border: 1px solid var(--color-border);
-            border-radius: 4px;
-            background: var(--color-bg-primary);
+            padding: 0;
+            border: 0;
+            outline: none;
+            background: transparent;
             color: var(--color-text-primary);
             font-size: 0.95rem;
         }
 
-        .pi-sort-select {
-            max-width: 140px;
+        .pi-sort-field {
+            min-width: 160px;
             flex-shrink: 0;
-            padding: 0.5rem;
-            border: 1px solid var(--color-border);
-            border-radius: 4px;
-            background: var(--color-bg-primary);
+            justify-content: space-between;
+        }
+
+        .pi-field-label {
+            font-size: 0.8rem;
+            font-weight: 600;
+            color: var(--color-text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .pi-sort-select {
+            width: 100%;
+            padding: 0;
+            border: 0;
+            outline: none;
+            background: transparent;
             color: var(--color-text-primary);
-            font-size: 0.9rem;
+            font-size: 0.95rem;
+        }
+
+        .pi-filter-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.6rem;
+        }
+
+        .pi-filter-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            padding: 0.45rem 0.75rem;
+            border: 1px solid var(--color-border);
+            border-radius: 999px;
+            background: var(--color-panel);
+            color: var(--color-text-secondary);
+            font-size: 0.85rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: border-color 0.15s, background 0.15s, color 0.15s;
+        }
+
+        .pi-filter-chip:hover {
+            color: var(--color-text-primary);
+            background: rgba(255, 255, 255, 0.04);
+        }
+
+        .pi-filter-chip.active {
+            border-color: var(--color-border);
+            background: rgba(255, 255, 255, 0.08);
+            color: var(--color-text-primary);
+        }
+
+        .pi-filter-count {
+            padding: 0.12rem 0.4rem;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.06);
+            color: var(--color-text-muted);
+            font-size: 0.75rem;
+        }
+
+        .pi-state-card {
+            display: flex;
+            align-items: center;
+            gap: 0.85rem;
+            padding: 1rem 1.05rem;
+            border: 1px solid var(--color-border);
+            border-radius: 14px;
+            background: var(--color-panel);
+        }
+
+        .pi-state-card .material-symbols-outlined {
+            font-size: 1.5rem;
+        }
+
+        .pi-state-title {
+            font-size: 0.95rem;
+            font-weight: 600;
+            color: var(--color-text-primary);
+        }
+
+        .pi-state-text {
+            margin-top: 0.15rem;
+            font-size: 0.88rem;
+            color: var(--color-text-secondary);
+        }
+
+        .pi-state-loading .material-symbols-outlined {
+            color: var(--color-highlight);
+        }
+
+        .pi-state-error {
+            border-color: rgba(239, 68, 68, 0.28);
+            background: rgba(239, 68, 68, 0.1);
+            color: var(--color-error);
+        }
+
+        .pi-state-empty .material-symbols-outlined {
+            color: var(--color-text-muted);
         }
 
         .pi-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-            gap: 0.75rem;
+            grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+            gap: 0.95rem;
         }
 
         .pi-card {
+            width: 100%;
+            padding: 0;
             border: 1px solid var(--color-border);
-            border-radius: 6px;
+            border-radius: 16px;
             background: var(--color-background);
+            color: inherit;
+            text-align: left;
             cursor: pointer;
-            transition: border-color 0.15s, box-shadow 0.15s;
             display: flex;
             flex-direction: column;
             overflow: hidden;
+            transition: transform 0.15s, border-color 0.15s, box-shadow 0.15s;
         }
 
         .pi-card:hover {
-            border-color: var(--color-highlight);
-            box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+            transform: translateY(-2px);
+            box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
         }
 
         .pi-card-thumb {
-            width: 100%;
-            height: 140px;
-            overflow: hidden;
+            position: relative;
             display: flex;
             align-items: center;
             justify-content: center;
-            background: var(--color-panel);
-            position: relative;
+            height: 148px;
+            padding: 1rem;
+            background:
+                radial-gradient(circle at top, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0)),
+                var(--color-panel);
+            border-bottom: 1px solid var(--color-border);
         }
 
         .pi-card-thumb img {
             width: 100%;
             height: 100%;
             object-fit: contain;
-            padding: 0.5rem;
         }
 
         .pi-card-placeholder {
-            font-size: 4.5rem;
+            font-size: 4rem;
             color: var(--color-text-muted);
         }
 
-        .pi-card-thumb-overlay {
+        .pi-card-installed-pill {
             position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            padding: 0.4rem 0.6rem;
-            background: rgba(0, 0, 0, 0.55);
-            display: flex;
-            align-items: center;
-            gap: 0.4rem;
-        }
-
-        .pi-card-thumb-title {
-            font-weight: 600;
-            font-size: 0.85rem;
-            color: #fff;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            flex: 1;
-            min-width: 0;
-        }
-
-        .pi-badge-installed {
-            font-size: 0.65rem;
-            font-weight: 600;
-            padding: 0.1rem 0.4rem;
-            border-radius: 3px;
-            background: rgba(34,197,94,0.3);
+            top: 0.75rem;
+            right: 0.75rem;
+            padding: 0.24rem 0.5rem;
+            border-radius: 999px;
+            background: rgba(34, 197, 94, 0.15);
             color: #4ade80;
-            flex-shrink: 0;
+            font-size: 0.72rem;
+            font-weight: 700;
         }
 
         .pi-card-body {
-            padding: 0.5rem 0.75rem;
             flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 0.8rem;
+            padding: 1rem;
+        }
+
+        .pi-card-head {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 0.75rem;
+        }
+
+        .pi-card-heading {
+            min-width: 0;
+        }
+
+        .pi-card-title {
+            margin: 0;
+            font-size: 1rem;
+            line-height: 1.25;
+            color: var(--color-text-primary);
+        }
+
+        .pi-card-subtitle {
+            margin-top: 0.25rem;
+            font-size: 0.82rem;
+            color: var(--color-text-muted);
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .pi-card-arrow {
+            font-size: 1rem;
+            color: var(--color-text-muted);
+            flex-shrink: 0;
         }
 
         .pi-card-desc {
-            font-size: 0.8rem;
+            font-size: 0.88rem;
+            line-height: 1.5;
             color: var(--color-text-secondary);
-            line-height: 1.3;
         }
 
         .pi-card-footer {
-            padding: 0.4rem 0.75rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.5rem;
+            padding: 0.9rem 1rem 1rem;
             border-top: 1px solid var(--color-border);
-            font-size: 0.8rem;
+        }
+
+        .pi-card-stars {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.3rem;
+            font-size: 0.85rem;
             color: var(--color-text-secondary);
         }
 
-        .pi-stars {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.2rem;
+        .pi-card-stars .material-symbols-outlined {
+            font-size: 1rem;
+            color: #fbbf24;
+        }
+
+        .pi-card-tag {
+            padding: 0.22rem 0.55rem;
+            border-radius: 999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            background: var(--color-panel);
+            color: var(--color-text-secondary);
+            border: 1px solid var(--color-border);
         }
 
         .pi-pagination {
@@ -227,8 +500,7 @@
             align-items: center;
             justify-content: center;
             gap: 0.75rem;
-            margin-top: 1rem;
-            padding: 0.5rem 0;
+            padding: 0.4rem 0 0.1rem;
         }
 
         .pi-page-info {
@@ -236,28 +508,27 @@
             color: var(--color-text-secondary);
         }
 
-        .pi-loading {
-            text-align: center;
-            padding: 2rem;
-            color: var(--color-text-secondary);
-        }
+        @media (max-width: 720px) {
+            .pi-browse-hero {
+                flex-direction: column;
+            }
 
-        .pi-error {
-            color: var(--color-error);
-            padding: 0.75rem;
-            background: var(--color-error-bg, rgba(239,68,68,0.1));
-            border-radius: 4px;
-        }
+            .pi-index-toolbar {
+                flex-direction: column;
+            }
 
-        .pi-empty {
-            text-align: center;
-            padding: 2rem;
-            color: var(--color-text-secondary);
+            .pi-sort-field {
+                min-width: 0;
+            }
         }
 
         @media (max-width: 500px) {
             .pi-grid {
                 grid-template-columns: 1fr;
+            }
+
+            .pi-card-thumb {
+                height: 164px;
             }
         }
     </style>

--- a/plugins/plugin_installer/webui/install-zip.html
+++ b/plugins/plugin_installer/webui/install-zip.html
@@ -8,7 +8,8 @@
 <body>
     <div x-data>
         <template x-if="$store.pluginInstallStore">
-            <div x-init="$store.pluginInstallStore.resetZip()">
+            <div x-init="$store.pluginInstallStore.resetZip()"
+                 x-destroy="$store.pluginInstallStore.refreshPluginList()">
 
                 <div class="pi-upload-section">
                     <label for="plugin-zip-file" class="pi-upload-btn button confirm"

--- a/plugins/plugin_installer/webui/main.html
+++ b/plugins/plugin_installer/webui/main.html
@@ -8,7 +8,8 @@
 <body>
     <div x-data>
         <template x-if="$store.pluginInstallStore">
-            <div x-init="$store.pluginInstallStore.setTab('store')">
+            <div x-init="$store.pluginInstallStore.setTab('store')"
+                 x-destroy="$store.pluginInstallStore.refreshPluginList()">
 
                 <ul class="nav nav-tabs" role="tablist">
                     <li class="nav-item" role="presentation">
@@ -41,75 +42,141 @@
                 <div x-show="$store.pluginInstallStore.activeTab === 'store'"
                      x-init="$store.pluginInstallStore.resetIndex(); $store.pluginInstallStore.fetchIndex()">
 
-                    <div class="pi-index-toolbar">
-                        <input type="text" class="pi-search-input"
-                            x-model="$store.pluginInstallStore.search"
-                            @input="$store.pluginInstallStore.page = 1"
-                            placeholder="Search plugins...">
-                        <select class="pi-sort-select"
-                            x-model="$store.pluginInstallStore.sortBy">
-                            <option value="stars">Stars</option>
-                            <option value="name">Name</option>
-                        </select>
-                    </div>
+                    <div class="pi-browse-shell">
+                        <section class="pi-browse-hero">
+                            <div class="pi-browse-copy">
+                                <div class="pi-browse-eyebrow">Community Marketplace</div>
+                                <h2 class="pi-browse-title">Discover plugins for Agent Zero</h2>
+                                <p class="pi-browse-description">
+                                    Browse community plugins, filter by what you already have installed, and open each listing for screenshots, README, and install actions.
+                                </p>
+                            </div>
+                            <div class="pi-browse-summary" x-text="$store.pluginInstallStore.browseResultsSummary"></div>
+                        </section>
 
-                    <div x-show="$store.pluginInstallStore.loading" class="pi-loading">
-                        <span x-text="$store.pluginInstallStore.loadingMessage || 'Loading...'"></span>
-                    </div>
+                        <div class="pi-index-toolbar">
+                            <label class="pi-search-field">
+                                <span class="material-symbols-outlined">search</span>
+                                <input type="text"
+                                    class="pi-search-input"
+                                    x-model="$store.pluginInstallStore.search"
+                                    @input="$store.pluginInstallStore.page = 1"
+                                    placeholder="Search plugins, authors, or tags...">
+                            </label>
 
-                    <div x-show="$store.pluginInstallStore.error && !$store.pluginInstallStore.loading" class="pi-error">
-                        <span x-text="$store.pluginInstallStore.error"></span>
-                    </div>
+                            <label class="pi-sort-field">
+                                <span class="pi-field-label">Sort</span>
+                                <select class="pi-sort-select"
+                                    x-model="$store.pluginInstallStore.sortBy">
+                                    <option value="stars">Stars</option>
+                                    <option value="name">Name</option>
+                                </select>
+                            </label>
+                        </div>
 
-                    <div x-show="$store.pluginInstallStore.index && !$store.pluginInstallStore.loading" class="pi-grid">
-                        <template x-for="plugin in $store.pluginInstallStore.paginatedPlugins" :key="plugin.key">
-                            <div class="pi-card" @click="$store.pluginInstallStore.openDetail(plugin)">
-                                <div class="pi-card-thumb">
-                                    <template x-if="plugin.thumbnail">
-                                        <img :src="plugin.thumbnail" :alt="plugin.title" loading="lazy">
-                                    </template>
-                                    <template x-if="!plugin.thumbnail">
-                                        <span class="material-symbols-outlined pi-card-placeholder">extension</span>
-                                    </template>
-                                    <div class="pi-card-thumb-overlay">
-                                        <span class="pi-card-thumb-title" x-text="plugin.title || plugin.key"></span>
+                        <div class="pi-filter-row" x-show="$store.pluginInstallStore.browseFilters.length > 1">
+                            <template x-for="filter in $store.pluginInstallStore.browseFilters" :key="filter.key">
+                                <button type="button"
+                                    class="pi-filter-chip"
+                                    :class="{ active: $store.pluginInstallStore.browseFilter === filter.key }"
+                                    @click="$store.pluginInstallStore.setBrowseFilter(filter.key)">
+                                    <span x-text="filter.label"></span>
+                                    <span class="pi-filter-count" x-text="filter.count"></span>
+                                </button>
+                            </template>
+                        </div>
+
+                        <div x-show="$store.pluginInstallStore.loading" class="pi-state-card pi-state-loading">
+                            <span class="material-symbols-outlined">progress_activity</span>
+                            <div>
+                                <div class="pi-state-title">Loading marketplace</div>
+                                <div class="pi-state-text" x-text="$store.pluginInstallStore.loadingMessage || 'Loading plugins...'"></div>
+                            </div>
+                        </div>
+
+                        <div x-show="$store.pluginInstallStore.error && !$store.pluginInstallStore.loading" class="pi-state-card pi-state-error">
+                            <span class="material-symbols-outlined">error</span>
+                            <div>
+                                <div class="pi-state-title">Marketplace unavailable</div>
+                                <div class="pi-state-text" x-text="$store.pluginInstallStore.error"></div>
+                            </div>
+                        </div>
+
+                        <div x-show="$store.pluginInstallStore.index && !$store.pluginInstallStore.loading && $store.pluginInstallStore.filteredPlugins.length > 0"
+                            class="pi-grid">
+                            <template x-for="plugin in $store.pluginInstallStore.paginatedPlugins" :key="plugin.key">
+                                <button type="button" class="pi-card" @click="$store.pluginInstallStore.openDetail(plugin)">
+                                    <div class="pi-card-thumb">
+                                        <template x-if="plugin.thumbnail">
+                                            <img :src="plugin.thumbnail" :alt="plugin.title" loading="lazy">
+                                        </template>
+                                        <template x-if="!plugin.thumbnail">
+                                            <span class="material-symbols-outlined pi-card-placeholder">extension</span>
+                                        </template>
+
                                         <template x-if="plugin.installed">
-                                            <span class="pi-badge-installed">Installed</span>
+                                            <span class="pi-card-installed-pill">Installed</span>
                                         </template>
                                     </div>
-                                </div>
-                                <div class="pi-card-body">
-                                    <div class="pi-card-desc" x-text="$store.pluginInstallStore.truncate(plugin.description, 100)"></div>
-                                </div>
-                                <div class="pi-card-footer">
-                                    <span class="pi-stars">
-                                        <span class="material-symbols-outlined" style="font-size:0.9rem">star</span>
-                                        <span x-text="plugin.stars || 0"></span>
-                                    </span>
+
+                                    <div class="pi-card-body">
+                                        <div class="pi-card-head">
+                                            <div class="pi-card-heading">
+                                                <h3 class="pi-card-title" x-text="plugin.title || plugin.key"></h3>
+                                                <div class="pi-card-subtitle"
+                                                    x-text="$store.pluginInstallStore.getBrowseSubtitle(plugin)">
+                                                </div>
+                                            </div>
+                                            <span class="material-symbols-outlined pi-card-arrow">arrow_outward</span>
+                                        </div>
+
+                                        <div class="pi-card-desc"
+                                            x-text="$store.pluginInstallStore.truncate(plugin.description, 110)">
+                                        </div>
+                                    </div>
+
+                                    <div class="pi-card-footer">
+                                        <span class="pi-card-stars">
+                                            <span class="material-symbols-outlined">star</span>
+                                            <span x-text="plugin.stars || 0"></span>
+                                        </span>
+
+                                        <template x-if="$store.pluginInstallStore.getBrowsePrimaryTag(plugin)">
+                                            <span class="pi-card-tag"
+                                                x-text="$store.pluginInstallStore.getBrowsePrimaryTag(plugin)">
+                                            </span>
+                                        </template>
+                                    </div>
+                                </button>
+                            </template>
+                        </div>
+
+                        <div x-show="$store.pluginInstallStore.index && !$store.pluginInstallStore.loading && $store.pluginInstallStore.filteredPlugins.length === 0"
+                            class="pi-state-card pi-state-empty">
+                            <span class="material-symbols-outlined">search_off</span>
+                            <div>
+                                <div class="pi-state-title">No plugins match this view</div>
+                                <div class="pi-state-text">
+                                    Try a different search or switch to another marketplace filter.
                                 </div>
                             </div>
-                        </template>
-                    </div>
+                        </div>
 
-                    <div x-show="$store.pluginInstallStore.index && !$store.pluginInstallStore.loading && $store.pluginInstallStore.filteredPlugins.length === 0"
-                        class="pi-empty">
-                        No plugins found matching your search.
-                    </div>
-
-                    <div x-show="$store.pluginInstallStore.totalPages > 1" class="pi-pagination">
-                        <button class="button"
-                            :disabled="$store.pluginInstallStore.page <= 1"
-                            @click="$store.pluginInstallStore.setPage($store.pluginInstallStore.page - 1)">
-                            <span class="material-symbols-outlined">chevron_left</span>
-                        </button>
-                        <span class="pi-page-info"
-                            x-text="$store.pluginInstallStore.page + ' / ' + $store.pluginInstallStore.totalPages">
-                        </span>
-                        <button class="button"
-                            :disabled="$store.pluginInstallStore.page >= $store.pluginInstallStore.totalPages"
-                            @click="$store.pluginInstallStore.setPage($store.pluginInstallStore.page + 1)">
-                            <span class="material-symbols-outlined">chevron_right</span>
-                        </button>
+                        <div x-show="$store.pluginInstallStore.totalPages > 1" class="pi-pagination">
+                            <button class="button"
+                                :disabled="$store.pluginInstallStore.page <= 1"
+                                @click="$store.pluginInstallStore.setPage($store.pluginInstallStore.page - 1)">
+                                <span class="material-symbols-outlined">chevron_left</span>
+                            </button>
+                            <span class="pi-page-info"
+                                x-text="'Page ' + $store.pluginInstallStore.page + ' of ' + $store.pluginInstallStore.totalPages">
+                            </span>
+                            <button class="button"
+                                :disabled="$store.pluginInstallStore.page >= $store.pluginInstallStore.totalPages"
+                                @click="$store.pluginInstallStore.setPage($store.pluginInstallStore.page + 1)">
+                                <span class="material-symbols-outlined">chevron_right</span>
+                            </button>
+                        </div>
                     </div>
                 </div>
 
@@ -251,136 +318,350 @@
             font-size: 1.1rem;
         }
 
-        /* ── Store Tab: Toolbar ──────────────── */
+        /* ── Store Tab ───────────────────────── */
+        .pi-browse-shell {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            font-family: "Rubik", Arial, Helvetica, sans-serif;
+        }
+
+        .pi-browse-shell button,
+        .pi-browse-shell input,
+        .pi-browse-shell select {
+            font-family: inherit;
+        }
+
+        .pi-browse-hero {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 1rem;
+            padding: 0.25rem 0 0.35rem;
+        }
+
+        .pi-browse-copy {
+            max-width: 44rem;
+        }
+
+        .pi-browse-eyebrow {
+            margin-bottom: 0.4rem;
+            font-size: 0.78rem;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--color-highlight);
+        }
+
+        .pi-browse-title {
+            margin: 0;
+            font-size: 1.6rem;
+            line-height: 1.15;
+            color: var(--color-text-primary);
+        }
+
+        .pi-browse-description {
+            margin: 0.5rem 0 0;
+            max-width: 38rem;
+            font-size: 0.95rem;
+            line-height: 1.55;
+            color: var(--color-text-secondary);
+        }
+
+        .pi-browse-summary {
+            flex-shrink: 0;
+            padding: 0.6rem 0.85rem;
+            border: 1px solid var(--color-border);
+            border-radius: 999px;
+            background: var(--color-panel);
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: var(--color-text-primary);
+        }
+
         .pi-index-toolbar {
             display: flex;
-            gap: 0.5rem;
-            margin-bottom: 1rem;
+            gap: 0.75rem;
+            align-items: stretch;
+        }
+
+        .pi-search-field,
+        .pi-sort-field {
+            display: flex;
+            align-items: center;
+            gap: 0.55rem;
+            padding: 0.55rem 0;
+            border: 0;
+            border-bottom: 1px solid var(--color-border);
+            border-radius: 0;
+            background: transparent;
+        }
+
+        .pi-search-field {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .pi-search-field .material-symbols-outlined {
+            font-size: 1.15rem;
+            color: var(--color-text-muted);
         }
 
         .pi-search-input {
-            flex: 1;
+            width: 100%;
             min-width: 0;
-            padding: 0.5rem 0.75rem;
-            border: 1px solid var(--color-border);
-            border-radius: 4px;
-            background: var(--color-bg-primary);
+            padding: 0;
+            border: 0;
+            outline: none;
+            background: transparent;
             color: var(--color-text-primary);
             font-size: 0.95rem;
         }
 
-        .pi-sort-select {
-            padding: 0.5rem;
-            border: 1px solid var(--color-border);
-            border-radius: 4px;
-            background: var(--color-bg-primary);
-            color: var(--color-text-primary);
-            font-size: 0.9rem;
-            max-width: 140px;
+        .pi-sort-field {
+            min-width: 160px;
             flex-shrink: 0;
+            justify-content: space-between;
         }
 
-        /* ── Store Tab: Grid ─────────────────── */
+        .pi-field-label {
+            font-size: 0.8rem;
+            font-weight: 600;
+            color: var(--color-text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .pi-sort-select {
+            width: 100%;
+            padding: 0;
+            border: 0;
+            outline: none;
+            background: transparent;
+            color: var(--color-text-primary);
+            font-size: 0.95rem;
+        }
+
+        .pi-filter-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.6rem;
+        }
+
+        .pi-filter-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            padding: 0.45rem 0.75rem;
+            border: 1px solid var(--color-border);
+            border-radius: 999px;
+            background: var(--color-panel);
+            color: var(--color-text-secondary);
+            font-size: 0.85rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: border-color 0.15s, background 0.15s, color 0.15s;
+        }
+
+        .pi-filter-chip:hover {
+            color: var(--color-text-primary);
+            background: rgba(255, 255, 255, 0.04);
+        }
+
+        .pi-filter-chip.active {
+            border-color: var(--color-border);
+            background: rgba(255, 255, 255, 0.08);
+            color: var(--color-text-primary);
+        }
+
+        .pi-filter-count {
+            padding: 0.12rem 0.4rem;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.06);
+            color: var(--color-text-muted);
+            font-size: 0.75rem;
+        }
+
         .pi-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-            gap: 0.75rem;
+            grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+            gap: 0.95rem;
         }
 
         .pi-card {
+            width: 100%;
+            padding: 0;
             border: 1px solid var(--color-border);
-            border-radius: 6px;
+            border-radius: 16px;
             background: var(--color-background);
+            color: inherit;
+            text-align: left;
             cursor: pointer;
-            transition: border-color 0.15s, box-shadow 0.15s;
+            transition: transform 0.15s, border-color 0.15s, box-shadow 0.15s;
             display: flex;
             flex-direction: column;
             overflow: hidden;
         }
 
         .pi-card:hover {
-            border-color: var(--color-highlight);
-            box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+            transform: translateY(-2px);
+            box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
         }
 
         .pi-card-thumb {
-            width: 100%;
-            height: 140px;
-            overflow: hidden;
+            position: relative;
             display: flex;
             align-items: center;
             justify-content: center;
-            background: var(--color-panel);
-            position: relative;
+            height: 148px;
+            padding: 1rem;
+            background:
+                radial-gradient(circle at top, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0)),
+                var(--color-panel);
+            border-bottom: 1px solid var(--color-border);
         }
 
         .pi-card-thumb img {
             width: 100%;
             height: 100%;
             object-fit: contain;
-            padding: 0.5rem;
         }
 
         .pi-card-placeholder {
-            font-size: 4.5rem;
+            font-size: 4rem;
             color: var(--color-text-muted);
         }
 
-        .pi-card-thumb-overlay {
+        .pi-card-installed-pill {
             position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            padding: 0.4rem 0.6rem;
-            background: rgba(0, 0, 0, 0.55);
-            display: flex;
-            align-items: center;
-            gap: 0.4rem;
-        }
-
-        .pi-card-thumb-title {
-            font-weight: 600;
-            font-size: 0.85rem;
-            color: #fff;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            flex: 1;
-            min-width: 0;
-        }
-
-        .pi-badge-installed {
-            font-size: 0.65rem;
-            font-weight: 600;
-            padding: 0.1rem 0.4rem;
-            border-radius: 3px;
-            background: rgba(34,197,94,0.3);
+            top: 0.75rem;
+            right: 0.75rem;
+            padding: 0.24rem 0.5rem;
+            border-radius: 8px;
+            background: rgba(34, 197, 94, 0.15);
             color: #4ade80;
-            flex-shrink: 0;
+            font-size: 0.72rem;
+            font-weight: 700;
         }
 
         .pi-card-body {
-            padding: 0.5rem 0.75rem;
             flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 0.8rem;
+            padding: 1rem;
+        }
+
+        .pi-card-head {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 0.75rem;
+        }
+
+        .pi-card-heading {
+            min-width: 0;
+        }
+
+        .pi-card-title {
+            margin: 0;
+            font-size: 1rem;
+            line-height: 1.25;
+            color: var(--color-text-primary);
+        }
+
+        .pi-card-subtitle {
+            margin-top: 0.25rem;
+            font-size: 0.82rem;
+            color: var(--color-text-muted);
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .pi-card-arrow {
+            font-size: 1rem;
+            color: var(--color-text-muted);
+            flex-shrink: 0;
         }
 
         .pi-card-desc {
-            font-size: 0.8rem;
+            font-size: 0.88rem;
+            line-height: 1.5;
             color: var(--color-text-secondary);
-            line-height: 1.3;
         }
 
         .pi-card-footer {
-            padding: 0.4rem 0.75rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.5rem;
+            padding: 0.9rem 1rem 1rem;
             border-top: 1px solid var(--color-border);
-            font-size: 0.8rem;
+        }
+
+        .pi-card-stars {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.3rem;
+            font-size: 0.85rem;
             color: var(--color-text-secondary);
         }
 
-        .pi-stars {
-            display: inline-flex;
+        .pi-card-stars .material-symbols-outlined {
+            font-size: 1rem;
+            color: #fbbf24;
+        }
+
+        .pi-card-tag {
+            padding: 0.22rem 0.55rem;
+            border-radius: 999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            background: var(--color-panel);
+            color: var(--color-text-secondary);
+            border: 1px solid var(--color-border);
+        }
+
+        .pi-state-card {
+            display: flex;
             align-items: center;
-            gap: 0.2rem;
+            gap: 0.85rem;
+            padding: 1rem 1.05rem;
+            border: 1px solid var(--color-border);
+            border-radius: 14px;
+            background: var(--color-panel);
+        }
+
+        .pi-state-card .material-symbols-outlined {
+            font-size: 1.5rem;
+        }
+
+        .pi-state-title {
+            font-size: 0.95rem;
+            font-weight: 600;
+            color: var(--color-text-primary);
+        }
+
+        .pi-state-text {
+            margin-top: 0.15rem;
+            font-size: 0.88rem;
+            color: var(--color-text-secondary);
+        }
+
+        .pi-state-loading .material-symbols-outlined {
+            color: var(--color-highlight);
+        }
+
+        .pi-state-error {
+            border-color: rgba(239, 68, 68, 0.28);
+            background: rgba(239, 68, 68, 0.1);
+            color: var(--color-error);
+            margin-top: 0;
+        }
+
+        .pi-state-empty .material-symbols-outlined {
+            color: var(--color-text-muted);
         }
 
         .pi-pagination {
@@ -388,8 +669,7 @@
             align-items: center;
             justify-content: center;
             gap: 0.75rem;
-            margin-top: 1rem;
-            padding: 0.5rem 0;
+            padding: 0.4rem 0 0.1rem;
         }
 
         .pi-page-info {
@@ -397,6 +677,25 @@
             color: var(--color-text-secondary);
         }
 
+        @media (max-width: 720px) {
+            .pi-browse-hero {
+                flex-direction: column;
+            }
+
+            .pi-index-toolbar {
+                flex-direction: column;
+            }
+
+            .pi-sort-field {
+                min-width: 0;
+            }
+        }
+
+        @media (max-width: 500px) {
+            .pi-card-thumb {
+                height: 164px;
+            }
+        }
         /* ── Git Tab ─────────────────────────── */
         .pi-form-group {
             margin-bottom: 1rem;

--- a/plugins/plugin_installer/webui/main.html
+++ b/plugins/plugin_installer/webui/main.html
@@ -372,7 +372,7 @@
             flex-shrink: 0;
             padding: 0.6rem 0.85rem;
             border: 1px solid var(--color-border);
-            border-radius: 999px;
+            border-radius: 0.5rem;
             background: var(--color-panel);
             font-size: 0.85rem;
             font-weight: 600;
@@ -454,7 +454,7 @@
             gap: 0.45rem;
             padding: 0.45rem 0.75rem;
             border: 1px solid var(--color-border);
-            border-radius: 999px;
+            border-radius: 0.5rem;
             background: var(--color-panel);
             color: var(--color-text-secondary);
             font-size: 0.85rem;
@@ -476,7 +476,7 @@
 
         .pi-filter-count {
             padding: 0.12rem 0.4rem;
-            border-radius: 999px;
+            border-radius: 0.5rem;
             background: rgba(255, 255, 255, 0.06);
             color: var(--color-text-muted);
             font-size: 0.75rem;
@@ -615,7 +615,7 @@
 
         .pi-card-tag {
             padding: 0.22rem 0.55rem;
-            border-radius: 999px;
+            border-radius: 0.5rem;
             font-size: 0.75rem;
             font-weight: 600;
             background: var(--color-panel);

--- a/plugins/plugin_installer/webui/pluginInstallStore.js
+++ b/plugins/plugin_installer/webui/pluginInstallStore.js
@@ -157,7 +157,8 @@ const model = {
         "Plugin Installer"
       );
     } catch (e) {
-      this.error = `Installation error: ${e.message}`;
+      const message = e instanceof Error ? e.message : String(e);
+      this.error = `Installation error: ${message}`;
     } finally {
       this.loading = false;
       this.loadingMessage = "";
@@ -197,7 +198,8 @@ const model = {
         "Plugin Installer"
       );
     } catch (e) {
-      this.error = `Clone error: ${e.message}`;
+      const message = e instanceof Error ? e.message : String(e);
+      this.error = `Clone error: ${message}`;
     } finally {
       this.loading = false;
       this.loadingMessage = "";
@@ -226,7 +228,8 @@ const model = {
       this.installedPlugins = data.installed_plugins || [];
       this.page = 1;
     } catch (e) {
-      this.error = `Failed to load plugin index: ${e.message}`;
+      const message = e instanceof Error ? e.message : String(e);
+      this.error = `Failed to load plugin index: ${message}`;
     } finally {
       this.loading = false;
       this.loadingMessage = "";
@@ -339,17 +342,18 @@ const model = {
   },
 
   openDetail(plugin) {
-    this.selectedPlugin = plugin;
+    const detailPlugin = plugin ? { ...plugin } : null;
+    this.selectedPlugin = detailPlugin;
     this.error = "";
     this.installedPluginInfo = null;
     this.readmeContent = null;
-    this.detailPluginName = this._pluginName(plugin);
-    this.detailThumbnailSources = this.getDetailThumbnailSources(plugin);
+    this.detailPluginName = this._pluginName(detailPlugin);
+    this.detailThumbnailSources = this.getDetailThumbnailSources(detailPlugin);
     this.detailThumbnailIndex = 0;
-    if (plugin.installed) {
+    if (detailPlugin?.installed) {
       this.fetchInstalledPluginInfo(this.detailPluginName);
     }
-    this.fetchReadme(plugin);
+    this.fetchReadme(detailPlugin);
     openModal("/plugins/plugin_installer/webui/install-detail.html");
   },
 
@@ -360,14 +364,24 @@ const model = {
     try {
       this.readmeLoading = true;
       this.readmeContent = null;
+      let lastError = null;
 
-      const response = await fetch(`${rawBase}/main/README.md`);
-      if (response.ok) {
-        const readme = await response.text();
-        this.readmeContent = marked.parse(readme, { breaks: true });
+      for (const branch of ["main", "master"]) {
+        try {
+          const response = await fetch(`${rawBase}/${branch}/README.md`);
+          if (!response.ok) continue;
+
+          const readme = await response.text();
+          this.readmeContent = marked.parse(readme, { breaks: true });
+          return;
+        } catch (error) {
+          lastError = error;
+        }
       }
-    } catch (e) {
-      console.warn("Failed to fetch readme:", e);
+
+      if (lastError) {
+        console.warn("Failed to fetch readme:", lastError);
+      }
     } finally {
       this.readmeLoading = false;
     }
@@ -406,11 +420,15 @@ const model = {
         return;
       }
 
-      if (!this.installedPlugins.includes(plugin.key)) {
-        this.installedPlugins.push(plugin.key);
+      const installedKey = plugin.key || data.plugin_name;
+      if (installedKey && !this.installedPlugins.includes(installedKey)) {
+        this.installedPlugins = [...this.installedPlugins, installedKey];
       }
-      plugin.installed = true;
-      this.selectedPlugin = { ...this.selectedPlugin, installed: true };
+      this.selectedPlugin = {
+        ...plugin,
+        ...(this.selectedPlugin || {}),
+        installed: true,
+      };
       this.detailPluginName = data.plugin_name;
       this.detailThumbnailSources = this.getDetailThumbnailSources(this.selectedPlugin);
       this.detailThumbnailIndex = 0;
@@ -421,7 +439,8 @@ const model = {
         "Plugin Installer"
       );
     } catch (e) {
-      this.error = `Installation error: ${e.message}`;
+      const message = e instanceof Error ? e.message : String(e);
+      this.error = `Installation error: ${message}`;
     } finally {
       this.loading = false;
       this.loadingMessage = "";
@@ -438,7 +457,7 @@ const model = {
       });
       const plugins = Array.isArray(response.plugins) ? response.plugins : [];
       this.installedPluginInfo = plugins.find((p) => p.name === pluginName) || null;
-    } catch (e) {
+    } catch (_error) {
       this.installedPluginInfo = null;
     }
   },
@@ -453,7 +472,7 @@ const model = {
 
   manageOpenPlugin() {
     const info = this.installedPluginInfo;
-    if (!info?.name || !info?.has_main_screen) return;
+    if (!info || !info.name || !info.has_main_screen) return;
     openModal(`/plugins/${info.name}/webui/main.html`);
   },
 
@@ -489,10 +508,12 @@ const model = {
     const pls = this._pluginListStore();
     if (pls?.deletePlugin && this.installedPluginInfo) {
       await pls.deletePlugin(this.installedPluginInfo);
-      if (this.selectedPlugin) {
-        this.selectedPlugin.installed = false;
-        const idx = this.installedPlugins.indexOf(this.selectedPlugin.key);
-        if (idx !== -1) this.installedPlugins.splice(idx, 1);
+      const currentPlugin = this.selectedPlugin;
+      if (currentPlugin) {
+        this.selectedPlugin = { ...currentPlugin, installed: false };
+        this.installedPlugins = this.installedPlugins.filter(
+          (key) => key !== currentPlugin.key
+        );
       }
       this.installedPluginInfo = null;
     }
@@ -523,13 +544,20 @@ const model = {
    */
   getDetailThumbnailSources(plugin) {
     const currentPlugin = plugin || this.selectedPlugin;
-    const sources = [
+    const rawSources = [
       this.getThumbnailUrl(currentPlugin),
       this.getLocalThumbnailUrl(),
     ];
-    return sources.filter(
-      (url, index) => typeof url === "string" && sources.indexOf(url) === index
-    );
+    const uniqueSources = [];
+    const seen = new Set();
+
+    for (const url of rawSources) {
+      if (typeof url !== "string" || seen.has(url)) continue;
+      seen.add(url);
+      uniqueSources.push(url);
+    }
+
+    return uniqueSources;
   },
 
   getDetailThumbnailUrl() {

--- a/plugins/plugin_installer/webui/pluginInstallStore.js
+++ b/plugins/plugin_installer/webui/pluginInstallStore.js
@@ -1,6 +1,12 @@
-import { createStore } from "/js/AlpineStore.js";
+import { createStore, getStore } from "/js/AlpineStore.js";
 import * as api from "/js/api.js";
+import { openModal } from "/js/modals.js";
+import { marked } from "/vendor/marked/marked.esm.js";
+import { toastFrontendSuccess } from "/components/notifications/notification-store.js";
 import { showConfirmDialog } from "/js/confirmDialog.js";
+import "/components/plugins/list/pluginListStore.js";
+import "/components/plugins/list/plugin-init-store.js";
+import "/components/modals/image-viewer/image-viewer-store.js";
 
 const PLUGIN_API = "plugins/plugin_installer/plugin_install";
 const PER_PAGE = 20;
@@ -36,13 +42,26 @@ const model = {
   search: "",
   page: 1,
   sortBy: "stars",
+  browseFilter: "all",
   selectedPlugin: null,
 
   // Shared state
   loading: false,
   loadingMessage: "",
   error: "",
-  result: null,
+
+  // README state
+  readmeContent: null,
+  readmeLoading: false,
+
+  // Installed plugin detail (for manage buttons)
+  installedPluginInfo: null,
+
+  // Detail hero thumbnail fallbacks
+  detailPluginName: "",
+  /** @type {string[]} */
+  detailThumbnailSources: [],
+  detailThumbnailIndex: 0,
 
   // Tab state
   activeTab: "store",
@@ -50,7 +69,48 @@ const model = {
   setTab(tab) {
     this.activeTab = tab;
     this.error = "";
-    this.result = null;
+  },
+
+  setBrowseFilter(filter) {
+    this.browseFilter = filter || "all";
+    this.page = 1;
+  },
+
+  /** Normalize GitHub URL and return raw.githubusercontent.com base (no trailing slash). */
+  _githubRawBase(githubUrl) {
+    if (!githubUrl || typeof githubUrl !== "string") return null;
+    let url = githubUrl.trim().replace(/\.git$/i, "");
+    if (!url.includes("github.com")) return null;
+    return url.replace("https://github.com/", "https://raw.githubusercontent.com/");
+  },
+
+  _pluginName(plugin) {
+    const repoUrl = (plugin?.github || "").replace(/\.git$/, "");
+    return repoUrl.split("/").pop() || plugin?.key || "";
+  },
+
+  _pluginPrimaryTag(plugin) {
+    const tags = Array.isArray(plugin?.tags) ? plugin.tags.filter(Boolean) : [];
+    return tags[0] || "";
+  },
+
+  _formatBrowseTag(tag) {
+    if (!tag || typeof tag !== "string") return "";
+    return tag
+      .split(/[-_]/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ");
+  },
+
+  _matchesBrowseFilter(plugin, filterKey) {
+    if (!filterKey || filterKey === "all") return true;
+    if (filterKey === "installed") return !!plugin?.installed;
+    if (filterKey === "popular") return (plugin?.stars || 0) > 0;
+    if (filterKey.startsWith("tag:")) {
+      return this._pluginPrimaryTag(plugin) === filterKey.slice(4);
+    }
+    return false;
   },
 
   // ── ZIP Install ──────────────────────────────
@@ -61,7 +121,6 @@ const model = {
     this.zipFile = file;
     this.zipFileName = file.name;
     this.error = "";
-    this.result = null;
   },
 
   async installZip() {
@@ -77,7 +136,6 @@ const model = {
       this.loading = true;
       this.loadingMessage = "Installing plugin from ZIP...";
       this.error = "";
-      this.result = null;
 
       const formData = new FormData();
       formData.append("action", "install_zip");
@@ -94,14 +152,10 @@ const model = {
         return;
       }
 
-      this.result = data;
-      if (window.toastFrontendSuccess) {
-        window.toastFrontendSuccess(
-          `Plugin "${data.title || data.plugin_name}" installed`,
-          "Plugin Installer"
-        );
-      }
-      this._refreshPluginList();
+      toastFrontendSuccess(
+        `Plugin "${data.title || data.plugin_name}" installed`,
+        "Plugin Installer"
+      );
     } catch (e) {
       this.error = `Installation error: ${e.message}`;
     } finally {
@@ -126,7 +180,6 @@ const model = {
       this.loading = true;
       this.loadingMessage = "Cloning repository...";
       this.error = "";
-      this.result = null;
 
       const data = await api.callJsonApi(PLUGIN_API, {
         action: "install_git",
@@ -139,14 +192,10 @@ const model = {
         return;
       }
 
-      this.result = data;
-      if (window.toastFrontendSuccess) {
-        window.toastFrontendSuccess(
-          `Plugin "${data.title || data.plugin_name}" installed`,
-          "Plugin Installer"
-        );
-      }
-      this._refreshPluginList();
+      toastFrontendSuccess(
+        `Plugin "${data.title || data.plugin_name}" installed`,
+        "Plugin Installer"
+      );
     } catch (e) {
       this.error = `Clone error: ${e.message}`;
     } finally {
@@ -193,13 +242,52 @@ const model = {
     }));
   },
 
+  get browseFilters() {
+    const plugins = this.pluginsList;
+    const filters = [{ key: "all", label: "All", count: plugins.length }];
+
+    if (!plugins.length) return filters;
+
+    const installedCount = plugins.filter((plugin) => plugin.installed).length;
+    if (installedCount) {
+      filters.push({ key: "installed", label: "Installed", count: installedCount });
+    }
+
+    const popularCount = plugins.filter((plugin) => (plugin.stars || 0) > 0).length;
+    if (popularCount) {
+      filters.push({ key: "popular", label: "Popular", count: popularCount });
+    }
+
+    const tagCounts = new Map();
+    for (const plugin of plugins) {
+      const tag = this._pluginPrimaryTag(plugin);
+      if (!tag) continue;
+      tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
+    }
+
+    for (const [tag, count] of Array.from(tagCounts.entries())
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .slice(0, 4)) {
+      filters.push({
+        key: `tag:${tag}`,
+        label: this._formatBrowseTag(tag),
+        count,
+      });
+    }
+
+    return filters;
+  },
+
   get filteredPlugins() {
-    let list = this.pluginsList;
+    let list = this.pluginsList.filter((plugin) =>
+      this._matchesBrowseFilter(plugin, this.browseFilter)
+    );
     const q = (this.search || "").toLowerCase().trim();
     if (q) {
       list = list.filter(
         (p) =>
           (p.title || "").toLowerCase().includes(q) ||
+          (p.author || "").toLowerCase().includes(q) ||
           (p.description || "").toLowerCase().includes(q) ||
           (p.key || "").toLowerCase().includes(q) ||
           (p.tags || []).some((t) => t.toLowerCase().includes(q))
@@ -215,6 +303,16 @@ const model = {
     return list;
   },
 
+  get browseResultsSummary() {
+    const total = this.pluginsList.length;
+    const visible = this.filteredPlugins.length;
+    if (!total) return "No plugins available";
+    if (visible === total) {
+      return `${total} plugin${total === 1 ? "" : "s"} available`;
+    }
+    return `Showing ${visible} of ${total} plugins`;
+  },
+
   get totalPages() {
     return Math.max(1, Math.ceil(this.filteredPlugins.length / PER_PAGE));
   },
@@ -224,6 +322,18 @@ const model = {
     return this.filteredPlugins.slice(start, start + PER_PAGE);
   },
 
+  getBrowseSubtitle(plugin) {
+    const author = (plugin?.author || "").trim();
+    if (author) return author;
+    const tag = this._pluginPrimaryTag(plugin);
+    if (tag) return this._formatBrowseTag(tag);
+    return plugin?.key || "";
+  },
+
+  getBrowsePrimaryTag(plugin) {
+    return this._formatBrowseTag(this._pluginPrimaryTag(plugin));
+  },
+
   setPage(p) {
     this.page = Math.max(1, Math.min(p, this.totalPages));
   },
@@ -231,12 +341,36 @@ const model = {
   openDetail(plugin) {
     this.selectedPlugin = plugin;
     this.error = "";
-    this.result = null;
     this.installedPluginInfo = null;
+    this.readmeContent = null;
+    this.detailPluginName = this._pluginName(plugin);
+    this.detailThumbnailSources = this.getDetailThumbnailSources(plugin);
+    this.detailThumbnailIndex = 0;
     if (plugin.installed) {
-      this.fetchInstalledPluginInfo(plugin.key);
+      this.fetchInstalledPluginInfo(this.detailPluginName);
     }
-    window.openModal?.("../plugins/plugin_installer/webui/install-detail.html");
+    this.fetchReadme(plugin);
+    openModal("/plugins/plugin_installer/webui/install-detail.html");
+  },
+
+  async fetchReadme(plugin) {
+    const rawBase = this._githubRawBase(plugin?.github);
+    if (!rawBase) return;
+
+    try {
+      this.readmeLoading = true;
+      this.readmeContent = null;
+
+      const response = await fetch(`${rawBase}/main/README.md`);
+      if (response.ok) {
+        const readme = await response.text();
+        this.readmeContent = marked.parse(readme, { breaks: true });
+      }
+    } catch (e) {
+      console.warn("Failed to fetch readme:", e);
+    } finally {
+      this.readmeLoading = false;
+    }
   },
 
   async installFromIndex(plugin) {
@@ -252,7 +386,6 @@ const model = {
       this.loading = true;
       this.loadingMessage = `Installing ${plugin.title || plugin.key}...`;
       this.error = "";
-      this.result = null;
 
       const data = await api.callJsonApi(PLUGIN_API, {
         action: "install_git",
@@ -264,19 +397,20 @@ const model = {
         return;
       }
 
-      this.result = data;
       if (!this.installedPlugins.includes(plugin.key)) {
         this.installedPlugins.push(plugin.key);
       }
       plugin.installed = true;
+      this.selectedPlugin = { ...this.selectedPlugin, installed: true };
+      this.detailPluginName = data.plugin_name;
+      this.detailThumbnailSources = this.getDetailThumbnailSources(this.selectedPlugin);
+      this.detailThumbnailIndex = 0;
+      this.fetchInstalledPluginInfo(data.plugin_name);
 
-      if (window.toastFrontendSuccess) {
-        window.toastFrontendSuccess(
-          `Plugin "${data.title || data.plugin_name}" installed`,
-          "Plugin Installer"
-        );
-      }
-      this._refreshPluginList();
+      toastFrontendSuccess(
+        `Plugin "${data.title || data.plugin_name}" installed`,
+        "Plugin Installer"
+      );
     } catch (e) {
       this.error = `Installation error: ${e.message}`;
     } finally {
@@ -287,59 +421,65 @@ const model = {
 
   // ── Installed Plugin Info ─────────────────────
 
-  installedPluginInfo: null,
-  installedPluginInfoLoading: false,
-
-  async fetchInstalledPluginInfo(pluginKey) {
+  async fetchInstalledPluginInfo(pluginName) {
     this.installedPluginInfo = null;
-    this.installedPluginInfoLoading = true;
     try {
       const response = await api.callJsonApi("plugins_list", {
         filter: { custom: true, builtin: true, search: "" },
       });
       const plugins = Array.isArray(response.plugins) ? response.plugins : [];
-      this.installedPluginInfo = plugins.find(
-        (p) => p.name === pluginKey
-      ) || null;
+      this.installedPluginInfo = plugins.find((p) => p.name === pluginName) || null;
     } catch (e) {
       this.installedPluginInfo = null;
-    } finally {
-      this.installedPluginInfoLoading = false;
     }
+  },
+
+  _pluginListStore() {
+    return getStore("pluginListStore");
+  },
+
+  _pluginInitStore() {
+    return getStore("pluginInitStore");
   },
 
   manageOpenPlugin() {
     const info = this.installedPluginInfo;
     if (!info?.name || !info?.has_main_screen) return;
-    window.openModal?.(`/plugins/${info.name}/webui/main.html`);
+    openModal(`/plugins/${info.name}/webui/main.html`);
   },
 
   async manageOpenConfig() {
-    const pls = Alpine.store("pluginListStore");
+    const pls = this._pluginListStore();
     if (pls?.openPluginConfig && this.installedPluginInfo) {
       await pls.openPluginConfig(this.installedPluginInfo);
     }
   },
 
   async manageOpenDoc(doc) {
-    const pls = Alpine.store("pluginListStore");
+    const pls = this._pluginListStore();
     if (pls?.openPluginDoc && this.installedPluginInfo) {
       await pls.openPluginDoc(this.installedPluginInfo, doc);
     }
   },
 
   manageOpenInfo() {
-    const pls = Alpine.store("pluginListStore");
+    const pls = this._pluginListStore();
     if (pls?.openPluginInfo && this.installedPluginInfo) {
       pls.openPluginInfo(this.installedPluginInfo);
     }
   },
 
+  manageOpenInit() {
+    const initStore = this._pluginInitStore();
+    if (initStore?.open && this.installedPluginInfo) {
+      initStore.open(this.installedPluginInfo);
+    }
+  },
+
   async manageDeletePlugin() {
-    const pls = Alpine.store("pluginListStore");
+    const pls = this._pluginListStore();
     if (pls?.deletePlugin && this.installedPluginInfo) {
       await pls.deletePlugin(this.installedPluginInfo);
-      // Mark as no longer installed in the index view
       if (this.selectedPlugin) {
         this.selectedPlugin.installed = false;
         const idx = this.installedPlugins.indexOf(this.selectedPlugin.key);
@@ -349,33 +489,74 @@ const model = {
     }
   },
 
+  getIndexUrl(pluginKey) {
+    if (!pluginKey) return "";
+    return `https://github.com/agent0ai/a0-plugins/tree/main/plugins/${pluginKey}`;
+  },
+
+  getThumbnailUrl(plugin) {
+    if (!plugin) return null;
+    if (plugin.thumbnail && typeof plugin.thumbnail === "string") return plugin.thumbnail;
+    const rawBase = this._githubRawBase(plugin?.github);
+    return rawBase ? `${rawBase}/main/thumbnail.png` : null;
+  },
+
+  getLocalThumbnailUrl() {
+    const name = this.detailPluginName;
+    return name ? `/plugins/${name}/thumbnail.png` : null;
+  },
+
+  /**
+   * Build the ordered thumbnail URLs for the detail view.
+   * First try GitHub, then the local plugin asset.
+   * @param {any} plugin
+   * @returns {string[]}
+   */
+  getDetailThumbnailSources(plugin) {
+    const currentPlugin = plugin || this.selectedPlugin;
+    const sources = [
+      this.getThumbnailUrl(currentPlugin),
+      this.getLocalThumbnailUrl(),
+    ];
+    return sources.filter(
+      (url, index) => typeof url === "string" && sources.indexOf(url) === index
+    );
+  },
+
+  getDetailThumbnailUrl() {
+    return this.detailThumbnailSources[this.detailThumbnailIndex] || null;
+  },
+
+  nextDetailThumbnail() {
+    this.detailThumbnailIndex += 1;
+  },
+
   // ── Shared ───────────────────────────────────
 
   resetZip() {
     this.zipFile = null;
     this.zipFileName = "";
     this.error = "";
-    this.result = null;
   },
 
   resetGit() {
     this.gitUrl = "";
     this.gitToken = "";
     this.error = "";
-    this.result = null;
   },
 
   resetIndex() {
     this.search = "";
     this.page = 1;
     this.sortBy = "stars";
+    this.browseFilter = "all";
     this.error = "";
-    this.result = null;
     this.selectedPlugin = null;
   },
 
-  _refreshPluginList() {
-    window.dispatchEvent(new CustomEvent("plugin-modal-closed"));
+  /** Called from x-destroy when the installer modal is torn down; refreshes the plugin list store */
+  refreshPluginList() {
+    getStore("pluginListStore")?.refresh();
   },
 
   truncate(text, max) {

--- a/plugins/plugin_installer/webui/pluginInstallStore.js
+++ b/plugins/plugin_installer/webui/pluginInstallStore.js
@@ -379,7 +379,16 @@ const model = {
       return;
     }
 
-    const confirmed = await showConfirmDialog(SECURITY_WARNING);
+    const confirmed = await showConfirmDialog({
+      ...SECURITY_WARNING,
+      extensionContext: {
+        kind: "marketplace_plugin_install_warning",
+        source: "plugin_installer",
+        pluginKey: plugin.key || "",
+        pluginTitle: plugin.title || plugin.key || "",
+        gitUrl: plugin.github,
+      },
+    });
     if (!confirmed) return;
 
     try {

--- a/plugins/plugin_scan/extensions/webui/confirm_dialog_after_render/add-marketplace-scan-action.js
+++ b/plugins/plugin_scan/extensions/webui/confirm_dialog_after_render/add-marketplace-scan-action.js
@@ -1,0 +1,48 @@
+import { store as pluginScanStore } from "/plugins/plugin_scan/webui/plugin-scan-store.js";
+
+const NOTE_CLASS = "confirm-dialog-extension-note";
+const BUTTON_CLASS = "confirm-dialog-plugin-scan-button";
+const DIALOG_CLOSE_DELAY_MS = 220;
+
+function isMarketplaceInstallWarning(extensionContext) {
+  return (
+    extensionContext?.kind === "marketplace_plugin_install_warning"
+    && extensionContext?.source === "plugin_installer"
+    && typeof extensionContext?.gitUrl === "string"
+    && extensionContext.gitUrl.trim().length > 0
+  );
+}
+
+export default async function addMarketplaceScanAction(context) {
+  const extensionContext = context?.extensionContext;
+  if (!isMarketplaceInstallWarning(extensionContext)) return;
+
+  const bodyElement = context?.bodyElement;
+  const footerElement = context?.footerElement;
+  const cancelButton = context?.cancelButton;
+  if (!bodyElement || !footerElement || !cancelButton) return;
+
+  if (!bodyElement.querySelector(`.${NOTE_CLASS}`)) {
+    const note = document.createElement("p");
+    note.className = NOTE_CLASS;
+    note.textContent = "It is always recommended to scan all plugins and updates with A0 itself.";
+    bodyElement.appendChild(note);
+  }
+
+  if (footerElement.querySelector(`.${BUTTON_CLASS}`)) return;
+
+  const scanButton = document.createElement("button");
+  scanButton.type = "button";
+  scanButton.className = `button ${BUTTON_CLASS}`;
+  scanButton.textContent = "Scan with A0";
+  scanButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    context.close(false);
+    window.setTimeout(() => {
+      void pluginScanStore.openModal(extensionContext.gitUrl.trim());
+    }, DIALOG_CLOSE_DELAY_MS);
+  });
+
+  footerElement.insertBefore(scanButton, cancelButton);
+}

--- a/webui/components/modals/scheduler/scheduler-modal.html
+++ b/webui/components/modals/scheduler/scheduler-modal.html
@@ -49,7 +49,7 @@
       padding: 0;
     }
     .scheduler-dashboard-description {
-      padding: 1rem 0;
+      padding: 0 0 1rem 0;
     }
 
     .scheduler-modal-footer {

--- a/webui/components/plugins/list/plugin-list.html
+++ b/webui/components/plugins/list/plugin-list.html
@@ -7,7 +7,7 @@
 </head>
 
 <body>
-    <div x-data x-on:plugin-modal-closed.window="$store.pluginListStore.refresh()">
+    <div x-data>
         <template x-if="$store.pluginListStore">
             <div x-init="$store.pluginListStore.init && $store.pluginListStore.init()">
 
@@ -224,7 +224,9 @@
 
         .plugins-toolbar-actions {
             margin-left: auto;
+            display: flex;
             flex: 0 0 auto;
+            gap: var(--spacing-sm);
         }
 
         .plugins-list {
@@ -233,7 +235,7 @@
 
         .plugin-card {
             border: 1px solid var(--color-border);
-            border-radius: 4px;
+            border-radius: 0.5rem;
             padding: 0.75rem;
             margin-top: 0.75rem;
             background: var(--color-background);

--- a/webui/components/plugins/plugin-settings.html
+++ b/webui/components/plugins/plugin-settings.html
@@ -9,7 +9,7 @@
     <div x-data>
         <template x-if="$store.pluginSettings">
             <div x-create="$store.pluginSettings.onModalOpen()"
-                 x-destroy="$store.pluginSettings.cleanup(); window.dispatchEvent(new Event('plugin-modal-closed'))">
+                 x-destroy="$store.pluginSettings.cleanup(); $store.pluginListStore?.refresh()">
 
                 <!-- Context toolbar: Project + Agent profile (only when at least one scope is configurable) -->
                 <div class="plugin-settings-scope-section"

--- a/webui/components/plugins/toggle/plugin-toggle-advanced.html
+++ b/webui/components/plugins/toggle/plugin-toggle-advanced.html
@@ -9,7 +9,7 @@
     <div x-data>
         <template x-if="$store.pluginToggle">
             <div x-create="$store.pluginToggle.open($store.pluginListStore?.selectedPlugin || '')"
-                 x-destroy="$store.pluginToggle.cleanup(); window.dispatchEvent(new Event('plugin-modal-closed'))">
+                 x-destroy="$store.pluginToggle.cleanup(); $store.pluginListStore?.refresh()">
 
                 <!-- Error -->
                 <div x-show="$store.pluginToggle.error" class="plugin-settings-error">

--- a/webui/css/modals.css
+++ b/webui/css/modals.css
@@ -136,7 +136,7 @@ some classes like modal-header are shared between the old and the new system */
 .modal-scroll {
   max-height: 90vh;
   overflow-y: auto;
-  padding: 0 1rem 1rem 1rem;
+  padding: 1rem;
 }
 
 .modal-x {

--- a/webui/css/modals.css
+++ b/webui/css/modals.css
@@ -589,6 +589,10 @@ input[type="range"]::-moz-range-thumb {
   margin: 0;
 }
 
+.confirm-dialog-body .confirm-dialog-extension-note {
+  margin-top: 0.75em;
+}
+
 .confirm-dialog-footer {
   display: flex;
   justify-content: flex-end;

--- a/webui/css/settings.css
+++ b/webui/css/settings.css
@@ -251,7 +251,6 @@ nav ul li a img {
   width: 100%;
   margin-bottom: 8px;
   padding: 0;
-  margin-top: 20px;
   position: relative;
   overflow: visible;
 }

--- a/webui/js/confirmDialog.js
+++ b/webui/js/confirmDialog.js
@@ -1,5 +1,7 @@
 // Custom confirmation dialog. CSS in /css/modals.css
 
+import { callJsExtensions } from "/js/extensions.js";
+
 const DIALOG_TYPES = {
   warning: { icon: 'warning', color: 'var(--color-warning, #f59e0b)' },
   danger: { icon: 'error', color: 'var(--color-error, #ef4444)' },
@@ -12,7 +14,8 @@ export function showConfirmDialog(options) {
     message = '',
     confirmText = 'Confirm',
     cancelText = 'Cancel',
-    type = 'warning'
+    type = 'warning',
+    extensionContext = null,
   } = options;
 
   const typeConfig = DIALOG_TYPES[type] || DIALOG_TYPES.warning;
@@ -40,14 +43,25 @@ export function showConfirmDialog(options) {
     backdrop.appendChild(dialog);
     document.body.appendChild(backdrop);
 
+    const titleElement = dialog.querySelector('.confirm-dialog-title');
+    const bodyElement = dialog.querySelector('.confirm-dialog-body');
+    const footerElement = dialog.querySelector('.confirm-dialog-footer');
+    const cancelButton = dialog.querySelector('.confirm-dialog-cancel');
+    const confirmButton = dialog.querySelector('.confirm-dialog-confirm');
+    let isClosed = false;
+
     // Show with animation
-    requestAnimationFrame(() => {
-      backdrop.classList.add('visible');
-      dialog.querySelector('.confirm-dialog-cancel').focus();
-    });
+    const showDialog = () => {
+      requestAnimationFrame(() => {
+        backdrop.classList.add('visible');
+        cancelButton?.focus();
+      });
+    };
 
     // Close handler
     const close = (result) => {
+      if (isClosed) return;
+      isClosed = true;
       backdrop.classList.remove('visible');
       document.removeEventListener('keydown', handleKeydown);
       setTimeout(() => {
@@ -57,15 +71,60 @@ export function showConfirmDialog(options) {
     };
 
     // Event listeners
-    dialog.querySelector('.confirm-dialog-cancel').addEventListener('click', () => close(false));
-    dialog.querySelector('.confirm-dialog-confirm').addEventListener('click', () => close(true));
+    cancelButton.addEventListener('click', () => close(false));
+    confirmButton.addEventListener('click', () => close(true));
     backdrop.addEventListener('click', (e) => e.target === backdrop && close(false));
 
     // Keyboard handling
     const handleKeydown = (e) => {
-      if (e.key === 'Escape') close(false);
-      else if (e.key === 'Enter') close(true);
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close(false);
+        return;
+      }
+
+      if (e.key !== 'Enter') return;
+
+      const activeElement = document.activeElement;
+      if (
+        activeElement
+        && dialog.contains(activeElement)
+        && (
+          activeElement.tagName === 'BUTTON'
+          || activeElement.tagName === 'A'
+          || activeElement.tagName === 'INPUT'
+          || activeElement.tagName === 'TEXTAREA'
+          || activeElement.tagName === 'SELECT'
+          || activeElement.isContentEditable
+        )
+      ) {
+        return;
+      }
+
+      e.preventDefault();
+      close(true);
     };
     document.addEventListener('keydown', handleKeydown);
+
+    const extensionData = {
+      options,
+      dialog,
+      backdrop,
+      titleElement,
+      bodyElement,
+      footerElement,
+      confirmButton,
+      cancelButton,
+      close,
+      title,
+      message,
+      type,
+      confirmText,
+      cancelText,
+      extensionContext,
+    };
+
+    callJsExtensions('confirm_dialog_after_render', extensionData)
+      .finally(showDialog);
   });
 }


### PR DESCRIPTION
**1. fix padding in basic modals style** (`87035128`)
- Simplify padding in modals.css to allow for seamless modal creation without additional CSS, and remove redundant margin-top in settings.css. Adjust margin in memory-dashboard.html and padding in scheduler-modal.html for layout consistency.

**2. redesign plugin marketplace; simplify API** (`eac0d3bc`)
- Plugin install API: fetch and augment plugin discussions from GitHub; index response includes discussion links.
- Plugin install UI: refactor for clearer plugin details and management actions for installed plugins.
- Browse UI: layout and styling updates, search/sort, and a summary of available plugins.

**3. marketplace polish; add confirm-dialog extension hook and plugin_scan marketplace note** (`ae62cfc1`)
- Add generic JS extension point `confirm_dialog_after_render` on the shared confirm dialog so plugins can augment body and footer without hardcoding in the installer.
- Plugin installer passes `extensionContext` only from marketplace install; ZIP/Git flows unchanged.
- Plugin Scanner: when enabled, injects a recommendation note and "Scan with A0" in the marketplace third-party warning; button opens scanner modal with the repo URL.
- Docs: document the new hook and when to use JS hooks vs HTML breakpoints.