### PR TITLE
fix(deps): remove non-existent [all-docs] extra from langchain-unstructured

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ kokoro>=0.9.2
 simpleeval==1.0.3
 langchain-core==0.3.49
 langchain-community==0.3.19
-langchain-unstructured[all-docs]==0.1.6
+langchain-unstructured==0.1.6
 openai-whisper==20250625
 lxml_html_clean>=0.4.0  # CVE-2024-52595 fix: XSS CWE-79 CVSS 8.4
 markdown==3.7


### PR DESCRIPTION
## Summary

Remove the `[all-docs]` extra from the `langchain-unstructured` dependency pin in `requirements.txt`. This extra does not exist on the `langchain-unstructured` package (verified across all published versions 0.1.1–1.0.1).

## Problem

Every build produces this warning from uv:

> warning: The package `langchain-unstructured==0.1.6` does not have an extra named `all-docs`

The `[all-docs]` extra is defined by the `unstructured` package, not its `langchain-unstructured` wrapper. The actual document parser dependencies are correctly pulled in by the separate pin:

```
unstructured[all-docs]==0.16.23
```

## Change

```diff
- langchain-unstructured[all-docs]==0.1.6
+ langchain-unstructured==0.1.6
```

## Impact

- **Zero functional change** — installed packages are identical
- **Eliminates build warning** — cleaner build logs
- **No new dependencies** added or removed

## Verification

Confirmed that `langchain-unstructured` has no `Provides-Extra: all-docs` in any published version metadata. The `unstructured[all-docs]==0.16.23` pin continues to provide all document parser dependencies.