### PR TITLE
fix: Add duplicate response loop breaker to prevent infinite loops

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -382,6 +382,7 @@ class Agent:
 
     async def monologue(self):
         error_retries = 0  # counter for critical error retries
+        duplicate_retries = 0  # counter for duplicate response retries
         while True:
             try:
                 # loop data dictionary to pass to extensions
@@ -473,6 +474,17 @@ class Agent:
                         if (
                             self.loop_data.last_response == agent_response
                         ):  # if assistant_response is the same as last message in history, let him know
+                            # Increment duplicate counter
+                            duplicate_retries += 1
+
+                            # Check if max duplicates reached - break the loop
+                            if duplicate_retries >= 3:
+                                from python.helpers.errors import HandledException
+                                error_msg = "Agent stuck in duplicate response loop (3 consecutive identical responses). Breaking loop."
+                                PrintStyle(font_color="red", padding=True).print(error_msg)
+                                self.context.log.log(type="error", content=error_msg)
+                                raise HandledException(Exception(error_msg))
+
                             # Append the assistant's response to the history
                             self.hist_add_ai_response(agent_response)
                             # Append warning message to the history
@@ -492,6 +504,7 @@ class Agent:
                                 return tools_result  # break the execution if the task is done
 
                         error_retries = 0  # reset retry counter on successful iteration
+                        duplicate_retries = 0  # reset duplicate counter on successful iteration
 
                     # exceptions inside message loop:
                     except InterventionException as e:


### PR DESCRIPTION
## Summary
This PR adds a duplicate response loop breaker to prevent the agent from getting stuck in infinite loops when receiving "You have sent the same message again" errors from external APIs.

## Problem
The agent can get stuck in an infinite loop when:
1. External LLM API (e.g., ZAI/GLM-5, Ollama) rejects a message as a duplicate
2. Agent receives "You have sent the same message again" error
3. Agent retries with the exact same message
4. Loop continues indefinitely

## Solution
- Add `duplicate_retries` counter to track consecutive duplicate responses
- Break loop after 3 consecutive identical responses with `HandledException`
- Log clear error message when loop is broken
- Reset `duplicate_retries` on successful iteration

## Changes
- `agent.py`: Added duplicate_retries counter and loop breaker logic (13 lines added)

## Testing
Tested by triggering duplicate response scenarios - agent now breaks out after 3 attempts with clear error message.

## Related Issues
Fixes #1056
Fixes #1000
Related to #1187, #1011

## Notes
This is a core code fix that cannot be solved through agent behavior changes alone, as the LLM is not in a coherent state during a loop to recognize and break the pattern.