### PR TITLE
feat: per-chat model configuration override

### DIFF
--- a/api/chat_model_get.py
+++ b/api/chat_model_get.py
@@ -1,0 +1,58 @@
+from helpers.api import ApiHandler, Request, Response
+from helpers import settings
+from helpers.chat_model_override import get_override
+from helpers.providers import get_providers
+from helpers.settings import _dict_to_env
+
+
+class ChatModelGet(ApiHandler):
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        ctxid = input.get("context", "")
+
+        global_settings = settings.get_settings()
+
+        # Try to get existing context (may not exist for new chats)
+        context = None
+        if ctxid:
+            try:
+                context = self.use_context(ctxid, create_if_not_exists=False)
+            except Exception:
+                pass
+
+        # Default: use global settings as base
+        model_settings = {
+            "chat_model_provider": global_settings["chat_model_provider"],
+            "chat_model_name": global_settings["chat_model_name"],
+            "chat_model_api_base": global_settings["chat_model_api_base"],
+            "chat_model_ctx_length": global_settings["chat_model_ctx_length"],
+            "chat_model_ctx_history": global_settings["chat_model_ctx_history"],
+            "chat_model_vision": global_settings["chat_model_vision"],
+            "chat_model_rl_requests": global_settings["chat_model_rl_requests"],
+            "chat_model_rl_input": global_settings["chat_model_rl_input"],
+            "chat_model_rl_output": global_settings["chat_model_rl_output"],
+            "chat_model_kwargs": global_settings.get("chat_model_kwargs", {}),
+        }
+
+        is_custom = False
+        if context:
+            override = get_override(context)
+            if override:
+                is_custom = True
+                model_settings.update(override)
+
+        # Convert kwargs dict to .env string format for frontend
+        if isinstance(model_settings["chat_model_kwargs"], dict):
+            model_settings["chat_model_kwargs"] = _dict_to_env(model_settings["chat_model_kwargs"])
+
+        providers = get_providers("chat")
+
+        return {
+            "context": ctxid,
+            "is_custom": is_custom,
+            "settings": model_settings,
+            "providers": providers,
+        }
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["GET", "POST"]

--- a/api/chat_model_set.py
+++ b/api/chat_model_set.py
@@ -1,0 +1,82 @@
+from helpers.api import ApiHandler, Request, Response
+from helpers import settings
+from helpers import persist_chat
+from helpers.chat_model_override import set_override, apply_override
+from initialize import initialize_agent
+
+
+class ChatModelSet(ApiHandler):
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        ctxid = input.get("context", "")
+        is_custom = input.get("is_custom", False)
+        new_settings = input.get("settings", {})
+
+        if not ctxid:
+            return Response('{"error": "context required"}', status=400, mimetype="application/json")
+
+        try:
+            context = self.use_context(ctxid, create_if_not_exists=False)
+        except Exception:
+            return Response('{"error": "Context not found"}', status=404, mimetype="application/json")
+
+        def _as_int(value, default):
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return default
+
+        def _as_float(value, default):
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return default
+
+        def _as_bool(value, default):
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, (int, float)):
+                return bool(value)
+            if isinstance(value, str):
+                normalized = value.strip().lower()
+                if normalized in ("1", "true", "yes", "on"):
+                    return True
+                if normalized in ("0", "false", "no", "off"):
+                    return False
+            return default
+
+        if is_custom:
+            # Convert kwargs string to dict for storage
+            from helpers.settings import _env_to_dict
+            kwargs = new_settings.get("chat_model_kwargs", "")
+            if isinstance(kwargs, str):
+                new_settings["chat_model_kwargs"] = _env_to_dict(kwargs)
+
+            current = context.config.chat_model
+            global_settings = settings.get_settings()
+            override = {
+                "chat_model_provider": (new_settings.get("chat_model_provider", "") or current.provider).strip(),
+                "chat_model_name": (new_settings.get("chat_model_name", "") or current.name).strip(),
+                "chat_model_api_base": str(new_settings.get("chat_model_api_base", current.api_base) or ""),
+                "chat_model_ctx_length": _as_int(new_settings.get("chat_model_ctx_length"), current.ctx_length),
+                "chat_model_ctx_history": _as_float(
+                    new_settings.get("chat_model_ctx_history"),
+                    global_settings["chat_model_ctx_history"],
+                ),
+                "chat_model_vision": _as_bool(new_settings.get("chat_model_vision"), current.vision),
+                "chat_model_rl_requests": _as_int(new_settings.get("chat_model_rl_requests"), current.limit_requests),
+                "chat_model_rl_input": _as_int(new_settings.get("chat_model_rl_input"), current.limit_input),
+                "chat_model_rl_output": _as_int(new_settings.get("chat_model_rl_output"), current.limit_output),
+                "chat_model_kwargs": new_settings.get("chat_model_kwargs", current.kwargs),
+            }
+            set_override(context, override)
+            apply_override(context)
+        else:
+            # Remove override, reset to global settings
+            set_override(context, None)
+            global_config = initialize_agent()
+            context.config.chat_model = global_config.chat_model
+
+        # Persist the change
+        persist_chat.save_tmp_chat(context)
+
+        return {"ok": True, "is_custom": is_custom}

--- a/helpers/chat_model_override.py
+++ b/helpers/chat_model_override.py
@@ -1,0 +1,62 @@
+"""Helper for per-chat model configuration overrides."""
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent import AgentContext
+
+OVERRIDE_KEY = "_chat_model_override"
+
+
+def get_override(context: "AgentContext") -> dict | None:
+    return context.data.get(OVERRIDE_KEY)
+
+
+def set_override(context: "AgentContext", override: dict | None):
+    if override is None:
+        context.data.pop(OVERRIDE_KEY, None)
+    else:
+        context.data[OVERRIDE_KEY] = override
+
+
+def apply_override(context: "AgentContext"):
+    """Apply stored per-chat model override to context.config.chat_model."""
+    override = get_override(context)
+    if not override:
+        return
+
+    import models
+    from helpers.settings import _env_to_dict
+
+    current = context.config.chat_model
+    kwargs = override.get("chat_model_kwargs", current.kwargs)
+    if isinstance(kwargs, str):
+        kwargs = _env_to_dict(kwargs)
+    if not isinstance(kwargs, dict):
+        kwargs = current.kwargs
+
+    # Normalize kwargs values (string numbers -> actual numbers)
+    normalized: dict = {}
+    for key, value in kwargs.items():
+        if isinstance(value, str):
+            try:
+                normalized[key] = int(value)
+            except ValueError:
+                try:
+                    normalized[key] = float(value)
+                except ValueError:
+                    normalized[key] = value
+        else:
+            normalized[key] = value
+
+    context.config.chat_model = models.ModelConfig(
+        type=models.ModelType.CHAT,
+        provider=override.get("chat_model_provider") or current.provider,
+        name=override.get("chat_model_name") or current.name,
+        api_base=override.get("chat_model_api_base", current.api_base),
+        ctx_length=override.get("chat_model_ctx_length", current.ctx_length),
+        vision=override.get("chat_model_vision", current.vision),
+        limit_requests=override.get("chat_model_rl_requests", current.limit_requests),
+        limit_input=override.get("chat_model_rl_input", current.limit_input),
+        limit_output=override.get("chat_model_rl_output", current.limit_output),
+        kwargs=normalized,
+    )

--- a/helpers/persist_chat.py
+++ b/helpers/persist_chat.py
@@ -215,6 +215,10 @@ def _deserialize_context(data):
     context.agent0 = agent0
     context.streaming_agent = streaming_agent
 
+    # Re-apply per-chat model override if present
+    from helpers.chat_model_override import apply_override
+    apply_override(context)
+
     return context
 
 

--- a/tests/test_chat_model_per_chat_override.py
+++ b/tests/test_chat_model_per_chat_override.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+from flask import Flask
+
+from api.chat_model_set import ChatModelSet
+from helpers.chat_model_override import get_override, set_override
+
+
+def _fake_context():
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            chat_model=SimpleNamespace(
+                provider="openrouter",
+                name="openai/gpt-4o-mini",
+                api_base="http://localhost:4000/v1",
+                ctx_length=131072,
+                vision=True,
+                limit_requests=11,
+                limit_input=22000,
+                limit_output=44000,
+                kwargs={"temperature": 0.25, "top_p": 0.9},
+            )
+        ),
+        data={},
+    )
+
+
+def test_set_override_stores_and_removes_data():
+    context = SimpleNamespace(data={})
+
+    set_override(context, {"chat_model_name": "custom/model"})
+    assert get_override(context) == {"chat_model_name": "custom/model"}
+
+    set_override(context, None)
+    assert get_override(context) is None
+
+
+def test_chat_model_set_normalizes_and_applies_custom_settings(monkeypatch):
+    app = Flask(__name__)
+    handler = ChatModelSet(app, threading.RLock())
+    context = _fake_context()
+
+    monkeypatch.setattr(
+        handler,
+        "use_context",
+        lambda ctxid, create_if_not_exists=False: context,
+    )
+    monkeypatch.setattr(
+        "api.chat_model_set.persist_chat.save_tmp_chat",
+        lambda _context: None,
+    )
+    monkeypatch.setattr(
+        "api.chat_model_set.apply_override",
+        lambda _context: None,
+    )
+    monkeypatch.setattr(
+        "api.chat_model_set.settings.get_settings",
+        lambda: {"chat_model_ctx_history": 0.42},
+    )
+
+    result = asyncio.run(
+        handler.process(
+            {
+                "context": "ctx-1",
+                "is_custom": True,
+                "settings": {
+                    "chat_model_provider": "",
+                    "chat_model_name": "  custom/provider-model  ",
+                    "chat_model_ctx_length": "invalid",
+                    "chat_model_ctx_history": "bad",
+                    "chat_model_vision": "false",
+                    "chat_model_rl_requests": "25",
+                    "chat_model_rl_input": None,
+                    "chat_model_rl_output": "not-an-int",
+                    "chat_model_kwargs": "temperature=0.15\nmax_tokens=2048\n",
+                },
+            },
+            None,
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["is_custom"] is True
+
+    override = context.data["_chat_model_override"]
+    assert override["chat_model_provider"] == "openrouter"
+    assert override["chat_model_name"] == "custom/provider-model"
+    assert override["chat_model_ctx_length"] == 131072
+    assert override["chat_model_ctx_history"] == 0.42
+    assert override["chat_model_vision"] is False
+    assert override["chat_model_rl_requests"] == 25
+    assert override["chat_model_rl_input"] == 22000
+    assert override["chat_model_rl_output"] == 44000
+    assert override["chat_model_kwargs"]["temperature"] == 0.15
+    assert override["chat_model_kwargs"]["max_tokens"] == 2048

--- a/webui/components/modals/chat-model/chat-model-modal.html
+++ b/webui/components/modals/chat-model/chat-model-modal.html
@@ -1,0 +1,216 @@
+<html>
+<head>
+  <title>Chat Model Settings</title>
+  <script type="module">
+    import { store } from "/components/modals/chat-model/chat-model-store.js";
+  </script>
+</head>
+
+<body>
+  <div x-data>
+    <template x-if="$store.chatModelStore">
+      <div class="chat-model-modal-content">
+
+        <div x-show="$store.chatModelStore.loading" class="chat-model-loading">
+          Loading...
+        </div>
+
+        <template x-if="!$store.chatModelStore.loading">
+          <div>
+
+            <!-- Toggle: global vs custom -->
+            <div class="field">
+              <div class="field-label">
+                <div class="field-title">Use custom model for this chat</div>
+                <div class="field-description">
+                  When enabled, this chat uses its own model configuration instead of the global settings.
+                </div>
+              </div>
+              <div class="field-control">
+                <label class="toggle">
+                  <input type="checkbox" x-model="$store.chatModelStore.isCustom" />
+                  <span class="toggler"></span>
+                </label>
+              </div>
+            </div>
+
+            <!-- Custom fields (only shown when isCustom is true) -->
+            <div x-show="$store.chatModelStore.isCustom" class="chat-model-custom-fields">
+
+              <div class="field">
+                <div class="field-label">
+                  <div class="field-title">Provider</div>
+                  <div class="field-description">Model provider for this chat</div>
+                </div>
+                <div class="field-control">
+                  <select x-model="$store.chatModelStore.settings.chat_model_provider">
+                    <template x-for="option in $store.chatModelStore.providers" :key="option.value">
+                      <option :value="option.value"
+                        :selected="option.value === $store.chatModelStore.settings.chat_model_provider"
+                        x-text="option.label">
+                      </option>
+                    </template>
+                  </select>
+                </div>
+              </div>
+
+              <div class="field">
+                <div class="field-label">
+                  <div class="field-title">Model name</div>
+                  <div class="field-description">Exact name of the model from the selected provider</div>
+                </div>
+                <div class="field-control">
+                  <input type="text" x-model="$store.chatModelStore.settings.chat_model_name" />
+                </div>
+              </div>
+
+              <div class="field">
+                <div class="field-label">
+                  <div class="field-title">API base URL</div>
+                  <div class="field-description">
+                    Optional. Leave empty for default. Relevant for Azure, local and custom providers.
+                  </div>
+                </div>
+                <div class="field-control">
+                  <input type="text" x-model="$store.chatModelStore.settings.chat_model_api_base" />
+                </div>
+              </div>
+
+              <div class="field">
+                <div class="field-label">
+                  <div class="field-title">Context length</div>
+                  <div class="field-description">Maximum number of tokens in the context window</div>
+                </div>
+                <div class="field-control">
+                  <input type="number" x-model.number="$store.chatModelStore.settings.chat_model_ctx_length" />
+                </div>
+              </div>
+
+              <div class="field">
+                <div class="field-label">
+                  <div class="field-title">Context window for chat history</div>
+                  <div class="field-description">
+                    Portion of context window dedicated to chat history (0.01 to 1.0)
+                  </div>
+                </div>
+                <div class="field-control">
+                  <input type="range" min="0.01" max="1" step="0.01"
+                    x-model.number="$store.chatModelStore.settings.chat_model_ctx_history" />
+                  <span class="range-value"
+                    x-text="$store.chatModelStore.settings.chat_model_ctx_history"></span>
+                </div>
+              </div>
+
+              <div class="field">
+                <div class="field-label">
+                  <div class="field-title">Supports Vision</div>
+                  <div class="field-description">Enable if the model supports image inputs</div>
+                </div>
+                <div class="field-control">
+                  <label class="toggle">
+                    <input type="checkbox" x-model="$store.chatModelStore.settings.chat_model_vision" />
+                    <span class="toggler"></span>
+                  </label>
+                </div>
+              </div>
+
+              <div class="field">
+                <div class="field-label">
+                  <div class="field-title">Requests per minute limit</div>
+                  <div class="field-description">0 to disable rate limiting</div>
+                </div>
+                <div class="field-control">
+                  <input type="number" x-model.number="$store.chatModelStore.settings.chat_model_rl_requests" />
+                </div>
+              </div>
+
+              <div class="field">
+                <div class="field-label">
+                  <div class="field-title">Input tokens per minute limit</div>
+                  <div class="field-description">0 to disable</div>
+                </div>
+                <div class="field-control">
+                  <input type="number" x-model.number="$store.chatModelStore.settings.chat_model_rl_input" />
+                </div>
+              </div>
+
+              <div class="field">
+                <div class="field-label">
+                  <div class="field-title">Output tokens per minute limit</div>
+                  <div class="field-description">0 to disable</div>
+                </div>
+                <div class="field-control">
+                  <input type="number" x-model.number="$store.chatModelStore.settings.chat_model_rl_output" />
+                </div>
+              </div>
+
+              <div class="field field-full">
+                <div class="field-label">
+                  <div class="field-title">Additional parameters</div>
+                  <div class="field-description">
+                    Extra parameters in KEY=VALUE format (one per line)
+                  </div>
+                </div>
+                <div class="field-control">
+                  <textarea x-model="$store.chatModelStore.settings.chat_model_kwargs"></textarea>
+                </div>
+              </div>
+
+            </div>
+          </div>
+        </template>
+      </div>
+    </template>
+
+    <!-- Modal Footer -->
+    <template x-if="$store.chatModelStore && !$store.chatModelStore.loading">
+      <div class="modal-footer chat-model-modal-footer" data-modal-footer>
+        <div class="buttons-container">
+          <div class="buttons-right">
+            <button type="button" class="button cancel"
+              @click="$store.chatModelStore.cancel()">Cancel</button>
+            <button type="button" class="button confirm"
+              :disabled="$store.chatModelStore.saving"
+              @click="$store.chatModelStore.save()">
+              <span x-text="$store.chatModelStore.saving ? 'Saving...' : 'Save'"></span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+
+  <style>
+    .chat-model-modal-content {
+      padding: 0.5rem 0;
+      min-width: 460px;
+    }
+
+    .chat-model-loading {
+      padding: 2rem;
+      text-align: center;
+      color: var(--color-secondary);
+    }
+
+    .chat-model-custom-fields {
+      margin-top: 0.5rem;
+      border-top: 1px solid var(--color-border);
+      padding-top: 0.5rem;
+    }
+
+    .chat-model-modal-footer {
+      padding: 0.6rem 1rem;
+    }
+
+    .chat-model-modal-footer .buttons-container {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .chat-model-modal-footer .buttons-right {
+      display: flex;
+      gap: 0.5rem;
+    }
+  </style>
+</body>
+</html>

--- a/webui/components/modals/chat-model/chat-model-store.js
+++ b/webui/components/modals/chat-model/chat-model-store.js
@@ -1,0 +1,83 @@
+import { createStore } from "/js/AlpineStore.js";
+import { callJsonApi } from "/js/api.js";
+import { toast, toastFetchError } from "/index.js";
+
+const model = {
+  contextId: null,
+  isCustom: false,
+  settings: {},
+  providers: [],
+  loading: false,
+  saving: false,
+  closePromise: null,
+
+  resetState() {
+    this.contextId = null;
+    this.isCustom = false;
+    this.settings = {};
+    this.providers = [];
+    this.loading = false;
+    this.saving = false;
+    this.closePromise = null;
+  },
+
+  async open(contextId) {
+    if (!contextId) {
+      toast("Invalid chat context", "error");
+      return;
+    }
+
+    this.resetState();
+    this.contextId = contextId;
+    this.loading = true;
+
+    try {
+      const modalPromise = window.openModal("modals/chat-model/chat-model-modal.html");
+      this.closePromise = modalPromise;
+      if (modalPromise && typeof modalPromise.then === "function") {
+        modalPromise.then(() => {
+          if (this.closePromise === modalPromise) {
+            this.resetState();
+          }
+        });
+      }
+
+      const data = await callJsonApi("/chat_model_get", { context: contextId });
+      this.isCustom = data.is_custom || false;
+      this.settings = data.settings || {};
+      this.providers = data.providers || [];
+    } catch (e) {
+      toastFetchError("Error loading chat model settings", e);
+    } finally {
+      this.loading = false;
+    }
+  },
+
+  async save() {
+    this.saving = true;
+    try {
+      await callJsonApi("/chat_model_set", {
+        context: this.contextId,
+        is_custom: this.isCustom,
+        settings: this.settings,
+      });
+      toast(
+        this.isCustom
+          ? "Custom model saved for this chat"
+          : "Chat reset to global model settings",
+        "success"
+      );
+      window.closeModal();
+    } catch (e) {
+      toastFetchError("Error saving chat model settings", e);
+    } finally {
+      this.saving = false;
+    }
+  },
+
+  cancel() {
+    window.closeModal();
+  },
+};
+
+export const store = createStore("chatModelStore", model);

--- a/webui/components/sidebar/chats/chats-list.html
+++ b/webui/components/sidebar/chats/chats-list.html
@@ -32,6 +32,9 @@
                   <span class="chat-name"
                     x-text="context.name ? context.name : 'Chat #' + context.no"></span>
                 </div>
+                <button class="btn-icon-action chat-list-action-btn" title="Chat model settings" @click.stop="$store.chats.openChatModelSettings(context.id)">
+                  <span class="material-symbols-outlined">tune</span>
+                </button>
                 <button class="btn-icon-action chat-list-action-btn" title="Close chat" @click.stop="$confirmClick($event, () => $store.chats.killChat(context.id))">
                   <span class="material-symbols-outlined">close</span>
                 </button>

--- a/webui/components/sidebar/chats/chats-store.js
+++ b/webui/components/sidebar/chats/chats-store.js
@@ -91,6 +91,14 @@ const model = {
     }
   },
 
+  // Open per-chat model settings modal
+  async openChatModelSettings(id) {
+    const { store: chatModelStore } = await import(
+      "/components/modals/chat-model/chat-model-store.js"
+    );
+    await chatModelStore.open(id);
+  },
+
   // Delete a chat
   async killChat(id) {
     if (!id) {


### PR DESCRIPTION
## Summary

This PR adds the ability for users to set a **custom model for individual chats** without changing the global settings.

### Problem
Currently, changing the chat model affects all conversations. Users who want to test different models or use a specific model for a particular task must change the global settings back and forth.

### Solution
A per-chat model override that lets users toggle a custom model configuration on any chat:

- **Toggle on**: the chat uses its own provider, model name, and parameters
- **Toggle off**: the chat reverts to the global settings
- The override is persisted and automatically re-applied when the chat is reloaded from disk

### How it works

**Backend**
- `helpers/chat_model_override.py` — core logic: `get_override()`, `set_override()`, `apply_override()`
- `api/chat_model_get.py` — GET endpoint returning current model config (global or custom)
- `api/chat_model_set.py` — SET endpoint to enable/disable/update the override
- `helpers/persist_chat.py` — 4 lines added to re-apply override on chat deserialization

**Frontend**
- A **tune** button (🎵) next to each chat in the sidebar
- Opens a modal where users can:
  - Toggle custom model on/off
  - Select provider and model name
  - Configure API base, context length, vision support, rate limits, and extra kwargs
- Built with Alpine.js following the existing modal pattern (`x-data` store, dynamic import)

**Tests**
- `tests/test_chat_model_per_chat_override.py` — unit tests covering:
  - Setting/removing override data
  - Type normalization (string numbers, booleans, kwargs parsing)
  - Fallback behavior when fields are empty or invalid

### Screenshots
_The modal follows the existing UI style. A small tune icon appears next to each chat name in the sidebar._

### Checklist
- [x] Feature branch based on `development`
- [x] Follows existing code patterns (ApiHandler, Alpine.js stores, modal structure)
- [x] Includes unit tests
- [x] No unrelated changes