### PR TITLE
fix(deps): bump lxml-html-clean to >=0.4.0 — XSS vulnerability (CWE-79)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ langchain-core==0.3.49
 langchain-community==0.3.19
 langchain-unstructured[all-docs]==0.1.6
 openai-whisper==20250625
-lxml_html_clean==0.3.1
+lxml_html_clean>=0.4.0  # CVE-2024-52595 fix: XSS CWE-79 CVSS 8.4
 markdown==3.7
 mcp==1.22.0
 newspaper3k==0.2.8


### PR DESCRIPTION
## Security Fix: lxml-html-clean XSS Vulnerability

### Snyk Finding
- **Package:** lxml-html-clean 0.3.1
- **Vulnerability:** Cross-Site Scripting (XSS) via HTML context-switching elements
- **CVE:** CVE-2024-52595
- **CWE:** CWE-79 — Improper Neutralization of Input During Web Page Generation
- **CVSS:** 8.4 (HIGH)
- **Snyk Priority Score:** 634
- **Fixed in:** 0.4.0

### Change
Single-line change in `requirements.txt`:
```diff
- lxml_html_clean==0.3.1
+ lxml_html_clean>=0.4.0  # CVE-2024-52595 fix: XSS CWE-79 CVSS 8.4
```

Changed from exact pin (`==0.3.1`) to floor pin (`>=0.4.0`) to ensure the security fix is included while allowing compatible future patches.

### Impact Assessment
- **Breaking changes:** None — 0.4.0 is purely a security fix
- **API changes:** None — stricter handling of `<svg>`, `<math>`, `<noscript>` HTML elements (desired behavior)
- **Codebase usage:** No direct imports of `lxml_html_clean` found in source; consumed by `unstructured` / `langchain-unstructured` for HTML sanitisation
- **Blast radius:** Minimal — tighter HTML sanitisation is the intended outcome

### Testing
- All 104 existing tests pass with lxml-html-clean 0.4.0
- 22 functional API tests pass
- Zero regressions detected
- Import smoke test confirms package loads correctly

### Reference
- https://security.snyk.io/vuln/SNYK-PYTHON-LXMLHTMLCLEAN-8267703
- https://nvd.nist.gov/vuln/detail/CVE-2024-52595