### PR TITLE
fix(settings): defer models import to prevent NameError after model config migration

### DIFF
--- a/helpers/settings.py
+++ b/helpers/settings.py
@@ -6,7 +6,6 @@ import re
 import subprocess
 from typing import Any, Literal, TypedDict, cast, TypeVar
 
-import models
 from helpers import runtime, whisper, defer, git, subagents
 from . import files, dotenv
 from helpers.print_style import PrintStyle
@@ -185,6 +184,7 @@ def _ensure_option_present(options: list[OptionT] | None, current_value: str | N
     return opts
 
 def convert_out(settings: Settings) -> SettingsOutput:
+    import models  # deferred to avoid circular import with models.py
     out = SettingsOutput(
         settings = settings.copy(),
         additional = SettingsOutputAdditional(
@@ -267,6 +267,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
     return out
 
 def _get_api_key_field(settings: Settings, provider: str, title: str) -> SettingsField:
+    import models  # deferred to avoid circular import with models.py
     key = settings["api_keys"].get(provider, models.get_api_key(provider))
     # For API keys, use simple asterisk placeholder for existing keys
     return {
@@ -376,6 +377,7 @@ def _adjust_to_version(settings: Settings, default: Settings):
 
 
 def _load_sensitive_settings(settings: Settings):
+    import models  # deferred to avoid circular import with models.py
     # load api keys from .env
     providers = get_providers("chat") + get_providers("embedding")
     for provider in providers:


### PR DESCRIPTION
## Problem

After the _model_config plugin refactor (PR #1262), the top-level `import models` in `helpers/settings.py` creates a circular import risk. Three functions still reference the `models` module directly:

- `convert_out()` — calls `models.get_api_key()` via `_get_api_key_field()`
- `_get_api_key_field()` — calls `models.get_api_key(provider)`
- `_load_sensitive_settings()` — calls `models.get_api_key(provider)`

If the top-level import is removed (as would be natural during further cleanup), these functions crash with `NameError: name models is not defined`.

Even with the current code, the circular dependency between `settings.py` and `models.py` can cause import-order issues in certain initialization sequences.

## Fix

Move `import models` from the module top-level into each function body that uses it, following the established pattern for circular dependency avoidance already used elsewhere in the codebase (e.g., `from helpers import projects` inside functions).

## Changes

- `helpers/settings.py`: Remove top-level `import models`, add deferred `import models` in `convert_out()`, `_get_api_key_field()`, and `_load_sensitive_settings()`

## Testing

- Verified all three functions work correctly with deferred import
- No circular import errors on startup
- Settings page loads and displays API key fields correctly