### PR TITLE
feat: add native support for GitHub Copilot ghu_ tokens

### DIFF
--- a/conf/model_providers.yaml
+++ b/conf/model_providers.yaml
@@ -86,6 +86,13 @@ chat:
     litellm_provider: openai
     kwargs:
       api_base: https://api.venice.ai/api/v1
+  copilot:
+    name: GitHub Copilot
+    litellm_provider: github_copilot
+    kwargs:
+      extra_headers:
+        Editor-Version: vscode/1.90.0
+        Copilot-Integration-Id: vscode-chat
       venice_parameters:
         include_venice_system_prompt: false
   xai:


### PR DESCRIPTION
This commit adds the 'github_copilot' provider to model_providers.yaml with mandatory IDE identity headers (Editor-Version and Copilot-Integration-Id).

SOLVES:
- Enables usage of 'ghu_' user tokens (Copilot Chat).
- Fixes AuthenticationError in enterprise environments where GitHub Models Marketplace is restricted.
- Automatically initiates OAuth device flow.