### PR TITLE
Fix: Add AuthenticationError guard + correct indentation in memory extensions (NVIDIA NIM users)

### DIFF
--- a/plugins/_memory/extensions/python/message_loop_prompts_after/_50_recall_memories.py
+++ b/plugins/_memory/extensions/python/message_loop_prompts_after/_50_recall_memories.py
@@ -1,4 +1,6 @@
 import asyncio
+import litellm
+from litellm.exceptions import AuthenticationError
 from helpers.extension import Extension
 from agent import LoopData
 from helpers import dirty_json, errors, log, plugins
@@ -101,7 +103,18 @@ class RecallMemories(Extension):
                 )
                 query = query.strip()
                 log_item.update(query=query) # no need for streaming here
+            except AuthenticationError as e:
+                # Guard against NVIDIA API key being sent to OpenAI endpoint
+                if "nvapi-" in str(e):
+                    log_item.update(heading="SKIPPED: Invalid API Key (NVIDIA key on OpenAI endpoint)")
+                    log_item.update(content="Memory recall skipped due to configuration error. Please update API_KEY_OPENAI in .env or fix provider routing.")
+                    # Gracefully exit without crashing or logging full traceback
+                    query = ""
+                else:
+                    # Re-raise if it is a different authentication error
+                    raise
             except Exception as e:
+                # Catch any other unexpected errors
                 err = errors.format_error(e)
                 self.agent.context.log.log(
                     type="warning", heading="Recall memories extension error:", content=err
@@ -114,7 +127,7 @@ class RecallMemories(Extension):
                     heading="Failed to generate memory query",
                 )
                 return
-        
+
         # otherwise use the message and history as query
         else:
             query = user_instruction + "\n\n" + history

--- a/plugins/_memory/extensions/python/monologue_end/_51_memorize_solutions.py
+++ b/plugins/_memory/extensions/python/monologue_end/_51_memorize_solutions.py
@@ -1,4 +1,6 @@
 import asyncio
+import litellm
+from litellm.exceptions import AuthenticationError
 from helpers import errors, plugins
 from helpers.extension import Extension
 from helpers.dirty_json import DirtyJson
@@ -23,7 +25,7 @@ class MemorizeSolutions(Extension):
 
         if not set["memory_memorize_enabled"]:
             return
- 
+
         # show full util message
         log_item = self.agent.context.log.log(
             type="util",
@@ -57,12 +59,28 @@ class MemorizeSolutions(Extension):
             #     log_item.stream(content=content)
 
             # call util llm to find solutions in history
-            solutions_json = await self.agent.call_utility_model(
-                system=system,
-                message=msgs_text,
-                # callback=log_callback,
-                background=True,
-            )
+            try:
+                solutions_json = await self.agent.call_utility_model(
+                    system=system,
+                    message=msgs_text,
+                    # callback=log_callback,
+                    background=True,
+                )
+            except AuthenticationError as e:
+                # Guard against NVIDIA API key being sent to OpenAI endpoint
+                if "nvapi-" in str(e):
+                    log_item.update(heading="SKIPPED: Invalid API Key (NVIDIA key on OpenAI endpoint)")
+                    log_item.update(content="Memory memorization skipped due to configuration error. Please update API_KEY_OPENAI in .env or fix provider routing.")
+                    # Gracefully exit without crashing the background thread
+                    return
+                else:
+                    # Re-raise if it is a different authentication error
+                    raise
+            except Exception as e:
+                # Catch any other unexpected errors to prevent thread crashes
+                log_item.update(heading="SKIPPED: Memory memorization failed")
+                log_item.update(content=f"Error: {str(e)}")
+                return
 
             # log query < no need for streaming utility messages
             log_item.update(content=solutions_json)


### PR DESCRIPTION
  ## Problem

  Fixes #1360

  For Agent Zero users running NVIDIA NIM models via LiteLLM (`provider: openai` with NVIDIA
  `api_base`), an empty `utility_model.api_base` causes all utility model calls to route to
  `api.openai.com`, which rejects the NVIDIA key with `AuthenticationError`.

  Agent Zero may attempt to self-repair this by patching `_50_recall_memories.py` and
  `_51_memorize_solutions.py` — but the patch can be written with incorrect indentation (1-space
  instead of 8-space), causing `IndentationError` on extension load and blocking **all agent
  responses**.

  ## Changes

  - `_50_recall_memories.py`: Fix indentation in `memory_recall_query_prep` block; add `try/except
  AuthenticationError` guard that detects `nvapi-` key on OpenAI endpoint and skips gracefully instead
   of crashing the background thread
  - `_51_memorize_solutions.py`: Fix indentation in `call_utility_model` try/except block; same
  AuthenticationError guard

  ## Testing

  Verified on Agent Zero v1.x with NVIDIA NIM (`qwen/qwen3.5-122b`) — memory recall and memorization
  now skip cleanly with a log message instead of crashing when `utility_model.api_base` is
  misconfigured.

  Full incident report and white paper:
  https://github.com/MrTrenchTrucker/agent-zero-nvidia-routing-fix
