### PR TITLE
fix: speech-to-text chat input population after Alpine Store refactor

### DIFF
--- a/webui/index.js
+++ b/webui/index.js
@@ -177,6 +177,15 @@ export function updateChatInput(text) {
   }
   console.log("updateChatInput called with:", text);
 
+  // ✅ FIX: Update Alpine store directly (source of truth) to prevent x-model overwrite
+  const inputStore = window.Alpine?.store('chatInput');
+  if (inputStore) {
+    const currentValue = inputStore.message || "";
+    const needsSpace = currentValue.length > 0 && !currentValue.endsWith(" ");
+    inputStore.message = currentValue + (needsSpace ? " " : "") + text + " ";
+    console.log("Updated Alpine store message:", inputStore.message);
+  }
+
   // Append text with proper spacing
   const currentValue = chatInputEl.value;
   const needsSpace = currentValue.length > 0 && !currentValue.endsWith(" ");


### PR DESCRIPTION
## 🎯 Summary

Fixes speech-to-text chat input population issue introduced in v1.6 due to Alpine Store refactor.

## 🐛 Problem

After Agent Zero v1.6, speech-to-text transcription results were not populating the chat input field. The microphone activated and transcription succeeded, but the chat input remained empty.

**Root Cause:** The v1.6 Alpine Store refactor changed the frontend architecture to use Alpine's reactive binding (`x-model`) as the single source of truth. The speech-to-text code was never updated to match this new pattern.

**Technical Details:**
- `updateChatInput()` was using direct DOM manipulation (`chatInputEl.value = text`)
- Alpine's `x-model` binding reads from `$store.chatInput.message`
- Race condition: Alpine overwrites DOM value with empty store data immediately after DOM update

## ✅ Solution

Add Alpine store synchronization BEFORE DOM manipulation in `updateChatInput()`:

```javascript
// ✅ FIX: Update Alpine store directly (source of truth) to prevent x-model overwrite
const inputStore = window.Alpine?.store('chatInput');
if (inputStore) {
  const currentValue = inputStore.message || "";
  const needsSpace = currentValue.length > 0 && !currentValue.endsWith(" ");
  inputStore.message = currentValue + (needsSpace ? " " : "") + text + " ";
  console.log("Updated Alpine store message:", inputStore.message);
}
