### PR TITLE
fix: validate_tool_request rejects valid empty tool_args dict

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -978,7 +978,7 @@ class Agent:
             raise ValueError("Tool request must be a dictionary")
         if not tool_request.get("tool_name") or not isinstance(tool_request.get("tool_name"), str):
             raise ValueError("Tool request must have a tool_name (type string) field")
-        if not tool_request.get("tool_args") or not isinstance(tool_request.get("tool_args"), dict):
+        if "tool_args" not in tool_request or not isinstance(tool_request.get("tool_args"), dict):
             raise ValueError("Tool request must have a tool_args (type dictionary) field")
 
 


### PR DESCRIPTION
## Bug: `validate_tool_request()` rejects valid empty `tool_args: {}`

### Problem

`validate_tool_request()` in `agent.py` uses a truthiness check on `tool_args`:

```python
if not tool_request.get("tool_args") or not isinstance(tool_request.get("tool_args"), dict):
```

In Python, `not {}` evaluates to `True` because empty dicts are falsy. This means **any tool call with empty arguments** crashes with:

```
ValueError: Tool request must have a tool_args (type dictionary) field
```

### Impact

- **Scheduler completely broken** — `list_tasks`, `show_task`, and all read-only scheduler calls send `tool_args: {}`
- **Any LLM** that outputs `"tool_args": {}` (valid JSON) triggers this crash
- **Custom tools** with no arguments are unusable
- **All users affected** — framework-level bug, not configuration-dependent

### Fix

1-line change: truthiness check → existence check

```diff
- if not tool_request.get("tool_args") or not isinstance(tool_request.get("tool_args"), dict):
+ if "tool_args" not in tool_request or not isinstance(tool_request.get("tool_args"), dict):
```

### Testing

| Input | Before | After |
|-------|--------|-------|
| `tool_args: {}` | ❌ ValueError | ✅ Passes |
| `tool_args: {"key": "val"}` | ✅ Passes | ✅ Passes |
| `tool_args` missing | ❌ ValueError | ❌ ValueError (correct) |
| `tool_args: null` | ❌ ValueError | ❌ ValueError (correct) |
| `tool_args: "string"` | ❌ ValueError | ❌ ValueError (correct) |

### Files Changed

| File | Lines | Change |
|------|-------|--------|
| `agent.py` | L981 | Truthiness → existence check |

1 file changed, 1 insertion(+), 1 deletion(-)
