### PR TITLE
feat: add Exa as an optional search provider

### DIFF
--- a/helpers/exa_search.py
+++ b/helpers/exa_search.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+import models
+
+try:
+    from exa_py import Exa
+except ImportError:
+    Exa = None  # type: ignore[assignment,misc]
+
+NUM_RESULTS = 10
+
+
+def _get_client() -> Any:
+    if Exa is None:
+        raise ImportError("exa-py is required for Exa search: pip install exa-py")
+    api_key = models.get_api_key("exa")
+    if not api_key or api_key == "None":
+        raise RuntimeError("EXA_API_KEY is not set")
+    client = Exa(api_key=api_key)
+    client.headers["x-exa-integration"] = "agent-zero"
+    return client
+
+
+def is_available() -> bool:
+    """Return True if an Exa API key is configured."""
+    key = models.get_api_key("exa")
+    return bool(key and key != "None" and Exa is not None)
+
+
+async def search(query: str) -> list[dict[str, str]]:
+    """Search the web via Exa and return a list of result dicts.
+
+    Each dict contains 'title', 'url', and 'content' keys to match the
+    format expected by SearchEngine.format_result_searxng().
+    """
+    client = _get_client()
+    response = client.search_and_contents(
+        query,
+        num_results=NUM_RESULTS,
+        highlights=True,
+    )
+    results = []
+    for item in response.results:
+        highlights = getattr(item, "highlights", None) or []
+        content = " ".join(highlights) if highlights else (getattr(item, "text", "") or "")
+        results.append({
+            "title": getattr(item, "title", "") or "",
+            "url": getattr(item, "url", "") or "",
+            "content": content,
+        })
+    return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ ansio==0.0.1
 browser-use==0.5.11
 docker==7.1.0
 duckduckgo-search==6.1.12
+exa-py>=1.0.0
 faiss-cpu==1.11.0
 fastmcp==2.13.1
 fasta2a==0.5.0

--- a/tools/search_engine.py
+++ b/tools/search_engine.py
@@ -5,6 +5,7 @@ from helpers.tool import Tool, Response
 from helpers.print_style import PrintStyle
 from helpers.errors import handle_error
 from helpers.searxng import search as searxng
+from helpers import exa_search
 
 SEARCH_ENGINE_RESULTS = 10
 
@@ -12,19 +13,40 @@ SEARCH_ENGINE_RESULTS = 10
 class SearchEngine(Tool):
     async def execute(self, query="", **kwargs):
 
-
-        searxng_result = await self.searxng_search(query)
+        if exa_search.is_available():
+            result = await self.exa_search(query)
+        else:
+            result = await self.searxng_search(query)
 
         await self.agent.handle_intervention(
-            searxng_result
+            result
         )  # wait for intervention and handle it, if paused
 
-        return Response(message=searxng_result, break_loop=False)
+        return Response(message=result, break_loop=False)
 
+    async def exa_search(self, question):
+        try:
+            results = await exa_search.search(question)
+            return self.format_results(results, "Exa Search")
+        except Exception as e:
+            handle_error(e)
+            # fall back to SearXNG on Exa failure
+            return await self.searxng_search(question)
 
     async def searxng_search(self, question):
         results = await searxng(question)
         return self.format_result_searxng(results, "Search Engine")
+
+    def format_results(self, results, source):
+        if isinstance(results, Exception):
+            handle_error(results)
+            return f"{source} search failed: {str(results)}"
+
+        outputs = []
+        for item in (results or []):
+            outputs.append(f"{item['title']}\n{item['url']}\n{item['content']}")
+
+        return "\n\n".join(outputs[:SEARCH_ENGINE_RESULTS]).strip()
 
     def format_result_searxng(self, result, source):
         if isinstance(result, Exception):


### PR DESCRIPTION
## Description

Adds [Exa](https://exa.ai) as an optional, drop-in search provider for the `search_engine` tool. When `EXA_API_KEY` is set in the environment (or `usr/.env`), the agent automatically uses Exa's neural search instead of SearXNG. If the key is absent or a request fails, it falls back to SearXNG transparently.

**Why Exa?** Exa is an AI-native search engine built on neural embeddings. It returns semantically relevant results rather than keyword matches, which is a better fit for agent workloads where queries are natural-language questions. Highlights mode keeps token usage efficient.

## Changes

- **`helpers/exa_search.py`** (new) — Thin async wrapper around the `exa-py` SDK. Returns results in the same `{title, url, content}` format the existing `format_result_searxng` expects, so no prompt or downstream changes are needed.
- **`tools/search_engine.py`** — Checks `exa_search.is_available()` at call time. Routes to Exa when configured; falls back to SearXNG on missing key or request error.
- **`requirements.txt`** — Adds `exa-py>=1.0.0`.

## Design decisions

- **Opt-in, zero breaking changes.** Existing users who don't set `EXA_API_KEY` see no difference.
- **Graceful fallback.** If Exa errors mid-session, the tool retries with SearXNG rather than failing the agent loop.
- **Uses `models.get_api_key("exa")`** so it picks up `API_KEY_EXA`, `EXA_API_KEY`, or `EXA_API_TOKEN` automatically, consistent with how other API keys are managed in Agent Zero.
- **Includes `x-exa-integration: agent-zero` header** for integration-level usage tracking on Exa's side. (See also: [HKUDS/CLI-Anything#205](https://github.com/HKUDS/CLI-Anything/pull/205) for the same pattern in another open-source integration.)

## Setup

```bash
# In usr/.env or your shell environment:
EXA_API_KEY=your-key-here
```

Get a free key at https://dashboard.exa.ai/api-keys

## Test plan

- [ ] Without `EXA_API_KEY`: search works exactly as before (SearXNG)
- [ ] With `EXA_API_KEY`: search returns Exa results (title/url/highlight)
- [ ] With invalid `EXA_API_KEY`: gracefully falls back to SearXNG
- [ ] `pip install -r requirements.txt` installs `exa-py` without conflicts