### PR TITLE
fix(deps): add security floor pins for transitive dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,11 @@ pywinpty==3.0.2; sys_platform == "win32"
 python-socketio>=5.14.2
 uvicorn>=0.38.0
 wsproto>=1.2.0
+# Security floor pins for transitive dependencies
+# These packages are pulled transitively — floor pins prevent resolver regressions
+Pillow>=10.2.0  # security floor: heap buffer overflow CWE-122, eval injection CWE-95, DoS CWE-400
+nltk>=3.9.3  # security floor: RCE CWE-94, code injection CWE-94
+h11>=0.16.0  # security floor: HTTP request smuggling CWE-444
+urllib3>=2.6.0  # security floor: resource exhaustion CWE-770, data amplification CWE-409
+cryptography>=46.0.0  # security floor: insufficient data authenticity CWE-345
+werkzeug>=3.0.3  # security floor: RCE CWE-94


### PR DESCRIPTION
## Security: Defensive Floor Pins for Transitive Dependencies

### Problem

Six transitive dependencies have known critical/high vulnerabilities in older versions. While `pip` currently resolves these above the vulnerable versions, there are **no explicit floor pins** in `requirements.txt` to prevent future regressions.

Without floor pins, a change in any parent package constraint, pip resolver behavior, or dependency conflict could silently pull in a vulnerable version.

### Dependency Chain

```
newspaper3k==0.2.8    → Pillow>=3.3.0  (could resolve to 9.x = VULNERABLE)
newspaper3k==0.2.8    → nltk>=3.2.1    (could resolve to 3.8.x = VULNERABLE)
uvicorn>=0.38.0       → h11>=0.8       (could resolve to 0.14.x = VULNERABLE)
requests (transitive) → urllib3>=1.21.1 (could resolve to 2.0.x = VULNERABLE)
paramiko==3.5.0       → cryptography>=3.3 (could resolve to 45.x = VULNERABLE)
flask[async]==3.0.3   → Werkzeug>=3.0.0 (could resolve to 3.0.0-3.0.2 = VULNERABLE)
```

### Changes

Adds minimum version constraints for 6 packages:

| Package | Floor Pin | Vulnerability | CWE | CVSS | Pulled By |
|---------|-----------|---------------|-----|------|-----------|
| **Pillow** | `>=10.2.0` | Heap buffer overflow, eval injection, DoS | CWE-122, CWE-95, CWE-400 | 9.6 (CRITICAL) | newspaper3k, sentence-transformers |
| **nltk** | `>=3.9.3` | RCE via pickle deserialization | CWE-94 | 8.4 (HIGH) | newspaper3k |
| **h11** | `>=0.16.0` | HTTP request smuggling | CWE-444 | 9.3 (CRITICAL) | uvicorn, wsproto |
| **urllib3** | `>=2.6.0` | Resource exhaustion, data amplification | CWE-770, CWE-409 | 8.9 (HIGH) | requests (via newspaper3k, docker) |
| **cryptography** | `>=46.0.0` | Insufficient data authenticity verification | CWE-345 | 8.2 (HIGH) | paramiko |
| **werkzeug** | `>=3.0.3` | Remote Code Execution | CWE-94 | 7.5 (HIGH) | flask |

### Why Floor Pins?

These are **NOT version bumps** — pip already installs versions above all these floors today. These constraints:
1. **Prevent future pip resolver regressions** to vulnerable versions
2. **Make security requirements explicit** and auditable in requirements.txt
3. **Follow defense-in-depth** principle
4. **Zero risk** — no functional change to current installations

### Impact Assessment

- **Breaking changes:** None — pip already installs versions above all floors
- **Codebase verified:** All 6 packages checked for API usage patterns against their respective breaking change lists:
  - Pillow: codebase uses `Image.Resampling.LANCZOS` (modern API, compatible with >=10.x)
  - nltk: zero direct imports (purely transitive from newspaper3k)
  - h11: zero direct imports (consumed by uvicorn internally)
  - urllib3: zero direct imports (consumed by requests)
  - cryptography: uses stable RSA/OAEP primitives (unaffected by 46.x changes)
  - werkzeug: uses FileStorage, secure_filename, Response, Request (all stable in 3.x)

### Testing

- All existing tests pass with currently-resolved versions (which are above these floors)
- Functional API tests for Pillow, cryptography, and werkzeug usage patterns pass
- `pip check` reports no dependency conflicts

### Identified via Snyk security scan