### PR TITLE
ux: onboarding flow for missing API key

### DIFF
--- a/plugins/_model_config/extensions/python/banners/_20_missing_api_key.py
+++ b/plugins/_model_config/extensions/python/banners/_20_missing_api_key.py
@@ -7,58 +7,30 @@ class MissingApiKeyCheck(Extension):
     """Check if API keys are configured for selected model providers."""
 
     LOCAL_PROVIDERS = {"ollama", "lm_studio"}
-    LOCAL_EMBEDDING = {"huggingface"}
     CONFIGURE_MODEL_SETTINGS_LINK = (
-        """<a href="#" onclick="(async()=>{"""
-        """const { store: s } = await import('/components/plugins/plugin-settings-store.js');"""
-        """if(s&&s.openConfig){await s.openConfig('_model_config');}"""
-        """})();return false;">"""
-        """Configure model settings</a>"""
+        """<div class="onboarding-banner-btn-container" style="margin-top: 12px;">"""
+        """<button class="btn btn-ok" onclick="window.openModal('/plugins/_onboarding/webui/onboarding.html');return false;">"""
+        """Start Onboarding</button>"""
+        """</div>"""
     )
 
     async def execute(self, banners: list = [], frontend_context: dict = {}, **kwargs):
         cfg = plugins.get_plugin_config("_model_config") or {}
-        missing_providers = []
-        checks = [
-            ("Chat Model", cfg.get("chat_model", {})),
-            ("Utility Model", cfg.get("utility_model", {})),
-            ("Embedding Model", cfg.get("embedding_model", {})),
-        ]
+        missing_providers = model_config.get_missing_api_key_providers()
 
-        for label, model_cfg in checks:
-            provider = model_cfg.get("provider", "")
-            if not provider:
-                continue
-            provider_lower = provider.lower()
-            if provider_lower in self.LOCAL_PROVIDERS:
-                continue
-            if label == "Embedding Model" and provider_lower in self.LOCAL_EMBEDDING:
-                continue
-
-            if not model_config.has_provider_api_key(
-                provider_lower,
-                model_cfg.get("api_key", ""),
-            ):
-                missing_providers.append({
-                    "model_type": label,
-                    "provider": provider,
-                })
-        
         if missing_providers:
-            model_list = ", ".join(
-                f"{p['model_type']} ({p['provider']})" for p in missing_providers
-            )
-            
             banners.append({
                 "id": "missing-api-key",
                 "type": "error",
                 "priority": 100,
-                "title": "Missing LLM API Key for current settings",
-                "html": f"""No API key configured for: {model_list}.<br>
-                         Agent Zero will not be able to function properly unless you provide an API key or change your settings.<br>
+                "title": "Welcome to Agent Zero!",
+                "html": f"""You're almost ready to chat. Please configure your models to continue.<br>
+                         Insert your API key in the onboarding wizard.
                          {self.CONFIGURE_MODEL_SETTINGS_LINK}""",
                 "dismissible": False,
-                "source": "backend"
+                "source": "backend",
+                # For programmatic clients (e.g. chat composer) reusing this banner pipeline
+                "missing_providers": missing_providers,
             })
 
         # Check preset providers for missing API keys (warning level)

--- a/plugins/_onboarding/plugin.yaml
+++ b/plugins/_onboarding/plugin.yaml
@@ -1,0 +1,8 @@
+name: _onboarding
+title: Onboarding Wizard
+description: Built-in onboarding wizard for configuring first-time models.
+version: 1.0.0
+settings_sections: []
+always_enabled: true
+per_project_config: false
+per_agent_config: false

--- a/plugins/_onboarding/webui/onboarding-store.js
+++ b/plugins/_onboarding/webui/onboarding-store.js
@@ -1,0 +1,101 @@
+import { createStore } from "/js/AlpineStore.js";
+import { store as modelConfigStore } from "/plugins/_model_config/webui/model-config-store.js";
+import { store as chatsStore } from "/components/sidebar/chats/chats-store.js";
+
+const fetchApi = globalThis.fetchApi;
+
+export const store = createStore("onboarding", {
+    step: 1,
+    config: null,
+    loading: true,
+
+    async init() {
+        this.step = 1;
+        this.loading = true;
+        this.config = null;
+    },
+
+    async onOpen() {
+        await this.init();
+        await modelConfigStore.ensureLoaded();
+        modelConfigStore.resetApiKeyDrafts();
+        await modelConfigStore.refreshApiKeyStatus();
+        
+        // Fetch current config
+        const response = await fetchApi("/plugins", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                action: "get_config",
+                plugin_name: "_model_config",
+                project_name: "",
+                agent_profile: "",
+            }),
+        });
+        const result = await response.json().catch(() => ({}));
+        this.config = result.ok ? (result.data || {}) : {};
+        
+        // Ensure slots exist
+        if (!this.config.chat_model) this.config.chat_model = { provider: "", name: "", api_key: "" };
+        if (!this.config.utility_model) this.config.utility_model = { provider: "", name: "", api_key: "" };
+        
+        modelConfigStore.initConfigFields(this.config);
+        
+        this.loading = false;
+    },
+
+    cleanup() {
+        this.step = 1;
+        this.config = null;
+        this.loading = true;
+    },
+
+    prev() {
+        if (this.step > 1) {
+            this.step--;
+        }
+    },
+
+    next() {
+        if (this.step < 3) {
+            this.step++;
+        }
+    },
+
+    async finish() {
+        this.loading = true;
+        try {
+            // Save model config
+            await fetchApi("/plugins", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    action: "save_config",
+                    plugin_name: "_model_config",
+                    project_name: "",
+                    agent_profile: "",
+                    settings: this.config,
+                }),
+            });
+            
+            // Save API keys
+            await modelConfigStore.persistApiKeysForConfig(this.config);
+            
+            // Open a new chat after finishing
+            window.closeModal?.();
+            chatsStore.newChat();
+        } catch (e) {
+            console.error("Failed to finish onboarding", e);
+            globalThis.justToast?.("Failed to save settings", "error");
+        } finally {
+            this.loading = false;
+        }
+    },
+    
+    async openAdvancedSettings() {
+        window.closeModal?.();
+        // Dynamic import since we just removed the static import to fix cyclic imports
+        const { store: pluginSettingsStore } = await import("/components/plugins/plugin-settings-store.js");
+        await pluginSettingsStore.openConfig("_model_config");
+    }
+});

--- a/plugins/_onboarding/webui/onboarding.html
+++ b/plugins/_onboarding/webui/onboarding.html
@@ -1,0 +1,396 @@
+<html>
+<head>
+    <title>Welcome to Agent Zero</title>
+    <script type="module">
+        import { store } from "/plugins/_onboarding/webui/onboarding-store.js";
+    </script>
+    <style>
+        .onboarding-logo {
+            text-align: center;
+            margin-bottom: 24px;
+        }
+        .onboarding-logo img {
+            width: 200px;
+            max-width: 100%;
+            height: auto;
+        }
+        .onboarding-welcome-text {
+            text-align: center;
+            margin: var(--spacing-md) 0;
+            color: var(--text-2);
+            font-size: 1.1rem;
+            line-height: 1.5;
+        }
+        .onboarding-welcome-title {
+            color: var(--text-1);
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 12px;
+        }
+        .onboarding-success {
+            text-align: center;
+            padding: 40px 0;
+        }
+        .onboarding-success-icon {
+            font-size: 64px;
+            color: var(--success, #22c55e);
+            margin-bottom: 24px;
+        }
+        .onboarding-success-text {
+            margin-bottom: 0;
+        }
+        .onboarding-advanced-link {
+            text-align: center;
+            margin-top: 32px;
+            padding-top: 16px;
+            border-top: 1px solid var(--surface-3);
+        }
+        .onboarding-advanced-link a {
+            color: var(--text-3);
+            text-decoration: none;
+            font-size: 0.9rem;
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+        .onboarding-advanced-link a:hover {
+            color: var(--text-1);
+        }
+        .onboarding-advanced-link-icon {
+            font-size: 16px;
+        }
+        /* Scoped overrides to make the fields look nice here */
+        .onboarding-body .model-section {
+            background: var(--surface-2);
+            border-radius: 8px;
+            border: 1px solid var(--surface-3);
+        }
+        .onboarding-body .section-title { margin-bottom: 8px; }
+        .onboarding-body .section-description { margin-bottom: 24px; }
+        .onboarding-body .loading-container { height: 200px; }
+        .onboarding-body .input-with-icon { padding-right: 32px; }
+        .onboarding-body .relative-container { position: relative; }
+        .onboarding-footer-left { flex: 1; display: flex; gap: 8px; }
+        .onboarding-footer-right { display: flex; gap: 8px; }
+        .onboarding-icon-right { font-size: 18px; margin-left: 4px; }
+        .onboarding-banner-btn-container { margin-top: 12px; }
+
+        /* Same as plugins/_model_config/webui/config.html: icons sit inside padded inputs */
+        .onboarding-body .eye-toggle {
+            position: absolute;
+            right: 8px;
+            top: 50%;
+            transform: translateY(-50%);
+            font-size: 18px;
+            cursor: pointer;
+            user-select: none;
+            opacity: 0.6;
+            z-index: 1;
+        }
+        .onboarding-body .eye-toggle:hover {
+            opacity: 1;
+        }
+        .onboarding-body .model-search-btn {
+            position: absolute;
+            right: 8px;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 20px;
+            height: 20px;
+            display: grid;
+            place-items: center;
+            cursor: pointer;
+            user-select: none;
+            opacity: 0.6;
+            z-index: 1;
+        }
+        .onboarding-body .model-search-btn:hover {
+            opacity: 1;
+        }
+        .onboarding-body .model-search-btn > span {
+            grid-area: 1 / 1;
+            font-size: 18px;
+            transition: opacity 0.15s;
+        }
+        .onboarding-body .model-search-spinner {
+            animation: onboarding-model-search-spin 0.8s linear infinite;
+        }
+        @keyframes onboarding-model-search-spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+        }
+        .onboarding-body .model-search-results {
+            position: absolute;
+            top: calc(100% + 4px);
+            left: 0;
+            right: 0;
+            max-height: 200px;
+            overflow-y: auto;
+            background: var(--color-input);
+            border: 1px solid var(--color-border);
+            border-radius: 6px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+            z-index: 50;
+            padding: 4px;
+        }
+        .onboarding-body .model-search-item {
+            padding: 5px 8px;
+            font-size: 0.8rem;
+            border-radius: 4px;
+            cursor: pointer;
+            word-break: break-all;
+        }
+        .onboarding-body .model-search-item:hover {
+            background: var(--color-background-hover, rgba(255,255,255,0.06));
+        }
+        .onboarding-body .model-search-item.disabled {
+            opacity: 0.4;
+            cursor: default;
+            font-style: italic;
+        }
+        .onboarding-body .model-search-item.matched {
+            font-weight: 500;
+        }
+        .onboarding-body .model-search-separator {
+            height: 1px;
+            margin: 4px 8px;
+            background: var(--color-border);
+            opacity: 0.5;
+        }
+        .onboarding-body .model-search-item.disabled:hover {
+            background: transparent;
+        }
+    </style>
+</head>
+
+<body>
+    <div x-data>
+        <template x-if="$store.onboarding">
+            <div x-init="$store.onboarding.onOpen()" x-destroy="$store.onboarding.cleanup()">
+                
+                <div class="modal-header">
+                    <div class="onboarding-logo">
+                        <img src="/public/a0-fullDark.svg" alt="Agent Zero">
+                    </div>
+                </div>
+
+                <div class="modal-scroll">
+                    <div class="modal-bd onboarding-body">
+                        
+                        <div x-show="$store.onboarding.loading" class="loading loading-container"></div>
+
+                        <template x-if="!$store.onboarding.loading && $store.onboarding.config">
+                            <div>
+
+                                <!-- Step 1: Main Model -->
+                                <div x-show="$store.onboarding.step === 1">
+                                    <div class="onboarding-welcome-text">
+                                        <div class="onboarding-welcome-title">Welcome to Agent Zero</div>
+                                        Let's get your models configured. The <b>Main Model</b> handles chat, tool calls, skills, and browser automation.<br> We recommend a capable model like Claude Sonnet 4.6, GPT-5.4, Kimi 2.5, or similar.
+                                    </div>
+
+                                    <div class="model-section">
+                                        <div class="section-title" x-text="$store.modelConfig.MODEL_SECTIONS[0].title"></div>
+                                        <div class="section-description" x-text="$store.modelConfig.MODEL_SECTIONS[0].desc"></div>
+                                        
+                                        <!-- Provider -->
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Provider</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <select x-model="$store.onboarding.config.chat_model.provider"
+                                                        x-effect="$nextTick(() => { if ($store.modelConfig.getProviders('chat_model').length) $el.value = $store.onboarding.config.chat_model.provider })">
+                                                    <template x-for="p in $store.modelConfig.getProviders('chat_model')" :key="p.value">
+                                                        <option :value="p.value" x-text="p.label"></option>
+                                                    </template>
+                                                </select>
+                                            </div>
+                                        </div>
+
+                                        <!-- Model search -->
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Model name</div>
+                                                <div class="field-description">Model identifier. Click the search icon to browse available models.</div>
+                                            </div>
+                                            <div class="field-control relative-container"
+                                                x-data="{ results: [], open: false, searching: false,
+                                                    doSearch() { this.searching = true; $store.modelConfig.searchModels($store.onboarding.config.chat_model.provider, $store.onboarding.config.chat_model.name, $store.modelConfig.getSearchType('chat_model'), $store.onboarding.config.chat_model.api_base).then(r => { this.results = r; this.open = true; }).finally(() => this.searching = false); },
+                                                    grouped() { return $store.modelConfig.groupResults(this.results, $store.onboarding.config.chat_model.name); }
+                                                }"
+                                                @click.outside="open = false">
+                                                <input type="text" x-model="$store.onboarding.config.chat_model.name" class="input-with-icon" @keydown.enter.prevent="doSearch()" />
+                                                <span class="model-search-btn" @click="if (!searching) doSearch()" title="Search available models">
+                                                    <span class="material-symbols-outlined" :style="searching && 'opacity:0'">search</span>
+                                                    <span class="material-symbols-outlined model-search-spinner" :style="!searching && 'opacity:0'">progress_activity</span>
+                                                </span>
+                                                <div class="model-search-results" x-show="open && results.length > 0" x-transition.opacity>
+                                                    <template x-for="m in grouped().matched" :key="'m_'+m">
+                                                        <div class="model-search-item matched" @click="$store.onboarding.config.chat_model.name = m; open = false;" x-text="m"></div>
+                                                    </template>
+                                                    <div class="model-search-separator" x-show="grouped().matched.length > 0 && grouped().rest.length > 0"></div>
+                                                    <template x-for="m in grouped().rest" :key="'r_'+m">
+                                                        <div class="model-search-item" @click="$store.onboarding.config.chat_model.name = m; open = false;" x-text="m"></div>
+                                                    </template>
+                                                </div>
+                                                <div class="model-search-results" x-show="open && results.length === 0 && !searching">
+                                                    <div class="model-search-item disabled">No models found</div>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <!-- API Key -->
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">API key</div>
+                                            </div>
+                                            <div class="field-control relative-container" x-data="{ showKey: false }">
+                                                <input :type="showKey ? 'text' : 'password'"
+                                                    x-model="$store.modelConfig.apiKeyValues[$store.onboarding.config.chat_model.provider]"
+                                                    :placeholder="$store.modelConfig.apiKeyStatus[$store.onboarding.config.chat_model.provider] ? '••••••••••••' : ''"
+                                                    autocomplete="off"
+                                                    class="input-with-icon"
+                                                    @input="$store.modelConfig.touchApiKey($store.onboarding.config.chat_model.provider)" />
+                                                <span class="material-symbols-outlined eye-toggle"
+                                                    @click="
+                                                        showKey = !showKey;
+                                                        const prov = $store.onboarding.config.chat_model.provider;
+                                                        if (showKey && !$store.modelConfig.apiKeyValues[prov] && $store.modelConfig.apiKeyStatus[prov]) {
+                                                        $store.modelConfig.revealApiKey(prov).then(v => { if (v) $store.modelConfig.apiKeyValues[prov] = v; });
+                                                        }
+                                                    "
+                                                    x-text="showKey ? 'visibility' : 'visibility_off'"></span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- Step 2: Utility Model -->
+                                <div x-show="$store.onboarding.step === 2">
+                                    <div class="onboarding-welcome-text">
+                                        <div class="onboarding-welcome-title">Almost there!</div>
+                                        The <b>Utility Model</b> handles background tasks like summarization and memory updates.<br> A fast, cheap model like GPT-5.4-mini, Gemini 3.1 Flash Lite, or similar works best here.
+                                    </div>
+
+                                    <div class="model-section">
+                                        <div class="section-title" x-text="$store.modelConfig.MODEL_SECTIONS[1].title"></div>
+                                        <div class="section-description" x-text="$store.modelConfig.MODEL_SECTIONS[1].desc"></div>
+                                        
+                                        <!-- Provider -->
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Provider</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <select x-model="$store.onboarding.config.utility_model.provider"
+                                                        x-effect="$nextTick(() => { if ($store.modelConfig.getProviders('utility_model').length) $el.value = $store.onboarding.config.utility_model.provider })">
+                                                    <template x-for="p in $store.modelConfig.getProviders('utility_model')" :key="p.value">
+                                                        <option :value="p.value" x-text="p.label"></option>
+                                                    </template>
+                                                </select>
+                                            </div>
+                                        </div>
+
+                                        <!-- Model search -->
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Model name</div>
+                                                <div class="field-description">Model identifier. Click the search icon to browse available models.</div>
+                                            </div>
+                                            <div class="field-control relative-container"
+                                                x-data="{ results: [], open: false, searching: false,
+                                                    doSearch() { this.searching = true; $store.modelConfig.searchModels($store.onboarding.config.utility_model.provider, $store.onboarding.config.utility_model.name, $store.modelConfig.getSearchType('utility_model'), $store.onboarding.config.utility_model.api_base).then(r => { this.results = r; this.open = true; }).finally(() => this.searching = false); },
+                                                    grouped() { return $store.modelConfig.groupResults(this.results, $store.onboarding.config.utility_model.name); }
+                                                }"
+                                                @click.outside="open = false">
+                                                <input type="text" x-model="$store.onboarding.config.utility_model.name" class="input-with-icon" @keydown.enter.prevent="doSearch()" />
+                                                <span class="model-search-btn" @click="if (!searching) doSearch()" title="Search available models">
+                                                    <span class="material-symbols-outlined" :style="searching && 'opacity:0'">search</span>
+                                                    <span class="material-symbols-outlined model-search-spinner" :style="!searching && 'opacity:0'">progress_activity</span>
+                                                </span>
+                                                <div class="model-search-results" x-show="open && results.length > 0" x-transition.opacity>
+                                                    <template x-for="m in grouped().matched" :key="'m_'+m">
+                                                        <div class="model-search-item matched" @click="$store.onboarding.config.utility_model.name = m; open = false;" x-text="m"></div>
+                                                    </template>
+                                                    <div class="model-search-separator" x-show="grouped().matched.length > 0 && grouped().rest.length > 0"></div>
+                                                    <template x-for="m in grouped().rest" :key="'r_'+m">
+                                                        <div class="model-search-item" @click="$store.onboarding.config.utility_model.name = m; open = false;" x-text="m"></div>
+                                                    </template>
+                                                </div>
+                                                <div class="model-search-results" x-show="open && results.length === 0 && !searching">
+                                                    <div class="model-search-item disabled">No models found</div>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <!-- API Key -->
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">API key</div>
+                                            </div>
+                                            <div class="field-control relative-container" x-data="{ showKey: false }">
+                                                <input :type="showKey ? 'text' : 'password'"
+                                                    x-model="$store.modelConfig.apiKeyValues[$store.onboarding.config.utility_model.provider]"
+                                                    :placeholder="$store.modelConfig.apiKeyStatus[$store.onboarding.config.utility_model.provider] ? '••••••••••••' : ''"
+                                                    autocomplete="off"
+                                                    class="input-with-icon"
+                                                    @input="$store.modelConfig.touchApiKey($store.onboarding.config.utility_model.provider)" />
+                                                <span class="material-symbols-outlined eye-toggle"
+                                                    @click="
+                                                        showKey = !showKey;
+                                                        const prov = $store.onboarding.config.utility_model.provider;
+                                                        if (showKey && !$store.modelConfig.apiKeyValues[prov] && $store.modelConfig.apiKeyStatus[prov]) {
+                                                        $store.modelConfig.revealApiKey(prov).then(v => { if (v) $store.modelConfig.apiKeyValues[prov] = v; });
+                                                        }
+                                                    "
+                                                    x-text="showKey ? 'visibility' : 'visibility_off'"></span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- Step 3: Success -->
+                                <div x-show="$store.onboarding.step === 3" class="onboarding-success">
+                                    <div class="material-symbols-outlined onboarding-success-icon">check_circle</div>
+                                    <div class="onboarding-welcome-title">Ready to chat!</div>
+                                    <div class="onboarding-welcome-text onboarding-success-text">
+                                        Your models are configured. You can change these anytime in Settings.
+                                    </div>
+                                </div>
+
+                                <div class="onboarding-advanced-link" x-show="$store.onboarding.step < 3">
+                                    <a href="#" @click.prevent="$store.onboarding.openAdvancedSettings()">
+                                        Advanced Settings <span class="material-symbols-outlined onboarding-advanced-link-icon">arrow_drop_down</span>
+                                    </a>
+                                </div>
+                            </div>
+                        </template>
+
+                    </div>
+                </div>
+
+                <div class="modal-footer" data-modal-footer>
+                    <div class="onboarding-footer-left">
+                        <button class="btn btn-cancel" @click="window.closeModal()" :disabled="$store.onboarding.loading">Cancel</button>
+                    </div>
+                    <div class="onboarding-footer-right">
+                        <button class="btn" x-show="$store.onboarding.step > 1" @click="$store.onboarding.prev()" :disabled="$store.onboarding.loading">
+                            Back
+                        </button>
+                        
+                        <button class="btn btn-ok" x-show="$store.onboarding.step < 3" @click="$store.onboarding.next()" :disabled="$store.onboarding.loading">
+                            Next <span class="material-symbols-outlined onboarding-icon-right">arrow_forward</span>
+                        </button>
+
+                        <button class="btn btn-ok" x-show="$store.onboarding.step === 3" @click="$store.onboarding.finish()" :disabled="$store.onboarding.loading">
+                            Start Chatting
+                        </button>
+                    </div>
+                </div>
+
+            </div>
+        </template>
+    </div>
+</body>
+</html>

--- a/tests/test_model_config_api_keys.py
+++ b/tests/test_model_config_api_keys.py
@@ -3,6 +3,7 @@ import threading
 import types
 from pathlib import Path
 
+import pytest
 from flask import Flask
 
 
@@ -44,6 +45,7 @@ sys.modules["watchdog.observers"] = watchdog.observers
 sys.modules["watchdog.events"] = watchdog.events
 
 from plugins._model_config.api.api_keys import ApiKeys
+from plugins._model_config.extensions.python.banners import _20_missing_api_key as missing_key_banner
 import models
 
 
@@ -66,12 +68,29 @@ def test_model_config_api_keys_can_be_cleared_via_backend(monkeypatch, tmp_path)
     assert handler._reveal_key({"provider": "openrouter"}) == {"ok": True, "value": ""}
 
 
+@pytest.mark.asyncio
+async def test_missing_api_key_banner_exposes_missing_providers(monkeypatch):
+    from plugins._model_config.helpers import model_config
+
+    fake = [{"model_type": "Chat Model", "provider": "openai"}]
+    monkeypatch.setattr(model_config, "get_missing_api_key_providers", lambda: fake)
+
+    banners = []
+    await missing_key_banner.MissingApiKeyCheck(agent=None).execute(
+        banners=banners, frontend_context={}
+    )
+    row = next(b for b in banners if b.get("id") == "missing-api-key")
+    assert row.get("missing_providers") == fake
+
+
 def test_model_config_frontend_tracks_inline_api_key_edits():
     store_path = PROJECT_ROOT / "plugins" / "_model_config" / "webui" / "model-config-store.js"
+    composer_store_path = PROJECT_ROOT / "webui" / "components" / "chat" / "input" / "composer-banner-store.js"
     config_path = PROJECT_ROOT / "plugins" / "_model_config" / "webui" / "config.html"
     modal_path = PROJECT_ROOT / "plugins" / "_model_config" / "webui" / "api-keys.html"
 
     store_content = store_path.read_text(encoding="utf-8")
+    composer_store_content = composer_store_path.read_text(encoding="utf-8")
     config_content = config_path.read_text(encoding="utf-8")
     modal_content = modal_path.read_text(encoding="utf-8")
 
@@ -79,6 +98,9 @@ def test_model_config_frontend_tracks_inline_api_key_edits():
     assert "resetApiKeyDrafts()" in store_content
     assert "!provider || seen.has(provider) || !this.apiKeyDirty[provider]" in store_content
     assert "normalized[provider] = value.trim() ? value : '';" in store_content
+    assert '"missing-api-key"' in composer_store_content
+    assert 'callJsonApi("/banners"' in composer_store_content
+    assert "/plugins/_model_config/missing_api_key_status" not in composer_store_content
     assert "$store.modelConfig.resetApiKeyDrafts();" in config_content
     assert '@input="$store.modelConfig.touchApiKey(config[section.key].provider)"' in config_content
     assert "updates[provider] = this.keys[provider] || '';" in modal_content

--- a/webui/components/chat/input/chat-bar.html
+++ b/webui/components/chat/input/chat-bar.html
@@ -3,13 +3,31 @@
     <script type="module">
         import { store } from "/components/chat/input/input-store.js";
         import { store as messageQueueStore } from "/components/chat/message-queue/message-queue-store.js";
+        import { store as composerBannerStore } from "/components/chat/input/composer-banner-store.js";
     </script>
 </head>
 <body>
     <div id="input-section" x-data>
         <x-extension id="chat-input-start"></x-extension>
         <template x-if="$store.chatInput">
-            <div style="width: 100%; display: contents;">
+            <div style="width: 100%; display: contents;"
+                 x-init="$store.composerBanner?.init()"
+                 x-effect="$store.chats?.selected && $store.composerBanner?.refresh()">
+                <!-- Missing API keys (global model config) -->
+                <template x-if="$store.composerBanner && $store.composerBanner.hasMissingApiKeys">
+                    <div class="composer-banner composer-banner--danger" role="alert">
+                        <span class="material-symbols-outlined composer-banner-icon" aria-hidden="true">error</span>
+                        <div class="composer-banner-text">
+                            <span class="composer-banner-title">API key missing</span>
+                            <span class="composer-banner-detail" x-text="$store.composerBanner.missingApiKeysSummaryText"></span>
+                        </div>
+                        <button type="button" class="btn btn-ok composer-banner-cta"
+                                @click="window.openModal('/plugins/_onboarding/webui/onboarding.html')">
+                            Insert API key
+                        </button>
+                    </div>
+                </template>
+
                 <!-- Message Queue section -->
                 <x-component path="chat/message-queue/message-queue.html"></x-component>
 
@@ -46,7 +64,61 @@
     @media (max-width: 768px) {
       #input-section { align-items: normal !important; }
     }
+
+    .composer-banner {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-sm);
+      width: 100%;
+      padding: var(--spacing-xs) var(--spacing-sm);
+      margin-bottom: var(--spacing-xxs);
+      background: var(--color-panel);
+      border: 1px solid var(--color-border);
+      border-radius: 6px;
+      box-sizing: border-box;
+    }
+    .composer-banner--danger {
+      border-left: 4px solid #F44336;
+    }
+    .composer-banner--danger .composer-banner-icon {
+      color: #F44336;
+    }
+    .composer-banner-icon {
+      flex-shrink: 0;
+      font-size: 1.25rem;
+    }
+    .composer-banner-text {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      text-align: left;
+    }
+    .composer-banner-title {
+      font-weight: 600;
+      font-size: 0.85rem;
+      color: var(--color-text);
+    }
+    .composer-banner-detail {
+      font-size: 0.78rem;
+      color: var(--color-secondary);
+      line-height: 1.35;
+      word-break: break-word;
+    }
+    .composer-banner-cta {
+      flex-shrink: 0;
+      font-size: 0.8rem;
+      padding: 0.35rem 0.65rem;
+    }
+    @media (max-width: 768px) {
+      .composer-banner {
+        flex-wrap: wrap;
+      }
+      .composer-banner-cta {
+        width: 100%;
+      }
+    }
     </style>
 </body>
 </html>
-

--- a/webui/components/chat/input/composer-banner-store.js
+++ b/webui/components/chat/input/composer-banner-store.js
@@ -1,0 +1,68 @@
+import { createStore } from "/js/AlpineStore.js";
+import { callJsonApi } from "/js/api.js";
+
+function buildBannersContext() {
+  return {
+    url: window.location.href,
+    protocol: window.location.protocol,
+    hostname: window.location.hostname,
+    port: window.location.port,
+    browser: navigator.userAgent,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export const store = createStore("composerBanner", {
+  missingApiKeys: [],
+  hasMissingApiKeyBanner: false,
+  loading: false,
+  lastRefresh: 0,
+  _modalCloseBound: false,
+
+  get hasMissingApiKeys() {
+    return this.hasMissingApiKeyBanner;
+  },
+
+  get missingApiKeysSummaryText() {
+    if (!this.hasMissingApiKeys) return "";
+    if (!Array.isArray(this.missingApiKeys) || this.missingApiKeys.length === 0) {
+      return "Configure your model provider API keys to continue.";
+    }
+    return this.missingApiKeys
+      .map((p) => `${p.model_type} (${p.provider})`)
+      .join(", ");
+  },
+
+  init() {
+    if (this._modalCloseBound) return;
+    this._modalCloseBound = true;
+    document.addEventListener("modal-closed", () => {
+      this.refresh(true);
+    });
+  },
+
+  async refresh(force = false) {
+    const now = Date.now();
+    if (!force && now - this.lastRefresh < 1000) return;
+    this.lastRefresh = now;
+    this.loading = true;
+    try {
+      const response = await callJsonApi("/banners", {
+        banners: [],
+        context: buildBannersContext(),
+      });
+      const banners = Array.isArray(response?.banners) ? response.banners : [];
+      const missingApiKeyBanner = banners.find((banner) => banner?.id === "missing-api-key");
+      this.hasMissingApiKeyBanner = !!missingApiKeyBanner;
+      this.missingApiKeys = Array.isArray(missingApiKeyBanner?.missing_providers)
+        ? missingApiKeyBanner.missing_providers
+        : [];
+    } catch (e) {
+      console.error("composerBanner refresh failed", e);
+      this.hasMissingApiKeyBanner = false;
+      this.missingApiKeys = [];
+    } finally {
+      this.loading = false;
+    }
+  },
+});


### PR DESCRIPTION
This PR ships the first onboarding flow for model setup and wires API-key guidance directly into chat composer.

- Added a new always-enabled `_onboarding` plugin with a modal wizard for first-time model setup (main + utility) and API-key entry.
- Updated missing API-key backend banner logic to include machine-readable `missing_providers`, so frontend clients can consume targeted status data outside of the regular banner system.
- Added a composer-level warning banner in chat input that surfaces missing API keys and links users to onboarding.