### PR TITLE
feat: Add Jina AI embedding provider

### DIFF
--- a/conf/model_providers.yaml
+++ b/conf/model_providers.yaml
@@ -112,6 +112,9 @@ embedding:
   huggingface:
     name: HuggingFace
     litellm_provider: huggingface
+  jina:
+    name: Jina AI
+    litellm_provider: jina_ai
   google:
     name: Google
     litellm_provider: gemini


### PR DESCRIPTION
This PR adds support for Jina AI as an embedding provider in the model configuration.

- Added Jina AI to the embedding section in conf/model_providers.yaml.
- Configured to use litellm_provider: jina_ai.