### PR TITLE
ui: increased chat input height

### DIFF
--- a/webui/components/chat/input/chat-bar-input.html
+++ b/webui/components/chat/input/chat-bar-input.html
@@ -27,9 +27,7 @@
                       @input="$store.chatInput.adjustTextareaHeight()"
                       x-model="$store.chatInput.message"></textarea>
             <button id="expand-button" @click="$store.fullScreenInputModal.openModal()" aria-label="Expand input">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
-                </svg>
+                <span class="material-symbols-outlined" aria-hidden="true">open_in_full</span>
             </button>
         </div>
 
@@ -80,7 +78,7 @@
     font-optical-sizing: auto;
     -webkit-font-optical-sizing: auto;
     font-size: 0.9rem;
-    max-height: 7rem;
+    max-height: 60vh;
     min-height: 3.05rem;
     width: 100%;
     padding: 0.48rem 40px var(--spacing-sm) var(--spacing-sm);
@@ -102,10 +100,22 @@
     #chat-input:focus { outline: 0.05rem solid rgba(155,155,155,0.5); font-size: 0.955rem; padding-top: 0.45rem; background-color: var(--color-input-focus); }
     #chat-input::placeholder { color: var(--color-text-muted); opacity: 0.7; }
 
-    #expand-button { position: absolute; top: 12px; right: 10px; background: transparent; border: none; cursor: pointer; font-size: 1.2rem; color: var(--color-text); opacity: 0.4; transition: opacity 0.2s; }
+    #expand-button { 
+    position: absolute;
+    top: 12px;
+    right: 6px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    transform: scale(0.8);
+    font-size: 1.2rem;
+    color: var(--color-text);
+    opacity: 0.2;
+    transition: opacity 0.2s;
+    }
     #expand-button:hover { opacity: 0.7; }
     #expand-button:active { opacity: 1; }
-    #expand-button svg { width: 1.3rem; height: 1.3rem; }
+    #expand-button .material-symbols-outlined { display: block; font-size: 1.3rem; line-height: 1; }
 
     /* Chat buttons (Send/Mic) */
     #chat-buttons-wrapper { gap: var(--spacing-xs); padding-left: var(--spacing-xs); line-height: 0.5rem; display: -webkit-flex; display: flex; }

--- a/webui/components/chat/input/chat-bar.html
+++ b/webui/components/chat/input/chat-bar.html
@@ -37,6 +37,7 @@
       align-items: start;
       place-items: normal;
       flex-shrink: 0;
+      overflow: visible;
       z-index: 1001;
     }
 


### PR DESCRIPTION
Replace the custom expand SVG with the Material open_in_full icon.

Raise the textarea max height to `65vh` and remove the chat bar height cap.