### PR TITLE
fix: revert gitwildmatch change to resolve DeprecationWarning

### DIFF
--- a/helpers/backup.py
+++ b/helpers/backup.py
@@ -261,7 +261,7 @@ class BackupService:
         processed_count = 0
 
         try:
-            spec = PathSpec.from_lines("gitwildmatch", pattern_lines)
+            spec = PathSpec.from_lines("gitignore", pattern_lines)
 
             # Walk through base directories
             for base_pattern_path, base_real_path in self.base_paths.items():
@@ -507,7 +507,7 @@ class BackupService:
 
                     if pattern_lines:
                         from pathspec import PathSpec
-                        restore_spec = PathSpec.from_lines("gitwildmatch", pattern_lines)
+                        restore_spec = PathSpec.from_lines("gitignore", pattern_lines)
 
                 # Process each file in archive
                 for archive_path in archive_files:
@@ -663,7 +663,7 @@ class BackupService:
 
                     if pattern_lines:
                         from pathspec import PathSpec
-                        restore_spec = PathSpec.from_lines("gitwildmatch", pattern_lines)
+                        restore_spec = PathSpec.from_lines("gitignore", pattern_lines)
 
                 # Process each file in archive
                 for archive_path in archive_files:

--- a/helpers/file_tree.py
+++ b/helpers/file_tree.py
@@ -502,7 +502,7 @@ def _resolve_ignore_patterns(ignore: str | None, root_abs_path: str) -> Optional
     if not lines:
         return None
 
-    return PathSpec.from_lines("gitwildmatch", lines)
+    return PathSpec.from_lines("gitignore", lines)
 
 
 def _list_directory_children(

--- a/plugins/_promptinclude/helpers/scanner.py
+++ b/plugins/_promptinclude/helpers/scanner.py
@@ -131,7 +131,7 @@ def _build_ignore_spec(gitignore: str) -> PathSpec | None:
     ]
     if not lines:
         return None
-    return PathSpec.from_lines("gitwildmatch", lines)
+    return PathSpec.from_lines("gitignore", lines)
 
 
 def _find_matching_files(


### PR DESCRIPTION
It was fixed one time at development but was quickly changed back for some reason and now again causes spam of `DeprecationWarning: GitWildMatchPattern ('gitwildmatch') is deprecated.` in logs
According to [pathspec](https://pypi.org/project/pathspec/#:~:text=Deprecated%3A%20%E2%80%9Cgitwildmatch%E2%80%9D%20is%20now%20an%20alias%20for%20%E2%80%9Cgitignore%E2%80%9D.) it is now just an alias to 'gitignore' and pip install requirements.txt and requirements2.txt installs latest version of pathspec
