### PR TITLE
fix(plugins): prevent caching None when hooks.py missing

### DIFF
--- a/helpers/plugins.py
+++ b/helpers/plugins.py
@@ -826,7 +826,8 @@ def call_plugin_hook(
             if files.exists(hooks_script)
             else None
         )
-        cache.add(HOOKS_CACHE_AREA, plugin_name, hooks)
+        if hooks is not None:
+            cache.add(HOOKS_CACHE_AREA, plugin_name, hooks)
     else:
         hooks = cache.get(HOOKS_CACHE_AREA, plugin_name)
 


### PR DESCRIPTION
## Problem

In `call_plugin_hook()`, when a plugin directory exists but has no `hooks.py` file, the `hooks` variable is `None`. This `None` value gets cached via `cache.add(HOOKS_CACHE_AREA, plugin_name, hooks)`.

On subsequent calls, `cache.has()` returns `True` (the key exists), so the function takes the cache-hit path and retrieves `None` — permanently skipping any attempt to re-check whether a `hooks.py` file has been added since startup.

This is particularly problematic during plugin development: adding a `hooks.py` to an existing plugin requires a full restart because the `None` cache entry prevents discovery.

## Fix

Only cache the hooks module when it is not `None`. When `hooks` is `None`, the cache miss path runs on every call, allowing newly added `hooks.py` files to be discovered without restart.

## Changes

- `helpers/plugins.py`: Wrap `cache.add()` in `if hooks is not None:` guard

## Context

Note: the adjacent null-check for `plugin_dir` added in PR #1262 covers a different case (missing plugin directory). This fix covers the case where the plugin directory exists but has no hooks script.