### PR TITLE
plugins: polish hub, info modal; fix readme link handling; update docs

### DIFF
--- a/docs/agents/AGENTS.plugins.md
+++ b/docs/agents/AGENTS.plugins.md
@@ -27,8 +27,8 @@ usr/plugins/<plugin_name>/
 ├── execute.py                    # Optional: user-triggered plugin script
 ├── hooks.py                      # Optional: runtime hook functions callable by the framework
 ├── default_config.yaml           # Optional: fallback settings defaults
-├── README.md                     # Optional: shown in Plugin List UI
-├── LICENSE                       # Optional: shown in Plugin List UI
+├── README.md                     # Optional locally; strongly recommended for community plugins (Plugin Hub)
+├── LICENSE                       # Optional locally (shown in Plugin List UI when present); required at repo root for Plugin Index submission
 ├── conf/
 │   └── model_providers.yaml      # Optional: add or override model providers
 ├── api/                          # API handlers (ApiHandler subclasses)
@@ -263,7 +263,7 @@ screenshots:                    # optional, up to 5 full image URLs
   - https://raw.githubusercontent.com/yourname/your-plugin-repo/main/docs/screen.png
 ```
 
-The index manifest is named `index.yaml` (not `plugin.yaml`). Required fields: `title`, `description`, `github`. Optional: `tags` (up to 5), `screenshots` (up to 5 URLs). The `github` field must point to the root of a GitHub repository that contains a runtime `plugin.yaml` at the repository root, and that `plugin.yaml` must include a `name` field matching the index folder name exactly.
+The index manifest is named `index.yaml` (not `plugin.yaml`). Required fields: `title`, `description`, `github`. Optional: `tags` (up to 5), `screenshots` (up to 5 URLs). The `github` field must point to the root of a GitHub repository that contains a runtime `plugin.yaml` at the repository root, and that `plugin.yaml` must include a `name` field matching the index folder name exactly. That repository must also include a `LICENSE` file at its root so community users have explicit terms of use.
 
 ### Repository Structure for Community Plugins
 
@@ -274,7 +274,7 @@ your-plugin-repo/          ← GitHub repository root
 ├── plugin.yaml            ← runtime manifest (title, description, version, ...)
 ├── default_config.yaml
 ├── README.md
-├── LICENSE
+├── LICENSE                ← required for Plugin Index (community) plugins
 ├── api/
 ├── tools/
 ├── extensions/
@@ -297,6 +297,7 @@ Index submission rules:
 - Folder name must exactly match the `name` field in your remote `plugin.yaml`
 - Folders starting with `_` are reserved for internal use
 - `github` must point to a public repo that contains `plugin.yaml` at its root with a matching `name` field
+- The same repo must contain `LICENSE` at its root (community contribution requirement)
 - `title` max 50 characters, `description` max 500 characters
 - `index.yaml` total max 2000 characters
 - `tags`: optional, up to 5, use recommended tags from https://github.com/agent0ai/a0-plugins/blob/main/TAGS.md
@@ -313,4 +314,9 @@ Both routes surface Plugin Index entries inside Agent Zero. The Plugin Hub suppo
 
 ---
 
-*Refer to AGENTS.md for the main framework guide.*
+## 9. See Also
+
+- `docs/developer/plugins.md` for the developer-facing plugin lifecycle and publishing guide
+- `plugins/README.md` for the bundled-vs-user plugin directory overview and quick links
+- `skills/a0-plugin-router/SKILL.md` for the agent-facing entry point that routes plugin tasks to the right specialist skill
+- `AGENTS.md` for the main framework guide

--- a/docs/developer/plugins.md
+++ b/docs/developer/plugins.md
@@ -54,8 +54,8 @@ usr/plugins/<plugin_name>/
 ├── execute.py                       # optional user-triggered plugin script
 ├── hooks.py                         # optional runtime hook functions callable by the framework
 ├── default_config.yaml              # optional defaults
-├── README.md                        # optional, shown in Plugin List UI
-├── LICENSE                          # optional, shown in Plugin List UI
+├── README.md                        # optional locally; strongly recommended for community plugins
+├── LICENSE                          # optional locally (shown in Plugin List UI when present); required at repo root for Plugin Index submission
 ├── api/                             # ApiHandler implementations
 ├── tools/                           # Tool implementations
 ├── helpers/                         # shared Python logic
@@ -251,7 +251,7 @@ screenshots:                    # optional, up to 5 full image URLs
   - https://raw.githubusercontent.com/yourname/your-plugin-repo/main/docs/screen.png
 ```
 
-The index manifest file is named `index.yaml` (not `plugin.yaml`). Required fields: `title`, `description`, `github`. Optional: `tags` (up to 5), `screenshots` (up to 5 URLs). The `github` URL must point to a public GitHub repository that contains a runtime `plugin.yaml` at the **repository root**, and that `plugin.yaml` must include a `name` field matching the index folder name exactly.
+The index manifest file is named `index.yaml` (not `plugin.yaml`). Required fields: `title`, `description`, `github`. Optional: `tags` (up to 5), `screenshots` (up to 5 URLs). The `github` URL must point to a public GitHub repository that contains a runtime `plugin.yaml` at the **repository root**, and that `plugin.yaml` must include a `name` field matching the index folder name exactly. That repository must also include a `LICENSE` file at its root (Plugin Index / community contribution requirement).
 
 ### Repository Structure for Community Plugins
 
@@ -262,7 +262,7 @@ your-plugin-repo/          ← GitHub repository root
 ├── plugin.yaml            ← runtime manifest (must include name field)
 ├── default_config.yaml
 ├── README.md
-├── LICENSE
+├── LICENSE                ← required for Plugin Index listings
 ├── api/
 ├── tools/
 ├── extensions/
@@ -280,6 +280,7 @@ your-plugin-repo/          ← GitHub repository root
 Submission rules:
 - Folder name: unique, stable, `^[a-z0-9_]+$` (lowercase, numbers, underscores — no hyphens)
 - Folder name must exactly match the `name` field in your remote `plugin.yaml`
+- The GitHub repo must include `LICENSE` at its root (community contribution requirement)
 - Folders starting with `_` are reserved for internal use
 - `title`: max 50 characters
 - `description`: max 500 characters
@@ -310,7 +311,8 @@ This keeps toasts and notification history consistent. See [Notifications](notif
 ## See Also
 
 - `docs/agents/AGENTS.plugins.md` for full architecture details
-- `skills/a0-create-plugin/SKILL.md` for plugin authoring workflow (agent-facing)
+- `skills/a0-plugin-router/SKILL.md` for the primary agent-facing entry point across plugin create/review/manage/contribute/debug tasks
+- `skills/a0-create-plugin/SKILL.md` for direct plugin authoring workflow when the task is specifically to build or extend a plugin
 - `plugins/README.md` for core plugin directory overview
 
 ## Frontend Extension Notes

--- a/helpers/plugins.py
+++ b/helpers/plugins.py
@@ -86,6 +86,8 @@ class PluginListItem(BaseModel):
     display_name: str = ""
     description: str = ""
     version: str = ""
+    author: str = ""
+    repo: str = ""
     settings_sections: List[str] = Field(default_factory=list)
     per_project_config: bool = False
     per_agent_config: bool = False
@@ -254,11 +256,16 @@ def get_enhanced_plugins_list(
                         break
                 current_commit = ""
                 current_commit_timestamp = ""
+                author = ""
+                repo_name = ""
                 if is_custom:
                     repo_info = git.get_repo_release_info(str(d))
-                    if repo_info.is_git_repo and repo_info.head:
-                        current_commit = repo_info.head.hash
-                        current_commit_timestamp = repo_info.head.committed_at
+                    if repo_info.is_git_repo:
+                        author = repo_info.author
+                        repo_name = repo_info.repo
+                        if repo_info.head:
+                            current_commit = repo_info.head.hash
+                            current_commit_timestamp = repo_info.head.committed_at
                 results.append(
                     PluginListItem(
                         name=d.name,
@@ -266,6 +273,8 @@ def get_enhanced_plugins_list(
                         display_name=meta.title or d.name,
                         description=meta.description,
                         version=meta.version,
+                        author=author,
+                        repo=repo_name,
                         settings_sections=meta.settings_sections,
                         per_project_config=meta.per_project_config,
                         per_agent_config=meta.per_agent_config,

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -14,6 +14,7 @@ For detailed guides on how to create, extend, or configure plugins, refer to:
 - [`docs/agents/AGENTS.plugins.md`](../docs/agents/AGENTS.plugins.md): Full-stack plugin architecture, manifest format, extension points, and Plugin Index submission.
 - [`docs/developer/plugins.md`](../docs/developer/plugins.md): Human-facing developer guide covering the full plugin lifecycle.
 - [`AGENTS.md`](../AGENTS.md): Main framework guide and backend context.
+- [`skills/a0-plugin-router/SKILL.md`](../skills/a0-plugin-router/SKILL.md): Agent-facing entry point that routes plugin tasks to the appropriate specialist skill.
 - [`skills/a0-create-plugin/SKILL.md`](../skills/a0-create-plugin/SKILL.md): Agent-facing authoring workflow (local and community plugins).
 
 ## What a Plugin Can Provide
@@ -31,6 +32,7 @@ Plugins are automatically discovered based on the presence of a `plugin.yaml` fi
 Every plugin requires a `plugin.yaml` at its root:
 
 ```yaml
+name: my_plugin              # required for community plugins
 title: My Plugin
 description: What this plugin does.
 version: 1.0.0
@@ -68,7 +70,7 @@ The **Plugin Index** at https://github.com/agent0ai/a0-plugins is the community-
 
 To share a plugin with the community:
 
-1. Create a standalone GitHub repository with the plugin contents at the repo root. The runtime `plugin.yaml` must include a `name` field matching the intended index folder name.
+1. Create a standalone GitHub repository with the plugin contents at the repo root. The runtime `plugin.yaml` must include a `name` field matching the intended index folder name. Add a `LICENSE` file at the repo root (required for Plugin Index listings so users have explicit terms of use).
 2. Fork `https://github.com/agent0ai/a0-plugins` and add a folder `plugins/<your_plugin_name>/` containing a separate index manifest named `index.yaml` (not `plugin.yaml`):
 
 ```yaml

--- a/plugins/_plugin_installer/webui/install-detail.html
+++ b/plugins/_plugin_installer/webui/install-detail.html
@@ -290,7 +290,8 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            background: var(--color-panel);
+            background: radial-gradient(circle at top, #6b728089, var(--color-panel)),
+                var(--color-panel);
             border: 1px solid var(--color-border);
         }
 
@@ -402,6 +403,36 @@
             display: flex;
             flex-wrap: wrap;
             gap: 0.4rem;
+        }
+
+        .pi-card-installed-pill {
+            display: inline-flex;
+            padding: 0.24rem 0.5rem;
+            border-radius: 0.5rem;
+            background: rgba(34, 197, 94, 0.15);
+            color: #4ade80;
+            font-size: 0.72rem;
+            font-weight: 700;
+        }
+
+        body.light-mode .pi-card-installed-pill {
+            background: rgba(34, 197, 94, 0.22);
+            color: #166534;
+        }
+
+        .pi-card-update-pill {
+            display: inline-flex;
+            padding: 0.24rem 0.5rem;
+            border-radius: 0.5rem;
+            background: rgba(59, 130, 246, 0.16);
+            color: #60a5fa;
+            font-size: 0.72rem;
+            font-weight: 700;
+        }
+
+        body.light-mode .pi-card-update-pill {
+            background: rgba(59, 130, 246, 0.2);
+            color: #1d4ed8;
         }
 
         .pi-status-badges .pi-card-installed-pill {

--- a/plugins/_plugin_installer/webui/install-index.html
+++ b/plugins/_plugin_installer/webui/install-index.html
@@ -86,18 +86,13 @@
                                         x-text="$store.pluginInstallStore.getBrowseSubtitle(plugin)">
                                     </div>
 
-                                    <div class="pi-card-pills">
-                                        <template x-if="plugin.installed">
-                                            <span class="pi-card-installed-pill">Installed</span>
-                                        </template>
-                                        <template x-if="plugin.has_update">
-                                            <span class="pi-card-update-pill">New version</span>
-                                        </template>
-                                    </div>
+                                    <span class="pi-card-stars">
+                                        <span class="material-symbols-outlined">star</span>
+                                        <span x-text="plugin.stars || 0"></span>
+                                    </span>
 
                                 </div>
 
-                                <span class="material-symbols-outlined pi-card-arrow">arrow_outward</span>
                             </div>
 
                             <div class="pi-card-body">
@@ -109,16 +104,32 @@
                             </div>
 
                             <div class="pi-card-footer">
-                                <span class="pi-card-stars">
-                                    <span class="material-symbols-outlined">star</span>
-                                    <span x-text="plugin.stars || 0"></span>
-                                </span>
 
-                                <template x-if="$store.pluginInstallStore.getBrowsePrimaryTag(plugin)">
-                                    <span class="pi-card-tag"
-                                        x-text="$store.pluginInstallStore.getBrowsePrimaryTag(plugin)">
-                                    </span>
-                                </template>
+                                <div class="pi-card-bubbles pi-card-bubbles-tags">
+                                    <template x-if="$store.pluginInstallStore.getBrowsePrimaryTag(plugin)">
+                                        <span class="pi-card-bubble pi-card-bubble-tag">
+                                            <span class="material-symbols-outlined">sell</span>
+                                            <span class="pi-card-bubble-text"
+                                                x-text="$store.pluginInstallStore.getBrowsePrimaryTag(plugin)"></span>
+                                        </span>
+                                    </template>
+                                </div>
+
+                                <div class="pi-card-bubbles pi-card-bubbles-status">
+                                    <template x-if="plugin.installed">
+                                        <span class="pi-card-bubble pi-card-bubble-installed">
+                                            <span class="material-symbols-outlined">check_circle</span>
+                                            <span class="pi-card-bubble-text">Installed</span>
+                                        </span>
+                                    </template>
+                                    <template x-if="plugin.has_update">
+                                        <span class="pi-card-bubble pi-card-bubble-update">
+                                            <span class="material-symbols-outlined">update</span>
+                                            <span class="pi-card-bubble-text">New version</span>
+                                        </span>
+                                    </template>
+                                </div>
+
                             </div>
                         </button>
                     </template>
@@ -394,7 +405,7 @@
             width: 100%;
             padding: 0;
             border: 1px solid var(--color-border);
-            border-radius: 16px;
+            border-radius: 10px;
             background: var(--color-background);
             color: inherit;
             text-align: left;
@@ -425,7 +436,8 @@
             justify-content: center;
             border-radius: 0.5rem;
             overflow: hidden;
-            background: var(--color-panel);
+            background: radial-gradient(circle at top, #6b728089, var(--color-panel)),
+                var(--color-panel);
             border: 1px solid var(--color-border);
         }
 
@@ -481,51 +493,12 @@
             color: var(--color-text-secondary);
         }
 
-        .pi-card-pills {
-            display: flex;
-            flex-wrap: wrap;
-            padding: var(--spacing-xs) 0;
-            gap: 0.4rem;
-        }
-
-        .pi-card-pills 
-
-        .pi-card-installed-pill {
-            display: inline-flex;
-            padding: 0.24rem 0.5rem;
-            border-radius: 0.5rem;
-            background: rgba(34, 197, 94, 0.15);
-            color: #4ade80;
-            font-size: 0.72rem;
-            font-weight: 700;
-        }
-
-        body.light-mode .pi-card-installed-pill {
-            background: rgba(34, 197, 94, 0.22);
-            color: #166534;
-        }
-
-        .pi-card-update-pill {
-            display: inline-flex;
-            padding: 0.24rem 0.5rem;
-            border-radius: 0.5rem;
-            background: rgba(59, 130, 246, 0.16);
-            color: #60a5fa;
-            font-size: 0.72rem;
-            font-weight: 700;
-        }
-
-        body.light-mode .pi-card-update-pill {
-            background: rgba(59, 130, 246, 0.2);
-            color: #1d4ed8;
-        }
-
         .pi-card-footer {
             display: flex;
             align-items: center;
             justify-content: space-between;
-            gap: 0.5rem;
-            padding: 0.9rem 1rem 1rem;
+            gap: 0.75rem;
+            padding: 0.65rem 0.85rem 0.75rem;
             border-top: 1px solid var(--color-border);
         }
 
@@ -533,6 +506,7 @@
             display: inline-flex;
             align-items: center;
             gap: 0.3rem;
+            padding: var(--spacing-xxs) 0;
             font-size: 0.85rem;
             color: var(--color-text-secondary);
         }
@@ -542,14 +516,127 @@
             color: #fbbf24;
         }
 
-        .pi-card-tag {
-            padding: 0.22rem 0.55rem;
-            border-radius: 0.5rem;
-            font-size: 0.75rem;
-            font-weight: 600;
-            background: var(--color-panel);
-            color: var(--color-text-secondary);
+        .pi-card-bubbles {
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+            flex-shrink: 0;
+        }
+
+        .pi-card-bubbles-tags {
+            min-width: 0;
+            flex: 1 1 auto;
+            justify-content: flex-start;
+        }
+
+        .pi-card-bubbles-status {
+            justify-content: flex-end;
+        }
+
+        .pi-card-bubble {
+            display: inline-flex;
+            align-items: center;
+            height: 26px;
+            padding: 0 0.45rem;
+            border-radius: 6px;
             border: 1px solid var(--color-border);
+            background: var(--color-panel);
+            overflow: hidden;
+            cursor: default;
+            transition: background 0.2s ease, border-color 0.2s ease;
+        }
+
+        .pi-card-bubble .material-symbols-outlined {
+            font-size: 0.95rem;
+            flex-shrink: 0;
+            line-height: 1;
+        }
+
+        .pi-card-bubble-text {
+            max-width: 0;
+            opacity: 0;
+            overflow: hidden;
+            white-space: nowrap;
+            font-size: 0.72rem;
+            font-weight: 600;
+            transition: max-width 0.25s ease, opacity 0.2s ease, margin-left 0.2s ease;
+            margin-left: 0;
+        }
+
+        /* Category tag (left): label always visible */
+        .pi-card-bubbles-tags .pi-card-bubble {
+            min-width: 0;
+            max-width: 100%;
+        }
+
+        .pi-card-bubbles-tags .pi-card-bubble-text {
+            flex: 1 1 auto;
+            min-width: 0;
+            max-width: 10rem;
+            opacity: 1;
+            margin-left: 0.3rem;
+            text-overflow: ellipsis;
+        }
+
+        /* Status pills (right): icon until hover */
+        .pi-card-bubbles-status .pi-card-bubble:hover .pi-card-bubble-text {
+            max-width: 8rem;
+            opacity: 1;
+            margin-left: 0.3rem;
+        }
+
+        .pi-card-bubble-tag .material-symbols-outlined {
+            color: var(--color-text-muted);
+        }
+
+        .pi-card-bubble-tag .pi-card-bubble-text {
+            color: var(--color-text-secondary);
+        }
+
+        .pi-card-bubble-installed .material-symbols-outlined {
+            color: #4ade80;
+        }
+
+        .pi-card-bubble-installed .pi-card-bubble-text {
+            color: #4ade80;
+        }
+
+        .pi-card-bubble-installed:hover {
+            background: rgba(34, 197, 94, 0.1);
+            border-color: rgba(34, 197, 94, 0.3);
+        }
+
+        .pi-card-bubble-update .material-symbols-outlined {
+            color: #60a5fa;
+        }
+
+        .pi-card-bubble-update .pi-card-bubble-text {
+            color: #60a5fa;
+        }
+
+        .pi-card-bubble-update:hover {
+            background: rgba(59, 130, 246, 0.1);
+            border-color: rgba(59, 130, 246, 0.3);
+        }
+
+        body.light-mode .pi-card-bubble-installed .material-symbols-outlined,
+        body.light-mode .pi-card-bubble-installed .pi-card-bubble-text {
+            color: #166534;
+        }
+
+        body.light-mode .pi-card-bubble-installed:hover {
+            background: rgba(34, 197, 94, 0.12);
+            border-color: rgba(34, 197, 94, 0.35);
+        }
+
+        body.light-mode .pi-card-bubble-update .material-symbols-outlined,
+        body.light-mode .pi-card-bubble-update .pi-card-bubble-text {
+            color: #1d4ed8;
+        }
+
+        body.light-mode .pi-card-bubble-update:hover {
+            background: rgba(59, 130, 246, 0.1);
+            border-color: rgba(59, 130, 246, 0.35);
         }
 
         .pi-pagination {

--- a/plugins/_plugin_installer/webui/pluginInstallStore.js
+++ b/plugins/_plugin_installer/webui/pluginInstallStore.js
@@ -608,9 +608,21 @@ const model = {
   },
 
   handleOpenInfo() {
-    if (this.installedPluginInfo) {
-      pluginListStore.openPluginInfo(this.installedPluginInfo);
-    }
+    if (!this.installedPluginInfo) return;
+    const pluginHubKey = (this.selectedPlugin?.key || "").trim();
+    const plugin = pluginHubKey
+      ? {
+          ...this.installedPluginInfo,
+          pluginHub: {
+            key: pluginHubKey,
+            title:
+              this.selectedPlugin?.title ||
+              this.installedPluginInfo.display_name ||
+              this.installedPluginInfo.name,
+          },
+        }
+      : this.installedPluginInfo;
+    pluginListStore.openPluginInfo(plugin);
   },
 
   handleOpenExecute() {

--- a/plugins/_plugin_installer/webui/pluginInstallStore.js
+++ b/plugins/_plugin_installer/webui/pluginInstallStore.js
@@ -1,5 +1,6 @@
 import { createStore } from "/js/AlpineStore.js";
 import * as api from "/js/api.js";
+import { addBlankTargetsToLinks } from "/js/messages.js";
 import { openModal } from "/js/modals.js";
 import { marked } from "/vendor/marked/marked.esm.js";
 import { toastFrontendSuccess, toastFrontendError } from "/components/notifications/notification-store.js";
@@ -76,6 +77,52 @@ const model = {
     let url = githubUrl.trim().replace(/\.git$/i, "");
     if (!url.includes("github.com")) return null;
     return url.replace("https://github.com/", "https://raw.githubusercontent.com/");
+  },
+
+  _rebaseReadmeLinks(html, githubUrl, branch) {
+    if (!html || typeof html !== "string" || !githubUrl || !branch) return html;
+
+    let repoUrl;
+    try {
+      repoUrl = new URL(githubUrl.trim().replace(/\.git$/i, ""));
+    } catch {
+      return html;
+    }
+
+    if (repoUrl.hostname !== "github.com") return html;
+
+    const [owner, repo] = repoUrl.pathname
+      .replace(/^\/+|\/+$/g, "")
+      .split("/");
+    if (!owner || !repo) return html;
+
+    const repoBlobBase = `https://github.com/${owner}/${repo}/blob/${branch}`;
+    const doc = new DOMParser().parseFromString(html, "text/html");
+
+    doc.querySelectorAll("a[href]").forEach((anchor) => {
+      const href = (anchor.getAttribute("href") || "").trim();
+      if (
+        !href ||
+        href.startsWith("#") ||
+        href.startsWith("//") ||
+        /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(href)
+      ) {
+        return;
+      }
+
+      try {
+        const resolved = new URL(href, "https://repo-root.invalid/");
+        const repoPath = resolved.pathname.replace(/^\/+/, "");
+        anchor.setAttribute(
+          "href",
+          `${repoBlobBase}/${repoPath}${resolved.search}${resolved.hash}`,
+        );
+      } catch {
+        // Leave malformed links unchanged.
+      }
+    });
+
+    return doc.body.innerHTML;
   },
 
   _pluginPrimaryTag(plugin) {
@@ -474,7 +521,9 @@ const model = {
           if (!response.ok) continue;
 
           const readme = await response.text();
-          this.readmeContent = marked.parse(readme, { breaks: true });
+          let html = marked.parse(readme, { breaks: true });
+          html = this._rebaseReadmeLinks(html, plugin?.github, branch);
+          this.readmeContent = addBlankTargetsToLinks(html);
           return;
         } catch (error) {
           lastError = error;

--- a/plugins/_plugin_validator/webui/plugin-validator-checks.json
+++ b/plugins/_plugin_validator/webui/plugin-validator-checks.json
@@ -7,7 +7,7 @@
   "checks": {
     "manifest": {
       "label": "Manifest Validation",
-      "detail": "Validate plugin.yaml at the plugin root. Confirm it is parseable YAML, contains the required name/title/description/version fields, uses a valid plugin name matching ^[a-z0-9_]+$, keeps boolean fields typed correctly, restricts settings_sections to the documented values, and avoids unknown schema keys.",
+      "detail": "Validate plugin.yaml at the plugin root. Confirm it is parseable YAML, contains the required title/description/version fields (and a valid name when intended for the community index), uses a plugin name matching ^[a-z0-9_]+$ when present, keeps boolean fields typed correctly, restricts settings_sections to the documented values, and avoids unknown schema keys.",
       "criteria": {
         "pass": "plugin.yaml exists, parses, and matches the expected schema with no required fixes",
         "warning": "Manifest is mostly valid but has extra keys, weak metadata, or non-blocking schema issues",
@@ -16,10 +16,10 @@
     },
     "structure": {
       "label": "Structure Validation",
-      "detail": "Inspect the directory layout and role of each top-level file or folder. Check that api/ contains Python ApiHandler files, tools/ contains Tool subclasses, extensions/ follows python/<point>/ or webui/<point>/ conventions, webui/config.html is backed by settings_sections, hooks.py exposes install when expected, execute.py follows the main()/sys.exit(main()) pattern, and the root contains only expected plugin files.",
+      "detail": "Inspect the directory layout and role of each top-level file or folder. Check that api/ contains Python ApiHandler files, tools/ contains Tool subclasses, extensions/ follows python/<point>/ or webui/<point>/ conventions, webui/config.html is backed by settings_sections, hooks.py exposes install when expected, execute.py follows the main()/sys.exit(main()) pattern, and the root contains only expected plugin files. Also verify a file named LICENSE exists at the plugin root (same directory as plugin.yaml). Agent Zero does not require LICENSE for loading a local plugin, but the Plugin Index requires LICENSE at the repository root for community listings; a missing LICENSE must not be rated pass for this phase.",
       "criteria": {
-        "pass": "Directory layout cleanly matches Agent Zero plugin conventions",
-        "warning": "Structure mostly works but contains unusual files or minor convention drift",
+        "pass": "Directory layout cleanly matches Agent Zero plugin conventions and LICENSE exists at the plugin root",
+        "warning": "Layout mostly works but LICENSE is missing at the plugin root (required for Plugin Index submission; optional for local-only use), or there are unusual files or minor convention drift",
         "fail": "Layout or required files clearly break plugin loading, installation, or contribution expectations"
       }
     },

--- a/plugins/_plugin_validator/webui/plugin-validator-guidance.md
+++ b/plugins/_plugin_validator/webui/plugin-validator-guidance.md
@@ -7,3 +7,4 @@
 - Hooks runtime targeting: use `sys.executable` only for framework runtime work and `/opt/venv/bin/python` for agent-runtime installs.
 - execute.py pattern: expose `main()` and end with `if __name__ == "__main__": sys.exit(main())`.
 - Community contribution: plugin name must match `^[a-z0-9_]+$`, match the directory name, and stay unique in the published index.
+- LICENSE: a file named `LICENSE` at the plugin root is optional for local-only plugins but required at the repository root before Plugin Index submission; if missing, rate Structure Validation as warning (not pass) and state that clearly in findings.

--- a/plugins/_plugin_validator/webui/plugin-validator-prompt.md
+++ b/plugins/_plugin_validator/webui/plugin-validator-prompt.md
@@ -20,7 +20,7 @@ Follow these steps in order:
 
 1. Resolve the plugin root and list every file below it. Do not sample; inspect the full plugin.
 2. Read `plugin.yaml` and record the plugin's name, title, description, and version.
-3. Map the directory structure and identify every top-level file or folder that affects behavior.
+3. Map the directory structure and identify every top-level file or folder that affects behavior. Record whether a `LICENSE` file exists at the plugin root (required for Plugin Index submission per project policy; optional for local-only plugins).
 4. Run ONLY the selected validation phases listed below.
 5. If a temporary clone or extracted directory was used, perform the cleanup exactly as instructed.
 

--- a/skills/a0-contribute-plugin/SKILL.md
+++ b/skills/a0-contribute-plugin/SKILL.md
@@ -52,7 +52,7 @@ The plugin must live in its **own standalone GitHub repository** with plugin con
 your-plugin-repo/           <- GitHub repository root
 ├── plugin.yaml             <- runtime manifest (REQUIRED)
 ├── README.md               <- strongly recommended (shown in Plugin Hub detail view)
-├── LICENSE                 <- strongly recommended
+├── LICENSE                 <- REQUIRED for Plugin Index submission (place at repo root)
 ├── default_config.yaml     <- optional
 ├── api/                    <- API handlers
 ├── tools/                  <- agent tools
@@ -174,6 +174,7 @@ Run these checks locally before opening the PR (mirrors what CI will verify):
 | `github` URL | Points to existing public repo |
 | Remote `plugin.yaml` | Exists at repo root |
 | Remote `plugin.yaml` `name` field | Matches index folder name exactly |
+| Remote `LICENSE` | Exists at repo root (Plugin Index policy) |
 | Folder name pattern | `^[a-z0-9_]+$`, no leading `_` |
 | `github` URL uniqueness | Not already in the index for another plugin |
 
@@ -227,6 +228,8 @@ gh pr create \
 
 ## References
 
+- Plugin architecture: `/a0/docs/agents/AGENTS.plugins.md`
+- Developer lifecycle guide: `/a0/docs/developer/plugins.md`
 - Plugin Index repo: https://github.com/agent0ai/a0-plugins
 - Recommended tags: https://github.com/agent0ai/a0-plugins/blob/main/TAGS.md
 - Review before contributing: read `/a0/skills/a0-review-plugin/SKILL.md`

--- a/skills/a0-create-plugin/SKILL.md
+++ b/skills/a0-create-plugin/SKILL.md
@@ -24,6 +24,7 @@ Primary references:
 - /a0/docs/agents/AGENTS.components.md (Component system deep dive)
 - /a0/docs/agents/AGENTS.modals.md (Modal system & CSS conventions)
 - /a0/docs/agents/AGENTS.plugins.md (Extension points, plugin.yaml, settings system, Plugin Index)
+- /a0/docs/developer/plugins.md (Developer lifecycle and publishing)
 
 ---
 
@@ -184,8 +185,8 @@ save_plugin_config(
   execute.py            # Optional user-triggered setup, post-install, or maintenance script
   hooks.py              # Optional framework runtime hook functions
   default_config.yaml   # Optional default settings fallback
-  README.md             # Optional, shown in Plugin List UI
-  LICENSE               # Optional, shown in Plugin List UI
+  README.md             # Optional locally; strongly recommended for community plugins
+  LICENSE               # Optional locally (shown in Plugin List UI when present); required at repo root for Plugin Index submission
   agents/
     <profile>/agent.yaml # Optional plugin-distributed agent profile
   api/                  # API Handlers (ApiHandler base class)
@@ -306,7 +307,7 @@ your-plugin-repo/          ← GitHub repository root
 ├── plugin.yaml            ← runtime manifest (must include name field!)
 ├── default_config.yaml
 ├── README.md
-├── LICENSE
+├── LICENSE                ← required at repo root before Plugin Index submission
 ├── api/
 ├── tools/
 ├── extensions/

--- a/skills/a0-manage-plugin/SKILL.md
+++ b/skills/a0-manage-plugin/SKILL.md
@@ -358,6 +358,7 @@ Plugins with `always_enabled: true` in `plugin.yaml` cannot be toggled (framewor
 ## References
 
 - Plugin architecture: `/a0/docs/agents/AGENTS.plugins.md`
+- Developer lifecycle guide: `/a0/docs/developer/plugins.md`
 - Debug a broken plugin: read `/a0/skills/a0-debug-plugin/SKILL.md`
 - Create a new plugin: read `/a0/skills/a0-create-plugin/SKILL.md`
 - Review a plugin: read `/a0/skills/a0-review-plugin/SKILL.md`

--- a/skills/a0-plugin-router/SKILL.md
+++ b/skills/a0-plugin-router/SKILL.md
@@ -79,8 +79,10 @@ always_enabled: false        # forces ON, disables toggle (framework use only)
 | `hooks.py` | Framework runtime hooks (install, cache, registration) |
 | `execute.py` | User-triggered script (setup, maintenance, repair) |
 | `default_config.yaml` | Settings defaults |
+| `README.md` | Optional locally; strongly recommended for community plugins so Plugin Hub users can inspect the plugin |
 | `agents/<profile>/agent.yaml` | Plugin-distributed agent profiles |
 | `conf/model_providers.yaml` | Add/override model providers |
+| `LICENSE` | Optional under `usr/plugins/`; required at the root of a plugin GitHub repo before submitting to the Plugin Index |
 
 ### Activation
 

--- a/skills/a0-review-plugin/SKILL.md
+++ b/skills/a0-review-plugin/SKILL.md
@@ -27,7 +27,7 @@ Read `usr/plugins/<name>/plugin.yaml`. Check:
 
 - [ ] File exists at plugin root
 - [ ] Valid YAML (parseable, mapping at top level)
-- [ ] `name` field present, non-empty, matches `^[a-z0-9_]+$` and matches the directory name
+- [ ] `name` field handling matches the intended distribution target: for community / Plugin Index plugins it must be present, non-empty, match `^[a-z0-9_]+$`, and match the directory name; for local-only plugins, a missing `name` is a WARN rather than a FAIL
 - [ ] `title` present and non-empty
 - [ ] `description` present and non-empty
 - [ ] `version` present, follows semver or simple `x.y.z` format
@@ -54,10 +54,11 @@ Inspect the plugin directory layout:
 - [ ] If `webui/config.html` exists: plugin must declare at least one `settings_sections` entry
 - [ ] If `hooks.py` exists: warn if it does NOT contain an `install` function (common oversight)
 - [ ] If `execute.py` exists: check it has a `main()` function and `if __name__ == "__main__": sys.exit(main())`
+- [ ] `LICENSE` at plugin root: Agent Zero does not require it for local plugins, but it is **required** at the repo root before submitting to the Plugin Index. If missing → **WARN** — `LICENSE absent — required for community contribution (Plugin Index); optional for local-only use`
 - [ ] `default_config.yaml` (if present): valid YAML
 - [ ] No unexpected top-level entries (WARN for anything outside the standard layout)
 
-Standard top-level layout: `plugin.yaml`, `execute.py`, `hooks.py`, `default_config.yaml`, `README.md`, `LICENSE`, `__init__.py`, `api/`, `tools/`, `extensions/`, `webui/`, `helpers/`, `prompts/`, `agents/`, `conf/`
+Standard top-level layout: `plugin.yaml`, `execute.py`, `hooks.py`, `default_config.yaml`, optional `README.md`, `LICENSE`, `__init__.py`, plus `api/`, `tools/`, `extensions/`, `webui/`, `helpers/`, `prompts/`, `agents/`, `conf/`
 
 ---
 
@@ -125,9 +126,9 @@ Check:
 ### Community readiness assessment
 
 Summarize whether the plugin is ready for contribution:
-- READY: all FAIL items resolved, no WARN items blocking
+- READY: all FAIL items resolved; for Plugin Index submission, no blocking WARN items (a missing `LICENSE` is a WARN but blocks contribution readiness until fixed)
 - NEEDS WORK: list specific FAIL items to fix
-- OPTIONAL IMPROVEMENTS: list WARN items
+- OPTIONAL IMPROVEMENTS: list non-blocking WARN items (if the user is only using the plugin locally, a missing `LICENSE` can be noted as optional)
 
 ---
 
@@ -168,5 +169,6 @@ Fix required: version missing in plugin.yaml, inline error box in webui/settings
 
 - Detailed pattern checklists: read `checklists.md` in this skill directory
 - Plugin architecture: `/a0/docs/agents/AGENTS.plugins.md`
+- Developer lifecycle guide: `/a0/docs/developer/plugins.md`
 - Component system: `/a0/docs/agents/AGENTS.components.md`
 - If review passes and user wants to publish: read `/a0/skills/a0-contribute-plugin/SKILL.md`

--- a/skills/a0-review-plugin/checklists.md
+++ b/skills/a0-review-plugin/checklists.md
@@ -264,7 +264,7 @@ Must: return `0` on success, non-zero on failure. Print progress. Be safe to rer
 ## plugin.yaml Schema Reference
 
 ```yaml
-name: my_plugin              # required for CI (^[a-z0-9_]+$, must match dir name)
+name: my_plugin              # required for community index (^[a-z0-9_]+$, must match dir name)
 title: My Plugin             # required, UI display name
 description: What it does.   # required
 version: 1.0.0               # required
@@ -289,6 +289,9 @@ When submitting to https://github.com/agent0ai/a0-plugins, CI validates:
 **Remote `plugin.yaml`** (your plugin's own repo):
 - Must exist at repo root
 - Must contain `name` field matching the index folder name exactly
+
+**`LICENSE`** (your plugin's own repo):
+- Must exist at repo root for Plugin Index / community listings (policy; same terms users expect from any open repo)
 
 **Folder name**:
 - Pattern: `^[a-z0-9_]+$` (underscores, no hyphens)

--- a/webui/components/plugins/list/plugin-list.html
+++ b/webui/components/plugins/list/plugin-list.html
@@ -291,7 +291,7 @@
 
         .plugin-card {
             border: 1px solid var(--color-border);
-            border-radius: 0.5rem;
+            border-radius: 10px;
             padding: 0.75rem;
             margin-top: 0.75rem;
             background: var(--color-background);

--- a/webui/components/plugins/list/pluginListStore.js
+++ b/webui/components/plugins/list/pluginListStore.js
@@ -3,6 +3,7 @@ import * as api from "/js/api.js";
 import { store as pluginSettingsStore } from "/components/plugins/plugin-settings-store.js";
 import { store as pluginToggleStore } from "/components/plugins/toggle/plugin-toggle-store.js";
 import { store as pluginExecuteStore } from "/components/plugins/list/plugin-execute-store.js";
+import { store as fileBrowserStore } from "/components/modals/file-browser/file-browser-store.js";
 import { store as markdownModalStore } from "/components/modals/markdown/markdown-store.js";
 import { callJsExtensions } from "/js/extensions.js";
 import {
@@ -154,6 +155,20 @@ const model = {
     if (!plugin) return;
     this.selectedPlugin = plugin;
     window.openModal?.("components/plugins/plugin-info.html");
+  },
+
+  async openPluginFolder(plugin) {
+    if (!plugin?.path) return;
+    await fileBrowserStore.open(plugin.path);
+  },
+
+  async openPluginHub(plugin) {
+    const pluginKey = (plugin?.pluginHub?.key || "").trim();
+    if (!pluginKey) return;
+    const { store: pluginInstallStore } = await import(
+      "/plugins/_plugin_installer/webui/pluginInstallStore.js"
+    );
+    await pluginInstallStore.openPluginHubDetailByKey(pluginKey);
   },
 
   async deletePlugin(plugin) {

--- a/webui/components/plugins/plugin-info.html
+++ b/webui/components/plugins/plugin-info.html
@@ -10,14 +10,24 @@
         <template x-if="$store.pluginListStore && $store.pluginListStore.selectedPlugin">
             <div class="plugin-info-view">
                 <div class="plugin-info-header">
-                    <h2 class="plugin-info-title"
-                        x-text="$store.pluginListStore.selectedPlugin.display_name || $store.pluginListStore.selectedPlugin.name"></h2>
-                    <div class="plugin-info-source"
-                        x-text="$store.pluginListStore.selectedPlugin.is_custom ? 'Custom plugin' : 'Builtin plugin'"></div>
-                </div>
+                    <template x-if="$store.pluginListStore.selectedPlugin.thumbnail_url">
+                        <div class="plugin-info-thumb">
+                            <img :src="$store.pluginListStore.selectedPlugin.thumbnail_url"
+                                :alt="$store.pluginListStore.selectedPlugin.display_name || $store.pluginListStore.selectedPlugin.name">
+                        </div>
+                    </template>
+                    <div class="plugin-info-header-main">
+                        <div class="plugin-info-heading">
+                            <h2 class="plugin-info-title"
+                                x-text="$store.pluginListStore.selectedPlugin.display_name || $store.pluginListStore.selectedPlugin.name"></h2>
+                            <div class="plugin-info-source"
+                                x-text="$store.pluginListStore.selectedPlugin.is_custom ? 'Custom plugin' : 'Builtin plugin'"></div>
+                        </div>
 
-                <div class="plugin-info-description"
-                    x-text="$store.pluginListStore.selectedPlugin.description || 'No description provided.'"></div>
+                        <div class="plugin-info-description"
+                            x-text="$store.pluginListStore.selectedPlugin.description || 'No description provided.'"></div>
+                    </div>
+                </div>
 
                 <div class="plugin-info-grid">
                     <div class="plugin-info-label">Plugin ID:</div>
@@ -28,6 +38,15 @@
                     <div class="plugin-info-label">Version:</div>
                     <div class="plugin-info-value"
                         x-text="$store.pluginListStore.selectedPlugin.version || 'n/a'"></div>
+
+                    <template x-if="$store.pluginListStore.selectedPlugin.author && $store.pluginListStore.selectedPlugin.repo">
+                        <div class="plugin-info-grid-pair">
+                            <div class="plugin-info-label">Repository:</div>
+                            <div class="plugin-info-value">
+                                <code x-text="`${$store.pluginListStore.selectedPlugin.author}/${$store.pluginListStore.selectedPlugin.repo}`"></code>
+                            </div>
+                        </div>
+                    </template>
 
                     <div class="plugin-info-label">Path:</div>
                     <div class="plugin-info-value">
@@ -56,10 +75,32 @@
                 </div>
             </div>
         </template>
-    </div>
 
-    <div class="modal-footer" data-modal-footer>
-        <button class="btn btn-cancel" @click="window.closeModal?.()">Close</button>
+        <template x-if="$store.pluginListStore?.selectedPlugin">
+            <div class="modal-footer plugin-info-footer" data-modal-footer>
+                <div class="plugin-info-footer-row">
+                    <div class="plugin-info-footer-left">
+                        <button type="button"
+                            class="button"
+                            title="Open plugin files"
+                            @click="$store.pluginListStore.openPluginFolder($store.pluginListStore.selectedPlugin)">
+                            <span class="icon material-symbols-outlined">folder_open</span> Files
+                        </button>
+                        <template x-if="$store.pluginListStore.selectedPlugin.pluginHub?.key">
+                            <button type="button"
+                                class="button"
+                                title="Open in Plugin Hub"
+                                @click="$store.pluginListStore.openPluginHub($store.pluginListStore.selectedPlugin)">
+                                <span class="icon material-symbols-outlined">storefront</span> Hub
+                            </button>
+                        </template>
+                    </div>
+                    <div class="plugin-info-footer-right">
+                        <button class="btn btn-cancel" @click="window.closeModal?.()">Close</button>
+                    </div>
+                </div>
+            </div>
+        </template>
     </div>
 
     <style>
@@ -68,6 +109,38 @@
         }
         
         .plugin-info-header {
+            display: flex;
+            align-items: flex-start;
+            gap: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .plugin-info-thumb {
+            width: 96px;
+            height: 96px;
+            flex-shrink: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            overflow: hidden;
+            border: 1px solid var(--color-border);
+            border-radius: 12px;
+            background: var(--color-panel);
+        }
+
+        .plugin-info-thumb img {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+            padding: 0.5rem;
+        }
+
+        .plugin-info-header-main {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .plugin-info-heading {
             display: flex;
             flex-wrap: wrap;
             align-items: baseline;
@@ -97,6 +170,10 @@
             gap: 0.5rem 0.75rem;
         }
 
+        .plugin-info-grid-pair {
+            display: contents;
+        }
+
         .plugin-info-label {
             font-weight: 600;
             color: var(--color-text-secondary);
@@ -108,7 +185,27 @@
             overflow-wrap: anywhere;
         }
 
+        .plugin-info-footer-row {
+            width: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .plugin-info-footer-left,
+        .plugin-info-footer-right {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
         @media (max-width: 640px) {
+            .plugin-info-header {
+                flex-direction: column;
+            }
+
             .plugin-info-grid {
                 grid-template-columns: 1fr;
                 gap: 0.25rem;
@@ -116,6 +213,16 @@
 
             .plugin-info-label {
                 margin-top: 0.5rem;
+            }
+
+            .plugin-info-footer-row {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            .plugin-info-footer-left,
+            .plugin-info-footer-right {
+                width: 100%;
             }
         }
     </style>

--- a/webui/components/settings/plugins/plugins-subsection.html
+++ b/webui/components/settings/plugins/plugins-subsection.html
@@ -61,7 +61,7 @@
 
         .plugin-card {
             border: 1px solid var(--color-border);
-            border-radius: 4px;
+            border-radius: 10px;
             padding: 0.75rem;
             margin-top: 0.75rem;
             background: var(--color-background);

--- a/webui/css/modals.css
+++ b/webui/css/modals.css
@@ -176,7 +176,7 @@ some classes like modal-header are shared between the old and the new system */
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  padding: 0.6rem 2rem 0.6rem 0;
+  padding: var(--spacing-sm) var(--spacing-lg);
   border-top: 1px solid var(--color-border);
   background: var(--color-background);
   gap: 1rem;


### PR DESCRIPTION
## Summary
- surface repository metadata for installed plugins and add quick actions in the plugin info modal to open plugin files or jump back into the Plugin Hub
- refresh Plugin Hub cards, status badges, and modal spacing to make plugin state and actions clearer
- rewrite relative links in plugin README content to GitHub blob URLs and force README links to open in a new tab using the shared link helper
- aligned plugin terminology, requirements, and cross-references across the
canonical docs, agent skills, and in-repo validator tooling.

## Test plan
- verify Plugin Hub cards render the updated metadata and install/update state correctly
- open an installed custom plugin in the info modal and confirm the Files and Hub actions behave correctly
- open a plugin README that contains relative links and confirm they no longer resolve to `localhost`, instead opening the matching GitHub path in a new tab