### PR TITLE
fix: treat empty dict as valid tool_args in MCP tool dispatch

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -954,7 +954,7 @@ class Agent:
             raise ValueError("Tool request must be a dictionary")
         if not tool_request.get("tool_name") or not isinstance(tool_request.get("tool_name"), str):
             raise ValueError("Tool request must have a tool_name (type string) field")
-        if not tool_request.get("tool_args") or not isinstance(tool_request.get("tool_args"), dict):
+        if not isinstance(tool_request.get("tool_args"), dict):
             raise ValueError("Tool request must have a tool_args (type dictionary) field")
 
 


### PR DESCRIPTION
The check 'if not tool_request.get("tool_args")' treats {} as falsy, blocking all MCP tools with no required arguments. Fixed by checking isinstance() only, which correctly accepts an empty dict.

Affected tools: cdp_snapshot, cdp_page_text, cdp_go_back, cdp_reload, cdp_screenshot, cdp_tabs — 6 of 17 MCP tools were blocked by this bug.

## Problem

MCP tools with no required arguments fail silently with:

    ValueError: Tool request must have a tool_args (type dictionary) field

This happens because `not tool_request.get("tool_args")` evaluates to True
when tool_args is an empty dict {}, since empty dicts are falsy in Python.

## Impact

6 of 17 MCP tools are broken for any MCP server whose tools have no required
arguments: cdp_snapshot, cdp_page_text, cdp_go_back, cdp_reload,
cdp_screenshot, and cdp_tabs. This is not an edge case — it affects all
argument-free tools by design, meaning the issue will affect any user
integrating MCP servers with tools that have no required parameters.

## Fix

Replace the compound falsy check with an explicit isinstance() check:

Before:
  if not tool_request.get("tool_args") or not isinstance(...):

After:
  if not isinstance(tool_request.get("tool_args"), dict):

This correctly accepts {} as a valid tool_args value while still rejecting
None, missing keys, and non-dict types.

## Testing

Verified against a 17-tool MCP test suite. All 6 previously failing tools
pass after this fix. The remaining 11 tools are unaffected.