### PR TITLE
ux: trigger focus on chat input after new chat and ctx switch

### DIFF
--- a/webui/components/chat/input/input-store.js
+++ b/webui/components/chat/input/input-store.js
@@ -219,6 +219,13 @@ const model = {
     await fileBrowserStore.open(path);
   },
 
+  focus() {
+    const chatInput = document.getElementById("chat-input");
+    if (chatInput) {
+      chatInput.focus();
+    }
+  },
+
   reset() {
     this.message = "";
     attachmentsStore.clearAttachments();

--- a/webui/components/sidebar/chats/chats-store.js
+++ b/webui/components/sidebar/chats/chats-store.js
@@ -12,6 +12,7 @@ import {
 import { store as notificationStore } from "/components/notifications/notification-store.js";
 import { store as tasksStore } from "/components/sidebar/tasks/tasks-store.js";
 import { store as syncStore } from "/components/sync/sync-store.js";
+import { store as chatInputStore } from "/components/chat/input/input-store.js";
 
 const model = {
   contexts: [],

--- a/webui/index.js
+++ b/webui/index.js
@@ -557,6 +557,13 @@ export const setContext = function (id) {
 
   //skip one speech if enabled when switching context
   if (preferencesStore.speech) skipOneSpeech = true;
+
+  // Focus the chat input
+  if (id) {
+    setTimeout(() => {
+      inputStore.focus();
+    }, 50);
+  }
 };
 
 export const deselectChat = function () {


### PR DESCRIPTION
We now trigger a focus of the chat-input textarea element when switching context hence also when opening a new chat.