### PR TITLE
feat: add _attachment_preview plugin

### DIFF
--- a/plugins/_attachment_preview/README.md
+++ b/plugins/_attachment_preview/README.md
@@ -1,0 +1,44 @@
+# Attachment Preview
+
+Inline preview panel for chat attachments and workdir file links — supports images, PDF, video, audio, markdown, HTML, and source code.
+
+## What It Does
+
+This plugin adds a split-screen preview panel below the chat area. Clicking a previewable attachment chip or a workdir file link in agent messages opens the file directly inside the UI instead of downloading or navigating away.
+
+## Main Behavior
+
+- **Attachment chips**
+  - Intercepts clicks on non-image attachment chips in the chat input area.
+  - Routes to the preview panel if the file extension is supported.
+- **Workdir links**
+  - Overrides `openFileLink()` to preview files linked in agent messages (`<a onclick="openFileLink(...)">`).
+  - Intercepts `<a href="/api/download_work_dir_file?...">` links in chat history via delegated click handler.
+- **Preview routing**
+  - Images → `/api/image_get` (reuses core API).
+  - Markdown / text / code → `/api/edit_work_dir_file` (fetches content, renders markdown with safe renderer).
+  - HTML / PDF / video / audio → `/api/plugins/_attachment_preview/preview_work_dir_file` (streams file inline with appropriate Content-Type).
+- **Panel features**
+  - Vertical split layout with drag-to-resize handle.
+  - Maximize to 80% centered overlay with blur backdrop.
+  - Download button for saving the previewed file.
+
+## Key Files
+
+- **API**
+  - `api/preview_work_dir_file.py` streams files inline with CSP sandbox for HTML. Handles both Docker and development environments.
+- **Frontend**
+  - `webui/preview-store.js` is the Alpine.js store (`attachmentPreview`) managing state, file type routing, resize, and maximize logic.
+  - `extensions/webui/right-panel-after-chat/preview-panel.html` is the panel component with inlined CSS, loaded via the `right-panel-after-chat` extension point.
+
+## Core File Modifications
+
+- `webui/index.html` — Added `<x-extension id="right-panel-after-chat">` between chat area and toast.
+- `webui/components/chat/attachments/attachmentsStore.js` — Added loose-coupled preview calls via `Alpine.store('attachmentPreview')`.
+
+## Plugin Metadata
+
+- **Name**: `_attachment_preview`
+- **Title**: `Attachment Preview`
+- **Description**: Inline preview panel for attachments - supports PDF, text, code, video, audio, markdown, and HTML files.
+- **Always enabled**: `true`

--- a/plugins/_attachment_preview/README.md
+++ b/plugins/_attachment_preview/README.md
@@ -41,4 +41,4 @@ This plugin adds a split-screen preview panel below the chat area. Clicking a pr
 - **Name**: `_attachment_preview`
 - **Title**: `Attachment Preview`
 - **Description**: Inline preview panel for attachments - supports PDF, text, code, video, audio, markdown, and HTML files.
-- **Always enabled**: `true`
+- **Always enabled**: `false` (can be toggled on/off)

--- a/plugins/_attachment_preview/README.md
+++ b/plugins/_attachment_preview/README.md
@@ -41,4 +41,4 @@ This plugin adds a split-screen preview panel below the chat area. Clicking a pr
 - **Name**: `_attachment_preview`
 - **Title**: `Attachment Preview`
 - **Description**: Inline preview panel for attachments - supports PDF, text, code, video, audio, markdown, and HTML files.
-- **Always enabled**: `false` (can be toggled on/off)
+- **Always enabled**: `false`

--- a/plugins/_attachment_preview/api/preview_work_dir_file.py
+++ b/plugins/_attachment_preview/api/preview_work_dir_file.py
@@ -107,6 +107,9 @@ class PreviewWorkDirFile(ApiHandler):
         filename = os.path.basename(info["file_name"])
 
         if runtime.is_development():
+            local_path = files.fix_dev_path(file_path)
+            if os.path.isfile(local_path):
+                return stream_file_inline(local_path, filename)
             b64 = await runtime.call_development_function(fetch_file, info["abs_path"])
             file_data = BytesIO(base64.b64decode(b64))
             return stream_file_inline(file_data, filename)

--- a/plugins/_attachment_preview/api/preview_work_dir_file.py
+++ b/plugins/_attachment_preview/api/preview_work_dir_file.py
@@ -1,0 +1,114 @@
+import base64
+from io import BytesIO
+import mimetypes
+import os
+
+from flask import Response
+from helpers.api import ApiHandler, Input, Output, Request
+from helpers import files, runtime
+from api import file_info
+from api.download_work_dir_file import fetch_file
+
+
+# Previewable extensions
+PREVIEWABLE_EXTENSIONS = {
+    ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".svg", ".ico", ".svgz",
+    ".pdf",
+    ".mp4", ".webm", ".ogg", ".mov",
+    ".mp3", ".wav", ".flac", ".aac", ".m4a",
+    ".html", ".htm", ".md", ".txt", ".json", ".yaml", ".yml",
+    ".xml", ".csv", ".log", ".ini", ".cfg", ".conf",
+    ".py", ".js", ".ts", ".css", ".sh", ".bash", ".zsh",
+    ".c", ".cpp", ".h", ".java", ".go", ".rs", ".rb",
+    ".php", ".sql", ".r", ".lua", ".pl", ".swift", ".kt",
+    ".toml", ".env", ".gitignore", ".dockerfile",
+}
+
+
+def stream_file_inline(file_source, filename, chunk_size=8192):
+    if isinstance(file_source, str):
+        file_size = os.path.getsize(file_source)
+    elif isinstance(file_source, BytesIO):
+        current_pos = file_source.tell()
+        file_source.seek(0, 2)
+        file_size = file_source.tell()
+        file_source.seek(current_pos)
+    else:
+        raise ValueError(f"Unsupported file source type: {type(file_source)}")
+
+    def generate():
+        if isinstance(file_source, str):
+            with open(file_source, 'rb') as f:
+                while True:
+                    chunk = f.read(chunk_size)
+                    if not chunk:
+                        break
+                    yield chunk
+        elif isinstance(file_source, BytesIO):
+            file_source.seek(0)
+            while True:
+                chunk = file_source.read(chunk_size)
+                if not chunk:
+                    break
+                yield chunk
+
+    content_type, _ = mimetypes.guess_type(filename)
+    if not content_type:
+        content_type = 'application/octet-stream'
+
+    headers = {
+        'Content-Disposition': f'inline; filename="{filename}"',
+        'Content-Length': str(file_size),
+        'Cache-Control': 'no-cache',
+        'X-Content-Type-Options': 'nosniff',
+    }
+
+    # Sandbox HTML
+    if content_type in ('text/html', 'application/xhtml+xml'):
+        headers['Content-Security-Policy'] = (
+            "default-src 'none'; style-src 'unsafe-inline'; img-src data: blob:;"
+        )
+
+    return Response(
+        generate(),
+        content_type=content_type,
+        direct_passthrough=True,
+        headers=headers,
+    )
+
+
+class PreviewWorkDirFile(ApiHandler):
+
+    @classmethod
+    def get_methods(cls):
+        return ["GET"]
+
+    async def process(self, input: Input, request: Request) -> Output:
+        file_path = request.args.get("path", input.get("path", ""))
+        if not file_path:
+            raise ValueError("No file path provided")
+        if not file_path.startswith("/"):
+            file_path = f"/{file_path}"
+
+        # Validate extension
+        ext = os.path.splitext(file_path)[1].lower()
+        if ext not in PREVIEWABLE_EXTENSIONS:
+            raise ValueError(f"File type '{ext}' is not supported for preview")
+
+        info = await runtime.call_development_function(
+            file_info.get_file_info, file_path
+        )
+
+        if not info["exists"]:
+            raise Exception(f"File {file_path} not found")
+        if not info["is_file"]:
+            raise Exception(f"Path {file_path} is not a file")
+
+        filename = os.path.basename(info["file_name"])
+
+        if runtime.is_development():
+            b64 = await runtime.call_development_function(fetch_file, info["abs_path"])
+            file_data = BytesIO(base64.b64decode(b64))
+            return stream_file_inline(file_data, filename)
+        else:
+            return stream_file_inline(info["abs_path"], filename)

--- a/plugins/_attachment_preview/extensions/webui/right-panel-after-chat/preview-panel.html
+++ b/plugins/_attachment_preview/extensions/webui/right-panel-after-chat/preview-panel.html
@@ -1,0 +1,389 @@
+<html>
+<head>
+  <script type="module">
+    import { store } from "/plugins/_attachment_preview/webui/preview-store.js";
+  </script>
+</head>
+<body>
+  <div x-data>
+    <template x-if="$store.attachmentPreview">
+      <div>
+        <!-- Backdrop -->
+        <div class="preview-maximized-backdrop"
+             :class="{ 'active': $store.attachmentPreview.isMaximized && $store.attachmentPreview.isOpen }"
+             @click="$store.attachmentPreview.toggleMaximize()">
+        </div>
+
+        <div id="preview-panel"
+             :class="{ 'open': $store.attachmentPreview.isOpen, 'maximized': $store.attachmentPreview.isMaximized }"
+             x-show="$store.attachmentPreview.isOpen">
+
+        <!-- Resize -->
+        <div class="preview-resize-handle"
+             @mousedown="$store.attachmentPreview.startResize($event)"
+             @touchstart="$store.attachmentPreview.startResize($event)">
+        </div>
+
+        <!-- Header -->
+        <div class="preview-header">
+          <div class="preview-header-info">
+            <span class="material-symbols-outlined preview-header-icon">description</span>
+            <span class="preview-header-name" x-text="$store.attachmentPreview.fileName" :title="$store.attachmentPreview.filePath"></span>
+          </div>
+          <div class="preview-header-actions">
+            <button class="btn-icon-action" @click="$store.attachmentPreview.downloadFile()" title="Download">
+              <span class="material-symbols-outlined">download</span>
+            </button>
+            <button class="btn-icon-action" @click="$store.attachmentPreview.toggleMaximize()" :title="$store.attachmentPreview.isMaximized ? 'Restore' : 'Maximize'">
+              <span class="material-symbols-outlined" x-text="$store.attachmentPreview.isMaximized ? 'close_fullscreen' : 'open_in_full'"></span>
+            </button>
+            <button class="btn-icon-action" @click="$store.attachmentPreview.close()" title="Close">
+              <span class="material-symbols-outlined">close</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- Body -->
+        <div class="preview-body">
+
+          <!-- Loading -->
+          <div x-show="$store.attachmentPreview.isLoading" class="preview-status">
+            <div class="loading-spinner"></div>
+            <p>Loading preview…</p>
+          </div>
+
+          <!-- Error -->
+          <div x-show="$store.attachmentPreview.error" class="preview-status preview-error">
+            <span class="material-symbols-outlined">error</span>
+            <p x-text="$store.attachmentPreview.error"></p>
+            <button class="btn btn-ok" @click="$store.attachmentPreview.downloadFile()">Download Instead</button>
+          </div>
+
+          <!-- Image -->
+          <template x-if="$store.attachmentPreview.fileType === 'image' && !$store.attachmentPreview.isLoading && !$store.attachmentPreview.error">
+            <div class="preview-content preview-image">
+              <img :src="$store.attachmentPreview.previewUrl" :alt="$store.attachmentPreview.fileName" />
+            </div>
+          </template>
+
+          <!-- Markdown -->
+          <template x-if="$store.attachmentPreview.fileType === 'markdown' && !$store.attachmentPreview.isLoading && !$store.attachmentPreview.error">
+            <div class="preview-content preview-markdown message-text" x-html="$store.attachmentPreview.content"></div>
+          </template>
+
+          <!-- Text -->
+          <template x-if="$store.attachmentPreview.fileType === 'text' && !$store.attachmentPreview.isLoading && !$store.attachmentPreview.error">
+            <div class="preview-content preview-text">
+              <pre x-text="$store.attachmentPreview.content"></pre>
+            </div>
+          </template>
+
+          <!-- HTML -->
+          <template x-if="$store.attachmentPreview.fileType === 'html' && !$store.attachmentPreview.isLoading && !$store.attachmentPreview.error">
+            <div class="preview-content preview-iframe">
+              <iframe :src="$store.attachmentPreview.previewUrl"
+                      sandbox="allow-same-origin"
+                      referrerpolicy="no-referrer"></iframe>
+            </div>
+          </template>
+
+          <!-- PDF -->
+          <template x-if="$store.attachmentPreview.fileType === 'pdf' && !$store.attachmentPreview.isLoading && !$store.attachmentPreview.error">
+            <div class="preview-content preview-iframe">
+              <iframe :src="$store.attachmentPreview.previewUrl"></iframe>
+            </div>
+          </template>
+
+          <!-- Video -->
+          <template x-if="$store.attachmentPreview.fileType === 'video' && !$store.attachmentPreview.isLoading && !$store.attachmentPreview.error">
+            <div class="preview-content preview-video">
+              <video controls :src="$store.attachmentPreview.previewUrl">
+                Your browser does not support video playback.
+              </video>
+            </div>
+          </template>
+
+          <!-- Audio -->
+          <template x-if="$store.attachmentPreview.fileType === 'audio' && !$store.attachmentPreview.isLoading && !$store.attachmentPreview.error">
+            <div class="preview-content preview-audio">
+              <span class="material-symbols-outlined preview-audio-icon">music_note</span>
+              <span class="preview-audio-name" x-text="$store.attachmentPreview.fileName"></span>
+              <audio controls :src="$store.attachmentPreview.previewUrl">
+                Your browser does not support audio playback.
+              </audio>
+            </div>
+          </template>
+
+          <!-- Unsupported -->
+          <template x-if="$store.attachmentPreview.fileType === 'unsupported' && !$store.attachmentPreview.isLoading && !$store.attachmentPreview.error">
+            <div class="preview-status">
+              <span class="material-symbols-outlined">visibility_off</span>
+              <p>This file type cannot be previewed.</p>
+              <button class="btn btn-ok" @click="$store.attachmentPreview.downloadFile()">Download File</button>
+            </div>
+          </template>
+
+        </div>
+      </div>
+      </div>
+    </template>
+  </div>
+
+<style>
+#preview-panel {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 0;
+  min-height: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+  background: var(--color-chat-background);
+  border-top: 0 solid var(--color-border);
+  transition: height 0.2s ease, min-height 0.2s ease, border-top-width 0.2s ease;
+  position: relative;
+}
+
+#preview-panel.open {
+  height: 40vh;
+  min-height: 180px;
+  border-top-width: 1px;
+}
+
+.preview-maximized-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  z-index: 1999;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+.preview-maximized-backdrop.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+#preview-panel.maximized {
+  position: fixed;
+  top: 10%;
+  left: 10%;
+  width: 80%;
+  height: 80% !important;
+  min-height: 0;
+  z-index: 2000;
+  border-top: none;
+  border-radius: 12px;
+  box-shadow: 0 4px 23px rgba(0, 0, 0, 0.2);
+}
+
+.preview-resize-handle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 5px;
+  cursor: row-resize;
+  z-index: 10;
+  background: transparent;
+  transition: background 0.15s;
+}
+.preview-resize-handle:hover,
+.preview-resize-handle:active {
+  background: var(--color-highlight);
+  opacity: 0.5;
+}
+#preview-panel.maximized .preview-resize-handle {
+  display: none;
+}
+
+.preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-panel);
+  flex-shrink: 0;
+  min-height: 42px;
+}
+
+.preview-header-info {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.preview-header-icon {
+  font-size: 1.1rem;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.preview-header-name {
+  font-size: var(--font-size-smaller);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preview-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.preview-header-actions .btn-icon-action {
+  padding: var(--spacing-xxs);
+}
+
+.preview-body {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+  position: relative;
+}
+
+.preview-status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-lg);
+  height: 100%;
+  text-align: center;
+  color: var(--color-text-muted);
+  gap: var(--spacing-sm);
+}
+
+.preview-status .material-symbols-outlined {
+  font-size: 2.5rem;
+  opacity: 0.5;
+}
+
+.preview-status p {
+  margin: 0;
+  font-size: var(--font-size-smaller);
+}
+
+.preview-error .material-symbols-outlined {
+  color: var(--color-error-text);
+}
+
+.preview-status .loading-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.preview-content {
+  width: 100%;
+  height: 100%;
+}
+
+.preview-image {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-sm);
+  overflow: auto;
+}
+.preview-image img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  border-radius: var(--border-radius-sm);
+}
+
+.preview-markdown {
+  padding: var(--spacing-md);
+  overflow: auto;
+  line-height: 1.6;
+}
+
+.preview-text {
+  overflow: auto;
+  padding: 0;
+}
+.preview-text pre {
+  margin: 0;
+  padding: var(--spacing-sm);
+  font-family: var(--font-family-code);
+  font-size: var(--font-size-small);
+  white-space: pre-wrap;
+  word-break: break-all;
+  line-height: 1.5;
+  color: var(--color-text);
+}
+
+.preview-iframe {
+  display: flex;
+}
+.preview-iframe iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: #fff;
+}
+
+.preview-video {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-sm);
+}
+.preview-video video {
+  max-width: 100%;
+  max-height: 100%;
+  border-radius: var(--border-radius-sm);
+}
+
+.preview-audio {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-lg);
+}
+.preview-audio-icon {
+  font-size: 3rem;
+  color: var(--color-text-muted);
+  opacity: 0.4;
+}
+.preview-audio-name {
+  font-size: var(--font-size-smaller);
+  color: var(--color-text-muted);
+  word-break: break-all;
+  text-align: center;
+}
+.preview-audio audio {
+  width: 100%;
+  max-width: 400px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  #preview-panel.open {
+    height: 50vh;
+  }
+  .preview-resize-handle {
+    display: none;
+  }
+}
+</style>
+</body>
+</html>

--- a/plugins/_attachment_preview/plugin.yaml
+++ b/plugins/_attachment_preview/plugin.yaml
@@ -1,0 +1,5 @@
+name: _attachment_preview
+title: Attachment Preview
+description: Inline preview panel for attachments - supports PDF, text, code, video, audio, markdown, and HTML files.
+version: 1.0.0
+always_enabled: true

--- a/plugins/_attachment_preview/plugin.yaml
+++ b/plugins/_attachment_preview/plugin.yaml
@@ -2,4 +2,3 @@ name: _attachment_preview
 title: Attachment Preview
 description: Inline preview panel for attachments - supports PDF, text, code, video, audio, markdown, and HTML files.
 version: 1.0.0
-always_enabled: true

--- a/plugins/_attachment_preview/webui/preview-store.js
+++ b/plugins/_attachment_preview/webui/preview-store.js
@@ -41,6 +41,8 @@ function detectType(ext) {
 
 const PLUGIN_API_PREFIX = "/plugins/_attachment_preview";
 
+const WORKDIR_LINK_RE = /\/a0\/usr\/workdir\/|\/api\/download_work_dir_file\?/;
+
 const model = {
   isOpen: false,
   filePath: "",
@@ -53,6 +55,33 @@ const model = {
   error: /** @type {string|null} */ (null),
   isResizing: false,
   isMaximized: false,
+
+  init() {
+    const chatHistory = document.getElementById("chat-history");
+    if (!chatHistory) return;
+
+    chatHistory.addEventListener("click", (e) => {
+      const anchor = /** @type {HTMLElement} */ (e.target).closest("a[href]");
+      if (!anchor) return;
+
+      const href = anchor.getAttribute("href") || "";
+      if (!WORKDIR_LINK_RE.test(href)) return;
+
+      const filename = href.split("/").pop()?.split("?")[0] || "";
+      if (!ALL_PREVIEWABLE.has(getExt(filename))) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      let filePath = href;
+      if (href.includes("/api/download_work_dir_file?")) {
+        const url = new URL(href, location.origin);
+        filePath = url.searchParams.get("path") || href;
+      }
+
+      this.open(filePath, filename);
+    });
+  },
 
   isPreviewable(filename) {
     return ALL_PREVIEWABLE.has(getExt(filename));

--- a/plugins/_attachment_preview/webui/preview-store.js
+++ b/plugins/_attachment_preview/webui/preview-store.js
@@ -1,0 +1,200 @@
+import { createStore } from "/js/AlpineStore.js";
+import { fetchApi } from "/js/api.js";
+import { renderSafeMarkdown } from "/js/safe-markdown.js";
+
+const IMAGE_EXTS = new Set([
+  "jpg", "jpeg", "png", "gif", "bmp", "webp", "svg", "ico", "svgz",
+]);
+const PDF_EXTS = new Set(["pdf"]);
+const VIDEO_EXTS = new Set(["mp4", "webm", "ogg", "mov"]);
+const AUDIO_EXTS = new Set(["mp3", "wav", "flac", "aac", "m4a"]);
+const MARKDOWN_EXTS = new Set(["md"]);
+const HTML_EXTS = new Set(["html", "htm"]);
+const TEXT_EXTS = new Set([
+  "txt", "json", "yaml", "yml", "xml", "csv", "log", "ini", "cfg", "conf",
+  "py", "js", "ts", "css", "sh", "bash", "zsh",
+  "c", "cpp", "h", "java", "go", "rs", "rb",
+  "php", "sql", "r", "lua", "pl", "swift", "kt",
+  "toml", "env", "gitignore", "dockerfile",
+]);
+
+const ALL_PREVIEWABLE = new Set([
+  ...IMAGE_EXTS, ...PDF_EXTS, ...VIDEO_EXTS, ...AUDIO_EXTS,
+  ...MARKDOWN_EXTS, ...HTML_EXTS, ...TEXT_EXTS,
+]);
+
+function getExt(filename) {
+  const dot = filename.lastIndexOf(".");
+  return dot >= 0 ? filename.slice(dot + 1).toLowerCase() : "";
+}
+
+function detectType(ext) {
+  if (IMAGE_EXTS.has(ext)) return "image";
+  if (PDF_EXTS.has(ext)) return "pdf";
+  if (VIDEO_EXTS.has(ext)) return "video";
+  if (AUDIO_EXTS.has(ext)) return "audio";
+  if (MARKDOWN_EXTS.has(ext)) return "markdown";
+  if (HTML_EXTS.has(ext)) return "html";
+  if (TEXT_EXTS.has(ext)) return "text";
+  return "unsupported";
+}
+
+const PLUGIN_API_PREFIX = "/plugins/_attachment_preview";
+
+const model = {
+  isOpen: false,
+  filePath: "",
+  fileName: "",
+  fileExt: "",
+  fileType: "",
+  content: "",
+  previewUrl: "",
+  isLoading: false,
+  error: /** @type {string|null} */ (null),
+  isResizing: false,
+  isMaximized: false,
+
+  isPreviewable(filename) {
+    return ALL_PREVIEWABLE.has(getExt(filename));
+  },
+
+  async open(filePath, fileName) {
+    const ext = getExt(fileName || filePath);
+    const type = detectType(ext);
+
+    this.filePath = filePath;
+    this.fileName = fileName || filePath.split("/").pop() || "";
+    this.fileExt = ext;
+    this.fileType = type;
+    this.content = "";
+    this.previewUrl = "";
+    this.error = null;
+    this.isLoading = true;
+    this.isOpen = true;
+
+    try {
+      switch (type) {
+        case "image":
+          this.previewUrl = `/api/image_get?path=${encodeURIComponent(filePath)}`;
+          break;
+
+        case "markdown": {
+          const resp = await fetchApi(
+            `/edit_work_dir_file?path=${encodeURIComponent(filePath)}`
+          );
+          const data = await resp.json();
+          if (data.error) throw new Error(data.error);
+          this.content = renderSafeMarkdown(data.data.content);
+          break;
+        }
+
+        case "text": {
+          const resp = await fetchApi(
+            `/edit_work_dir_file?path=${encodeURIComponent(filePath)}`
+          );
+          const data = await resp.json();
+          if (data.error) throw new Error(data.error);
+          this.content = data.data.content;
+          break;
+        }
+
+        case "html":
+        case "pdf":
+        case "video":
+        case "audio":
+          this.previewUrl =
+            `/api${PLUGIN_API_PREFIX}/preview_work_dir_file?path=${encodeURIComponent(filePath)}`;
+          break;
+
+        default:
+          this.error = "This file type cannot be previewed.";
+      }
+    } catch (e) {
+      console.error("Preview error:", e);
+      this.error = e instanceof Error ? e.message : "Failed to load preview";
+    } finally {
+      this.isLoading = false;
+    }
+  },
+
+  close() {
+    this.isOpen = false;
+    this.isMaximized = false;
+    this.filePath = "";
+    this.fileName = "";
+    this.fileExt = "";
+    this.fileType = "";
+    this.content = "";
+    this.previewUrl = "";
+    this.isLoading = false;
+    this.error = null;
+  },
+
+  downloadFile() {
+    if (!this.filePath) return;
+    const link = document.createElement("a");
+    link.href = `/api/download_work_dir_file?path=${encodeURIComponent(this.filePath)}`;
+    link.download = this.fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  },
+
+  // Resize
+  startResize(e) {
+    e.preventDefault();
+    if (this.isMaximized) return;
+    this.isResizing = true;
+
+    const panel = document.getElementById("preview-panel");
+    const rightPanel = document.getElementById("right-panel");
+    if (!panel || !rightPanel) return;
+
+    const onMove = (ev) => {
+      const clientY = ev.touches ? ev.touches[0].clientY : ev.clientY;
+      const rect = rightPanel.getBoundingClientRect();
+      const newHeight = rect.bottom - clientY;
+      const clamped = Math.max(120, Math.min(newHeight, rect.height * 0.75));
+      panel.style.height = clamped + "px";
+    };
+
+    const onUp = () => {
+      this.isResizing = false;
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      document.removeEventListener("touchmove", onMove);
+      document.removeEventListener("touchend", onUp);
+    };
+
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+    document.addEventListener("touchmove", onMove, { passive: false });
+    document.addEventListener("touchend", onUp);
+  },
+
+  toggleMaximize() {
+    const panel = document.getElementById("preview-panel");
+    if (!panel) {
+      this.isMaximized = !this.isMaximized;
+      return;
+    }
+
+    if (this.isMaximized) {
+      panel.style.transition = "none";
+      panel.style.height = "";
+      this.isMaximized = false;
+      requestAnimationFrame(() => {
+        panel.style.transition = "";
+      });
+    } else {
+      panel.style.height = "";
+      this.isMaximized = true;
+    }
+  },
+};
+
+export const store = createStore("attachmentPreview", model);
+
+export function isPreviewable(filename) {
+  return ALL_PREVIEWABLE.has(getExt(filename));
+}

--- a/plugins/_attachment_preview/webui/preview-store.js
+++ b/plugins/_attachment_preview/webui/preview-store.js
@@ -240,7 +240,3 @@ const model = {
 };
 
 export const store = createStore("attachmentPreview", model);
-
-export function isPreviewable(filename) {
-  return ALL_PREVIEWABLE.has(getExt(filename));
-}

--- a/plugins/_attachment_preview/webui/preview-store.js
+++ b/plugins/_attachment_preview/webui/preview-store.js
@@ -41,8 +41,6 @@ function detectType(ext) {
 
 const PLUGIN_API_PREFIX = "/plugins/_attachment_preview";
 
-const WORKDIR_LINK_RE = /\/a0\/usr\/workdir\/|\/api\/download_work_dir_file\?/;
-
 const model = {
   isOpen: false,
   filePath: "",
@@ -56,7 +54,28 @@ const model = {
   isResizing: false,
   isMaximized: false,
 
+  // Intercept openFileLink + download_work_dir_file links
   init() {
+    this._interceptOpenFileLink();
+    this._interceptDownloadLinks();
+  },
+
+  _interceptOpenFileLink() {
+    const w = /** @type {any} */ (window);
+    const origFn = w.openFileLink;
+    if (!origFn) return;
+    const self = this;
+    w.openFileLink = function (path) {
+      const filename = path.split("/").pop() || "";
+      if (ALL_PREVIEWABLE.has(getExt(filename))) {
+        self.open(path, filename);
+        return;
+      }
+      return origFn.call(this, path);
+    };
+  },
+
+  _interceptDownloadLinks() {
     const chatHistory = document.getElementById("chat-history");
     if (!chatHistory) return;
 
@@ -65,20 +84,17 @@ const model = {
       if (!anchor) return;
 
       const href = anchor.getAttribute("href") || "";
-      if (!WORKDIR_LINK_RE.test(href)) return;
+      if (!href.includes("/api/download_work_dir_file?")) return;
 
-      const filename = href.split("/").pop()?.split("?")[0] || "";
+      const url = new URL(href, location.origin);
+      const filePath = url.searchParams.get("path") || "";
+      if (!filePath) return;
+
+      const filename = filePath.split("/").pop()?.split("?")[0] || "";
       if (!ALL_PREVIEWABLE.has(getExt(filename))) return;
 
       e.preventDefault();
       e.stopPropagation();
-
-      let filePath = href;
-      if (href.includes("/api/download_work_dir_file?")) {
-        const url = new URL(href, location.origin);
-        filePath = url.searchParams.get("path") || href;
-      }
-
       this.open(filePath, filename);
     });
   },
@@ -88,6 +104,7 @@ const model = {
   },
 
   async open(filePath, fileName) {
+    filePath = decodeURIComponent(filePath);
     const ext = getExt(fileName || filePath);
     const type = detectType(ext);
 

--- a/webui/components/chat/attachments/attachmentsStore.js
+++ b/webui/components/chat/attachments/attachmentsStore.js
@@ -354,6 +354,8 @@ const model = {
         clickHandler: () => {
           if (this.isImageFile(filename)) {
             imageViewerStore.open(this.getServerImgUrl(filename), { name: filename });
+          } else if (Alpine.store('attachmentPreview')?.isPreviewable?.(filename)) {
+            Alpine.store('attachmentPreview').open(this.getServerFileUrl(filename), filename);
           } else {
             this.downloadAttachment(filename);
           }
@@ -376,6 +378,8 @@ const model = {
           if (attachment.type === "image") {
             const imageUrl = this.getServerImgUrl(attachment.name);
             imageViewerStore.open(imageUrl, { name: attachment.name });
+          } else if (Alpine.store('attachmentPreview')?.isPreviewable?.(attachment.name)) {
+            Alpine.store('attachmentPreview').open(this.getServerFileUrl(attachment.name), attachment.name);
           } else {
             this.downloadAttachment(attachment.name);
           }

--- a/webui/index.html
+++ b/webui/index.html
@@ -117,6 +117,9 @@
               </div>
             </div>
 
+            <!-- Extension Point -->
+            <x-extension id="right-panel-after-chat"></x-extension>
+
             <!-- NEW: Toast Stack Component -->
             <div style="position: relative; height: 0;">
                 <x-component path="notifications/notification-toast-stack.html"></x-component>


### PR DESCRIPTION
Adds a built-in plugin _attachment_preview that provides an inline preview panel for chat attachments and workdir file links, eliminating the need to download files to view them.

---

- Supported formats: Images, PDF, video, audio, Markdown, HTML, and 30+ source code / config file types
- Three trigger paths:
 - Attachment chip clicks in chat input
 - openFileLink() calls in agent message content
 - download_work_dir_file <a href> links in chat history
- Panel UX: Vertical split below chat, drag-to-resize, maximize to 80% centered overlay with blur backdrop
- Backend API: preview_work_dir_file streams files inline with CSP sandbox for HTML; handles both Docker and development environments
- Loose coupling: attachmentsStore.js references the preview store via Alpine.store() — gracefully degrades to download if plugin is disabled
- Extension point: Adds <x-extension id="right-panel-after-chat"> to index.html for plugin injection