### PR TITLE
feat: expose extra_env in LocalInteractiveSession and tool instance in tool_execute extensions

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -907,6 +907,7 @@ class Agent:
                         self,
                         tool_args=tool_args or {},
                         tool_name=tool_name,
+                        tool=tool,
                     )
 
                     response = await tool.execute(**tool_args)
@@ -918,6 +919,7 @@ class Agent:
                         self,
                         response=response,
                         tool_name=tool_name,
+                        tool=tool,
                     )
 
                     await tool.after_execution(response)

--- a/plugins/_code_execution/helpers/shell_local.py
+++ b/plugins/_code_execution/helpers/shell_local.py
@@ -9,13 +9,16 @@ from plugins._code_execution.helpers import tty_session
 from plugins._code_execution.helpers.shell_ssh import clean_string
 
 class LocalInteractiveSession:
-    def __init__(self, cwd: str|None = None):
+    def __init__(self, cwd: str|None = None, extra_env: dict|None = None):
         self.session: tty_session.TTYSession|None = None
         self.full_output = ''
         self.cwd = cwd
+        self.extra_env = extra_env or {}
 
     async def connect(self):
-        self.session = tty_session.TTYSession(runtime.get_terminal_executable(), cwd=self.cwd)
+        import os
+        env = {**os.environ, **self.extra_env} if self.extra_env else None
+        self.session = tty_session.TTYSession(runtime.get_terminal_executable(), cwd=self.cwd, env=env)
         await self.session.start()
         await self.session.read_full_until_idle(idle_timeout=1, total_timeout=1)
 


### PR DESCRIPTION
## Summary

Two small additive changes to improve plugin extensibility for subprocess credential isolation and type-safe tool detection in extensions.

## Changes

### 1. `LocalInteractiveSession.extra_env` (`plugins/_code_execution/helpers/shell_local.py`)

Adds an optional `extra_env: dict | None` parameter to `LocalInteractiveSession.__init__()`. When provided, it is merged over `os.environ` and passed to `TTYSession` at `connect()` time.

`TTYSession` already accepts `env=` — this change plumbs it through the `LocalInteractiveSession` surface.

**Use case:** Plugins can inject scoped credentials into shell sessions without polluting the parent process `os.environ`. This enables proper secrets isolation — the A0 process environment stays clean while subprocesses receive only the credentials they need.

### 2. `tool=tool` in `tool_execute_before` / `tool_execute_after` (`agent.py`)

Passes the `Tool` instance alongside the existing `tool_name` string to both extension calls.

**Use case:** Extensions can use `isinstance()` checks and access tool state rather than fragile string matching on `tool_name`. Completes the extension contract — both hooks now have access to the full tool context.

## Non-breaking

- `extra_env` defaults to `None` — existing callers unchanged, `LocalInteractiveSession()` behaves identically
- `tool=tool` is an additional kwarg — existing extensions receive it via `**kwargs` and can safely ignore it
- No behaviour change when the new parameters are not used