### PR TITLE
feat(webui): add page-head extension point for plugin script/style injection

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -71,6 +71,8 @@
             loggedIn: "{{logged_in}}" === "true",
         };
     </script>
+    <!-- Plugin head injections (scripts, stylesheets) -->
+    <x-extension id="page-head"></x-extension>
 </head>
 
 <body class="dark-mode device-pointer" x-data>


### PR DESCRIPTION
## Summary

Adds a `<x-extension id="page-head">` injection point inside `<head>` in `webui/index.html`.

## Motivation

The plugin extension system currently supports sidebar injection points (`sidebar-start`, `sidebar-end`) but has no equivalent for the document `<head>`. This means plugins that need to load vendor libraries or stylesheets at page-load time (e.g. mermaid.js for diagram rendering, custom icon fonts, polyfills) must resort to dynamic `<script>` DOM injection from within JS extension hooks — a fragile pattern with race condition risks.

A `page-head` extension point allows plugins to inject `<script defer>` and `<link rel="stylesheet">` tags cleanly, consistently with the established extension mechanism.

## Change

`webui/index.html`: two lines added — a comment and `<x-extension id="page-head">` inside `<head>`, immediately before `</head>`.

```html
<!-- Plugin head injections (scripts, stylesheets) -->
<x-extension id="page-head"></x-extension>
```

## Compatibility

- Zero breaking changes
- No impact on existing plugins or functionality  
- Follows identical pattern to existing `sidebar-start` / `sidebar-end` extension points
- The extension point is a no-op if no plugin registers a `page-head` extension
- Already in use by `deimos_webui` plugin for mermaid.js loading