### PR TITLE
fix: prevent embedding 422 on strict OpenAI-compatible endpoints (DeepInfra, vLLM, TEI)

### DIFF
--- a/models.py
+++ b/models.py
@@ -600,7 +600,8 @@ class LiteLLMEmbeddingWrapper(Embeddings):
         # Apply rate limiting if configured
         apply_rate_limiter_sync(self.a0_model_conf, " ".join(texts))
 
-        resp = embedding(model=self.model_name, input=texts, **self.kwargs)
+        embed_kwargs = {"encoding_format": "float", **self.kwargs}
+        resp = embedding(model=self.model_name, input=texts, **embed_kwargs)
         return [
             item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
             for item in resp.data  # type: ignore
@@ -610,7 +611,8 @@ class LiteLLMEmbeddingWrapper(Embeddings):
         # Apply rate limiting if configured
         apply_rate_limiter_sync(self.a0_model_conf, text)
 
-        resp = embedding(model=self.model_name, input=[text], **self.kwargs)
+        embed_kwargs = {"encoding_format": "float", **self.kwargs}
+        resp = embedding(model=self.model_name, input=[text], **embed_kwargs)
         item = resp.data[0]  # type: ignore
         return item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
 


### PR DESCRIPTION
Fixes #1429

## Summary

LiteLLM ≥1.80.11 sends `encoding_format: null` in embedding requests when the parameter is not explicitly set. Strict OpenAI-compatible validators (DeepInfra, vLLM, HuggingFace TEI) reject `null` with a 422 error. This fix sets `"float"` as the default — the OpenAI spec default — before merging caller kwargs, so any explicitly configured value still takes precedence.

## Changes

| File | Change |
|------|--------|
| `models.py` | `embed_documents` and `embed_query`: build `embed_kwargs` with `encoding_format="float"` default before `**self.kwargs` |

## Testing

Tested on helpa0.com with DeepInfra embedding provider (`openai/BAAI/bge-m3`) and LiteLLM 1.82.3. Memory search and recall both work correctly after the fix.

Upstream LiteLLM issue: [BerriAI/litellm#19174](https://github.com/BerriAI/litellm/issues/19174)
Partial upstream fix (openai_like handler only): [BerriAI/litellm#20056](https://github.com/BerriAI/litellm/pull/20056)
Pending upstream fix (openai handler): [BerriAI/litellm#24277](https://github.com/BerriAI/litellm/pull/24277)