### PR TITLE
feat: add tool_output_update extension hook for output secrets masking

### DIFF
--- a/helpers/tool.py
+++ b/helpers/tool.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from agent import Agent, LoopData
+from helpers.extension import call_extensions_async
 from helpers.print_style import PrintStyle
 from helpers.strings import sanitize_string
 
@@ -28,8 +29,10 @@ class Tool:
     async def execute(self,**kwargs) -> Response:
         pass
 
-    def set_progress(self, content: str | None):
-        self.progress = content or ""
+    async def set_progress(self, content: str | None):
+        ctx = {"content": content or ""}
+        await call_extensions_async("tool_output_update", self.agent, ctx=ctx)
+        self.progress = ctx["content"]
 
     def add_progress(self, content: str | None):
         if not content:
@@ -41,8 +44,11 @@ class Tool:
         self.log = self.get_log_object()
         if self.args and isinstance(self.args, dict):
             for key, value in self.args.items():
+                ctx = {"content": str(value) if not isinstance(value, str) else value}
+                await call_extensions_async("tool_output_update", self.agent, ctx=ctx)
+                display_value = ctx["content"]
                 PrintStyle(font_color="#85C1E9", bold=True).stream(self.nice_key(key)+": ")
-                PrintStyle(font_color="#85C1E9", padding=isinstance(value,str) and "\n" in value).stream(value)
+                PrintStyle(font_color="#85C1E9", padding=isinstance(value,str) and "\n" in value).stream(display_value)
                 PrintStyle().print()
 
     async def after_execution(self, response: Response, **kwargs):


### PR DESCRIPTION
## Problem

Secrets are unmasked between `tool_execute_before` and `tool_execute_after`, leaking in two places:
- `before_execution()` — arg values printed to console via `PrintStyle.stream`
- `set_progress()` — progress UI updated with unmasked content

No extension hook exists on the output path, so plugins cannot intercept and mask values before display.

## Solution

Add a `tool_output_update` extension hook that fires before any tool output reaches a display or log channel. This is the hook/firing point itself — upstream `helpers/tool.py` has no such hook today.

## Changes

`helpers/tool.py` only:
- `set_progress()` promoted from `sync` to `async def` — fires `tool_output_update` hook before updating `self.progress`
- `before_execution()` arg display loop fires `tool_output_update` hook per arg before `PrintStyle.stream`
- Both pass a mutable `ctx = {"content": ...}` dict so subscribers can rewrite values in-place

## Extension Point Contract

Plugins subscribe by placing a file at:
```
extensions/python/tool_output_update/_NN_my_masker.py
```

Example subscriber:
```python
from helpers.extension import Extension
from agent import Agent

class MyMasker(Extension):
    async def execute(self, ctx: dict, **kwargs):
        ctx["content"] = ctx["content"].replace("secret", "***")
```

## ⚠ Breaking Change

All callers of `set_progress()` must now `await` it.

## Testing

- Trigger any tool that uses secrets in args (e.g. `code_execution_tool` with a token)
- Place a subscriber at `extensions/python/tool_output_update/_10_test.py`
- Confirm subscriber is called and can rewrite `ctx["content"]` before display
- Confirm args display and progress UI reflect the rewritten value