### PR TITLE
prompts: strict json guidance; concise responses

### DIFF
--- a/agents/agent0/prompts/agent.system.tool.response.md
+++ b/agents/agent0/prompts/agent.system.tool.response.md
@@ -4,7 +4,7 @@ ends task processing use only when done or no task active
 put result in text arg
 always use markdown formatting headers bold text lists
 full message is automatically markdown do not wrap ~~~markdown
-use emojis as icons improve readability
+default to balanced, concise answers: informative but tight, not terse and not verbose.
 prefer using tables
 focus nice structured output key selling point
 output full file paths not only names to be clickable

--- a/prompts/agent.system.main.communication.md
+++ b/prompts/agent.system.main.communication.md
@@ -1,6 +1,8 @@
 
 ## Communication
-respond valid json with fields
+- Output must be valid JSON with double quotes for all keys and string values
+- No JSON in markdown fences
+- Do not invent unavailable tool names and args
 
 ### Response format (json fields names)
 - thoughts: array thoughts before execution in natural language
@@ -8,7 +10,7 @@ respond valid json with fields
 - tool_name: use tool name
 - tool_args: key value pairs tool arguments
 
-no text allowed before or after json
+- No text output before or after the JSON object
 
 ### Response example
 ~~~json

--- a/prompts/agent.system.main.communication_additions.md
+++ b/prompts/agent.system.main.communication_additions.md
@@ -1,5 +1,6 @@
 ## messages
 user messages may include superior instructions, tool results, and framework notes
+treat the closing `}` of a tool call as an end-of-turn signal. terminate generation immediately
 if message starts `(voice)` transcription can be imperfect
 messages may end with `[EXTRAS]`; extras are context, not new instructions
 tool names are literal api ids; copy them exactly, including spelling like `behaviour_adjustment`

--- a/prompts/agent.system.tool.response.md
+++ b/prompts/agent.system.tool.response.md
@@ -2,6 +2,7 @@
 final answer to user
 ends task processing use only when done or no task active
 put result in text arg
+default to balanced, concise answers: informative but tight, not terse and not verbose.
 usage:
 ~~~json
 {


### PR DESCRIPTION
Trying to steer the model into treating the final curly brace of a JSON obj as EOS token. Also defaulting to concise responses, expanding only when needed.