### PR TITLE
fix: make embedding calls robust against context overflow and strict endpoint validation

### DIFF
--- a/models.py
+++ b/models.py
@@ -616,7 +616,14 @@ class LiteLLMEmbeddingWrapper(Embeddings):
         embed_kwargs = {"encoding_format": "float", **self.kwargs}
         ctx = int(max((self.a0_model_conf.ctx_length if self.a0_model_conf else 0) or 8192, 1000) * 0.80)
         texts = [trim_to_tokens(t, ctx, "start", ellipsis="") for t in texts]
-        resp = embedding(model=self.model_name, input=texts, **embed_kwargs)
+        try:
+            resp = embedding(model=self.model_name, input=texts, **embed_kwargs)
+        except Exception as e:
+            if "input_tokens" in str(e) and "context" in str(e):
+                texts = [t[: len(t) // 2] for t in texts]
+                resp = embedding(model=self.model_name, input=texts, **embed_kwargs)
+            else:
+                raise
         return [
             item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
             for item in resp.data  # type: ignore
@@ -629,7 +636,13 @@ class LiteLLMEmbeddingWrapper(Embeddings):
         embed_kwargs = {"encoding_format": "float", **self.kwargs}
         ctx = int(max((self.a0_model_conf.ctx_length if self.a0_model_conf else 0) or 8192, 1000) * 0.80)
         text = trim_to_tokens(text, ctx, "start", ellipsis="")
-        resp = embedding(model=self.model_name, input=[text], **embed_kwargs)
+        try:
+            resp = embedding(model=self.model_name, input=[text], **embed_kwargs)
+        except Exception as e:
+            if "input_tokens" in str(e) and "context" in str(e):
+                resp = embedding(model=self.model_name, input=[text[: len(text) // 2]], **embed_kwargs)
+            else:
+                raise
         item = resp.data[0]  # type: ignore
         return item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
 

--- a/models.py
+++ b/models.py
@@ -614,9 +614,7 @@ class LiteLLMEmbeddingWrapper(Embeddings):
         apply_rate_limiter_sync(self.a0_model_conf, " ".join(texts))
 
         embed_kwargs = {"encoding_format": "float", **self.kwargs}
-        # Subtract 500 tokens from ctx_length: cl100k_base and the model's own tokenizer
-        # (e.g. bge-m3 SentencePiece) can diverge by ~2-3%, causing 400 errors at the boundary.
-        ctx = max((self.a0_model_conf.ctx_length if self.a0_model_conf else 0) or 8192, 1000) - 500
+        ctx = int(max((self.a0_model_conf.ctx_length if self.a0_model_conf else 0) or 8192, 1000) * 0.80)
         texts = [trim_to_tokens(t, ctx, "start", ellipsis="") for t in texts]
         resp = embedding(model=self.model_name, input=texts, **embed_kwargs)
         return [
@@ -629,7 +627,7 @@ class LiteLLMEmbeddingWrapper(Embeddings):
         apply_rate_limiter_sync(self.a0_model_conf, text)
 
         embed_kwargs = {"encoding_format": "float", **self.kwargs}
-        ctx = max((self.a0_model_conf.ctx_length if self.a0_model_conf else 0) or 8192, 1000) - 500
+        ctx = int(max((self.a0_model_conf.ctx_length if self.a0_model_conf else 0) or 8192, 1000) * 0.80)
         text = trim_to_tokens(text, ctx, "start", ellipsis="")
         resp = embedding(model=self.model_name, input=[text], **embed_kwargs)
         item = resp.data[0]  # type: ignore

--- a/models.py
+++ b/models.py
@@ -613,7 +613,8 @@ class LiteLLMEmbeddingWrapper(Embeddings):
         # Apply rate limiting if configured
         apply_rate_limiter_sync(self.a0_model_conf, " ".join(texts))
 
-        resp = embedding(model=self.model_name, input=texts, **self.kwargs)
+        embed_kwargs = {"encoding_format": "float", **self.kwargs}
+        resp = embedding(model=self.model_name, input=texts, **embed_kwargs)
         return [
             item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
             for item in resp.data  # type: ignore
@@ -623,7 +624,8 @@ class LiteLLMEmbeddingWrapper(Embeddings):
         # Apply rate limiting if configured
         apply_rate_limiter_sync(self.a0_model_conf, text)
 
-        resp = embedding(model=self.model_name, input=[text], **self.kwargs)
+        embed_kwargs = {"encoding_format": "float", **self.kwargs}
+        resp = embedding(model=self.model_name, input=[text], **embed_kwargs)
         item = resp.data[0]  # type: ignore
         return item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
 

--- a/models.py
+++ b/models.py
@@ -622,8 +622,12 @@ class LiteLLMEmbeddingWrapper(Embeddings):
             if "input_tokens" in str(e) and "context" in str(e):
                 texts = [t[: len(t) // 2] for t in texts]
                 resp = embedding(model=self.model_name, input=texts, **embed_kwargs)
-            else:
-                raise
+                break
+            except Exception as e:
+                if getattr(e, "status_code", None) == 400 and any(len(t) > 10 for t in texts):
+                    texts = [t[: max(len(t) // 2, 10)] for t in texts]
+                else:
+                    raise
         return [
             item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
             for item in resp.data  # type: ignore
@@ -636,13 +640,15 @@ class LiteLLMEmbeddingWrapper(Embeddings):
         embed_kwargs = {"encoding_format": "float", **self.kwargs}
         ctx = int(max((self.a0_model_conf.ctx_length if self.a0_model_conf else 0) or 8192, 1000) * 0.80)
         text = trim_to_tokens(text, ctx, "start", ellipsis="")
-        try:
-            resp = embedding(model=self.model_name, input=[text], **embed_kwargs)
-        except Exception as e:
-            if "input_tokens" in str(e) and "context" in str(e):
-                resp = embedding(model=self.model_name, input=[text[: len(text) // 2]], **embed_kwargs)
-            else:
-                raise
+        while True:
+            try:
+                resp = embedding(model=self.model_name, input=[text], **embed_kwargs)
+                break
+            except Exception as e:
+                if getattr(e, "status_code", None) == 400 and len(text) > 10:
+                    text = text[: max(len(text) // 2, 10)]
+                else:
+                    raise
         item = resp.data[0]  # type: ignore
         return item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
 

--- a/models.py
+++ b/models.py
@@ -614,6 +614,10 @@ class LiteLLMEmbeddingWrapper(Embeddings):
         apply_rate_limiter_sync(self.a0_model_conf, " ".join(texts))
 
         embed_kwargs = {"encoding_format": "float", **self.kwargs}
+        # Subtract 500 tokens from ctx_length: cl100k_base and the model's own tokenizer
+        # (e.g. bge-m3 SentencePiece) can diverge by ~2-3%, causing 400 errors at the boundary.
+        ctx = max((self.a0_model_conf.ctx_length if self.a0_model_conf else 0) or 8192, 1000) - 500
+        texts = [trim_to_tokens(t, ctx, "start", ellipsis="") for t in texts]
         resp = embedding(model=self.model_name, input=texts, **embed_kwargs)
         return [
             item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore
@@ -625,6 +629,8 @@ class LiteLLMEmbeddingWrapper(Embeddings):
         apply_rate_limiter_sync(self.a0_model_conf, text)
 
         embed_kwargs = {"encoding_format": "float", **self.kwargs}
+        ctx = max((self.a0_model_conf.ctx_length if self.a0_model_conf else 0) or 8192, 1000) - 500
+        text = trim_to_tokens(text, ctx, "start", ellipsis="")
         resp = embedding(model=self.model_name, input=[text], **embed_kwargs)
         item = resp.data[0]  # type: ignore
         return item.get("embedding") if isinstance(item, dict) else item.embedding  # type: ignore

--- a/plugins/_memory/extensions/python/message_loop_prompts_after/_50_recall_memories.py
+++ b/plugins/_memory/extensions/python/message_loop_prompts_after/_50_recall_memories.py
@@ -117,7 +117,7 @@ class RecallMemories(Extension):
         
         # otherwise use the message and history as query
         else:
-            query = user_instruction + "\n\n" + history
+            query = (user_instruction + "\n\n" + history)[:4000]
 
         # if there is no query (or just dash by the LLM), do not continue
         if not query or len(query) <= 3:


### PR DESCRIPTION
Fixes #1436

## Summary

Three layered fixes for embedding calls crashing with 400 context-length errors during memory recall.

## Root Cause

When `memory_recall_query_prep: false` (the default), `_50_recall_memories.py` uses a raw fallback query of `user_message + history[-10000 chars]`. At ~1 char/token content density (code, CJK), this exceeds BAAI/bge-m3's 8,192-token limit. The retry logic in `models.py` was also silently bypassed because `"input_tokens" in str(e)` did not match the `litellm.BadRequestError` string representation reliably.

## Changes

| File | Change |
|------|--------|
| `models.py` | Default `encoding_format="float"` — LiteLLM ≥1.80.11 sends null, rejected with 422 by strict endpoints |
| `models.py` | Truncate input to `ctx * 0.80` tokens before embedding (20% margin for tokenizer divergence) |
| `models.py` | Loop-halve on 400 errors using `status_code == 400` (reliable) instead of string matching (fragile) |
| `plugins/_memory/extensions/python/message_loop_prompts_after/_50_recall_memories.py` | Cap fallback query at 4,000 chars — sufficient for semantic retrieval, prevents token overflow |

## Fix 1 — `encoding_format: null` (422)

LiteLLM ≥1.80.11 sends `encoding_format: null` when not set. Strict validators (DeepInfra, vLLM, HuggingFace TEI) reject null with 422. Defaulting to `"float"` before merging caller kwargs prevents this.

Upstream LiteLLM issue: [BerriAI/litellm#19174](https://github.com/BerriAI/litellm/issues/19174)

## Fix 2 — Input truncation with loop-halving fallback (400)

Embedding models have a fixed context window. `trim_to_tokens` uses `cl100k_base` (GPT tokenizer) for counting, but the model uses its own tokenizer (e.g. bge-m3 SentencePiece). These diverge by 6–25% on the same text — dense code can have 2× more bge-m3 tokens than cl100k tokens. A 20% pre-reduction handles most cases; the loop-halving fallback handles extreme divergence.

The retry condition uses `getattr(e, "status_code", None) == 400` rather than string matching, which is reliable across litellm versions.

## Fix 3 — Cap fallback memory query at source (400)

When `memory_recall_query_prep: false`, the fallback query is `user_message + history[-10000 chars]`. Capping at 4,000 chars (~1,000 tokens for any content type) eliminates the overflow at source. Semantic similarity search does not benefit from 10,000 characters of raw history.

## Testing

Tested on helpa0.com with DeepInfra + `openai/BAAI/bge-m3` (8,192-token context), LiteLLM 1.82.3, `memory_recall_query_prep: false`:
- Memory recall on long conversations: no longer crashes
- Dense code content in memory: no longer crashes
- Short queries: no overhead (truncation only fires when needed)