### PR TITLE
Fix: Add SPECIAL_TOKEN_BUFFER for llama.cpp BOS/EOS tokens

### DIFF
--- a/helpers/history.py
+++ b/helpers/history.py
@@ -539,7 +539,9 @@ class History(Record):
         chat_cfg = get_chat_model_config(self.agent)
         ctx_length = int(chat_cfg.get("ctx_length", 128000))
         ctx_history = float(chat_cfg.get("ctx_history", 0.7))
-        return int(ctx_length * ctx_history)
+        # Buffer for BOS/EOS/system tokens (llama.cpp adds 3 special tokens)
+        SPECIAL_TOKEN_BUFFER = 10
+        return int(ctx_length * ctx_history) - SPECIAL_TOKEN_BUFFER
 
     def _get_max_embeds(self) -> int:
         chat_cfg = get_chat_model_config(self.agent)

--- a/plugins/_chat_compaction/helpers/compactor.py
+++ b/plugins/_chat_compaction/helpers/compactor.py
@@ -107,7 +107,9 @@ async def run_compaction(
 
         resolved_cfg, model = _build_model(use_chat_model, preset_name, agent)
         ctx_length = int(resolved_cfg.get("ctx_length", 128000)) if resolved_cfg else 128000
-        max_input_tokens = int(ctx_length * 0.7)
+        # Buffer for BOS/EOS/system tokens (llama.cpp adds 3 special tokens)
+        SPECIAL_TOKEN_BUFFER = 10
+        max_input_tokens = int(ctx_length * 0.7) - SPECIAL_TOKEN_BUFFER
         
         # Step 3: Create progress log item (count user-visible messages only)
         visible_types = {"user", "response"}


### PR DESCRIPTION
## Problem

When using llama.cpp-based models (like Puzzle 88B), Agent Zero throws:
```
litellm.exceptions.BadRequestError: Error code: 400 - {"error": "prompt too long; exceeded max context length by 3 tokens"}
```

This error occurs on **BOTH short and long chats**, indicating a fixed overhead issue, not a chat history size problem.

## Root Cause

llama.cpp automatically adds **3 special tokens** to every request:
- `<s>` (BOS - Beginning of Sequence)
- `</s>` (EOS - End of Sequence)  
- Often a system token

Agent Zero's context window calculation does not account for these special tokens.

## Solution

Add a `SPECIAL_TOKEN_BUFFER = 10` constant and subtract it from the context calculation.

### Files Changed

1. **helpers/history.py** - Added buffer to `_get_ctx_size_for_history()`
2. **plugins/_chat_compaction/helpers/compactor.py** - Added buffer to `max_input_tokens` calculation

## Impact

- **Affects**: All llama.cpp users (Puzzle 88B, local models, etc.)
- **Risk**: Low - reduces context budget by only 10 tokens
- **Benefit**: Prevents "exceeded by 3 tokens" errors

## Testing

- Verified patches applied correctly
- Tested with Puzzle 88B on llama.cpp
- No more +3 token overflow errors
