### PR TITLE
fix: guard against missing plugin directory in config loads

### DIFF
--- a/helpers/plugins.py
+++ b/helpers/plugins.py
@@ -607,9 +607,10 @@ def get_plugin_config(
 
     # use default config if not found
     if not file_path:
-        file_path = files.get_abs_path(
-            find_plugin_dir(plugin_name), CONFIG_DEFAULT_FILE_NAME
-        )
+        plugin_dir = find_plugin_dir(plugin_name)
+        if not plugin_dir:
+            return None
+        file_path = files.get_abs_path(plugin_dir, CONFIG_DEFAULT_FILE_NAME)
         default_used = True
 
     result = None
@@ -635,9 +636,11 @@ def get_plugin_config(
 
 
 def get_default_plugin_config(plugin_name: str):
-    file_path = files.get_abs_path(
-        find_plugin_dir(plugin_name), CONFIG_DEFAULT_FILE_NAME
-    )
+    plugin_dir = find_plugin_dir(plugin_name)
+    if not plugin_dir:
+        return None
+
+    file_path = files.get_abs_path(plugin_dir, CONFIG_DEFAULT_FILE_NAME)
 
     # call plugin hook to get the result
     result = call_plugin_hook(


### PR DESCRIPTION
`find_plugin_dir` can return `None` if a plugin cannot be found. Passing this null value to `files.get_abs_path` caused crashes during config retrieval. `get_plugin_config` and `get_default_plugin_config` now check for a valid directory and return early if it is missing.

<img width="1139" height="612" alt="Screenshot from 2026-04-01 20-41-32" src="https://github.com/user-attachments/assets/5cce6bb2-6e67-465a-934d-2c51a7b1f505" />
