### PR TITLE
ux: ease Email connector setup and refresh copy

### DIFF
--- a/plugins/_discovery/extensions/python/banners/10_discovery_cards.py
+++ b/plugins/_discovery/extensions/python/banners/10_discovery_cards.py
@@ -9,7 +9,6 @@ class DiscoveryCardsExtension(Extension):
         # Telegram, Email, Whatsapp are built-in, so we only need to check if they've been configured.
         
         telegram_config = plugins.get_plugin_config("_telegram_integration") or {}
-        email_config = plugins.get_plugin_config("_email_integration") or {}
         whatsapp_config = plugins.get_plugin_config("_whatsapp_integration") or {}
 
         # 1. Plugin Hub Hero
@@ -44,20 +43,19 @@ class DiscoveryCardsExtension(Extension):
             })
 
         # 3. Email
-        if not email_config.get("imap_username") and not email_config.get("smtp_username"):
-            banners.append({
-                "id": "discovery-email",
-                "type": "feature",
-                "title": "Setup Email",
-                "description": "Let Agent Zero read and send emails on your behalf.",
-                "thumbnail": "/plugins/_discovery/webui/assets/thumb-email.png",
-                "icon": "mail",
-                "cta_text": "Setup",
-                "cta_action": "open-plugin-config:_email_integration",
-                "dismissible": True,
-                "priority": 50,
-                "show_in_onboarding": True
-            })
+        banners.append({
+            "id": "discovery-email",
+            "type": "feature",
+            "title": "Setup Email",
+            "description": "Connect an inbox, test it, or fine-tune how Agent Zero replies.",
+            "thumbnail": "/plugins/_discovery/webui/assets/thumb-email.png",
+            "icon": "mail",
+            "cta_text": "Open Setup",
+            "cta_action": "open-plugin-config:_email_integration",
+            "dismissible": True,
+            "priority": 50,
+            "show_in_onboarding": True
+        })
 
         # 4. WhatsApp
         if not whatsapp_config.get("phone_number_id"):
@@ -74,4 +72,3 @@ class DiscoveryCardsExtension(Extension):
                 "priority": 50,
                 "show_in_onboarding": True
             })
-

--- a/plugins/_email_integration/api/test_connection.py
+++ b/plugins/_email_integration/api/test_connection.py
@@ -1,9 +1,12 @@
-"""Test IMAP/SMTP connection for an email handler config."""
+"""Test inbound and outbound email connectivity for a handler config."""
+
+import asyncio
 
 from helpers.api import ApiHandler, Request
 from helpers.errors import format_error
 
 from plugins._email_integration.helpers.imap_client import (
+    connect_exchange,
     connect_imap,
     disconnect_imap,
     get_highest_uid,
@@ -18,7 +21,9 @@ class TestConnection(ApiHandler):
         results: list[dict] = []
         account_type = handler.get("account_type", "imap")
 
-        if account_type == "imap":
+        if account_type == "exchange":
+            await self._test_exchange(handler, results)
+        else:
             await self._test_imap(handler, results)
         await self._test_smtp(handler, results)
         if all(r["ok"] for r in results):
@@ -35,18 +40,39 @@ class TestConnection(ApiHandler):
                 username=handler.get("username", ""),
                 password=handler.get("password", ""),
             )
-            uid = await get_highest_uid(client)
+            await get_highest_uid(client)
             await disconnect_imap(client)
             results.append({
-                "test": "IMAP",
+                "test": "Incoming",
                 "ok": True,
-                "message": f"Connected, highest UID: {uid}",
+                "message": "Incoming mail looks good.",
             })
         except Exception as e:
             results.append({
-                "test": "IMAP",
+                "test": "Incoming",
                 "ok": False,
-                "message": format_error(e),
+                "message": f"Could not reach the inbox: {format_error(e)}",
+            })
+
+    async def _test_exchange(self, handler: dict, results: list[dict]):
+        try:
+            account = await connect_exchange(
+                server=handler.get("imap_server", ""),
+                username=handler.get("username", ""),
+                password=handler.get("password", ""),
+            )
+            loop = asyncio.get_event_loop()
+            await loop.run_in_executor(None, lambda: account.inbox.total_count)
+            results.append({
+                "test": "Incoming",
+                "ok": True,
+                "message": "Exchange inbox looks good.",
+            })
+        except Exception as e:
+            results.append({
+                "test": "Incoming",
+                "ok": False,
+                "message": f"Could not reach the Exchange inbox: {format_error(e)}",
             })
 
     def _smtp_config(self, handler: dict) -> SmtpConfig:
@@ -62,18 +88,22 @@ class TestConnection(ApiHandler):
         try:
             error = await test_smtp(self._smtp_config(handler))
             if error:
-                results.append({"test": "SMTP", "ok": False, "message": error})
+                results.append({
+                    "test": "Outgoing",
+                    "ok": False,
+                    "message": f"Could not sign in for sending mail: {error}",
+                })
             else:
                 results.append({
-                    "test": "SMTP",
+                    "test": "Outgoing",
                     "ok": True,
-                    "message": "Authenticated successfully",
+                    "message": "Outgoing mail looks good.",
                 })
         except Exception as e:
             results.append({
-                "test": "SMTP",
+                "test": "Outgoing",
                 "ok": False,
-                "message": format_error(e),
+                "message": f"Could not sign in for sending mail: {format_error(e)}",
             })
 
     async def _test_send(self, handler: dict, results: list[dict]):
@@ -85,16 +115,20 @@ class TestConnection(ApiHandler):
                 body="This is a test email from Agent Zero email integration.",
             )
             if error:
-                results.append({"test": "Send", "ok": False, "message": error})
+                results.append({
+                    "test": "Send test email",
+                    "ok": False,
+                    "message": f"Could not send the test email: {error}",
+                })
             else:
                 results.append({
-                    "test": "Send",
+                    "test": "Send test email",
                     "ok": True,
-                    "message": "Test email sent to self",
+                    "message": "Test email sent to this inbox.",
                 })
         except Exception as e:
             results.append({
-                "test": "Send",
+                "test": "Send test email",
                 "ok": False,
-                "message": format_error(e),
+                "message": f"Could not send the test email: {format_error(e)}",
             })

--- a/plugins/_email_integration/webui/config.html
+++ b/plugins/_email_integration/webui/config.html
@@ -5,22 +5,87 @@
 
 <body>
     <div x-data="{
-        get handlers() { return config?.handlers || [] },
+        get handlers() {
+            return Array.isArray(config?.handlers) ? config.handlers : [];
+        },
         editing: null,
         testing: null,
         test_results: null,
+        test_results_for: null,
+        guide_open: false,
         projects: [],
+        presets: {
+            '': {
+                label: 'Choose a provider',
+                account_type: 'imap',
+                imap_server: '',
+                imap_port: 993,
+                smtp_server: '',
+                smtp_port: 587,
+            },
+            gmail: {
+                label: 'Gmail',
+                account_type: 'imap',
+                imap_server: 'imap.gmail.com',
+                imap_port: 993,
+                smtp_server: 'smtp.gmail.com',
+                smtp_port: 587,
+            },
+            icloud: {
+                label: 'iCloud Mail',
+                account_type: 'imap',
+                imap_server: 'imap.mail.me.com',
+                imap_port: 993,
+                smtp_server: 'smtp.mail.me.com',
+                smtp_port: 587,
+            },
+            microsoft365: {
+                label: 'Outlook / Microsoft 365',
+                account_type: 'imap',
+                imap_server: 'outlook.office365.com',
+                imap_port: 993,
+                smtp_server: 'smtp.office365.com',
+                smtp_port: 587,
+            },
+            yahoo: {
+                label: 'Yahoo Mail',
+                account_type: 'imap',
+                imap_server: 'imap.mail.yahoo.com',
+                imap_port: 993,
+                smtp_server: 'smtp.mail.yahoo.com',
+                smtp_port: 587,
+            },
+            exchange: {
+                label: 'Exchange',
+                account_type: 'exchange',
+                imap_server: 'outlook.office365.com',
+                imap_port: 993,
+                smtp_server: 'smtp.office365.com',
+                smtp_port: 587,
+            },
+            'custom-imap': {
+                label: 'Custom IMAP',
+                account_type: 'imap',
+                imap_server: '',
+                imap_port: 993,
+                smtp_server: '',
+                smtp_port: 587,
+            },
+        },
         async init() {
             try {
                 const { callJsonApi } = await import('/js/api.js');
                 const res = await callJsonApi('projects', { action: 'list' });
                 this.projects = res.data || [];
-            } catch (e) { this.projects = []; }
+            } catch (e) {
+                this.projects = [];
+            }
+            this.guide_open = this.handlers.length === 0 && window.innerWidth > 720;
+            if (this.handlers.length === 1) this.editing = 0;
         },
-        add_handler() {
-            if (!config.handlers) config.handlers = [];
-            config.handlers.push({
-                name: 'handler_' + (config.handlers.length + 1),
+        new_handler() {
+            return {
+                name: '',
                 enabled: false,
                 account_type: 'imap',
                 imap_server: '',
@@ -30,7 +95,7 @@
                 username: '',
                 password: '',
                 poll_mode: 'seconds',
-                poll_interval_seconds: 15,
+                poll_interval_seconds: 60,
                 poll_interval_cron: '*/2 * * * *',
                 process_unread_days: 0,
                 sender_whitelist: [],
@@ -38,22 +103,206 @@
                 dispatcher_model: 'utility',
                 dispatcher_instructions: '',
                 agent_instructions: ''
-            });
+            };
+        },
+        add_handler() {
+            if (!config.handlers) config.handlers = [];
+            config.handlers.push(this.new_handler());
             this.editing = config.handlers.length - 1;
+            this.test_results = null;
+            this.test_results_for = null;
         },
         remove_handler(idx) {
             config.handlers.splice(idx, 1);
-            this.editing = null;
+            if (this.editing === idx) this.editing = null;
+            if (this.editing !== null && this.editing > idx) this.editing -= 1;
+            if (this.test_results_for === idx) {
+                this.test_results = null;
+                this.test_results_for = null;
+            }
+        },
+        toggle_editing(idx) {
+            this.editing = this.editing === idx ? null : idx;
+            if (this.test_results_for !== idx) {
+                this.test_results = null;
+                this.test_results_for = null;
+            }
+        },
+        provider_value(handler) {
+            const incoming = String(handler.imap_server || '').trim().toLowerCase();
+            const outgoing = String(handler.smtp_server || '').trim().toLowerCase();
+            const accountType = handler.account_type || 'imap';
+
+            if (!incoming && !outgoing && !handler.username && !handler.password) return '';
+            if (accountType === 'exchange') return 'exchange';
+            if (incoming === 'imap.gmail.com' || outgoing === 'smtp.gmail.com') return 'gmail';
+            if (incoming === 'imap.mail.me.com' || outgoing === 'smtp.mail.me.com') return 'icloud';
+            if (incoming === 'outlook.office365.com' || outgoing === 'smtp.office365.com') return 'microsoft365';
+            if (incoming === 'imap.mail.yahoo.com' || outgoing === 'smtp.mail.yahoo.com') return 'yahoo';
+            return 'custom-imap';
+        },
+        provider_label(value) {
+            return this.presets[value]?.label || 'Custom IMAP';
+        },
+        apply_provider(handler, value) {
+            const preset = this.presets[value];
+            if (!preset) return;
+            const previous = this.provider_value(handler);
+
+            handler.account_type = preset.account_type;
+
+            if (value === 'custom-imap') {
+                if (previous !== 'custom-imap') {
+                    handler.imap_server = '';
+                    handler.smtp_server = '';
+                }
+                if (!handler.imap_port) handler.imap_port = 993;
+                if (!handler.smtp_port) handler.smtp_port = 587;
+                return;
+            }
+
+            handler.imap_server = preset.imap_server;
+            handler.imap_port = preset.imap_port;
+            handler.smtp_server = preset.smtp_server;
+            handler.smtp_port = preset.smtp_port;
+        },
+        provider_hint(handler) {
+            const provider = this.provider_value(handler);
+            if (provider === 'gmail') return 'Use a Google App Password. A regular Gmail password usually will not work here.';
+            if (provider === 'icloud') return 'Use an app-specific password from your Apple account settings.';
+            if (provider === 'microsoft365') return 'Most Outlook and Microsoft 365 inboxes work with this preset.';
+            if (provider === 'yahoo') return 'Yahoo Mail usually works best with an app password.';
+            if (provider === 'exchange') return 'Choose Exchange only if your organization requires it. For the simplest setup, try Outlook / Microsoft 365 first.';
+            if (provider === 'custom-imap') return 'Bring your own incoming and outgoing mail server details.';
+            return 'Start with your provider, then add your email address and password.';
+        },
+        show_manual_servers(handler) {
+            return this.provider_value(handler) === 'custom-imap';
+        },
+        show_exchange_server(handler) {
+            return this.provider_value(handler) === 'exchange';
+        },
+        incoming_label(handler) {
+            return this.show_exchange_server(handler) ? 'Exchange server' : 'Incoming mail server';
+        },
+        incoming_description(handler) {
+            return this.show_exchange_server(handler)
+                ? 'The Exchange or Microsoft 365 server for this inbox'
+                : 'The IMAP server for incoming mail';
+        },
+        incoming_placeholder(handler) {
+            return this.show_exchange_server(handler) ? 'outlook.office365.com' : 'imap.your-provider.com';
+        },
+        schedule_label(handler) {
+            const value = this.frequency_value(handler);
+            if (value === '15') return 'Checks every 15 seconds';
+            if (value === '30') return 'Checks every 30 seconds';
+            if (value === '60') return 'Checks every minute';
+            if (value === '300') return 'Checks every 5 minutes';
+            if (value === '900') return 'Checks every 15 minutes';
+            return 'Uses a custom schedule';
+        },
+        frequency_value(handler) {
+            if (handler.poll_mode !== 'seconds') return 'custom';
+            const seconds = Number(handler.poll_interval_seconds || 0);
+            if ([15, 30, 60, 300, 900].includes(seconds)) return String(seconds);
+            return 'custom';
+        },
+        apply_frequency(handler, value) {
+            if (value === 'custom') {
+                if (handler.poll_mode !== 'cron') handler.poll_mode = 'seconds';
+                if (!handler.poll_interval_seconds) handler.poll_interval_seconds = 60;
+                return;
+            }
+            handler.poll_mode = 'seconds';
+            handler.poll_interval_seconds = Number(value);
+        },
+        frequency_hint(handler) {
+            return this.frequency_value(handler) === 'custom'
+                ? 'You are using a custom schedule. You can change the raw timing in Advanced.'
+                : this.schedule_label(handler);
         },
         whitelist_text(handler) {
             return (handler.sender_whitelist || []).join(', ');
         },
-        set_whitelist(handler, val) {
-            handler.sender_whitelist = val.split(',').map(s => s.trim()).filter(s => s);
+        set_whitelist(handler, value) {
+            handler.sender_whitelist = value.split(',').map((entry) => entry.trim()).filter((entry) => entry);
+        },
+        slugify(value) {
+            return String(value || '')
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, '_')
+                .replace(/^_+|_+$/g, '');
+        },
+        maybe_autoname(handler) {
+            const current = String(handler.name || '').trim();
+            if (current && !/^handler_\\d+$/.test(current)) return;
+            const email = String(handler.username || '').trim();
+            const localPart = email.split('@')[0] || '';
+            const nextName = this.slugify(localPart);
+            if (nextName) handler.name = nextName;
+        },
+        missing_bits(handler) {
+            const missing = [];
+            const provider = this.provider_value(handler);
+            if (!provider) missing.push('provider');
+            if (!handler.username) missing.push('email address');
+            if (!handler.password) missing.push('password');
+            if ((this.show_manual_servers(handler) || this.show_exchange_server(handler)) && !handler.imap_server) {
+                missing.push(this.show_exchange_server(handler) ? 'Exchange server' : 'incoming server');
+            }
+            if (this.show_manual_servers(handler) && !handler.smtp_server) missing.push('outgoing server');
+            return missing;
+        },
+        can_test(handler) {
+            return this.missing_bits(handler).length === 0;
+        },
+        status_label(handler) {
+            if (!handler.username && !this.provider_value(handler)) return 'New';
+            if (handler.enabled && this.can_test(handler)) return 'Live';
+            if (this.can_test(handler)) return 'Ready';
+            return 'Needs info';
+        },
+        status_tone(handler) {
+            if (!handler.username && !this.provider_value(handler)) return 'muted';
+            if (handler.enabled && this.can_test(handler)) return 'success';
+            if (this.can_test(handler)) return 'ready';
+            return 'warning';
+        },
+        handler_title(handler, idx) {
+            return handler.username || handler.name || ('Inbox ' + (idx + 1));
+        },
+        handler_subtitle(handler) {
+            const pieces = [];
+            const provider = this.provider_value(handler);
+            if (provider) pieces.push(this.provider_label(provider));
+            pieces.push(this.schedule_label(handler).replace('Checks ', ''));
+            if (handler.project) pieces.push('Project: ' + handler.project);
+            return pieces.join(' · ');
+        },
+        test_button_label(handler, idx) {
+            if (this.testing === idx) return 'Checking...';
+            if (this.can_test(handler)) return 'Check setup';
+            return 'Fill in the basics first';
+        },
+        test_intro(handler) {
+            const provider = this.provider_value(handler);
+            if (provider === 'exchange') {
+                return 'We will check the inbox, check outgoing mail, then send a test email to this address.';
+            }
+            return 'We will check incoming mail, check outgoing mail, then send a test email to this inbox.';
+        },
+        result_title(result) {
+            return result.test || 'Check';
+        },
+        result_message(result) {
+            return result.message || (result.ok ? 'Done.' : 'Something went wrong.');
         },
         async test_connection(idx) {
+            if (!this.can_test(this.handlers[idx])) return;
             this.testing = idx;
             this.test_results = null;
+            this.test_results_for = idx;
             try {
                 const { callJsonApi } = await import('/js/api.js');
                 const res = await callJsonApi('/plugins/_email_integration/test_connection', {
@@ -61,43 +310,82 @@
                 });
                 this.test_results = res;
             } catch (e) {
-                this.test_results = { success: false, results: [{ test: 'Connection', ok: false, message: String(e) }] };
+                this.test_results = {
+                    success: false,
+                    results: [{ test: 'Connection', ok: false, message: String(e) }]
+                };
             }
             this.testing = null;
         }
-    }">
+    }" x-init="init()">
         <template x-if="config">
-            <div>
-                <div class="section-title">Email Integration</div>
+            <div class="email-settings">
+                <div class="section-title">Email</div>
                 <div class="section-description">
-                    Configure email handlers to communicate with Agent Zero via email.
-                    Each handler connects to an email account and polls for new messages.
+                    Connect an inbox and Agent Zero can read new messages, reply by email, and keep every conversation in one place.
                 </div>
 
-                <!-- Handler list -->
-                <template x-for="(handler, idx) in handlers" :key="idx">
-                    <div style="border: 1px solid var(--border-color, #333); border-radius: 8px; padding: 12px; margin-bottom: 8px; margin-top: 8px;">
+                <details class="email-guide" :open="guide_open" @toggle="guide_open = $event.target.open">
+                    <summary>Start in under two minutes</summary>
+                    <div class="email-guide-body">
+                        <div class="email-guide-card">
+                            <div class="email-guide-title">What you need</div>
+                            <ul class="email-guide-list">
+                                <li>Your email address</li>
+                                <li>Your password or app password</li>
+                                <li>Server names only if your provider is not listed</li>
+                            </ul>
+                        </div>
+                        <div class="email-guide-card">
+                            <div class="email-guide-title">What Agent Zero checks</div>
+                            <ul class="email-guide-list">
+                                <li>Incoming mail</li>
+                                <li>Outgoing mail</li>
+                                <li>A test email sent back to you</li>
+                            </ul>
+                        </div>
+                    </div>
+                </details>
 
-                        <!-- Header row -->
-                        <div style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;"
-                             @click="editing = editing === idx ? null : idx">
-                            <div>
-                                <span style="font-weight: bold;" x-text="handler.name"></span>
-                                <span style="opacity: 0.6; margin-left: 8px;" x-text="handler.enabled ? 'Enabled' : 'Disabled'"></span>
+                <template x-if="handlers.length === 0">
+                    <div class="email-empty">
+                        <div class="email-empty-title">Start with one inbox</div>
+                        <div class="email-empty-copy">
+                            Most people only need a provider, an email address, and an app password.
+                        </div>
+                        <button class="btn btn-field" @click="add_handler()">
+                            Connect an inbox
+                        </button>
+                    </div>
+                </template>
+
+                <template x-for="(handler, idx) in handlers" :key="idx">
+                    <div class="email-card">
+                        <div class="email-card-header" @click="toggle_editing(idx)">
+                            <div class="email-card-heading">
+                                <div class="email-card-title" x-text="handler_title(handler, idx)"></div>
+                                <div class="email-card-subtitle" x-text="handler_subtitle(handler)"></div>
                             </div>
-                            <button class="btn btn-action delete" @click.stop="$confirmClick($event, () => remove_handler(idx))" title="Remove handler">
-                                <span class="material-symbols-outlined">delete</span>
-                            </button>
+                            <div class="email-card-actions">
+                                <span class="email-status-pill" :class="'tone-' + status_tone(handler)" x-text="status_label(handler)"></span>
+                                <button class="btn btn-action delete"
+                                        @click.stop="$confirmClick($event, () => remove_handler(idx))"
+                                        title="Remove inbox">
+                                    <span class="material-symbols-outlined">delete</span>
+                                </button>
+                                <span class="material-symbols-outlined email-card-chevron"
+                                      :class="{ 'is-open': editing === idx }">expand_more</span>
+                            </div>
                         </div>
 
-                        <!-- Expanded editor -->
                         <template x-if="editing === idx">
-                            <div style="margin-top: 16px;">
+                            <div class="email-card-body">
+                                <div class="email-intro-copy" x-text="provider_hint(handler)"></div>
 
                                 <div class="field">
                                     <div class="field-label">
-                                        <div class="field-title">Enabled</div>
-                                        <div class="field-description">Enable or disable inbox polling for this handler</div>
+                                        <div class="field-title">Turn on this inbox</div>
+                                        <div class="field-description">Enable polling when you are ready for Agent Zero to start checking mail.</div>
                                     </div>
                                     <div class="field-control">
                                         <label class="toggle">
@@ -109,81 +397,39 @@
 
                                 <div class="field">
                                     <div class="field-label">
-                                        <div class="field-title">Handler Name</div>
-                                        <div class="field-description">Unique identifier for this email handler</div>
+                                        <div class="field-title">Provider</div>
+                                        <div class="field-description">Pick the provider first. We will fill in the common server settings for you.</div>
                                     </div>
                                     <div class="field-control">
-                                        <input type="text" x-model="handler.name" placeholder="e.g. support" />
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Account Type</div>
-                                        <div class="field-description">IMAP for most providers, Exchange for Microsoft Exchange/Office 365</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <select x-model="handler.account_type">
-                                            <option value="imap">IMAP</option>
+                                        <select :value="provider_value(handler)" @change="apply_provider(handler, $event.target.value)">
+                                            <option value="">Choose a provider</option>
+                                            <option value="gmail">Gmail</option>
+                                            <option value="icloud">iCloud Mail</option>
+                                            <option value="microsoft365">Outlook / Microsoft 365</option>
+                                            <option value="yahoo">Yahoo Mail</option>
                                             <option value="exchange">Exchange</option>
+                                            <option value="custom-imap">Custom IMAP</option>
                                         </select>
                                     </div>
                                 </div>
 
                                 <div class="field">
                                     <div class="field-label">
-                                        <div class="field-title">IMAP Server</div>
-                                        <div class="field-description">Incoming mail server hostname</div>
+                                        <div class="field-title">Email address</div>
+                                        <div class="field-description">Usually the full address for this inbox.</div>
                                     </div>
                                     <div class="field-control">
-                                        <input type="text" x-model="handler.imap_server" placeholder="imap.gmail.com" />
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">IMAP Port</div>
-                                        <div class="field-description">SSL port for incoming mail, usually 993</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <input type="number" x-model.number="handler.imap_port" placeholder="993" />
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">SMTP Server</div>
-                                        <div class="field-description">Outgoing mail server hostname. Defaults to IMAP server if empty</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <input type="text" x-model="handler.smtp_server" placeholder="smtp.gmail.com" />
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">SMTP Port</div>
-                                        <div class="field-description">TLS port for outgoing mail, usually 587</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <input type="number" x-model.number="handler.smtp_port" placeholder="587" />
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Username</div>
-                                        <div class="field-description">Email account login, usually the full email address</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <input type="text" x-model="handler.username" placeholder="user@domain.com" />
+                                        <input type="text"
+                                               x-model="handler.username"
+                                               @input="maybe_autoname(handler)"
+                                               placeholder="name@company.com" />
                                     </div>
                                 </div>
 
                                 <div class="field">
                                     <div class="field-label">
                                         <div class="field-title">Password</div>
-                                        <div class="field-description">Account password or app-specific password</div>
+                                        <div class="field-description">An app password is best. Many mail providers block regular account passwords.</div>
                                     </div>
                                     <div class="field-control">
                                         <input type="password" x-model="handler.password" />
@@ -192,140 +438,617 @@
 
                                 <div class="field">
                                     <div class="field-label">
-                                        <div class="field-title">Poll Mode</div>
-                                        <div class="field-description">How to schedule inbox checks</div>
+                                        <div class="field-title">Check for new mail</div>
+                                        <div class="field-description" x-text="frequency_hint(handler)"></div>
                                     </div>
                                     <div class="field-control">
-                                        <select x-model="handler.poll_mode">
-                                            <option value="seconds">Interval (seconds)</option>
-                                            <option value="cron">Cron expression</option>
+                                        <select :value="frequency_value(handler)" @change="apply_frequency(handler, $event.target.value)">
+                                            <option value="15">Every 15 seconds</option>
+                                            <option value="30">Every 30 seconds</option>
+                                            <option value="60">Every minute</option>
+                                            <option value="300">Every 5 minutes</option>
+                                            <option value="900">Every 15 minutes</option>
+                                            <option value="custom">Custom schedule</option>
                                         </select>
                                     </div>
                                 </div>
 
-                                <div class="field" x-show="handler.poll_mode === 'seconds'">
-                                    <div class="field-label">
-                                        <div class="field-title">Poll Interval (seconds)</div>
-                                        <div class="field-description">How often to check for new emails</div>
+                                <template x-if="show_exchange_server(handler)">
+                                    <div>
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title" x-text="incoming_label(handler)"></div>
+                                                <div class="field-description" x-text="incoming_description(handler)"></div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="text"
+                                                       x-model="handler.imap_server"
+                                                       :placeholder="incoming_placeholder(handler)" />
+                                            </div>
+                                        </div>
                                     </div>
-                                    <div class="field-control">
-                                        <input type="number" x-model.number="handler.poll_interval_seconds" min="5" placeholder="15" />
+                                </template>
+
+                                <template x-if="show_manual_servers(handler)">
+                                    <div class="email-grid">
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Incoming mail server</div>
+                                                <div class="field-description">The IMAP server for this inbox.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="text" x-model="handler.imap_server" placeholder="imap.your-provider.com" />
+                                            </div>
+                                        </div>
+
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Incoming port</div>
+                                                <div class="field-description">993 is the usual SSL port.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="number" x-model.number="handler.imap_port" placeholder="993" />
+                                            </div>
+                                        </div>
+
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Outgoing mail server</div>
+                                                <div class="field-description">The SMTP server used for replies.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="text" x-model="handler.smtp_server" placeholder="smtp.your-provider.com" />
+                                            </div>
+                                        </div>
+
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Outgoing port</div>
+                                                <div class="field-description">587 is the usual TLS port.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="number" x-model.number="handler.smtp_port" placeholder="587" />
+                                            </div>
+                                        </div>
                                     </div>
+                                </template>
+
+                                <template x-if="!show_manual_servers(handler) && !show_exchange_server(handler) && provider_value(handler)">
+                                    <div class="email-note">
+                                        Server settings are filled in for <span x-text="provider_label(provider_value(handler))"></span>.
+                                        You can change them any time in Advanced.
+                                    </div>
+                                </template>
+
+                                <div class="email-missing" x-show="missing_bits(handler).length > 0">
+                                    Still needed:
+                                    <span x-text="missing_bits(handler).join(', ')"></span>
                                 </div>
 
-                                <div class="field" x-show="handler.poll_mode !== 'seconds'">
-                                    <div class="field-label">
-                                        <div class="field-title">Cron Expression</div>
-                                        <div class="field-description">e.g. */2 * * * * for every 2 minutes</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <input type="text" x-model="handler.poll_interval_cron" placeholder="*/2 * * * *" />
-                                    </div>
-                                </div>
+                                <details class="email-advanced">
+                                    <summary>Advanced</summary>
+                                    <div class="email-advanced-body">
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Inbox name</div>
+                                                <div class="field-description">A friendly internal label for this connection.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="text" x-model="handler.name" placeholder="support" />
+                                            </div>
+                                        </div>
 
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Process Unread (days)</div>
-                                        <div class="field-description">Process unread emails from the last N days on every startup. 0 = only track new emails</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <input type="number" x-model.number="handler.process_unread_days" min="0" placeholder="0" />
-                                    </div>
-                                </div>
+                                        <div class="email-grid">
+                                            <div class="field">
+                                                <div class="field-label">
+                                                    <div class="field-title">Incoming mail server</div>
+                                                    <div class="field-description">Override the auto-filled incoming server if needed.</div>
+                                                </div>
+                                                <div class="field-control">
+                                                    <input type="text" x-model="handler.imap_server" placeholder="imap.your-provider.com" />
+                                                </div>
+                                            </div>
 
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Sender Whitelist</div>
-                                        <div class="field-description">Comma-separated. Empty = allow all. Wildcards supported (e.g. *@company.com)</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <input type="text" :value="whitelist_text(handler)" @input="set_whitelist(handler, $event.target.value)" placeholder="*@company.com, boss@other.com" />
-                                    </div>
-                                </div>
+                                            <div class="field">
+                                                <div class="field-label">
+                                                    <div class="field-title">Incoming port</div>
+                                                    <div class="field-description">993 is the common SSL port.</div>
+                                                </div>
+                                                <div class="field-control">
+                                                    <input type="number" x-model.number="handler.imap_port" placeholder="993" />
+                                                </div>
+                                            </div>
 
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Project</div>
-                                        <div class="field-description">Project to activate for email chats</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <select :value="handler.project" @change="handler.project = $event.target.value">
-                                            <option value="">No project</option>
-                                            <template x-for="proj in projects" :key="proj.name">
-                                                <option :value="proj.name" x-text="proj.title || proj.name" :selected="handler.project === proj.name"></option>
-                                            </template>
-                                        </select>
-                                    </div>
-                                </div>
+                                            <div class="field">
+                                                <div class="field-label">
+                                                    <div class="field-title">Outgoing mail server</div>
+                                                    <div class="field-description">Override the auto-filled reply server if needed.</div>
+                                                </div>
+                                                <div class="field-control">
+                                                    <input type="text" x-model="handler.smtp_server" placeholder="smtp.your-provider.com" />
+                                                </div>
+                                            </div>
 
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Dispatcher Model</div>
-                                        <div class="field-description">LLM model used to route incoming emails to chats. Utility is faster, chat is more capable</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <select x-model="handler.dispatcher_model">
-                                            <option value="utility">Utility</option>
-                                            <option value="chat">Chat</option>
-                                        </select>
-                                    </div>
-                                </div>
+                                            <div class="field">
+                                                <div class="field-label">
+                                                    <div class="field-title">Outgoing port</div>
+                                                    <div class="field-description">587 is the common TLS port.</div>
+                                                </div>
+                                                <div class="field-control">
+                                                    <input type="number" x-model.number="handler.smtp_port" placeholder="587" />
+                                                </div>
+                                            </div>
+                                        </div>
 
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Dispatcher Instructions</div>
-                                        <div class="field-description">Extra instructions for the AI that routes emails to chats</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <textarea x-model="handler.dispatcher_instructions" rows="3" placeholder="e.g. Always start a new chat for emails from support@..."></textarea>
-                                    </div>
-                                </div>
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Project</div>
+                                                <div class="field-description">Open email conversations inside a specific project.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <select :value="handler.project" @change="handler.project = $event.target.value">
+                                                    <option value="">No project</option>
+                                                    <template x-for="proj in projects" :key="proj.name">
+                                                        <option :value="proj.name"
+                                                                x-text="proj.title || proj.name"
+                                                                :selected="handler.project === proj.name"></option>
+                                                    </template>
+                                                </select>
+                                            </div>
+                                        </div>
 
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Agent Instructions</div>
-                                        <div class="field-description">Extra instructions for the agent in email chats</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <textarea x-model="handler.agent_instructions" rows="3" placeholder="e.g. Always respond in formal English..."></textarea>
-                                    </div>
-                                </div>
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Allowed senders</div>
+                                                <div class="field-description">Leave empty to allow anyone. Wildcards like *@company.com work.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="text"
+                                                       :value="whitelist_text(handler)"
+                                                       @input="set_whitelist(handler, $event.target.value)"
+                                                       placeholder="*@company.com, founder@company.com" />
+                                            </div>
+                                        </div>
 
-                                <!-- Test connection -->
-                                <div style="margin-top: 12px; display: flex; align-items: center; gap: 12px;">
-                                    <button class="btn btn-field" @click.stop="test_connection(idx)"
-                                            :disabled="testing === idx">
-                                        <span x-show="testing !== idx">Test Connection</span>
-                                        <span x-show="testing === idx">Testing...</span>
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Catch up on unread mail</div>
+                                                <div class="field-description">On startup, process unread mail from the last N days. Use 0 for brand-new mail only.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="number" x-model.number="handler.process_unread_days" min="0" placeholder="0" />
+                                            </div>
+                                        </div>
+
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Scheduling mode</div>
+                                                <div class="field-description">Use seconds for the simple presets above, or switch to cron for full control.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <select x-model="handler.poll_mode">
+                                                    <option value="seconds">Seconds</option>
+                                                    <option value="cron">Cron</option>
+                                                </select>
+                                            </div>
+                                        </div>
+
+                                        <div class="field" x-show="handler.poll_mode === 'seconds'">
+                                            <div class="field-label">
+                                                <div class="field-title">Poll interval (seconds)</div>
+                                                <div class="field-description">The exact delay between inbox checks.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="number" x-model.number="handler.poll_interval_seconds" min="5" placeholder="60" />
+                                            </div>
+                                        </div>
+
+                                        <div class="field" x-show="handler.poll_mode === 'cron'">
+                                            <div class="field-label">
+                                                <div class="field-title">Cron expression</div>
+                                                <div class="field-description">For example, */2 * * * * checks every two minutes.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="text" x-model="handler.poll_interval_cron" placeholder="*/2 * * * *" />
+                                            </div>
+                                        </div>
+
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Routing model</div>
+                                                <div class="field-description">Utility is faster. Chat is more capable when routing gets nuanced.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <select x-model="handler.dispatcher_model">
+                                                    <option value="utility">Utility</option>
+                                                    <option value="chat">Chat</option>
+                                                </select>
+                                            </div>
+                                        </div>
+
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Routing instructions</div>
+                                                <div class="field-description">Extra guidance for how incoming email should be routed into chats.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <textarea x-model="handler.dispatcher_instructions"
+                                                          rows="3"
+                                                          placeholder="Always start a new chat for invoices or billing questions."></textarea>
+                                            </div>
+                                        </div>
+
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Reply instructions</div>
+                                                <div class="field-description">Extra guidance for the agent when it replies by email.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <textarea x-model="handler.agent_instructions"
+                                                          rows="3"
+                                                          placeholder="Reply in a calm, concise tone."></textarea>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </details>
+
+                                <div class="email-test-panel">
+                                    <div class="email-test-copy">
+                                        <div class="email-test-title">Check the connection</div>
+                                        <div class="email-test-description" x-text="test_intro(handler)"></div>
+                                    </div>
+                                    <button class="btn btn-field"
+                                            @click.stop="test_connection(idx)"
+                                            :disabled="testing === idx || !can_test(handler)">
+                                        <span x-text="test_button_label(handler, idx)"></span>
                                     </button>
                                 </div>
 
-                                <!-- Test results -->
-                                <template x-if="test_results && editing === idx">
-                                    <div style="margin-top: 8px; padding: 8px 12px; border-radius: 6px; font-size: 0.85rem;
-                                                border: 1px solid var(--border-color, #333);">
-                                        <template x-for="r in test_results.results" :key="r.test">
-                                            <div style="display: flex; align-items: center; gap: 8px; padding: 4px 0;">
-                                                <span x-text="r.ok ? '✓' : '✗'"
-                                                      :style="'font-weight: bold; color:' + (r.ok ? '#4caf50' : '#f44336')"></span>
-                                                <span style="font-weight: 500; min-width: 50px;" x-text="r.test"></span>
-                                                <span style="opacity: 0.8;" x-text="r.message"></span>
+                                <template x-if="test_results && test_results_for === idx">
+                                    <div class="email-results" :class="{ 'is-error': !test_results.success }">
+                                        <template x-for="result in test_results.results" :key="result.test + result.message">
+                                            <div class="email-result-row">
+                                                <span class="email-result-icon" x-text="result.ok ? '✓' : '✗'"></span>
+                                                <div class="email-result-copy">
+                                                    <div class="email-result-title" x-text="result_title(result)"></div>
+                                                    <div class="email-result-message" x-text="result_message(result)"></div>
+                                                </div>
                                             </div>
                                         </template>
                                     </div>
                                 </template>
-
                             </div>
                         </template>
                     </div>
                 </template>
 
-                <button class="btn btn-field" @click="add_handler()" style="margin-top: 8px;">
-                    Add Handler
-                </button>
+                <template x-if="handlers.length > 0">
+                    <button class="btn btn-field email-add-another" @click="add_handler()">
+                        Connect another inbox
+                    </button>
+                </template>
             </div>
         </template>
     </div>
+
+    <style>
+        .email-settings {
+            display: flex;
+            flex-direction: column;
+            gap: 0.9rem;
+        }
+
+        .email-guide {
+            border: 1px solid var(--color-border);
+            border-radius: 14px;
+            background: color-mix(in srgb, var(--color-background) 92%, white 8%);
+            overflow: hidden;
+        }
+
+        .email-guide summary,
+        .email-advanced summary {
+            cursor: pointer;
+            list-style: none;
+            font-weight: 700;
+        }
+
+        .email-guide summary::-webkit-details-marker,
+        .email-advanced summary::-webkit-details-marker {
+            display: none;
+        }
+
+        .email-guide summary {
+            padding: 0.95rem 1rem;
+        }
+
+        .email-guide-body {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 0.85rem;
+            padding: 0 1rem 1rem;
+        }
+
+        .email-guide-card {
+            border: 1px solid color-mix(in srgb, var(--color-border) 80%, white 20%);
+            border-radius: 12px;
+            padding: 0.9rem 1rem;
+            background: color-mix(in srgb, var(--color-background) 88%, white 12%);
+        }
+
+        .email-guide-title {
+            font-weight: 700;
+            margin-bottom: 0.55rem;
+        }
+
+        .email-guide-list {
+            margin: 0;
+            padding-left: 1.1rem;
+            color: var(--color-text-secondary);
+            line-height: 1.55;
+        }
+
+        .email-empty {
+            border: 1px dashed color-mix(in srgb, var(--color-border) 80%, white 20%);
+            border-radius: 16px;
+            padding: 1rem;
+            background: color-mix(in srgb, var(--color-background) 94%, white 6%);
+        }
+
+        .email-empty-title {
+            font-size: 1.05rem;
+            font-weight: 700;
+        }
+
+        .email-empty-copy {
+            margin-top: 0.35rem;
+            margin-bottom: 0.9rem;
+            color: var(--color-text-secondary);
+            line-height: 1.5;
+        }
+
+        .email-card {
+            border: 1px solid var(--color-border);
+            border-radius: 16px;
+            overflow: hidden;
+            background: color-mix(in srgb, var(--color-background) 94%, white 6%);
+        }
+
+        .email-card-header {
+            display: flex;
+            justify-content: space-between;
+            gap: 1rem;
+            align-items: flex-start;
+            padding: 1rem;
+            cursor: pointer;
+        }
+
+        .email-card-heading {
+            min-width: 0;
+            flex: 1 1 auto;
+        }
+
+        .email-card-title {
+            font-weight: 700;
+            font-size: 1rem;
+            line-height: 1.35;
+            overflow-wrap: anywhere;
+        }
+
+        .email-card-subtitle {
+            margin-top: 0.3rem;
+            color: var(--color-text-secondary);
+            font-size: var(--font-size-small);
+            line-height: 1.45;
+        }
+
+        .email-card-actions {
+            display: flex;
+            align-items: center;
+            gap: 0.45rem;
+            flex: 0 0 auto;
+        }
+
+        .email-card-chevron {
+            transition: transform 0.18s ease;
+            opacity: 0.7;
+        }
+
+        .email-card-chevron.is-open {
+            transform: rotate(180deg);
+        }
+
+        .email-card-body {
+            padding: 0 1rem 1rem;
+            border-top: 1px solid color-mix(in srgb, var(--color-border) 88%, white 12%);
+        }
+
+        .email-intro-copy {
+            margin: 1rem 0;
+            padding: 0.85rem 0.95rem;
+            border-radius: 12px;
+            background: color-mix(in srgb, #3b82f6 12%, var(--color-background) 88%);
+            color: var(--color-text-secondary);
+            line-height: 1.5;
+        }
+
+        .email-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 0.85rem;
+        }
+
+        .email-note,
+        .email-missing {
+            margin-top: 0.2rem;
+            margin-bottom: 0.85rem;
+            padding: 0.8rem 0.9rem;
+            border-radius: 12px;
+            font-size: var(--font-size-small);
+            line-height: 1.5;
+        }
+
+        .email-note {
+            background: color-mix(in srgb, var(--color-background) 82%, white 18%);
+            color: var(--color-text-secondary);
+        }
+
+        .email-missing {
+            background: color-mix(in srgb, #f59e0b 14%, var(--color-background) 86%);
+            color: var(--color-text-secondary);
+        }
+
+        .email-advanced {
+            margin-top: 0.95rem;
+            border: 1px solid color-mix(in srgb, var(--color-border) 88%, white 12%);
+            border-radius: 14px;
+            overflow: hidden;
+        }
+
+        .email-advanced summary {
+            padding: 0.9rem 1rem;
+            background: color-mix(in srgb, var(--color-background) 88%, white 12%);
+        }
+
+        .email-advanced-body {
+            padding: 1rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.2rem;
+        }
+
+        .email-test-panel {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-radius: 14px;
+            border: 1px solid color-mix(in srgb, var(--color-border) 88%, white 12%);
+            background: color-mix(in srgb, var(--color-background) 90%, white 10%);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        .email-test-copy {
+            min-width: 0;
+        }
+
+        .email-test-title {
+            font-weight: 700;
+            margin-bottom: 0.25rem;
+        }
+
+        .email-test-description {
+            color: var(--color-text-secondary);
+            line-height: 1.5;
+            font-size: var(--font-size-small);
+        }
+
+        .email-results {
+            margin-top: 0.9rem;
+            border-radius: 14px;
+            border: 1px solid color-mix(in srgb, #22c55e 28%, var(--color-border) 72%);
+            background: color-mix(in srgb, #22c55e 8%, var(--color-background) 92%);
+            padding: 0.35rem 0.9rem;
+        }
+
+        .email-results.is-error {
+            border-color: color-mix(in srgb, #ef4444 28%, var(--color-border) 72%);
+            background: color-mix(in srgb, #ef4444 8%, var(--color-background) 92%);
+        }
+
+        .email-result-row {
+            display: flex;
+            align-items: flex-start;
+            gap: 0.8rem;
+            padding: 0.7rem 0;
+        }
+
+        .email-result-row + .email-result-row {
+            border-top: 1px solid color-mix(in srgb, var(--color-border) 85%, white 15%);
+        }
+
+        .email-result-icon {
+            width: 1.25rem;
+            font-weight: 800;
+            line-height: 1.3;
+        }
+
+        .email-result-copy {
+            min-width: 0;
+        }
+
+        .email-result-title {
+            font-weight: 700;
+            margin-bottom: 0.18rem;
+        }
+
+        .email-result-message {
+            color: var(--color-text-secondary);
+            line-height: 1.5;
+            font-size: var(--font-size-small);
+            overflow-wrap: anywhere;
+        }
+
+        .email-status-pill {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 5.25rem;
+            padding: 0.35rem 0.7rem;
+            border-radius: 999px;
+            font-size: 0.8rem;
+            font-weight: 700;
+            letter-spacing: 0.01em;
+        }
+
+        .email-status-pill.tone-success {
+            background: rgba(34, 197, 94, 0.14);
+            color: #7ee7a4;
+        }
+
+        .email-status-pill.tone-ready {
+            background: rgba(59, 130, 246, 0.16);
+            color: #93c5fd;
+        }
+
+        .email-status-pill.tone-warning {
+            background: rgba(245, 158, 11, 0.16);
+            color: #fcd34d;
+        }
+
+        .email-status-pill.tone-muted {
+            background: rgba(148, 163, 184, 0.14);
+            color: #cbd5e1;
+        }
+
+        .email-add-another {
+            align-self: flex-start;
+        }
+
+        @media (max-width: 900px) {
+            .email-guide-body,
+            .email-grid {
+                grid-template-columns: minmax(0, 1fr);
+            }
+        }
+
+        @media (max-width: 640px) {
+            .email-card-header,
+            .email-test-panel {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            .email-card-actions {
+                justify-content: space-between;
+                width: 100%;
+            }
+
+            .email-status-pill {
+                min-width: 0;
+            }
+        }
+    </style>
 </body>
 
 </html>


### PR DESCRIPTION
- Redesign the Email connector settings around a guided first-run flow with a clearer empty state, provider presets, and much friendlier copy
- Move server, routing, and scheduling power-user controls into an `Advanced` section while keeping the existing config model compatible
- Improve connection-test messaging, add Exchange inbound validation, and refresh the dashboard Email card copy while keeping the card visible
- Verify the updated setup flow in the browser on desktop and mobile