### PR TITLE
feat(secrets): add @extensible decorator to secrets factory functions

### DIFF
--- a/helpers/secrets.py
+++ b/helpers/secrets.py
@@ -8,6 +8,7 @@ from typing import Dict, Optional, List, Literal, Set, Callable, Tuple, TYPE_CHE
 from dotenv.parser import parse_stream
 from helpers.errors import RepairableException
 from helpers import files
+from helpers.extension import extensible
 
 if TYPE_CHECKING:
     from agent import AgentContext
@@ -504,6 +505,7 @@ class SecretsManager:
         return merged
 
 
+@extensible
 def get_secrets_manager(context: "AgentContext|None" = None) -> SecretsManager:
     from helpers import projects
 
@@ -523,6 +525,7 @@ def get_secrets_manager(context: "AgentContext|None" = None) -> SecretsManager:
 
     return SecretsManager.get_instance(*secret_files)
 
+@extensible
 def get_project_secrets_manager(project_name: str, merge_with_global: bool = False) -> SecretsManager:
     from helpers import projects
 
@@ -537,5 +540,6 @@ def get_project_secrets_manager(project_name: str, merge_with_global: bool = Fal
 
     return SecretsManager.get_instance(*secret_files)
 
+@extensible
 def get_default_secrets_manager() -> SecretsManager:
     return SecretsManager.get_instance()


### PR DESCRIPTION
## Summary

Add `@extensible` decorator to all three secrets factory functions in `helpers/secrets.py`, enabling plugins to intercept or replace the `SecretsManager` instance returned by these functions.

## Changes

**1 file changed, 4 insertions:**

- Import `extensible` from `helpers.extension`
- Add `@extensible` to `get_secrets_manager()`
- Add `@extensible` to `get_project_secrets_manager()`
- Add `@extensible` to `get_default_secrets_manager()`

## Why all three functions?

| Factory Function | Called By |
|---|---|
| `get_secrets_manager()` | `log.py`, `print_style.py`, `browser_agent.py` |
| `get_default_secrets_manager()` | `settings.py` (x3 call sites) |
| `get_project_secrets_manager()` | `projects.py` (x2 call sites) |

Decorating only `get_secrets_manager()` would miss secrets access from settings and project loading paths.

## Motivating use case

OpenBao secrets backend plugin that replaces the default `.env`-based `SecretsManager` with an OpenBao KV v2 backed instance. A plugin extension at the `_start` point can set `data["result"]` to short-circuit the factory and return a custom manager.

## Verification

- Extension discovery works with `agent=None` (common case for these functions) via `subagents.get_paths()` plugin path resolution
- All three functions are sync, so `call_extensions_sync` is used correctly
- Zero behavioral change for existing users — decorator only adds extension hooks
- This is the first consumer of `@extensible`