### PR TITLE
Synchronize speech input store before immediate send

### DIFF
--- a/tests/test_speech_input_race_regression.py
+++ b/tests/test_speech_input_race_regression.py
@@ -4,28 +4,50 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
+def _extract_function_block(source: str, signature: str) -> str:
+    start = source.index(signature)
+    block_start = source.index("{", start)
+    depth = 0
+
+    for index in range(block_start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+
+    raise ValueError(f"Could not find closing brace for function: {signature}")
+
+
 def test_update_chat_input_syncs_store_before_follow_up_send():
     index_js = (PROJECT_ROOT / "webui" / "index.js").read_text(encoding="utf-8")
     speech_store_js = (
         PROJECT_ROOT / "webui" / "components" / "chat" / "speech" / "speech-store.js"
     ).read_text(encoding="utf-8")
-    update_chat_input_start = index_js.index("export function updateChatInput(text) {")
-    update_chat_input_end = index_js.index("async function updateUserTime()")
-    update_chat_input_block = index_js[
-        update_chat_input_start:update_chat_input_end
-    ]
+    update_chat_input_block = _extract_function_block(
+        index_js, "export function updateChatInput(text)"
+    )
 
-    next_value_marker = "const nextValue = currentValue + (needsSpace ? \" \" : \"\") + text + \" \";"
+    next_value_marker = "const nextValue ="
+    value_assign_marker = "chatInputEl.value = nextValue;"
     sync_marker = "inputStore.message = nextValue;"
     adjust_marker = "adjustTextareaHeight();"
-    dispatch_marker = 'chatInputEl.dispatchEvent(new Event("input"));'
+    dispatch_marker = "chatInputEl.dispatchEvent("
+    update_call_marker = "updateChatInput(text);"
+    send_marker = "await sendMessage();"
 
     assert next_value_marker in update_chat_input_block
+    assert value_assign_marker in update_chat_input_block
     assert sync_marker in update_chat_input_block
     assert adjust_marker in update_chat_input_block
     assert dispatch_marker in update_chat_input_block
+    assert update_chat_input_block.index(next_value_marker) < update_chat_input_block.index(value_assign_marker)
+    assert update_chat_input_block.index(value_assign_marker) < update_chat_input_block.index(sync_marker)
     assert update_chat_input_block.index(sync_marker) < update_chat_input_block.index(adjust_marker)
     assert update_chat_input_block.index(sync_marker) < update_chat_input_block.index(dispatch_marker)
 
-    assert "updateChatInput(text);" in speech_store_js
-    assert "await sendMessage();" in speech_store_js
+    assert update_call_marker in speech_store_js
+    assert send_marker in speech_store_js
+    assert speech_store_js.index(update_call_marker) < speech_store_js.index(send_marker)

--- a/tests/test_speech_input_race_regression.py
+++ b/tests/test_speech_input_race_regression.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_update_chat_input_syncs_store_before_follow_up_send():
+    index_js = (PROJECT_ROOT / "webui" / "index.js").read_text(encoding="utf-8")
+    speech_store_js = (
+        PROJECT_ROOT / "webui" / "components" / "chat" / "speech" / "speech-store.js"
+    ).read_text(encoding="utf-8")
+    update_chat_input_start = index_js.index("export function updateChatInput(text) {")
+    update_chat_input_end = index_js.index("async function updateUserTime()")
+    update_chat_input_block = index_js[
+        update_chat_input_start:update_chat_input_end
+    ]
+
+    next_value_marker = "const nextValue = currentValue + (needsSpace ? \" \" : \"\") + text + \" \";"
+    sync_marker = "inputStore.message = nextValue;"
+    adjust_marker = "adjustTextareaHeight();"
+    dispatch_marker = 'chatInputEl.dispatchEvent(new Event("input"));'
+
+    assert next_value_marker in update_chat_input_block
+    assert sync_marker in update_chat_input_block
+    assert adjust_marker in update_chat_input_block
+    assert dispatch_marker in update_chat_input_block
+    assert update_chat_input_block.index(sync_marker) < update_chat_input_block.index(adjust_marker)
+    assert update_chat_input_block.index(sync_marker) < update_chat_input_block.index(dispatch_marker)
+
+    assert "updateChatInput(text);" in speech_store_js
+    assert "await sendMessage();" in speech_store_js

--- a/webui/index.js
+++ b/webui/index.js
@@ -180,7 +180,13 @@ export function updateChatInput(text) {
   // Append text with proper spacing
   const currentValue = chatInputEl.value;
   const needsSpace = currentValue.length > 0 && !currentValue.endsWith(" ");
-  chatInputEl.value = currentValue + (needsSpace ? " " : "") + text + " ";
+  const nextValue = currentValue + (needsSpace ? " " : "") + text + " ";
+  chatInputEl.value = nextValue;
+
+  // Keep the Alpine-backed input store synchronized immediately.
+  // Speech-to-text sends the message right after this call, so waiting for
+  // Alpine's next input tick can race with sendMessage() reading stale state.
+  inputStore.message = nextValue;
 
   // Adjust height and trigger input event
   adjustTextareaHeight();


### PR DESCRIPTION
Summary:
- keep the Alpine-backed input store synchronized as soon as `updateChatInput()` appends speech-to-text content
- add a regression test that locks the ordering between store sync, resize/input dispatch, and the speech send flow

Root cause:
- speech-to-text updated the textarea DOM value and then immediately sent the message, but the Alpine store could lag behind the DOM update, allowing `sendMessage()` to read stale input

Testing:
- `docker exec agent-zero-live /opt/venv-a0/bin/python -m pytest /a0/tests/test_speech_input_race_regression.py -q` → `1 passed in 0.36s`