### PR TITLE
fix: Enhanced duplicate response guidance for self-correction

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -382,6 +382,7 @@ class Agent:
 
     async def monologue(self):
         error_retries = 0  # counter for critical error retries
+        duplicate_retries = 0  # counter for duplicate response retries
         while True:
             try:
                 # loop data dictionary to pass to extensions
@@ -473,10 +474,12 @@ class Agent:
                         if (
                             self.loop_data.last_response == agent_response
                         ):  # if assistant_response is the same as last message in history, let him know
+                            # Increment duplicate counter for context
+                            duplicate_retries += 1
                             # Append the assistant's response to the history
                             self.hist_add_ai_response(agent_response)
                             # Append warning message to the history
-                            warning_msg = self.read_prompt("fw.msg_repeat.md")
+                            warning_msg = self.read_prompt("fw.msg_repeat.md", retry_count=duplicate_retries)
                             self.hist_add_warning(message=warning_msg)
                             PrintStyle(font_color="orange", padding=True).print(
                                 warning_msg
@@ -492,6 +495,7 @@ class Agent:
                                 return tools_result  # break the execution if the task is done
 
                         error_retries = 0  # reset retry counter on successful iteration
+                        duplicate_retries = 0  # reset duplicate counter on successful iteration
 
                     # exceptions inside message loop:
                     except InterventionException as e:

--- a/prompts/fw.msg_repeat.md
+++ b/prompts/fw.msg_repeat.md
@@ -1,1 +1,14 @@
-You have sent the same message again. You have to do something else!
+You have sent the same message again (attempt {{retry_count}}/3).
+
+Your previous response was identical. This usually happens when:
+- You're unsure how to proceed
+- You're waiting for external input
+- You're stuck in a reasoning loop
+
+To break this loop, try ONE of these approaches:
+1. If uncertain: Use the response tool to ask the user for clarification
+2. If stuck: Try a different tool or approach to make progress
+3. If blocked: Explain the blocker and what you need to proceed
+4. If waiting: Check status and report current state instead of repeating
+
+IMPORTANT: Do NOT repeat the same message. Choose a different action now.


### PR DESCRIPTION
## Summary
This PR addresses the ROOT CAUSE of duplicate message loops by providing the LLM with context and specific guidance to self-correct BEFORE the circuit breaker kicks in.

## Problem
When the LLM gets stuck in a loop, it:
1. Doesn't know it's in a loop (no context)
2. Doesn't have specific guidance on alternatives

## Solution
1. **Add retry count context** - Pass  to warning message so LLM knows its loop status
2. **Provide specific alternatives** - 4 concrete approaches to break the loop:
   - If uncertain: Ask user for clarification
   - If stuck: Try different tool/approach
   - If blocked: Explain blocker and needs
   - If waiting: Report status instead of repeating
3. **Track duplicates** - Counter for context (resets on success)

## Changes
| File | Changes |
|------|--------|
|  | +6 lines (counter, increment, reset, pass retry_count) |
|  | +14 lines (enhanced guidance with template) |

## How It Works


## Relationship to PR #1265
- **PR #1265 (Circuit Breaker)**: Safety net - breaks loop after 3 duplicates
- **This PR (Enhanced Guidance)**: Root cause fix - helps LLM self-correct BEFORE circuit breaker

Both PRs work together for defense-in-depth:
1. First line of defense: Enhanced guidance (this PR)
2. Last line of defense: Circuit breaker (PR #1265)

## Testing
- Warning now shows "attempt X/3" for context
- LLM receives specific alternatives instead of generic "do something else"
- Counter resets on successful iteration

## Related Issues
Addresses root cause of #1056, #1000, #1187, #1011

## Notes
This is a minimal, elegant fix that addresses the root cause without modifying core logic. The LLM now has the context and guidance it needs to break loops itself.