### PR TITLE
fix: validate_tool_request accepts empty tool_args dict

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -978,7 +978,7 @@ class Agent:
             raise ValueError("Tool request must be a dictionary")
         if not tool_request.get("tool_name") or not isinstance(tool_request.get("tool_name"), str):
             raise ValueError("Tool request must have a tool_name (type string) field")
-        if not tool_request.get("tool_args") or not isinstance(tool_request.get("tool_args"), dict):
+        if not isinstance(tool_request.get("tool_args"), dict):
             raise ValueError("Tool request must have a tool_args (type dictionary) field")
 
 


### PR DESCRIPTION
## Summary

Fixes #1445

The `validate_tool_request` method in `agent.py` incorrectly rejected valid tool calls where `tool_args` was an empty dictionary `{}`.

## Root Cause

The original check on line 981:

```python
if not tool_request.get("tool_args") or not isinstance(tool_request.get("tool_args"), dict):
```

The expression `not tool_request.get("tool_args")` evaluates to `True` when `tool_args` is an empty dict `{}`, because `not {}` is `True` in Python. This caused the validation to incorrectly reject valid tool calls with no arguments.

## Fix

```python
if not isinstance(tool_request.get("tool_args"), dict):
```

A single `isinstance` check correctly handles all cases:

| Case | Before | After |
|---|---|---|
| `tool_args: {}` | ❌ raises ValueError | ✅ passes |
| `tool_args: {"k": "v"}` | ✅ passes | ✅ passes |
| `tool_args` missing (→ `None`) | ✅ raises ValueError | ✅ raises ValueError |
| `tool_args: "string"` | ✅ raises ValueError | ✅ raises ValueError |
