### PR TITLE
fix: defer DOM insertion in components.js

### DIFF
--- a/webui/js/components.js
+++ b/webui/js/components.js
@@ -57,6 +57,7 @@ export async function importComponent(path, targetElement) {
     ];
 
     const loadPromises = [];
+    const deferredNodes = [];
     let blobCounter = 0;
 
     for (const node of allNodes) {
@@ -156,13 +157,16 @@ export async function importComponent(path, targetElement) {
 
         targetElement.appendChild(clone);
       } else {
-        const clone = node.cloneNode(true);
-        targetElement.appendChild(clone);
+        deferredNodes.push(node.cloneNode(true));
       }
     }
 
     // Wait for all tracked external scripts/styles to finish loading
     await Promise.all(loadPromises);
+
+    for (const deferred of deferredNodes) {
+      targetElement.appendChild(deferred);
+    }
 
     // Remove loading indicator
     const loadingEl = targetElement.querySelector(':scope > .loading');


### PR DESCRIPTION
Body nodes (containing Alpine x-data directives) were appended to the
DOM immediately during the import loop, while <script type="module">
imports were awaited afterward. Alpine's MutationObserver would evaluate
x-data expressions before the module had registered its store, causing
"Cannot convert undefined or null to object" errors.

Collect body nodes into a buffer and append them only after
Promise.all(loadPromises) resolves, ensuring stores are registered
before Alpine processes the DOM.