### PR TITLE
fix: add credentials to API key save/reveal calls for CSRF protection

### DIFF
--- a/plugins/_model_config/webui/api-keys-mixin.js
+++ b/plugins/_model_config/webui/api-keys-mixin.js
@@ -111,6 +111,7 @@ export const apiKeysMethods = {
     }
 
     const res = await fetchApi(`${API_BASE}/api_keys`, {
+      credentials: 'same-origin',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'set', keys: normalized })
@@ -149,6 +150,7 @@ export const apiKeysMethods = {
 
   async revealApiKey(provider) {
     const res = await fetchApi(`${API_BASE}/api_keys`, {
+      credentials: 'same-origin',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'reveal', provider })


### PR DESCRIPTION
## Summary

The `saveApiKeys` and `revealApiKey` functions in `api-keys-mixin.js` were missing `credentials: 'same-origin'` in their `fetchApi` calls. Without this, the browser doesn't send the Flask session cookie, causing CSRF validation to fail with "CSRF token missing or invalid" (403).

## Root Cause

`fetchApi()` passes options through to `fetch()`, but the options object passed to these state-mutating POST calls didn't include `credentials: 'same-origin'`. As a result:

1. Browser makes POST request to `/api/plugins/_model_config/api_keys`
2. Flask's CSRF protection checks: `session.get("csrf_token")` vs `X-CSRF-Token` header
3. Since no session cookie was sent, the CSRF validation fails

## Fix

Add `credentials: 'same-origin'` to both `saveApiKeys()` and `revealApiKey()` to ensure the session cookie is sent with the request.

## Test plan

1. Open the API Keys modal in the Agent Zero UI
2. Enter an API key and click Save
3. Verify the key persists to `agent-zero-data/.env`
4. Verify no 403 CSRF errors in browser console