### PR TITLE
Fix WebSocket CSRF validation failure on Chromium browsers over HTTPS

### DIFF
--- a/run_ui.py
+++ b/run_ui.py
@@ -52,7 +52,7 @@ WerkzeugRequest.max_form_memory_size = UPLOAD_LIMIT_BYTES
 webapp.config.update(
     JSON_SORT_KEYS=False,
     SESSION_COOKIE_NAME="session_" + runtime.get_runtime_id(),  # bind the session cookie name to runtime id to prevent session collision on same host
-    SESSION_COOKIE_SAMESITE="Strict",
+    SESSION_COOKIE_SAMESITE="Lax",
     SESSION_PERMANENT=True,
     PERMANENT_SESSION_LIFETIME=timedelta(days=1),
     MAX_CONTENT_LENGTH=int(os.getenv("FLASK_MAX_CONTENT_LENGTH", str(UPLOAD_LIMIT_BYTES))),

--- a/webui/js/api.js
+++ b/webui/js/api.js
@@ -219,7 +219,7 @@ export async function getCsrfToken() {
       if (cookieRuntimeId) {
         const _secureFlag =
           window.location.protocol === "https:" ? "; Secure" : "";
-        document.cookie = `csrf_token_${cookieRuntimeId}=${csrfToken}; SameSite=Strict; Path=/${_secureFlag}`;
+        document.cookie = `csrf_token_${cookieRuntimeId}=${csrfToken}; SameSite=Lax; Path=/${_secureFlag}`;
       } else {
         console.warn("CSRF runtime id missing; skipping cookie name binding.");
       }


### PR DESCRIPTION
## Summary

- Change `SameSite=Strict` to `SameSite=Lax` for the Flask session cookie and the CSRF token cookie
- Fixes WebSocket `state_sync` connection being rejected on Chromium-based browsers (Brave confirmed) when deployed over HTTPS

Fixes #1237

## Problem

After #1144 added the `Secure` flag to the CSRF cookie on HTTPS deployments, the combination of `SameSite=Strict; Secure` causes Chromium-based browsers to exclude these cookies from WebSocket upgrade requests. The server-side CSRF validation at connect time (`run_ui.py` line 324) then fails with `csrf cookie mismatch`, breaking the `state_sync` namespace entirely — the UI shows zero chats and cannot sync state.

Safari is unaffected because it sends `SameSite=Strict` cookies on same-origin WebSocket upgrades.

## Fix

`SameSite=Lax` in two files:

| File | Change |
|------|--------|
| `run_ui.py` | `SESSION_COOKIE_SAMESITE="Strict"` → `"Lax"` |
| `webui/js/api.js` | CSRF cookie `SameSite=Strict` → `SameSite=Lax` |

`Lax` still prevents cross-site POST-based CSRF (the actual threat model for session cookies) while allowing same-origin WebSocket upgrade requests to include cookies. This is the [OWASP-recommended default](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html).

## Testing

- Tested on Brave (Chromium) with HTTPS deployment behind Kubernetes ingress with TLS termination
- WebSocket connects and passes CSRF validation after the fix
- Safari continues to work as before
- No impact on HTTP-only deployments (no behavioral change for `Lax` vs `Strict` on HTTP)