### PR TITLE
fix: Make tool_args optional in validate_tool_request (#1448)

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -978,8 +978,9 @@ class Agent:
             raise ValueError("Tool request must be a dictionary")
         if not tool_request.get("tool_name") or not isinstance(tool_request.get("tool_name"), str):
             raise ValueError("Tool request must have a tool_name (type string) field")
-        if not tool_request.get("tool_args") or not isinstance(tool_request.get("tool_args"), dict):
-            raise ValueError("Tool request must have a tool_args (type dictionary) field")
+        # tool_args is optional - will default to empty dict in process_tools
+        if tool_request.get("tool_args") is not None and not isinstance(tool_request.get("tool_args"), dict):
+            raise ValueError("Tool args must be a dictionary if provided")
 
 
 


### PR DESCRIPTION
## 🐛 Fixes #1448

### Problem
After upgrading to v1.7, calling any skill results in:
```
ValueError: Tool request must have a tool_args (type dictionary) field
```

This happens when tools are called without arguments, which should be valid.

### Root Cause
The `validate_tool_request` function requires `tool_args` to be present, but the subsequent `process_tools` function already handles missing `tool_args` with a default empty dict.

### Solution
Modified `validate_tool_request` to make `tool_args` optional:
- Only validate `tool_args` type if explicitly provided
- Allow tools to be called without arguments
- Maintains backward compatibility with v1.6 behavior

### Changes
- **File**: `agent.py`
- **Lines**: 976-982
- **Change**: 3 insertions, 2 deletions

### Testing
✅ Tools without arguments now work correctly
✅ Tools with arguments continue to work as before
✅ Backward compatible

---

**Ready for review!** 🚀