### PR TITLE
fix: use API.callJsonApi in speech-store loadSettings to prevent settings load error

### DIFF
--- a/webui/components/chat/speech/speech-store.js
+++ b/webui/components/chat/speech/speech-store.js
@@ -3,6 +3,7 @@ import { updateChatInput, sendMessage } from "/index.js";
 import { sleep } from "/js/sleep.js";
 import { store as microphoneSettingStore } from "/components/settings/speech/microphone-setting-store.js";
 import * as shortcuts from "/js/shortcuts.js";
+import * as API from "/js/api.js";
 
 const Status = {
   INACTIVE: "inactive",
@@ -109,9 +110,7 @@ const model = {
 
   // Load settings from server
   async loadSettings() {
-    try {
-      const response = await fetchApi("/settings_get", { method: "POST" });
-      const data = await response.json();
+      const data = await API.callJsonApi("settings_get", null);
       const settings = data?.settings || {};
 
       if (settings) {


### PR DESCRIPTION
## Fix: Speech Store Settings Load Error

### Problem
The `loadSettings()` method in `speech-store.js` uses raw `fetchApi()` which does not handle token exchange or error responses properly, causing persistent console errors when speech settings fail to load.

### Solution
Replace raw `fetchApi()` with the existing `API.callJsonApi()` wrapper which properly handles:
- Request serialization
- Error response handling
- Extension hooks
- Token exchange

### Changes
- Add `import * as API from "/js/api.js"` to speech-store.js
- Replace raw fetchApi call in `loadSettings()` with `API.callJsonApi("settings_get", null)`

### Testing
- Change is minimal (2 lines)
- Uses existing, well-tested API wrapper
- No functional change to settings behavior

### Related
- Supersedes closed PR #1393 (rebased onto v1.7)