### PR TITLE
feat: add @extensible to set_settings + resolve_mcp_server_headers hook in mcp_handler

### DIFF
--- a/helpers/mcp_handler.py
+++ b/helpers/mcp_handler.py
@@ -42,6 +42,7 @@ from pydantic import BaseModel, Field, Discriminator, Tag, PrivateAttr
 from helpers import dirty_json
 from helpers.print_style import PrintStyle
 from helpers.tool import Tool, Response
+from helpers.extension import call_extensions_async
 
 
 def normalize_name(name: str) -> str:
@@ -1105,10 +1106,21 @@ class MCPClientRemote(MCPClientBase):
         # Check if this is a streaming HTTP type
         if _is_streaming_http_type(server.type):
             # Use streamable HTTP client
+            # Before passing headers to httpx, allow extensions to resolve placeholders
+            resolved_headers = await call_extensions_async(
+                "resolve_mcp_server_headers",
+                agent=None,
+                server_name=server.name,
+                headers=dict(server.headers or {}),
+            )
+            if resolved_headers is not None:
+                headers_to_use = resolved_headers
+            else:
+                headers_to_use = server.headers
             transport_result = await current_exit_stack.enter_async_context(
                 streamablehttp_client(
                     url=server.url,
-                    headers=server.headers,
+                    headers=headers_to_use,
                     timeout=timedelta(seconds=init_timeout),
                     sse_read_timeout=timedelta(seconds=tool_timeout),
                     httpx_client_factory=client_factory,
@@ -1123,10 +1135,21 @@ class MCPClientRemote(MCPClientBase):
             return read_stream, write_stream
         else:
             # Use traditional SSE client (default behavior)
+            # Before passing headers to httpx, allow extensions to resolve placeholders
+            resolved_headers = await call_extensions_async(
+                "resolve_mcp_server_headers",
+                agent=None,
+                server_name=server.name,
+                headers=dict(server.headers or {}),
+            )
+            if resolved_headers is not None:
+                headers_to_use = resolved_headers
+            else:
+                headers_to_use = server.headers
             stdio_transport = await current_exit_stack.enter_async_context(
                 sse_client(
                     url=server.url,
-                    headers=server.headers,
+                    headers=headers_to_use,
                     timeout=init_timeout,
                     sse_read_timeout=tool_timeout,
                     httpx_client_factory=client_factory,

--- a/helpers/settings.py
+++ b/helpers/settings.py
@@ -14,6 +14,7 @@ from helpers.providers import get_providers, FieldOption as ProvidersFO
 from helpers.secrets import get_default_secrets_manager
 from helpers import dirty_json
 from helpers.notification import NotificationManager, NotificationType, NotificationPriority
+from helpers.extension import extensible
 
 
 T = TypeVar('T')
@@ -312,6 +313,7 @@ def set_runtime_settings_snapshot(settings: Settings) -> None:
     _runtime_settings_snapshot = settings.copy()
 
 
+@extensible
 def set_settings(settings: Settings, apply: bool = True):
     global _settings
     previous = _settings
@@ -322,6 +324,7 @@ def set_settings(settings: Settings, apply: bool = True):
     return reload_settings()
 
 
+@extensible
 def set_settings_delta(delta: dict, apply: bool = True):
     current = get_settings()
     new = {**current, **delta}


### PR DESCRIPTION
## Summary

Two small additive changes to improve plugin extensibility for credential management at the settings and MCP transport layers.

## Changes

### 1. `@extensible` on `set_settings()` and `set_settings_delta()` (`helpers/settings.py`)

Adds the `@extension.extensible` decorator to both settings write functions.

**Use case:** Plugins managing credentials need to intercept settings writes to scan for embedded credentials before they are persisted to disk. Without this hook, the only option is monkey-patching — which breaks silently on refactors with no runtime signal.

### 2. `resolve_mcp_server_headers(server_name, headers)` async hook (`helpers/mcp_handler.py`)

Adds an async `call_extensions_async()` call immediately before MCP server headers are passed to httpx at both transport paths (streamablehttp and sse).

**Use case:** Plugins can resolve credential placeholders to live values at HTTP transport time — without storing real credentials in `os.environ`, settings JSON, or config files on disk. Enables proper secrets isolation for MCP server authentication without monkey-patching `MCPConfig`.

## Non-breaking

- `@extensible` on settings: no behaviour change when no extension registers for it
- `resolve_mcp_server_headers`: returns `None` (not registered) → framework falls back to original `server.headers` unchanged
- Both changes are purely additive

## Motivation

These hooks are co-motivated: credential injection at the settings pipeline and MCP transport layer without `os.environ` mutation or monkey-patching. Neither hook is sufficient without the other for the MCP credential isolation use case.