### PR TITLE
feat(models): add @extensible decorator to get_api_key()

### DIFF
--- a/models.py
+++ b/models.py
@@ -26,6 +26,7 @@ from helpers.providers import ModelType as ProviderModelType, get_provider_confi
 from helpers.rate_limiter import RateLimiter
 from helpers.tokens import approximate_tokens
 from helpers import dirty_json
+from helpers.extension import extensible  # extensible: allows plugins to intercept get_api_key()
 
 from langchain_core.language_models.chat_models import SimpleChatModel
 from langchain_core.outputs.chat_generation import ChatGenerationChunk
@@ -198,6 +199,7 @@ rate_limiters: dict[str, RateLimiter] = {}
 api_keys_round_robin: dict[str, int] = {}
 
 
+@extensible
 def get_api_key(service: str) -> str:
     # get api key for the service
     key = (


### PR DESCRIPTION
## Problem

`get_api_key()` in `models.py` resolves API keys exclusively from OS environment variables via `os.getenv()`. This means external secrets backends (OpenBao/Vault, AWS Secrets Manager, Azure Key Vault, etc.) cannot provide API keys to LiteLLM without injecting them into the process environment — a workaround that is fragile, doesn't support cache TTLs, and bypasses the existing SecretsManager architecture.

While `helpers/secrets.py` factory functions were recently made extensible (#1246), the actual API key resolution path for chat/embedding/utility models goes through `models.get_api_key()` → `dotenv.get_dotenv_value()` → `os.getenv()`, completely bypassing SecretsManager.

## Solution

Add the `@extensible` decorator to `get_api_key()`, enabling plugins to intercept API key resolution at the `models_get_api_key_start` extension point.

This is a **2-line change**:
1. Import `extensible` from `helpers.extension`
2. Add `@extensible` decorator to `get_api_key()`

## How it works

With `@extensible`, a plugin extension can:
- Set `data["result"]` in a `_start` hook to provide an API key from any backend, short-circuiting the default dotenv lookup
- Fall through to the default `os.getenv()` behaviour when no plugin is active
- Modify `data["args"]` or `data["kwargs"]` to alter the service name lookup

## Backward Compatibility

**No behavioural change for existing users.** The `@extensible` decorator only adds extension hooks around the existing function. Without any registered extensions, `get_api_key()` behaves identically to before.

## Motivating Use Case

OpenBao secrets backend plugin that needs to provide LiteLLM API keys from a KV v2 secrets engine, with TTL-based caching and automatic fallback to `.env` files.

## Related

- Follows the same pattern established in #1246 for secrets factory functions
- Extension point naming: `models_get_api_key_start` / `models_get_api_key_end`