### PR TITLE
fix: let agents fix their own tool call format instead of erroring

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -848,8 +848,10 @@ class Agent:
         # search for tool usage requests in agent message
         tool_request = extract_tools.json_parse_dirty(msg)
 
-        # basic validation + extensions
-        await self.validate_tool_request(tool_request)
+        # Only validate when extraction produced an object; None means no JSON tool
+        # block was found — the misformat warning path below handles that.
+        if tool_request is not None:
+            await self.validate_tool_request(tool_request)
 
         if tool_request is not None:
             raw_tool_name = tool_request.get("tool_name", tool_request.get("tool",""))  # Get the raw tool name


### PR DESCRIPTION
This fix allows the missing tool calls to hit the warning path for the agent to fix itself rather than erroring and stopping

Right now some models like Kimi K2.5 are basically unusable for me without this fix, here's the error I keep getting:
<img width="591" height="580" alt="Captura de Tela 2026-03-28 às 11 00 47" src="https://github.com/user-attachments/assets/3819d3c7-4921-41ec-9691-f5089a66a2d8" />

After the Fix:
<img width="392" height="120" alt="Captura de Tela 2026-03-29 às 16 08 41" src="https://github.com/user-attachments/assets/dadb97d9-9b0f-4bcf-abe7-d74bf58164cd" />
