### PR TITLE
fix: use constant-time comparison for auth token (CWE-208)

### DIFF
--- a/helpers/fasta2a_server.py
+++ b/helpers/fasta2a_server.py
@@ -1,5 +1,6 @@
 # noqa: D401 (docstrings) – internal helper
 import asyncio
+import hmac
 import uuid
 import atexit
 from typing import Any, List
@@ -457,7 +458,7 @@ class DynamicA2AProxy:
             cfg = settings.get_settings()
             expected_token = cfg.get("mcp_server_token")
 
-            if expected_token and request_token != expected_token:
+            if expected_token and not hmac.compare_digest(request_token, expected_token):
                 # Invalid token, return 401
                 await send({
                     'type': 'http.response.start',
@@ -533,8 +534,8 @@ class DynamicA2AProxy:
                 api_key = request.headers.get("X-API-KEY") or request.query_params.get("api_key")
 
                 is_authorized = (
-                    (auth_header.startswith("Bearer ") and auth_header.split(" ", 1)[1] == expected) or
-                    (api_key == expected)
+                    (auth_header.startswith("Bearer ") and hmac.compare_digest(auth_header.split(" ", 1)[1], expected)) or
+                    (api_key is not None and hmac.compare_digest(api_key, expected))
                 )
 
                 if not is_authorized:


### PR DESCRIPTION
## Summary
Fixes #1351 — replaces timing-vulnerable `==` comparison with constant-time `hmac.compare_digest`.

## Changes
- Replace direct string comparison with constant-time comparison for MCP server token (2 locations)
- Add None guard to prevent TypeError when token is not set
- No behavioral change for valid authentication flows

## CWE Reference
- **CWE-208**: Observable Timing Discrepancy
- Uses stdlib only (`hmac`) — no new dependencies

---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*