### PR TITLE
fix: propagate embedding model api_base changes without restart

### DIFF
--- a/helpers/vector_db.py
+++ b/helpers/vector_db.py
@@ -41,11 +41,9 @@ class VectorDB:
         model = agent.get_embedding_model()
         if not cache:
             return model  # return raw embeddings if cache is False
-        namespace = getattr(
-            model,
-            "model_name",
-            "default",
-        )
+        model_name = getattr(model, "model_name", "default")
+        api_base = getattr(model, "kwargs", {}).get("api_base", "")
+        namespace = f"{model_name}:{api_base}" if api_base else model_name
         if namespace not in VectorDB._cached_embeddings:
             store = InMemoryByteStore()
             VectorDB._cached_embeddings[namespace] = (

--- a/plugins/_model_config/api/model_config_set.py
+++ b/plugins/_model_config/api/model_config_set.py
@@ -52,6 +52,7 @@ class ModelConfigSet(ApiHandler):
         if (
             prev_embed.get("provider") != new_embed.get("provider")
             or prev_embed.get("name") != new_embed.get("name")
+            or prev_embed.get("api_base") != new_embed.get("api_base")
             or prev_embed.get("kwargs") != new_embed.get("kwargs")
         ):
             defer.DeferredTask().start_task(

--- a/plugins/_model_config/extensions/python/embedding_model_changed/_10_invalidate_caches.py
+++ b/plugins/_model_config/extensions/python/embedding_model_changed/_10_invalidate_caches.py
@@ -1,0 +1,23 @@
+from helpers.extension import Extension
+from helpers.print_style import PrintStyle
+
+
+class InvalidateEmbeddingCaches(Extension):
+    def execute(self, **kwargs):
+        # Clear VectorDB embedding cache
+        from helpers.vector_db import VectorDB
+        count = len(VectorDB._cached_embeddings)
+        VectorDB._cached_embeddings.clear()
+
+        # Clear Memory index cache so VectorDBs are re-initialized with new embeddings
+        try:
+            from plugins._memory.helpers.memory import Memory
+            mem_count = len(Memory.index)
+            Memory.index.clear()
+        except ImportError:
+            mem_count = 0
+
+        PrintStyle().print(
+            f"Embedding model changed: cleared {count} cached embedding(s) "
+            f"and {mem_count} memory index(es)."
+        )


### PR DESCRIPTION
Three issues prevented embedding model host (api_base) changes from taking effect without restarting Agent Zero:

1. Change detection in model_config_set.py did not compare api_base, so host-only changes never triggered the embedding_model_changed event.

2. The embedding_model_changed event had no handler. Added an extension that clears VectorDB._cached_embeddings and Memory.index caches.

3. VectorDB._cached_embeddings keyed only on model_name, so different hosts serving the same model returned stale cached clients. The cache key now includes api_base.

Chat and utility models were unaffected because they are rebuilt from config on every call with no caching layer.