### PR TITLE
feat: add dict-like .get() method to AgentConfig dataclass

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -314,6 +314,26 @@ class AgentConfig:
     knowledge_subdirs: list[str] = field(default_factory=lambda: ["default", "custom"])
     additional: Dict[str, Any] = field(default_factory=dict)
 
+    def get(self, key: str, default: Any = None) -> Any:
+        """Dict-like access to config attributes.
+        
+        Provides dict-style .get() access to AgentConfig fields and
+        the additional dict. This is useful for extensions and skills
+        that treat config as a dict-like object.
+        
+        Args:
+            key: The attribute name to look up
+            default: Value to return if key not found
+            
+        Returns:
+            The attribute value, or value from additional dict, or default
+        """
+        if hasattr(self, key):
+            return getattr(self, key)
+        if key in self.additional:
+            return self.additional[key]
+        return default
+
 
 @dataclass
 class UserMessage:


### PR DESCRIPTION
## Summary

Adds a .get(key, default) method to the AgentConfig dataclass to provide dict-like access to config attributes.

## Problem

AgentConfig is a @dataclass used throughout the framework as a configuration object. Extensions, skills, and external tools often receive config objects and expect dict-like .get() access with default values.

Without this method, code that calls config.get('key', default) raises:

AttributeError: 'AgentConfig' object has no attribute 'get'


This caused 7 scheduled jobs in our deployment to fail silently.

## Solution

Adds a .get() method that:
- Returns the dataclass attribute if it exists
- Falls back to the additional dict for extra config values
- Returns the provided default if key is not found

## Changes

- agent.py: Added get() method to AgentConfig class (lines 317-335)

## Backwards Compatibility

Fully backwards compatible. No existing behavior changes. Only adds a new method.

## Testing

- Verified the method returns correct values for existing attributes
- Verified fallback to additional dict works
- Verified default value is returned for unknown keys
- 7 previously failing scheduled jobs now run successfully