### PR TITLE
fix: move_dir fails across Docker volume mount points + call_plugin_hook crashes on missing plugin dir

### DIFF
--- a/helpers/files.py
+++ b/helpers/files.py
@@ -486,8 +486,10 @@ def move_dir(old_path: str, new_path: str):
 
     try:
         os.rename(abs_old, abs_new)
-    except Exception:
-        pass  # suppress all errors, keep behavior consistent
+    except OSError:
+        # os.rename fails across Docker volume mount points
+        import shutil
+        shutil.move(abs_old, abs_new)
 
 
 # move dir safely, remove with number if needed

--- a/helpers/plugins.py
+++ b/helpers/plugins.py
@@ -798,7 +798,10 @@ def call_plugin_hook(
 
     # use cached hooks if enabled
     if not cache.has(HOOKS_CACHE_AREA, plugin_name):
-        hooks_script = files.get_abs_path(find_plugin_dir(plugin_name), HOOKS_SCRIPT)
+        plugin_dir = find_plugin_dir(plugin_name)
+        if not plugin_dir:
+            return default  # plugin directory not found, skip hooks
+        hooks_script = files.get_abs_path(plugin_dir, HOOKS_SCRIPT)
         hooks = (
             extract_tools.import_module(hooks_script)
             if files.exists(hooks_script)


### PR DESCRIPTION
## Problem

When deploying Agent Zero with **per-directory volume mounts** (as recommended to avoid volume shadowing), plugin installation from the Plugin Hub fails silently.

```yaml
volumes:
  - a0-tmp:/a0/tmp
  - a0-usr:/a0/usr
  - a0-agents:/a0/agents
```

Two bugs combine to break this:

### 1. move_dir silently fails across Docker volume mount points

os.rename raises OSError: [Errno 18] Invalid cross-device link when source (/a0/tmp/...) and destination (/a0/usr/plugins/...) are on different Docker bind mounts. The current except Exception: pass swallows the error, so the plugin directory never actually moves.

### 2. call_plugin_hook crashes when find_plugin_dir returns None

After the silent move_dir failure, run_install_hook calls call_plugin_hook, which passes find_plugin_dir(plugin_name) (returning None) directly to files.get_abs_path(), causing:

TypeError: join() argument must be str, bytes, or os.PathLike object, not 'NoneType'

## Fix

**helpers/files.py** — Fall back to shutil.move on OSError (handles cross-mount by copy + delete).

**helpers/plugins.py** — Guard find_plugin_dir returning None before passing to get_abs_path.

## Reproduction

1. Deploy A0 with per-directory volume mounts (separate named volumes for tmp, usr, agents)
2. Install any plugin from Plugin Hub (including official a0-example-plugin)
3. Observe: Installation failed: join() argument must be str, bytes, or os.PathLike object, not NoneType

Verified fix on Hetzner CPX41, Docker 27.x, overlay2, ext4.