### PR TITLE
feat: add per-row extension points inside sidebar chat list x-for loop

### DIFF
--- a/webui/components/sidebar/chats/chats-list.html
+++ b/webui/components/sidebar/chats/chats-list.html
@@ -26,6 +26,7 @@
             <li>
               <div :class="{'chat-container': true, 'chat-selected': context.id === $store.chats.selected}"
                 @click="$store.chats.selectChat(context.id)">
+                <x-extension id="sidebar-chat-item-start"></x-extension>
                 <div class="chat-list-button">
                   <span :class="{'project-color-ball': true, 'heartbeat': context.running}"
                     :style="context.project?.color ? { backgroundColor: context.project.color } : { border: '1px solid var(--color-border)' }"></span>
@@ -35,6 +36,7 @@
                 <button class="btn-icon-action chat-list-action-btn" title="Close chat" @click.stop="$confirmClick($event, () => $store.chats.killChat(context.id))">
                   <span class="material-symbols-outlined">close</span>
                 </button>
+                <x-extension id="sidebar-chat-item-end"></x-extension>
               </div>
             </li>
           </template>


### PR DESCRIPTION
## Summary

Adds two new `x-extension` points **inside** the `x-for` loop in `chats-list.html`:

- `sidebar-chat-item-start` — injected immediately after the opening `chat-container` div, before the chat label
- `sidebar-chat-item-end` — injected after the close button, before the closing `chat-container` div

## Motivation

Previously only `sidebar-chats-list-start` and `sidebar-chats-list-end` existed, both placed **outside** the `x-for` loop. Plugins that need to inject UI into individual chat rows had no framework-sanctioned way to do so.

This forced third-party plugins to work around the gap by:
- Monkey-patching internal store methods (`chatsStore.applyContexts`, `chatsStore.selectChat`)
- Using `MutationObserver` + index-based DOM scanning (`contexts[index]`) to locate rows
- Calling imperative `createElement` / `insertBefore` instead of declarative Alpine bindings

All three patterns are fragile — they break silently when internal store method names or DOM structure changes.

## Solution

With `sidebar-chat-item-start` / `sidebar-chat-item-end` inside the `x-for` loop, extension HTML has access to the reactive Alpine `context` object (including `context.id`, `context.name`, `context.running`, `context.project`, etc.) through the normal Alpine scope chain.

This enables purely declarative per-row plugin UI:

```html
<!-- No DOM scanning, no monkey-patching needed -->
<span x-show="context.running" class="my-running-dot"></span>
```

## Change

Minimal — 2 lines added to `webui/components/sidebar/chats/chats-list.html`. No logic changes, no style changes, no new dependencies.

## Backwards Compatibility

Fully backwards compatible. Existing `sidebar-chats-list-start` and `sidebar-chats-list-end` extension points are unchanged. The new points are no-ops when no plugin registers extensions for them.