### PR TITLE
fix: modal close button unclickable due to CSS grid column ratio

### DIFF
--- a/webui/css/modals.css
+++ b/webui/css/modals.css
@@ -78,7 +78,7 @@ some classes like modal-header are shared between the old and the new system */
 /* Modal Header */
 .modal-header {
   display: grid;
-  grid-template-columns: 40fr 0.5fr;
+  grid-template-columns: 1fr auto;
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem 1.5rem 0.5rem 2rem;


### PR DESCRIPTION
## Problem
The modal header used `grid-template-columns: 40fr 0.5fr` which gave the close button only ~1.2% of the header width, making it effectively unclickable.

## Solution
Changed to `grid-template-columns: 1fr auto` which gives the title flexible space while keeping the close button at its natural width.

## Changes
- Modified `webui/css/modals.css` line 81

This bug affects all modals in the web interface.