### PR TITLE
Decouple browser model wiring; sidebar quick actions; chat input height and fullscreen icon

### DIFF
--- a/plugins/_browser_agent/extensions/python/_functions/agent/Agent/get_browser_model/start/_10_browser_agent.py
+++ b/plugins/_browser_agent/extensions/python/_functions/agent/Agent/get_browser_model/start/_10_browser_agent.py
@@ -1,0 +1,7 @@
+from helpers.extension import Extension
+from plugins._browser_agent.helpers.browser_llm import build_browser_model_for_agent
+
+class BrowserModelProvider(Extension):
+    def execute(self, data: dict = {}, **kwargs):
+        if self.agent:
+            data["result"] = build_browser_model_for_agent(self.agent)

--- a/plugins/_browser_agent/helpers/browser_llm.py
+++ b/plugins/_browser_agent/helpers/browser_llm.py
@@ -129,3 +129,15 @@ def build_browser_model_from_config(
         model_config,
         **kwargs,
     )
+
+def build_browser_model_for_agent(agent=None) -> BrowserCompatibleChatWrapper:
+    """Build and return the browser-use adapter using chat model config."""
+    from plugins._model_config.helpers.model_config import (
+        get_chat_model_config,
+        build_model_config,
+    )
+    import models
+    
+    cfg = get_chat_model_config(agent)
+    mc = build_model_config(cfg, models.ModelType.CHAT)
+    return build_browser_model_from_config(mc)

--- a/plugins/_model_config/README.md
+++ b/plugins/_model_config/README.md
@@ -21,7 +21,8 @@ This plugin centralizes model selection and model-related settings for the appli
 - **Per-chat override**
   - Allows a chat context to store a temporary override or preset reference in context data.
 - **Model object construction**
-  - Builds `ModelConfig` objects and the runtime chat, browser, utility, and embedding wrappers used elsewhere in the app.
+  - Builds `ModelConfig` objects and the runtime chat, utility, and embedding wrappers used elsewhere in the app.
+  - Note: Browser model wiring now lives in the `_browser_agent` plugin.
 - **API key validation**
   - Reports configured providers that still require API keys.
 

--- a/plugins/_model_config/extensions/python/_functions/agent/Agent/get_browser_model/start/_10_model_config.py
+++ b/plugins/_model_config/extensions/python/_functions/agent/Agent/get_browser_model/start/_10_model_config.py
@@ -1,8 +1,0 @@
-from helpers.extension import Extension
-from plugins._model_config.helpers.model_config import build_browser_model
-
-
-class BrowserModelProvider(Extension):
-    def execute(self, data: dict = {}, **kwargs):
-        if self.agent:
-            data["result"] = build_browser_model(self.agent)

--- a/plugins/_model_config/helpers/model_config.py
+++ b/plugins/_model_config/helpers/model_config.py
@@ -189,17 +189,6 @@ def build_utility_model(agent=None):
     )
 
 
-def build_browser_model(agent=None):
-    """Build and return the browser-use adapter using chat model config."""
-    cfg = get_chat_model_config(agent)
-    mc = build_model_config(cfg, models.ModelType.CHAT)
-    from plugins._browser_agent.helpers.browser_llm import (
-        build_browser_model_from_config,
-    )
-
-    return build_browser_model_from_config(mc)
-
-
 def build_embedding_model(agent=None):
     """Build and return an embedding model wrapper."""
     cfg = get_embedding_model_config(agent)

--- a/webui/components/chat/input/chat-bar-input.html
+++ b/webui/components/chat/input/chat-bar-input.html
@@ -29,9 +29,7 @@
                       @input="$store.chatInput.adjustTextareaHeight()"
                       x-model="$store.chatInput.message"></textarea>
             <button id="expand-button" @click="$store.fullScreenInputModal.openModal()" aria-label="Expand input">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
-                </svg>
+                <span class="material-symbols-outlined" aria-hidden="true">open_in_full</span>
             </button>
         </div>
 
@@ -84,7 +82,7 @@
     font-optical-sizing: auto;
     -webkit-font-optical-sizing: auto;
     font-size: 0.9rem;
-    max-height: clamp(7rem, 40vh, 20rem);
+    max-height: 65vh;
     min-height: 3.05rem;
     width: 100%;
     padding: 0.48rem 40px var(--spacing-sm) var(--spacing-sm);
@@ -106,10 +104,22 @@
     #chat-input:focus { outline: 0.05rem solid rgba(155,155,155,0.5); font-size: 0.955rem; padding-top: 0.45rem; background-color: var(--color-input-focus); }
     #chat-input::placeholder { color: var(--color-text-muted); opacity: 0.7; }
 
-    #expand-button { position: absolute; top: 12px; right: 10px; background: transparent; border: none; cursor: pointer; font-size: 1.2rem; color: var(--color-text); opacity: 0.4; transition: opacity 0.2s; }
+    #expand-button { 
+    position: absolute;
+    top: 12px;
+    right: 6px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    transform: scale(0.8);
+    font-size: 1.2rem;
+    color: var(--color-text);
+    opacity: 0.2;
+    transition: opacity 0.2s;
+    }
     #expand-button:hover { opacity: 0.7; }
     #expand-button:active { opacity: 1; }
-    #expand-button svg { width: 1.3rem; height: 1.3rem; }
+    #expand-button .material-symbols-outlined { display: block; font-size: 1.3rem; line-height: 1; }
 
     /* Chat buttons (Send/Mic) */
     #chat-buttons-wrapper { gap: var(--spacing-xs); padding-left: var(--spacing-xs); line-height: 0.5rem; display: -webkit-flex; display: flex; }

--- a/webui/components/chat/input/chat-bar.html
+++ b/webui/components/chat/input/chat-bar.html
@@ -39,7 +39,6 @@
       align-items: start;
       place-items: normal;
       flex-shrink: 0;
-      max-height: 60vh;
       overflow: visible;
       z-index: 1001;
     }

--- a/webui/components/sidebar/left-sidebar.html
+++ b/webui/components/sidebar/left-sidebar.html
@@ -10,27 +10,30 @@
 <body>
   <div x-data>
     <template x-if="$store.sidebar">
-      <div id="left-panel" class="panel" x-data :class="{'hidden': !$store.sidebar.isOpen}">
-        <x-extension id="sidebar-start"></x-extension>
-        <!--Sidebar upper elements-->
-        <div class="left-panel-top no-scrollbar">
-          <!-- Top Section: Header Icons + Quick Actions -->
-          <x-component path="sidebar/top-section/sidebar-top.html"></x-component>
-          <!-- Chats List -->
-          <div class="config-section" id="chats-section">
-            <x-component path="sidebar/chats/chats-list.html"></x-component>
-          </div>
+      <div class="sidebar-shell">
+        <x-component path="sidebar/top-section/header-icons.html"></x-component>
+        <div id="left-panel" class="panel" x-data :class="{'hidden': !$store.sidebar.isOpen}">
+          <x-extension id="sidebar-start"></x-extension>
+          <!--Sidebar upper elements-->
+          <div class="left-panel-top no-scrollbar">
+            <!-- Top Section: Quick Actions -->
+            <x-component path="sidebar/top-section/sidebar-top.html"></x-component>
+            <!-- Chats List -->
+            <div class="config-section" id="chats-section">
+              <x-component path="sidebar/chats/chats-list.html"></x-component>
+            </div>
 
-          <!-- Tasks List -->
-          <div class="config-section" id="tasks-section">
-            <x-component path="sidebar/tasks/tasks-list.html"></x-component>
+            <!-- Tasks List -->
+            <div class="config-section" id="tasks-section">
+              <x-component path="sidebar/tasks/tasks-list.html"></x-component>
+            </div>
           </div>
+          <!--Sidebar lower elements-->
+          <div class="left-panel-bottom">
+            <x-component path="sidebar/bottom/sidebar-bottom.html"></x-component>
+          </div>
+          <x-extension id="sidebar-end"></x-extension>
         </div>
-        <!--Sidebar lower elements-->
-        <div class="left-panel-bottom">
-          <x-component path="sidebar/bottom/sidebar-bottom.html"></x-component>
-        </div>
-        <x-extension id="sidebar-end"></x-extension>
       </div>
     </template>
   </div>
@@ -85,7 +88,7 @@
       /* Critical for allowing flex children to shrink */
       overflow: hidden;
       justify-content: space-between;
-      margin-top: 6rem;
+      margin-top: 6.5rem;
       padding: var(--spacing-md) var(--spacing-md) 0 var(--spacing-md);
     }
 

--- a/webui/components/sidebar/sidebar-store.js
+++ b/webui/components/sidebar/sidebar-store.js
@@ -93,10 +93,16 @@ const model = {
   updateDropdownPosition(triggerElement) {
     if (!triggerElement) return;
     const rect = triggerElement.getBoundingClientRect();
+    const menuWidth = Math.max(rect.width, 180);
+    const viewportPadding = 8;
+    const maxLeft = Math.max(
+      viewportPadding,
+      window.innerWidth - menuWidth - viewportPadding,
+    );
     this.dropdownStyle = {
       top: `${rect.bottom + 8}px`,
-      left: `${rect.left}px`,
-      width: `${rect.width}px`
+      left: `${Math.min(Math.max(rect.left, viewportPadding), maxLeft)}px`,
+      width: `${menuWidth}px`
     };
   },
 };

--- a/webui/components/sidebar/top-section/header-icons.html
+++ b/webui/components/sidebar/top-section/header-icons.html
@@ -3,79 +3,165 @@
   <script type="module">
     import { store as sidebarStore } from "/components/sidebar/sidebar-store.js";
     import { store as chatsStore } from "/components/sidebar/chats/chats-store.js";
+    import { store as projectsStore } from "/components/projects/projects-store.js";
   </script>
 </head>
 <body>
-  <div class="sidebar-header-stack">
-    <!--
-      Single chrome block for logo + toolbar (tokens aligned with .config-button in quick-actions).
-      Spacer reserves in-flow height so quick-actions clears the fixed overlay (see .left-panel-top margin-top).
-    -->
-    <div id="sidebar-header-panel" class="sidebar-header-panel">
+  <div
+    class="sidebar-header-stack"
+    x-data="{ dropdownOpen: false }"
+    @click.outside="dropdownOpen = false"
+    @keydown.escape.window="dropdownOpen = false"
+    x-init="$watch('dropdownOpen', open => open && $nextTick(() => $store.sidebar.updateDropdownPosition($refs.quickActionsToggle)))"
+  >
+    <!-- Fixed panel that expands on hover -->
+    <div id="sidebar-header-panel" class="sidebar-header-panel" :class="{ 'sidebar-header-panel-open': $store.sidebar.isOpen }">
       <div id="logo-bar">
         <a href="https://github.com/agent0ai/agent-zero" target="_blank" rel="noopener noreferrer" aria-label="Agent Zero on GitHub">
-          <span id="a0-logo" role="img" aria-label="Agent Zero"></span>
+          <div class="logo-container">
+            <span id="a0-logo" class="logo-expanded" role="img" aria-label="Agent Zero"></span>
+            <!-- Placeholder for the single 'A' logo asset -->
+            <span id="a0-logo-collapsed" class="logo-collapsed" role="img" aria-label="Agent Zero"></span>
+          </div>
         </a>
       </div>
 
-      <div class="icons-section" id="hide-button" x-data>
+      <div class="icons-section" id="hide-button">
         <!-- Sidebar Toggle Button -->
         <button id="toggle-sidebar" class="toggle-sidebar-button" @click="$store.sidebar.toggle()" aria-label="Toggle Sidebar" aria-expanded="false">
           <span class="material-symbols-outlined" aria-hidden="true">menu</span>
         </button>
 
-        <button class="config-button header-action-button" id="header-dashboard" @click="deselectChat()" title="Dashboard" aria-label="Dashboard">
+        <button class="config-button header-action-button" id="header-dashboard" @click="deselectChat()" title="Dashboard" aria-label="Dashboard" tabindex="-1">
           <span class="material-symbols-outlined" aria-hidden="true">home</span>
         </button>
 
-        <button class="config-button header-action-button" id="header-plugins" @click="openModal('components/plugins/list/plugin-list.html')" title="Plugins" aria-label="Plugins">
+        <button class="config-button header-action-button" id="header-plugins" @click="openModal('components/plugins/list/plugin-list.html')" title="Plugins" aria-label="Plugins" tabindex="-1">
           <span class="material-symbols-outlined" aria-hidden="true">extension</span>
         </button>
 
-        <button class="config-button header-action-button" id="header-settings" @click="openModal('settings/settings.html')" title="Settings" aria-label="Settings">
+        <button class="config-button header-action-button" id="header-settings" @click="openModal('settings/settings.html')" title="Settings" aria-label="Settings" tabindex="-1">
           <span class="material-symbols-outlined" aria-hidden="true">settings</span>
         </button>
+
+        <button
+          class="config-button header-action-button dropdown-toggle"
+          id="header-more"
+          x-ref="quickActionsToggle"
+          @click="dropdownOpen = !dropdownOpen"
+          title="More options"
+          aria-label="More options"
+          tabindex="-1"
+        >
+          <span class="material-symbols-outlined" aria-hidden="true" :class="dropdownOpen ? 'rotated' : ''">expand_more</span>
+        </button>
+      </div>
+
+      <div class="dropdown-menu quick-actions-dropdown" x-show="dropdownOpen" :style="$store.sidebar.dropdownStyle">
+        <div id="sidebar-quick-actions-dropdown-slot-start"></div>
+
+        <div class="dropdown-header">Navigation</div>
+
+        <button class="dropdown-item" @click="deselectChat(); dropdownOpen = false">
+          <span class="material-symbols-outlined">home</span>
+          <span>Dashboard</span>
+        </button>
+
+        <button class="dropdown-item" @click="$store.projects.openProjectsModal(); dropdownOpen = false">
+          <span class="material-symbols-outlined">snippet_folder</span>
+          <span>Projects</span>
+        </button>
+
+        <button class="dropdown-item" @click="openModal('components/modals/scheduler/scheduler-modal.html'); dropdownOpen = false">
+          <span class="material-symbols-outlined">schedule</span>
+          <span>Scheduler</span>
+        </button>
+
+        <button class="dropdown-item" @click="openModal('settings/settings.html'); dropdownOpen = false">
+          <span class="material-symbols-outlined">settings</span>
+          <span>Settings</span>
+        </button>
+
+        <div class="dropdown-separator"></div>
+        <div class="dropdown-header">Chat Actions</div>
+
+        <button class="dropdown-item" @click="$store.chats.newChat(); dropdownOpen = false">
+          <span class="material-symbols-outlined">chat_add_on</span>
+          <span>New Chat</span>
+        </button>
+
+        <button class="dropdown-item" @click="$store.chats.loadChats(); dropdownOpen = false">
+          <span class="material-symbols-outlined">folder_open</span>
+          <span>Load Chat</span>
+        </button>
+
+        <button class="dropdown-item" @click="$store.chats.saveChat(); dropdownOpen = false" :disabled="!$store.chats.selected">
+          <span class="material-symbols-outlined">save</span>
+          <span>Save Chat</span>
+        </button>
+
+        <button class="dropdown-item" @click="$confirmClick($event, () => { $store.chats.resetChat(); dropdownOpen = false })" :disabled="!$store.chats.selected">
+          <span class="material-symbols-outlined">delete_sweep</span>
+          <span>Clear Chat</span>
+        </button>
+
+        <div class="dropdown-separator"></div>
+
+        <button class="dropdown-item" @click="$confirmClick($event, () => { $store.chats.logout(); dropdownOpen = false })" :disabled="!$store.chats.loggedIn">
+          <span class="material-symbols-outlined">logout</span>
+          <span>Logout</span>
+        </button>
+
+        <button class="dropdown-item" @click="$confirmClick($event, () => { $store.chats.restart(); dropdownOpen = false })">
+          <span class="material-symbols-outlined">restart_alt</span>
+          <span>Restart A0</span>
+        </button>
+
+        <div id="sidebar-quick-actions-dropdown-slot-end"></div>
       </div>
     </div>
-
   </div>
 
 
   <style>
-    .sidebar-header-stack {
-      /*
-        Panel top (viewport) minus .left-panel-top margin-top: flow starts at 5rem; reserve overlap region.
-        Tuned for: padding + logo 1.47rem + gap + icon row ~2.2rem + padding.
-      */
-      --sidebar-header-flow-clearance: calc(1.9rem + (var(--spacing-xs) * 5) + 1.47rem + 2.2rem - 5rem);
+    :root {
+      --header-panel-expanded-width: calc(250px - (var(--spacing-md) * 2));
+      /* Padding left (0.625rem) + hamburger width (2.2rem) + padding right (0.625rem) = 3.45rem */
+      --header-panel-collapsed-width: 3.45rem;
     }
 
-    /* Shell: same language as .config-button (quick-actions.html) */
+    /* Shell: fixed panel with hover expansion */
     .sidebar-header-panel {
       position: fixed;
       top: var(--spacing-md);
       left: var(--spacing-md);
-      width: calc(250px - (var(--spacing-md) * 2));
+      width: var(--header-panel-collapsed-width);
       box-sizing: border-box;
       z-index: 1004;
       display: flex;
       flex-direction: column;
-      align-items: stretch;
+      align-items: flex-start;
       padding: var(--spacing-xs) var(--spacing-sm);
-      background-color: var(--color-panel);
-      border: 0.05rem solid var(--color-border);
+      background-color: var(--color-chat-background);
+      border: none;
       border-radius: 8px;
-      transition: background-color var(--transition-speed),
-        border-color var(--transition-speed), box-shadow var(--transition-speed),
-        opacity var(--transition-speed) ease-in-out;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      overflow: hidden;
+      white-space: nowrap;
+      transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1), 
+                  background-color var(--transition-speed),
+                  border-color var(--transition-speed), 
+                  box-shadow var(--transition-speed);
     }
 
     #logo-bar {
       display: flex;
       align-items: center;
-      justify-content: center;
-      width: 100%;
+      justify-content: flex-start;
+      width: calc(var(--header-panel-expanded-width) - (var(--spacing-sm) * 2));
       padding-top: var(--spacing-xxs);
+      /* Align logo with the center of the 2.2rem hamburger */
+      padding-left: 0.1rem;
     }
 
     #logo-bar a {
@@ -84,20 +170,62 @@
       width: min(100%, 11.75rem);
     }
 
-    #hide-button {
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      gap: var(--spacing-xs);
+    .logo-container {
+      position: relative;
       width: 100%;
+      height: 1.64rem;
     }
 
-    /* Toolbar icons sit on the panel surface (no nested config-button boxes) */
+    #a0-logo, #a0-logo-collapsed {
+      position: absolute;
+      top: 0; left: 8px;
+      height: 100%;
+      -webkit-mask-repeat: no-repeat;
+      mask-repeat: no-repeat;
+      background-color: var(--color-text);
+      transition: opacity 0.3s ease;
+    }
+
+    /* Expanded wordmark logo */
+    #a0-logo {
+      width: 100%;
+      left: 8px;
+      -webkit-mask-image: url(/public/a0-fullDark.svg);
+      mask-image: url(/public/a0-fullDark.svg);
+      -webkit-mask-size: contain;
+      mask-size: contain;
+      -webkit-mask-position: left center;
+      mask-position: left center;
+      opacity: 0;
+    }
+
+    /* Collapsed symbol logo placeholder */
+    #a0-logo-collapsed {
+      width: 2.0rem; /* Scale to fit nicely above hamburger */
+      -webkit-mask-image: url(/public/a0-collapsed.svg);
+      mask-image: url(/public/a0-collapsed.svg);
+      -webkit-mask-size: contain;
+      mask-size: contain;
+      -webkit-mask-position: left center;
+      mask-position: left center;
+      opacity: 0.8;
+    }
+
+    #hide-button {
+      display: flex;
+      gap: var(--spacing-xs);
+      width: max-content;
+      margin-top: var(--spacing-xs);
+    }
+
+    /* Toolbar icons */
     .sidebar-header-panel #hide-button .config-button,
     .sidebar-header-panel .toggle-sidebar-button {
       background-color: transparent;
       border: none;
       border-radius: 4px;
       box-shadow: none;
+      flex: 0 0 auto;
     }
 
     .sidebar-header-panel #hide-button .config-button {
@@ -105,13 +233,16 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      opacity: 0.8;
       padding: var(--spacing-xs);
-      min-width: 0;
-      min-height: 2.2rem;
+      width: 2.2rem;
+      height: 2.2rem;
+      opacity: 0;
+      transform: translateX(-10px);
+      pointer-events: none; /* Disable when collapsed */
       transition: background-color var(--transition-speed),
-        border-color var(--transition-speed), box-shadow var(--transition-speed),
-        opacity var(--transition-speed);
+                  box-shadow var(--transition-speed),
+                  opacity 0.3s ease, 
+                  transform 0.3s ease;
     }
 
     .sidebar-header-panel #hide-button .config-button .material-symbols-outlined {
@@ -119,16 +250,18 @@
       transition: transform 0.2s ease;
     }
 
+    .sidebar-header-panel #hide-button .config-button .material-symbols-outlined.rotated {
+      transform: rotate(180deg);
+    }
+
     .sidebar-header-panel #hide-button .config-button:hover {
       background-color: var(--color-background-hover);
-      opacity: 1;
+      opacity: 1 !important;
       box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary) 18%, transparent);
-      z-index: 1;
-      position: relative;
     }
 
     .sidebar-header-panel #hide-button .config-button:active {
-      opacity: 0.5;
+      opacity: 0.5 !important;
       box-shadow: inset 0 0 0 999px rgba(0, 0, 0, 0.06);
     }
 
@@ -139,10 +272,9 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      min-width: 0;
-      min-height: 2.2rem;
+      width: 2.2rem;
+      height: 2.2rem;
       padding: var(--spacing-xs);
-      -webkit-transition: all var(--transition-speed) ease-in-out;
       transition: all var(--transition-speed) ease-in-out;
     }
 
@@ -159,37 +291,75 @@
 
     .toggle-sidebar-button .material-symbols-outlined {
       font-size: 22px;
-      -webkit-transition: all var(--transition-speed) ease;
       transition: all var(--transition-speed) ease;
     }
 
     .toggle-sidebar-button:active .material-symbols-outlined {
-      -webkit-transform: scaleY(0.8);
       transform: scaleY(0.8);
     }
 
-    #a0-logo {
-      display: block;
-      width: 100%;
-      height: 1.64rem;
-      -webkit-mask-image: url(/public/a0-fullDark.svg);
-      mask-image: url(/public/a0-fullDark.svg);
-      -webkit-mask-repeat: no-repeat;
-      mask-repeat: no-repeat;
-      -webkit-mask-size: contain;
-      mask-size: contain;
-      -webkit-mask-position: left;
-      mask-position: center;
-      background-color: var(--color-text);
-      opacity: 0.8;
-      -webkit-transition: opacity var(--transition-speed) ease, background-color var(--transition-speed) ease;
-      transition: opacity var(--transition-speed) ease, background-color var(--transition-speed) ease;
+    /* --- Desktop Hover Expand --- */
+    @media (min-width: 769px) {
+      .sidebar-header-panel.sidebar-header-panel-open,
+      .sidebar-header-panel:hover,
+      .sidebar-header-panel:focus-within {
+        width: var(--header-panel-expanded-width);
+      }
+
+      .sidebar-header-panel.sidebar-header-panel-open #a0-logo,
+      .sidebar-header-panel:hover #a0-logo,
+      .sidebar-header-panel:focus-within #a0-logo {
+        opacity: 0.8;
+      }
+      
+      .sidebar-header-panel.sidebar-header-panel-open #logo-bar a:hover #a0-logo,
+      .sidebar-header-panel:hover #logo-bar a:hover #a0-logo,
+      .sidebar-header-panel:focus-within #logo-bar a:hover #a0-logo {
+        opacity: 1;
+      }
+
+      .sidebar-header-panel.sidebar-header-panel-open #a0-logo-collapsed,
+      .sidebar-header-panel:hover #a0-logo-collapsed,
+      .sidebar-header-panel:focus-within #a0-logo-collapsed {
+        opacity: 0;
+      }
+
+      .sidebar-header-panel.sidebar-header-panel-open #hide-button .config-button,
+      .sidebar-header-panel:hover #hide-button .config-button,
+      .sidebar-header-panel:focus-within #hide-button .config-button {
+        opacity: 0.8;
+        transform: translateX(0);
+        pointer-events: auto;
+      }
     }
 
-    #logo-bar a:hover #a0-logo {
-      opacity: 1;
-    }
+    /* --- Mobile Always Expanded --- */
+    @media (max-width: 768px) {
+      .sidebar-header-panel {
+        width: var(--header-panel-expanded-width);
+        transition: all 0.3s ease;
+      }
+      
+      #a0-logo {
+        opacity: 0.8;
+      }
 
+      #logo-bar a:hover #a0-logo {
+        opacity: 1;
+      }
+
+      #a0-logo-collapsed {
+        opacity: 0;
+      }
+
+      .sidebar-header-panel #hide-button .config-button {
+        opacity: 0.8 !important;
+        transform: translateX(0) !important;
+        pointer-events: auto !important;
+      }
+    }
+    
+    /* Light mode fixes */
     .light-mode .sidebar-header-panel {
       background-color: var(--color-background);
       color: #333333;
@@ -204,14 +374,6 @@
     .light-mode .sidebar-header-panel .toggle-sidebar-button:active {
       background-color: var(--color-background-hover);
     }
-
-    @media (max-width: 768px) {
-      .sidebar-header-panel {
-        -webkit-transition: all 0.3s ease;
-        transition: all 0.3s ease;
-      }
-    }
   </style>
 </body>
 </html>
-

--- a/webui/components/sidebar/top-section/quick-actions.html
+++ b/webui/components/sidebar/top-section/quick-actions.html
@@ -1,104 +1,27 @@
 <html>
 
-<head>
-  <script type="module">
-    import { store as chatsStore } from "/components/sidebar/chats/chats-store.js";
-    import { store as projectsStore } from "/components/projects/projects-store.js";
-    import { store as sidebarStore } from "/components/sidebar/sidebar-store.js";
-  </script>
-</head>
+<head></head>
 
 <body>
-  <div class="wrapper" x-data="{ dropdownOpen: false }" @click.outside="dropdownOpen = false" @keydown.escape.window="dropdownOpen = false" x-init="$watch('dropdownOpen', v => v && $store.sidebar.updateDropdownPosition($el))">
-    <div id="quick-actions">
-
-      <x-extension id="sidebar-quick-actions-main-start"></x-extension>
-
-      <x-extension id="sidebar-quick-actions-main-end"></x-extension>
-
-      <!-- Dropdown Toggle -->
-      <button class="config-button dropdown-toggle" @click="dropdownOpen = !dropdownOpen" title="More options">
-        <span class="material-symbols-outlined" :class="dropdownOpen ? 'rotated' : ''">expand_more</span>
-      </button>
-    </div>
-
-    <!-- Dropdown Menu -->
-    <div class="dropdown-menu quick-actions-dropdown" 
-         x-show="dropdownOpen"
-         :style="$store.sidebar.dropdownStyle">
-      
+  <div class="quick-actions-surface-host" x-data>
+    <template x-teleport="#sidebar-quick-actions-dropdown-slot-start">
       <x-extension id="sidebar-quick-actions-dropdown-start"></x-extension>
+    </template>
 
-      <div class="dropdown-header">Navigation</div>
-      
-      <button class="dropdown-item" @click="deselectChat(); dropdownOpen = false">
-        <span class="material-symbols-outlined">home</span>
-        <span>Dashboard</span>
-      </button>
-
-      <button class="dropdown-item" @click="$store.projects.openProjectsModal(); dropdownOpen = false">
-        <span class="material-symbols-outlined">snippet_folder</span>
-        <span>Projects</span>
-      </button>
-            
-      <button class="dropdown-item" @click="openModal('components/modals/scheduler/scheduler-modal.html'); dropdownOpen = false">
-        <span class="material-symbols-outlined">schedule</span>
-        <span>Scheduler</span>
-      </button>
-      
-      <button class="dropdown-item" @click="openModal('settings/settings.html'); dropdownOpen = false">
-        <span class="material-symbols-outlined">settings</span>
-        <span>Settings</span>
-      </button>
-      
-      <div class="dropdown-separator"></div>
-      <div class="dropdown-header">Chat Actions</div>
-      
-      <button class="dropdown-item" @click="$store.chats.newChat(); dropdownOpen = false">
-        <span class="material-symbols-outlined">chat_add_on</span>
-        <span>New Chat</span>
-      </button>
-      
-      <button class="dropdown-item" @click="$store.chats.loadChats(); dropdownOpen = false">
-        <span class="material-symbols-outlined">folder_open</span>
-        <span>Load Chat</span>
-      </button>
-      
-      <button class="dropdown-item" @click="$store.chats.saveChat(); dropdownOpen = false" :disabled="!$store.chats.selected">
-        <span class="material-symbols-outlined">save</span>
-        <span>Save Chat</span>
-      </button>
-
-      <button class="dropdown-item" @click="$confirmClick($event, () => { $store.chats.resetChat(); dropdownOpen = false })" :disabled="!$store.chats.selected">
-        <span class="material-symbols-outlined">delete_sweep</span>
-        <span>Clear Chat</span>
-      </button>
-      
-      <div class="dropdown-separator"></div>
-      
-
-      <button class="dropdown-item" @click="$confirmClick($event, () => { $store.chats.logout(); dropdownOpen = false })" :disabled="!$store.chats.loggedIn">
-        <span class="material-symbols-outlined">logout</span>
-        <span>Logout</span>
-      </button>
-
-      <button class="dropdown-item" @click="$confirmClick($event, () => { $store.chats.restart(); dropdownOpen = false })">
-        <span class="material-symbols-outlined">restart_alt</span>
-        <span>Restart A0</span>
-      </button>
-
-      <x-extension id="sidebar-quick-actions-dropdown-end"></x-extension>
+    <div id="quick-actions">
+      <x-extension id="sidebar-quick-actions-main-start"></x-extension>
+      <x-extension id="sidebar-quick-actions-main-end"></x-extension>
     </div>
+
+    <template x-teleport="#sidebar-quick-actions-dropdown-slot-end">
+      <x-extension id="sidebar-quick-actions-dropdown-end"></x-extension>
+    </template>
   </div>
 </body>
 
 <style>
-  /* Wrapper container for icon toolbar */
-  .wrapper {
-    position: relative;
-    border-radius: 0.6rem;
-    z-index: 100;
-    /* Ensure dropdown appears above all sidebar content */
+  .quick-actions-surface-host {
+    display: contents;
   }
 
   /* Icon toolbar layout – grid for extension-friendly wrapping */
@@ -111,9 +34,8 @@
     gap: var(--spacing-xs);
   }
 
-  .quick-actions-anchor {
+  #quick-actions:not(:has(> x-extension:not(:empty))) {
     display: none;
-    pointer-events: none;
   }
 
   #quick-actions > x-extension:not(:empty) {

--- a/webui/components/sidebar/top-section/sidebar-top.html
+++ b/webui/components/sidebar/top-section/sidebar-top.html
@@ -9,9 +9,6 @@
     <template x-if="$store.sidebar">
       <div class="sidebar-top-wrapper">
         <x-extension id="sidebar-top-wrapper-start"></x-extension>
-        <!-- Header Icons (Toggle + Logo) -->
-        <x-component path="sidebar/top-section/header-icons.html"></x-component>
-        
         <!-- Quick Actions Buttons -->
         <x-component path="sidebar/top-section/quick-actions.html"></x-component>
         <x-extension id="sidebar-top-wrapper-end"></x-extension>
@@ -26,6 +23,11 @@
       display: flex;
       flex-direction: column;
       flex-shrink: 0;
+    }
+
+    .sidebar-top-wrapper > x-component,
+    .sidebar-top-wrapper > x-component > .quick-actions-surface-host {
+      display: contents;
     }
   </style>
 </body>

--- a/webui/public/a0-collapsed.svg
+++ b/webui/public/a0-collapsed.svg
@@ -1,0 +1,1 @@
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 26" width="16" height="26"><style>.a{fill:#7a7a7a}</style><path class="a" d="m13 19.6c-1.6-2.8-3.3-5.7-5-8.6q-2.6 4.3-5.1 8.7h-2.5c2.5-4.4 7.6-13.1 7.6-13.1 0 0 5.1 8.7 7.6 13.1h-2.6z"/><path class="a" d="m11.2 19.7h-6.5q0.6-1.2 1.2-2.3h4.1q0.6 1.1 1.2 2.3z"/></svg>


### PR DESCRIPTION
1. **Browser model wiring** (`5f235f73`) – Move browser LLM setup from `_model_config` into `_browser_agent` so the always-on model config plugin does not depend on the optional browser agent.

2. **Sidebar quick actions** (`1cc055c7`) – Quick actions redesign and collapsible wrapper (header-icons, quick-actions, left-sidebar, sidebar store, asset).

3. **Chat input** (`3485db32`) – Material `open_in_full` for fullscreen expand instead of custom SVG; textarea max height `65vh`; drop chat bar height cap (`chat-bar-input.html`, `chat-bar.html`).