### PR TITLE
fix: use RepairableException in validate_tool_request for graceful recovery

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -953,12 +953,14 @@ class Agent:
 
     @extension.extensible
     async def validate_tool_request(self, tool_request: Any):
+        if tool_request is None:
+            return  # let process_tools handle the misformat case
         if not isinstance(tool_request, dict):
-            raise ValueError("Tool request must be a dictionary")
+            raise RepairableException("Tool request must be a dictionary")
         if not tool_request.get("tool_name") or not isinstance(tool_request.get("tool_name"), str):
-            raise ValueError("Tool request must have a tool_name (type string) field")
+            raise RepairableException("Tool request must have a tool_name (type string) field")
         if not tool_request.get("tool_args") or not isinstance(tool_request.get("tool_args"), dict):
-            raise ValueError("Tool request must have a tool_args (type dictionary) field")
+            raise RepairableException("Tool request must have a tool_args (type dictionary) field")
 
 
 


### PR DESCRIPTION
## Summary

Fixes #1241 — `validate_tool_request()` raises plain `ValueError` which causes an unrecoverable agent crash when models produce malformed tool call JSON.

## Changes

- **Return early for `None`**: When `json_parse_dirty()` finds no tool in the response, `validate_tool_request` now returns instead of raising. The existing misformat handler in `process_tools()` already handles this case gracefully.
- **`ValueError` → `RepairableException`**: All three validation checks now raise `RepairableException`, which the existing `_50_handle_repairable_exception` extension catches, adds to the agent's history as a warning, and continues the message loop — allowing the agent to retry.

## How It Was Before

```
Model produces malformed tool JSON (list, string, None)
  → json_parse_dirty() returns non-dict
  → validate_tool_request() raises ValueError
  → handle_exception() re-raises (not RepairableException)
  → Agent loop crashes — unrecoverable
```

## How It Works Now

```
Model produces malformed tool JSON
  → validate_tool_request() raises RepairableException
  → _50_handle_repairable_exception catches it
  → Warning added to agent history
  → Message loop continues — agent retries
```

## Testing

Reproduced with MiniMax MiniMax-M1 and GLM-5 on OpenRouter — both models occasionally produce list-formatted or malformed tool calls. After this fix, the agent logs the warning and retries instead of crashing.