### PR TITLE
integrations: redesign messaging settings and add native chat controls

### DIFF
--- a/helpers/integration_commands.py
+++ b/helpers/integration_commands.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from helpers import message_queue as mq
+from helpers import projects
+from helpers.persist_chat import save_tmp_chat
+from helpers.state_monitor_integration import mark_dirty_for_context
+from plugins._model_config.helpers import model_config
+
+if TYPE_CHECKING:
+    from agent import AgentContext
+
+
+_CLEAR_VALUES = {"", "default", "none", "clear", "off"}
+_SUPPORTED_COMMANDS = {"/send", "/queue", "/project", "/config", "/preset"}
+
+
+def extract_command_line(text: str) -> str:
+    for line in (text or "").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        return stripped
+    return ""
+
+
+def parse_command(text: str) -> tuple[str, str] | None:
+    line = extract_command_line(text)
+    if not line.startswith("/"):
+        return None
+
+    command, _, args = line.partition(" ")
+    command = command.strip().lower()
+    if command not in _SUPPORTED_COMMANDS:
+        return None
+
+    return command, args.strip()
+
+
+def try_handle_command(context: "AgentContext", text: str) -> str | None:
+    parsed = parse_command(text)
+    if not parsed:
+        return None
+
+    command, args = parsed
+    if command == "/send":
+        return _handle_queue(context, "send")
+    if command == "/queue":
+        return _handle_queue(context, args)
+    if command == "/project":
+        return _handle_project(context, args)
+    if command in {"/config", "/preset"}:
+        return _handle_config(context, args)
+    return None
+
+
+def _handle_queue(context: "AgentContext", args: str) -> str:
+    queue = mq.get_queue(context)
+    count = len(queue)
+    action = args.strip().lower()
+
+    if not action:
+        noun = "message" if count == 1 else "messages"
+        return (
+            f"Queue has {count} {noun}.\n"
+            "Use /send or /queue send to send everything as one batch."
+        )
+
+    if action not in {"send", "all"}:
+        return "Unknown queue action. Use /queue send to flush the queue."
+
+    if count == 0:
+        return "Queue is empty."
+
+    sent_count = mq.send_all_aggregated(context)
+    mark_dirty_for_context(context.id, reason="integration_commands.queue_send")
+    noun = "message" if sent_count == 1 else "messages"
+    return f"Sent {sent_count} queued {noun} as one batch."
+
+
+def _handle_project(context: "AgentContext", args: str) -> str:
+    items = projects.get_active_projects_list() or []
+    current_name = context.get_data("project") or ""
+
+    if not args:
+        current_label = _describe_project(items, current_name)
+        available = ", ".join(_format_project_entry(item) for item in items) or "none"
+        return (
+            f"Current project: {current_label}\n"
+            f"Available projects: {available}\n"
+            "Use /project <name> to switch, or /project none to clear it."
+        )
+
+    desired = _strip_quotes(args)
+    if _normalize_lookup(desired) in _CLEAR_VALUES:
+        if not current_name:
+            return "No project is active."
+        projects.deactivate_project(context.id)
+        return "Cleared the active project."
+
+    match, ambiguous = _match_named_item(items, desired, keys=("name", "title"))
+    if ambiguous:
+        names = ", ".join(_format_project_entry(item) for item in ambiguous)
+        return f"Project name is ambiguous. Matches: {names}"
+    if not match:
+        available = ", ".join(_format_project_entry(item) for item in items) or "none"
+        return f"Project '{desired}' was not found. Available projects: {available}"
+
+    if match.get("name") == current_name:
+        return f"Already using project {match.get('title') or match.get('name')}."
+
+    projects.activate_project(context.id, match["name"])
+    return f"Switched project to {match.get('title') or match['name']}."
+
+
+def _handle_config(context: "AgentContext", args: str) -> str:
+    allowed = model_config.is_chat_override_allowed(context.agent0)
+    presets = [preset for preset in model_config.get_presets() if preset.get("name")]
+    current_override = context.get_data("chat_model_override")
+
+    if not args:
+        current_label = _describe_override(current_override)
+        available = ", ".join(preset["name"] for preset in presets) or "none"
+        suffix = "Use /config <name> to switch, or /config default to clear it."
+        if not allowed:
+            suffix = "Per-chat config switching is disabled in Model Configuration."
+        return (
+            f"Current config: {current_label}\n"
+            f"Available configs: {available}\n"
+            f"{suffix}"
+        )
+
+    if not allowed:
+        return "Config switching is disabled in Model Configuration."
+
+    desired = _strip_quotes(args)
+    if _normalize_lookup(desired) in _CLEAR_VALUES:
+        if not current_override:
+            return "Already using the default config."
+        context.set_data("chat_model_override", None)
+        save_tmp_chat(context)
+        mark_dirty_for_context(context.id, reason="integration_commands.config_clear")
+        return "Switched back to the default config."
+
+    match, ambiguous = _match_named_item(presets, desired, keys=("name",))
+    if ambiguous:
+        names = ", ".join(item["name"] for item in ambiguous)
+        return f"Config name is ambiguous. Matches: {names}"
+    if not match:
+        available = ", ".join(preset["name"] for preset in presets) or "none"
+        return f"Config '{desired}' was not found. Available configs: {available}"
+
+    preset_name = match["name"]
+    if isinstance(current_override, dict) and current_override.get("preset_name") == preset_name:
+        return f"Already using config {preset_name}."
+
+    context.set_data("chat_model_override", {"preset_name": preset_name})
+    save_tmp_chat(context)
+    mark_dirty_for_context(context.id, reason="integration_commands.config_set")
+    return f"Switched config to {preset_name}."
+
+
+def _format_project_entry(item: dict) -> str:
+    title = str(item.get("title", "") or "").strip()
+    name = str(item.get("name", "") or "").strip()
+    if title and title.lower() != name.lower():
+        return f"{title} ({name})"
+    return name or title
+
+
+def _describe_project(items: list[dict], current_name: str) -> str:
+    if not current_name:
+        return "none"
+    for item in items:
+        if item.get("name") == current_name:
+            return item.get("title") or current_name
+    return current_name
+
+
+def _describe_override(override: dict | None) -> str:
+    if not override:
+        return "Default"
+    if isinstance(override, dict) and override.get("preset_name"):
+        return str(override["preset_name"])
+    return "Custom override"
+
+
+def _strip_quotes(value: str) -> str:
+    trimmed = value.strip()
+    if len(trimmed) >= 2 and trimmed[0] == trimmed[-1] and trimmed[0] in {'"', "'"}:
+        return trimmed[1:-1].strip()
+    return trimmed
+
+
+def _normalize_lookup(value: str) -> str:
+    lowered = value.lower().strip()
+    lowered = re.sub(r"[\s_\-]+", " ", lowered)
+    lowered = re.sub(r"[^a-z0-9 ]+", "", lowered)
+    return lowered.strip()
+
+
+def _match_named_item(
+    items: list[dict],
+    desired: str,
+    *,
+    keys: tuple[str, ...],
+) -> tuple[dict | None, list[dict]]:
+    normalized = _normalize_lookup(desired)
+    exact_matches: list[dict] = []
+
+    for item in items:
+        values = [str(item.get(key, "") or "") for key in keys]
+        normalized_values = [_normalize_lookup(value) for value in values if value]
+        if normalized in normalized_values:
+            exact_matches.append(item)
+
+    if len(exact_matches) == 1:
+        return exact_matches[0], []
+    if len(exact_matches) > 1:
+        return None, exact_matches
+
+    partial_matches: list[dict] = []
+    for item in items:
+        values = [str(item.get(key, "") or "") for key in keys]
+        normalized_values = [_normalize_lookup(value) for value in values if value]
+        if any(normalized and normalized in value for value in normalized_values):
+            partial_matches.append(item)
+
+    if len(partial_matches) == 1:
+        return partial_matches[0], []
+    if len(partial_matches) > 1:
+        return None, partial_matches
+
+    return None, []

--- a/plugins/_discovery/extensions/python/banners/10_discovery_cards.py
+++ b/plugins/_discovery/extensions/python/banners/10_discovery_cards.py
@@ -44,7 +44,9 @@ class DiscoveryCardsExtension(Extension):
             })
 
         # 3. Email
-        if not email_config.get("imap_username") and not email_config.get("smtp_username"):
+        email_handlers = email_config.get("handlers") or []
+        email_is_configured = any((handler or {}).get("username") for handler in email_handlers)
+        if not email_is_configured:
             banners.append({
                 "id": "discovery-email",
                 "type": "feature",
@@ -52,7 +54,7 @@ class DiscoveryCardsExtension(Extension):
                 "description": "Let Agent Zero read and send emails on your behalf.",
                 "thumbnail": "/plugins/_discovery/webui/assets/thumb-email.png",
                 "icon": "mail",
-                "cta_text": "Setup",
+                "cta_text": "Open Setup",
                 "cta_action": "open-plugin-config:_email_integration",
                 "dismissible": True,
                 "priority": 50,
@@ -74,4 +76,3 @@ class DiscoveryCardsExtension(Extension):
                 "priority": 50,
                 "show_in_onboarding": True
             })
-

--- a/plugins/_email_integration/README.md
+++ b/plugins/_email_integration/README.md
@@ -22,9 +22,11 @@ It supports both:
 - **Dispatcher workflow**
   - Reuses or creates a background `Email Dispatcher` context.
   - Uses model prompts to decide whether an email belongs to an existing chat or should open a new one.
+  - Supports handler-level model presets for new chats, in addition to the dispatcher's utility/chat routing mode.
 - **Thread routing**
   - Can continue an existing chat by thread ID found in the email subject.
   - Falls back to model-based dispatch if no direct thread match is available.
+  - Email replies inside an existing Agent Zero thread can use `/project`, `/config`, and `/send` control commands.
 - **Notifications and persistence**
   - Saves chats after routing and emits notifications about new or continued conversations.
 

--- a/plugins/_email_integration/api/test_connection.py
+++ b/plugins/_email_integration/api/test_connection.py
@@ -1,9 +1,12 @@
-"""Test IMAP/SMTP connection for an email handler config."""
+"""Test inbound and outbound email connectivity for a handler config."""
+
+import asyncio
 
 from helpers.api import ApiHandler, Request
 from helpers.errors import format_error
 
 from plugins._email_integration.helpers.imap_client import (
+    connect_exchange,
     connect_imap,
     disconnect_imap,
     get_highest_uid,
@@ -18,7 +21,9 @@ class TestConnection(ApiHandler):
         results: list[dict] = []
         account_type = handler.get("account_type", "imap")
 
-        if account_type == "imap":
+        if account_type == "exchange":
+            await self._test_exchange(handler, results)
+        else:
             await self._test_imap(handler, results)
         await self._test_smtp(handler, results)
         if all(r["ok"] for r in results):
@@ -35,18 +40,39 @@ class TestConnection(ApiHandler):
                 username=handler.get("username", ""),
                 password=handler.get("password", ""),
             )
-            uid = await get_highest_uid(client)
+            await get_highest_uid(client)
             await disconnect_imap(client)
             results.append({
-                "test": "IMAP",
+                "test": "Incoming",
                 "ok": True,
-                "message": f"Connected, highest UID: {uid}",
+                "message": "Incoming mail looks good.",
             })
         except Exception as e:
             results.append({
-                "test": "IMAP",
+                "test": "Incoming",
                 "ok": False,
-                "message": format_error(e),
+                "message": f"Could not reach the inbox: {format_error(e)}",
+            })
+
+    async def _test_exchange(self, handler: dict, results: list[dict]):
+        try:
+            account = await connect_exchange(
+                server=handler.get("imap_server", ""),
+                username=handler.get("username", ""),
+                password=handler.get("password", ""),
+            )
+            loop = asyncio.get_event_loop()
+            await loop.run_in_executor(None, lambda: account.inbox.total_count)
+            results.append({
+                "test": "Incoming",
+                "ok": True,
+                "message": "Exchange inbox looks good.",
+            })
+        except Exception as e:
+            results.append({
+                "test": "Incoming",
+                "ok": False,
+                "message": f"Could not reach the Exchange inbox: {format_error(e)}",
             })
 
     def _smtp_config(self, handler: dict) -> SmtpConfig:
@@ -62,18 +88,22 @@ class TestConnection(ApiHandler):
         try:
             error = await test_smtp(self._smtp_config(handler))
             if error:
-                results.append({"test": "SMTP", "ok": False, "message": error})
+                results.append({
+                    "test": "Outgoing",
+                    "ok": False,
+                    "message": f"Could not sign in for sending mail: {error}",
+                })
             else:
                 results.append({
-                    "test": "SMTP",
+                    "test": "Outgoing",
                     "ok": True,
-                    "message": "Authenticated successfully",
+                    "message": "Outgoing mail looks good.",
                 })
         except Exception as e:
             results.append({
-                "test": "SMTP",
+                "test": "Outgoing",
                 "ok": False,
-                "message": format_error(e),
+                "message": f"Could not sign in for sending mail: {format_error(e)}",
             })
 
     async def _test_send(self, handler: dict, results: list[dict]):
@@ -85,16 +115,20 @@ class TestConnection(ApiHandler):
                 body="This is a test email from Agent Zero email integration.",
             )
             if error:
-                results.append({"test": "Send", "ok": False, "message": error})
+                results.append({
+                    "test": "Send test email",
+                    "ok": False,
+                    "message": f"Could not send the test email: {error}",
+                })
             else:
                 results.append({
-                    "test": "Send",
+                    "test": "Send test email",
                     "ok": True,
-                    "message": "Test email sent to self",
+                    "message": "Test email sent to this inbox.",
                 })
         except Exception as e:
             results.append({
-                "test": "Send",
+                "test": "Send test email",
                 "ok": False,
-                "message": format_error(e),
+                "message": f"Could not send the test email: {format_error(e)}",
             })

--- a/plugins/_email_integration/default_config.yaml
+++ b/plugins/_email_integration/default_config.yaml
@@ -16,5 +16,6 @@ handlers: []
 #   sender_whitelist: []
 #   project: ""
 #   dispatcher_model: utility
+#   chat_model_preset: ""       # Optional preset from Model Configuration for new email chats
 #   dispatcher_instructions: ""
 #   agent_instructions: ""

--- a/plugins/_email_integration/helpers/handler.py
+++ b/plugins/_email_integration/helpers/handler.py
@@ -13,12 +13,14 @@ import uuid
 from agent import Agent, AgentContext, AgentContextType, UserMessage
 from helpers import guids, plugins, files, runtime
 from helpers import message_queue as mq
+from helpers import integration_commands
 from helpers.persist_chat import save_tmp_chat
 from helpers.print_style import PrintStyle
 from helpers.errors import format_error
 from initialize import initialize_agent
 
 from plugins._email_integration.helpers import dispatcher as disp
+from plugins._model_config.helpers import model_config
 from plugins._email_integration.helpers.imap_client import (
     InboundMessage,
     connect_imap,
@@ -177,6 +179,9 @@ async def _dispatch_message(agent: Agent, handler_cfg: dict, msg: InboundMessage
 
     existing = _find_handler_chats(handler_name, msg.sender)
 
+    if await _handle_control_email(handler_cfg, msg, existing, thread_id):
+        return
+
     # Fast path: thread ID in subject matches a known chat
     if thread_id:
         for chat in existing:
@@ -281,6 +286,7 @@ async def _start_new_chat(agent: Agent, handler_cfg: dict, msg: InboundMessage):
     if project:
         projects.activate_project(context.id, project)
 
+    _apply_handler_model_preset(context, handler_cfg)
     save_tmp_chat(context)
 
     user_msg = _build_user_message(agent, msg, handler_cfg)
@@ -310,6 +316,8 @@ async def _route_to_chat(
 
     context.data[disp.CTX_EMAIL_MESSAGE_ID] = msg.message_id
     context.data[disp.CTX_EMAIL_LAST_BODY] = msg.body
+    if not context.get_data("chat_model_override"):
+        _apply_handler_model_preset(context, handler_cfg)
     
     refs = context.data.get(disp.CTX_EMAIL_REFERENCES, "")
     refs_list = refs.split() if refs else []
@@ -335,6 +343,131 @@ async def _route_to_chat(
 
     save_tmp_chat(context)
     PrintStyle.info(f"Email: continuing chat {context_id}")
+
+
+async def _handle_control_email(
+    handler_cfg: dict,
+    msg: InboundMessage,
+    existing_chats: list[disp.ChatSummary],
+    thread_id: str,
+) -> bool:
+    parsed = integration_commands.parse_command(msg.body)
+    if not parsed:
+        return False
+
+    target_context_id = ""
+    if thread_id:
+        for chat in existing_chats:
+            if chat["thread_id"] == thread_id:
+                target_context_id = chat["context_id"]
+                break
+
+    if not target_context_id:
+        if len(existing_chats) == 1:
+            target_context_id = existing_chats[0]["context_id"]
+        elif len(existing_chats) > 1:
+            await _send_control_email_reply(
+                handler_cfg,
+                msg,
+                "Multiple Agent Zero email chats match this sender. Reply inside the thread you want to control.",
+                thread_id=thread_id,
+            )
+            return True
+        else:
+            await _send_control_email_reply(
+                handler_cfg,
+                msg,
+                "No matching Agent Zero email chat was found. Reply inside an existing Agent Zero email thread to use /project, /config, or /send.",
+                thread_id=thread_id,
+            )
+            return True
+
+    context = AgentContext.get(target_context_id)
+    if not context:
+        await _send_control_email_reply(
+            handler_cfg,
+            msg,
+            "The matching Agent Zero email chat is no longer available. Send a normal email to start a fresh thread.",
+            thread_id=thread_id,
+        )
+        return True
+
+    response = integration_commands.try_handle_command(context, msg.body)
+    if response is None:
+        return False
+
+    await _send_control_email_reply(
+        handler_cfg,
+        msg,
+        response,
+        thread_id=context.data.get(disp.CTX_EMAIL_THREAD_ID, "") or thread_id,
+    )
+    return True
+
+
+def _apply_handler_model_preset(context: AgentContext, handler_cfg: dict) -> None:
+    preset_name = str(handler_cfg.get("chat_model_preset", "") or "").strip()
+    if not preset_name:
+        return
+    if not model_config.is_chat_override_allowed(context.agent0):
+        PrintStyle.warning(
+            f"Email ({handler_cfg.get('name', 'default')}): chat override is disabled,"
+            f" cannot apply preset '{preset_name}'"
+        )
+        return
+    if not model_config.get_preset_by_name(preset_name):
+        PrintStyle.warning(
+            f"Email ({handler_cfg.get('name', 'default')}): preset '{preset_name}' was not found"
+        )
+        return
+    context.set_data("chat_model_override", {"preset_name": preset_name})
+
+
+async def _send_control_email_reply(
+    handler_cfg: dict,
+    msg: InboundMessage,
+    body: str,
+    *,
+    thread_id: str = "",
+) -> str | None:
+    smtp_cfg = SmtpConfig(
+        server=handler_cfg.get("smtp_server", handler_cfg.get("imap_server", "")),
+        port=int(handler_cfg.get("smtp_port", 587)),
+        username=handler_cfg.get("username", ""),
+        password=handler_cfg.get("password", ""),
+    )
+
+    subject = _build_control_reply_subject(msg.subject, thread_id)
+    references = _merge_references(msg.references, msg.message_id)
+
+    return await send_reply(
+        config=smtp_cfg,
+        to=msg.sender,
+        subject=subject,
+        body=body,
+        in_reply_to=msg.message_id,
+        references=references,
+        attachments=None,
+    )
+
+
+def _build_control_reply_subject(subject: str, thread_id: str) -> str:
+    if thread_id:
+        return disp.build_reply_subject(subject, thread_id)
+    cleaned = subject.strip()
+    if not cleaned.lower().startswith("re:"):
+        cleaned = f"Re: {cleaned}"
+    return cleaned
+
+
+def _merge_references(existing: str, message_id: str) -> str:
+    refs = []
+    for ref in (existing or "").split():
+        if ref and ref not in refs:
+            refs.append(ref)
+    if message_id and message_id not in refs:
+        refs.append(message_id)
+    return " ".join(refs)
 
 
 # ------------------------------------------------------------------

--- a/plugins/_email_integration/webui/config.html
+++ b/plugins/_email_integration/webui/config.html
@@ -436,6 +436,21 @@
                                             </div>
                                         </div>
 
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Conversation config</div>
+                                                <div class="field-description">Optional model preset for new chats created from this inbox.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <select x-model="handler.chat_model_preset">
+                                                    <option value="">Default</option>
+                                                    <template x-for="preset in $store.emailConfig.modelPresets" :key="preset.name">
+                                                        <option :value="preset.name" x-text="preset.name"></option>
+                                                    </template>
+                                                </select>
+                                            </div>
+                                        </div>
+
                                     </div>
                                 </details>
                             </div>

--- a/plugins/_email_integration/webui/config.html
+++ b/plugins/_email_integration/webui/config.html
@@ -1,103 +1,71 @@
 <html>
+
 <head>
     <title>Email Integration</title>
+    <script type="module">
+        import { store } from "/plugins/_email_integration/webui/email-config-store.js";
+    </script>
 </head>
 
 <body>
-    <div x-data="{
-        get handlers() { return config?.handlers || [] },
-        editing: null,
-        testing: null,
-        test_results: null,
-        projects: [],
-        async init() {
-            try {
-                const { callJsonApi } = await import('/js/api.js');
-                const res = await callJsonApi('projects', { action: 'list' });
-                this.projects = res.data || [];
-            } catch (e) { this.projects = []; }
-        },
-        add_handler() {
-            if (!config.handlers) config.handlers = [];
-            config.handlers.push({
-                name: 'handler_' + (config.handlers.length + 1),
-                enabled: false,
-                account_type: 'imap',
-                imap_server: '',
-                imap_port: 993,
-                smtp_server: '',
-                smtp_port: 587,
-                username: '',
-                password: '',
-                poll_mode: 'seconds',
-                poll_interval_seconds: 15,
-                poll_interval_cron: '*/2 * * * *',
-                process_unread_days: 0,
-                sender_whitelist: [],
-                project: '',
-                dispatcher_model: 'utility',
-                dispatcher_instructions: '',
-                agent_instructions: ''
-            });
-            this.editing = config.handlers.length - 1;
-        },
-        remove_handler(idx) {
-            config.handlers.splice(idx, 1);
-            this.editing = null;
-        },
-        whitelist_text(handler) {
-            return (handler.sender_whitelist || []).join(', ');
-        },
-        set_whitelist(handler, val) {
-            handler.sender_whitelist = val.split(',').map(s => s.trim()).filter(s => s);
-        },
-        async test_connection(idx) {
-            this.testing = idx;
-            this.test_results = null;
-            try {
-                const { callJsonApi } = await import('/js/api.js');
-                const res = await callJsonApi('/plugins/_email_integration/test_connection', {
-                    handler: this.handlers[idx]
-                });
-                this.test_results = res;
-            } catch (e) {
-                this.test_results = { success: false, results: [{ test: 'Connection', ok: false, message: String(e) }] };
-            }
-            this.testing = null;
-        }
-    }">
+    <div x-data x-init="$store.emailConfig.init(config, context)" x-destroy="$store.emailConfig.cleanup()">
         <template x-if="config">
-            <div>
-                <div class="section-title">Email Integration</div>
-                <div class="section-description">
-                    Configure email handlers to communicate with Agent Zero via email.
-                    Each handler connects to an email account and polls for new messages.
-                </div>
+            <div class="email-settings">
+                <div class="section-title">Email</div>
 
-                <!-- Handler list -->
-                <template x-for="(handler, idx) in handlers" :key="idx">
-                    <div style="border: 1px solid var(--border-color, #333); border-radius: 8px; padding: 12px; margin-bottom: 8px; margin-top: 8px;">
+                <template x-if="$store.emailConfig.didInit && $store.emailConfig.handlers.length === 0">
+                    <div class="email-empty">
+                        <div class="email-empty-title">Connect Agent Zero and your email account</div>
+                        <div class="email-empty-copy">
+                            Most people only need a provider, an email address, and an app password.
+                        </div>
+                        <button class="btn btn-field" @click="$store.emailConfig.addHandler()">
+                            Connect
+                        </button>
+                    </div>
+                </template>
 
-                        <!-- Header row -->
-                        <div style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;"
-                             @click="editing = editing === idx ? null : idx">
-                            <div>
-                                <span style="font-weight: bold;" x-text="handler.name"></span>
-                                <span style="opacity: 0.6; margin-left: 8px;" x-text="handler.enabled ? 'Enabled' : 'Disabled'"></span>
+                <template x-for="(handler, idx) in $store.emailConfig.handlers" :key="idx">
+                    <div class="email-card">
+                        <div class="email-card-header" @click="$store.emailConfig.toggleEditing(idx)">
+                            <div class="email-card-heading">
+                                <div class="email-card-title" x-text="$store.emailConfig.handlerTitle(handler, idx)">
+                                </div>
+                                <div class="email-card-subtitle" x-text="$store.emailConfig.handlerSubtitle(handler)">
+                                </div>
                             </div>
-                            <button class="btn btn-action delete" @click.stop="$confirmClick($event, () => remove_handler(idx))" title="Remove handler">
-                                <span class="material-symbols-outlined">delete</span>
-                            </button>
+                            <div class="email-card-actions">
+                                <span class="email-status-pill"
+                                    :class="'tone-' + $store.emailConfig.statusTone(handler)"
+                                    x-text="$store.emailConfig.statusLabel(handler)"></span>
+                                <button class="btn btn-action delete"
+                                    @click.stop="$confirmClick($event, () => $store.emailConfig.removeHandler(idx))"
+                                    title="Remove inbox">
+                                    <span class="material-symbols-outlined">delete</span>
+                                </button>
+                                <span class="material-symbols-outlined email-card-chevron"
+                                    :class="{ 'is-open': $store.emailConfig.editing === idx }">expand_more</span>
+                            </div>
                         </div>
 
-                        <!-- Expanded editor -->
-                        <template x-if="editing === idx">
-                            <div style="margin-top: 16px;">
+                        <template x-if="$store.emailConfig.editing === idx">
+                            <div class="email-card-body">
+                                <div class="email-intro-copy">
+                                    <div x-text="$store.emailConfig.providerHint(handler)"></div>
+                                    <template x-if="$store.emailConfig.providerHelpUrl(handler)">
+                                        <a class="email-intro-link"
+                                           :href="$store.emailConfig.providerHelpUrl(handler)"
+                                           target="_blank"
+                                           rel="noopener"
+                                           x-text="$store.emailConfig.providerHelpLabel(handler)"></a>
+                                    </template>
+                                </div>
 
                                 <div class="field">
                                     <div class="field-label">
-                                        <div class="field-title">Enabled</div>
-                                        <div class="field-description">Enable or disable inbox polling for this handler</div>
+                                        <div class="field-title">Turn on this inbox</div>
+                                        <div class="field-description">Enable when you are ready for Agent Zero to start
+                                            checking mail.</div>
                                     </div>
                                     <div class="field-control">
                                         <label class="toggle">
@@ -109,223 +77,702 @@
 
                                 <div class="field">
                                     <div class="field-label">
-                                        <div class="field-title">Handler Name</div>
-                                        <div class="field-description">Unique identifier for this email handler</div>
+                                        <div class="field-title">Provider</div>
+                                        <div class="field-description">Pick the provider first. We will fill in the
+                                            common server settings for you.</div>
                                     </div>
                                     <div class="field-control">
-                                        <input type="text" x-model="handler.name" placeholder="e.g. support" />
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Account Type</div>
-                                        <div class="field-description">IMAP for most providers, Exchange for Microsoft Exchange/Office 365</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <select x-model="handler.account_type">
-                                            <option value="imap">IMAP</option>
+                                        <select :value="$store.emailConfig.providerValue(handler)"
+                                            @change="$store.emailConfig.applyProvider(handler, $event.target.value)">
+                                            <option value="">Choose a provider</option>
+                                            <option value="gmail">Gmail</option>
+                                            <option value="icloud">iCloud Mail</option>
+                                            <option value="microsoft365">Outlook / Microsoft 365</option>
+                                            <option value="yahoo">Yahoo Mail</option>
                                             <option value="exchange">Exchange</option>
+                                            <option value="custom-imap">Custom IMAP</option>
                                         </select>
                                     </div>
                                 </div>
 
                                 <div class="field">
                                     <div class="field-label">
-                                        <div class="field-title">IMAP Server</div>
-                                        <div class="field-description">Incoming mail server hostname</div>
+                                        <div class="field-title">Email address</div>
+                                        <div class="field-description">Usually the full address for this inbox.</div>
                                     </div>
                                     <div class="field-control">
-                                        <input type="text" x-model="handler.imap_server" placeholder="imap.gmail.com" />
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">IMAP Port</div>
-                                        <div class="field-description">SSL port for incoming mail, usually 993</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <input type="number" x-model.number="handler.imap_port" placeholder="993" />
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">SMTP Server</div>
-                                        <div class="field-description">Outgoing mail server hostname. Defaults to IMAP server if empty</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <input type="text" x-model="handler.smtp_server" placeholder="smtp.gmail.com" />
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">SMTP Port</div>
-                                        <div class="field-description">TLS port for outgoing mail, usually 587</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <input type="number" x-model.number="handler.smtp_port" placeholder="587" />
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Username</div>
-                                        <div class="field-description">Email account login, usually the full email address</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <input type="text" x-model="handler.username" placeholder="user@domain.com" />
+                                        <input type="text" x-model="handler.username"
+                                            @input="$store.emailConfig.maybeAutoname(handler)"
+                                            placeholder="name@company.com" />
                                     </div>
                                 </div>
 
                                 <div class="field">
                                     <div class="field-label">
                                         <div class="field-title">Password</div>
-                                        <div class="field-description">Account password or app-specific password</div>
+                                        <div class="field-description">An app password is best. Many mail providers
+                                            block regular account passwords.</div>
                                     </div>
                                     <div class="field-control">
                                         <input type="password" x-model="handler.password" />
                                     </div>
                                 </div>
 
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Poll Mode</div>
-                                        <div class="field-description">How to schedule inbox checks</div>
+                                <template x-if="$store.emailConfig.showExchangeServer(handler)">
+                                    <div>
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title"
+                                                    x-text="$store.emailConfig.incomingLabel(handler)"></div>
+                                                <div class="field-description"
+                                                    x-text="$store.emailConfig.incomingDescription(handler)"></div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="text" x-model="handler.imap_server"
+                                                    :placeholder="$store.emailConfig.incomingPlaceholder(handler)" />
+                                            </div>
+                                        </div>
                                     </div>
-                                    <div class="field-control">
-                                        <select x-model="handler.poll_mode">
-                                            <option value="seconds">Interval (seconds)</option>
-                                            <option value="cron">Cron expression</option>
-                                        </select>
-                                    </div>
-                                </div>
+                                </template>
 
-                                <div class="field" x-show="handler.poll_mode === 'seconds'">
-                                    <div class="field-label">
-                                        <div class="field-title">Poll Interval (seconds)</div>
-                                        <div class="field-description">How often to check for new emails</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <input type="number" x-model.number="handler.poll_interval_seconds" min="5" placeholder="15" />
-                                    </div>
-                                </div>
+                                <template x-if="$store.emailConfig.showManualServers(handler)">
+                                    <div class="email-grid">
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Incoming mail server</div>
+                                                <div class="field-description">The IMAP server for this inbox.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="text" x-model="handler.imap_server"
+                                                    placeholder="imap.your-provider.com" />
+                                            </div>
+                                        </div>
 
-                                <div class="field" x-show="handler.poll_mode !== 'seconds'">
-                                    <div class="field-label">
-                                        <div class="field-title">Cron Expression</div>
-                                        <div class="field-description">e.g. */2 * * * * for every 2 minutes</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <input type="text" x-model="handler.poll_interval_cron" placeholder="*/2 * * * *" />
-                                    </div>
-                                </div>
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Incoming port</div>
+                                                <div class="field-description">993 is the usual SSL port.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="number" x-model.number="handler.imap_port"
+                                                    placeholder="993" />
+                                            </div>
+                                        </div>
 
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Process Unread (days)</div>
-                                        <div class="field-description">Process unread emails from the last N days on every startup. 0 = only track new emails</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <input type="number" x-model.number="handler.process_unread_days" min="0" placeholder="0" />
-                                    </div>
-                                </div>
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Outgoing mail server</div>
+                                                <div class="field-description">The SMTP server used for replies.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="text" x-model="handler.smtp_server"
+                                                    placeholder="smtp.your-provider.com" />
+                                            </div>
+                                        </div>
 
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Sender Whitelist</div>
-                                        <div class="field-description">Comma-separated. Empty = allow all. Wildcards supported (e.g. *@company.com)</div>
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Outgoing port</div>
+                                                <div class="field-description">587 is the usual TLS port.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="number" x-model.number="handler.smtp_port"
+                                                    placeholder="587" />
+                                            </div>
+                                        </div>
                                     </div>
-                                    <div class="field-control">
-                                        <input type="text" :value="whitelist_text(handler)" @input="set_whitelist(handler, $event.target.value)" placeholder="*@company.com, boss@other.com" />
-                                    </div>
-                                </div>
+                                </template>
 
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Project</div>
-                                        <div class="field-description">Project to activate for email chats</div>
+                                <template
+                                    x-if="!$store.emailConfig.showManualServers(handler) && !$store.emailConfig.showExchangeServer(handler) && $store.emailConfig.providerValue(handler)">
+                                    <div class="email-note">
+                                        Server settings are filled in for <span
+                                            x-text="$store.emailConfig.providerLabel($store.emailConfig.providerValue(handler))"></span>.
+                                        You can change them any time in Advanced.
                                     </div>
-                                    <div class="field-control">
-                                        <select :value="handler.project" @change="handler.project = $event.target.value">
-                                            <option value="">No project</option>
-                                            <template x-for="proj in projects" :key="proj.name">
-                                                <option :value="proj.name" x-text="proj.title || proj.name" :selected="handler.project === proj.name"></option>
-                                            </template>
-                                        </select>
-                                    </div>
-                                </div>
+                                </template>
 
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Dispatcher Model</div>
-                                        <div class="field-description">LLM model used to route incoming emails to chats. Utility is faster, chat is more capable</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <select x-model="handler.dispatcher_model">
-                                            <option value="utility">Utility</option>
-                                            <option value="chat">Chat</option>
-                                        </select>
-                                    </div>
-                                </div>
-
-                                <div class="field">
-                                    <div class="field-label">
-                                        <div class="field-title">Dispatcher Instructions</div>
-                                        <div class="field-description">Extra instructions for the AI that routes emails to chats</div>
-                                    </div>
-                                    <div class="field-control">
-                                        <textarea x-model="handler.dispatcher_instructions" rows="3" placeholder="e.g. Always start a new chat for emails from support@..."></textarea>
-                                    </div>
+                                <div class="email-missing" x-show="$store.emailConfig.missingBits(handler).length > 0">
+                                    Still needed:
+                                    <span x-text="$store.emailConfig.missingBits(handler).join(', ')"></span>
                                 </div>
 
                                 <div class="field">
                                     <div class="field-label">
-                                        <div class="field-title">Agent Instructions</div>
-                                        <div class="field-description">Extra instructions for the agent in email chats</div>
+                                        <div class="field-title">Routing instructions</div>
+                                        <div class="field-description">Extra guidance for how incoming email should be
+                                            routed into chats.</div>
                                     </div>
                                     <div class="field-control">
-                                        <textarea x-model="handler.agent_instructions" rows="3" placeholder="e.g. Always respond in formal English..."></textarea>
+                                        <textarea x-model="handler.dispatcher_instructions" rows="3"
+                                            placeholder="Always start a new chat for invoices or billing questions."></textarea>
                                     </div>
                                 </div>
 
-                                <!-- Test connection -->
-                                <div style="margin-top: 12px; display: flex; align-items: center; gap: 12px;">
-                                    <button class="btn btn-field" @click.stop="test_connection(idx)"
-                                            :disabled="testing === idx">
-                                        <span x-show="testing !== idx">Test Connection</span>
-                                        <span x-show="testing === idx">Testing...</span>
+                                <div class="field">
+                                    <div class="field-label">
+                                        <div class="field-title">Reply instructions</div>
+                                        <div class="field-description">Extra guidance for the agent when it replies by
+                                            email.</div>
+                                    </div>
+                                    <div class="field-control">
+                                        <textarea x-model="handler.agent_instructions" rows="3"
+                                            placeholder="Reply in a calm, concise tone."></textarea>
+                                    </div>
+                                </div>
+
+                                <div class="email-test-panel">
+                                    <div class="email-test-copy">
+                                        <div class="email-test-title">Check the connection</div>
+                                        <div class="email-test-description"
+                                            x-text="$store.emailConfig.testIntro(handler)"></div>
+                                    </div>
+                                    <button class="btn btn-field" @click.stop="$store.emailConfig.testConnection(idx)"
+                                        :disabled="$store.emailConfig.testing === idx || !$store.emailConfig.canTest(handler)">
+                                        <span x-text="$store.emailConfig.testButtonLabel(handler, idx)"></span>
                                     </button>
                                 </div>
 
-                                <!-- Test results -->
-                                <template x-if="test_results && editing === idx">
-                                    <div style="margin-top: 8px; padding: 8px 12px; border-radius: 6px; font-size: 0.85rem;
-                                                border: 1px solid var(--border-color, #333);">
-                                        <template x-for="r in test_results.results" :key="r.test">
-                                            <div style="display: flex; align-items: center; gap: 8px; padding: 4px 0;">
-                                                <span x-text="r.ok ? '✓' : '✗'"
-                                                      :style="'font-weight: bold; color:' + (r.ok ? '#4caf50' : '#f44336')"></span>
-                                                <span style="font-weight: 500; min-width: 50px;" x-text="r.test"></span>
-                                                <span style="opacity: 0.8;" x-text="r.message"></span>
+                                <template
+                                    x-if="$store.emailConfig.testResults && $store.emailConfig.testResultsFor === idx">
+                                    <div class="email-results"
+                                        :class="{ 'is-error': !$store.emailConfig.testResults.success }">
+                                        <template x-for="result in $store.emailConfig.testResults.results"
+                                            :key="result.test + result.message">
+                                            <div class="email-result-row">
+                                                <span class="email-result-icon" x-text="result.ok ? '✓' : '✗'"></span>
+                                                <div class="email-result-copy">
+                                                    <div class="email-result-title"
+                                                        x-text="$store.emailConfig.resultTitle(result)"></div>
+                                                    <div class="email-result-message"
+                                                        x-text="$store.emailConfig.resultMessage(result)"></div>
+                                                </div>
                                             </div>
                                         </template>
                                     </div>
                                 </template>
 
+                                <details class="email-advanced">
+                                    <summary>
+                                        <span>Advanced</span>
+                                        <span class="material-symbols-outlined email-advanced-chevron"
+                                            aria-hidden="true">keyboard_arrow_down</span>
+                                    </summary>
+                                    <div class="email-advanced-body">
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Inbox name</div>
+                                                <div class="field-description">A friendly internal label for this
+                                                    connection.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="text" x-model="handler.name" placeholder="support" />
+                                            </div>
+                                        </div>
+
+                                        <div class="email-grid">
+                                            <div class="field">
+                                                <div class="field-label">
+                                                    <div class="field-title">Incoming mail server</div>
+                                                    <div class="field-description">Override the auto-filled incoming
+                                                        server if needed.</div>
+                                                </div>
+                                                <div class="field-control">
+                                                    <input type="text" x-model="handler.imap_server"
+                                                        placeholder="imap.your-provider.com" />
+                                                </div>
+                                            </div>
+
+                                            <div class="field">
+                                                <div class="field-label">
+                                                    <div class="field-title">Incoming port</div>
+                                                    <div class="field-description">993 is the common SSL port.</div>
+                                                </div>
+                                                <div class="field-control">
+                                                    <input type="number" x-model.number="handler.imap_port"
+                                                        placeholder="993" />
+                                                </div>
+                                            </div>
+
+                                            <div class="field">
+                                                <div class="field-label">
+                                                    <div class="field-title">Outgoing mail server</div>
+                                                    <div class="field-description">Override the auto-filled reply server
+                                                        if needed.</div>
+                                                </div>
+                                                <div class="field-control">
+                                                    <input type="text" x-model="handler.smtp_server"
+                                                        placeholder="smtp.your-provider.com" />
+                                                </div>
+                                            </div>
+
+                                            <div class="field">
+                                                <div class="field-label">
+                                                    <div class="field-title">Outgoing port</div>
+                                                    <div class="field-description">587 is the common TLS port.</div>
+                                                </div>
+                                                <div class="field-control">
+                                                    <input type="number" x-model.number="handler.smtp_port"
+                                                        placeholder="587" />
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Project</div>
+                                                <div class="field-description">Open email conversations inside a
+                                                    specific project.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <select :value="handler.project"
+                                                    @change="handler.project = $event.target.value">
+                                                    <option value="">No project</option>
+                                                    <template x-for="proj in $store.emailConfig.projects"
+                                                        :key="proj.name">
+                                                        <option :value="proj.name" x-text="proj.title || proj.name"
+                                                            :selected="handler.project === proj.name"></option>
+                                                    </template>
+                                                </select>
+                                            </div>
+                                        </div>
+
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Allowed senders</div>
+                                                <div class="field-description">Leave empty to allow anyone. Wildcards
+                                                    like *@company.com work.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="text" :value="$store.emailConfig.whitelistText(handler)"
+                                                    @input="$store.emailConfig.setWhitelist(handler, $event.target.value)"
+                                                    placeholder="*@company.com, founder@company.com" />
+                                            </div>
+                                        </div>
+
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Catch up on unread mail</div>
+                                                <div class="field-description">On startup, process unread mail from the
+                                                    last N days. Use 0 for brand-new mail only.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="number" x-model.number="handler.process_unread_days"
+                                                    min="0" placeholder="0" />
+                                            </div>
+                                        </div>
+
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Check for new mail</div>
+                                                <div class="field-description"
+                                                    x-text="$store.emailConfig.frequencyHint(handler)"></div>
+                                            </div>
+                                            <div class="field-control">
+                                                <select :value="$store.emailConfig.frequencyValue(handler)"
+                                                    @change="$store.emailConfig.applyFrequency(handler, $event.target.value)">
+                                                    <option value="15">Every 15 seconds</option>
+                                                    <option value="30">Every 30 seconds</option>
+                                                    <option value="60">Every minute</option>
+                                                    <option value="300">Every 5 minutes</option>
+                                                    <option value="900">Every 15 minutes</option>
+                                                    <option value="custom">Custom schedule</option>
+                                                </select>
+                                            </div>
+                                        </div>
+
+                                        <div class="field"
+                                            x-show="$store.emailConfig.frequencyValue(handler) === 'custom'">
+                                            <div class="field-label">
+                                                <div class="field-title">Scheduling mode</div>
+                                                <div class="field-description">Use seconds for a simple interval, or
+                                                    switch to cron for full control.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <select x-model="handler.poll_mode">
+                                                    <option value="seconds">Seconds</option>
+                                                    <option value="cron">Cron</option>
+                                                </select>
+                                            </div>
+                                        </div>
+
+                                        <div class="field"
+                                            x-show="$store.emailConfig.frequencyValue(handler) === 'custom' && handler.poll_mode === 'seconds'">
+                                            <div class="field-label">
+                                                <div class="field-title">Poll interval (seconds)</div>
+                                                <div class="field-description">The exact delay between inbox checks.
+                                                </div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="number" x-model.number="handler.poll_interval_seconds"
+                                                    min="5" placeholder="60" />
+                                            </div>
+                                        </div>
+
+                                        <div class="field"
+                                            x-show="$store.emailConfig.frequencyValue(handler) === 'custom' && handler.poll_mode === 'cron'">
+                                            <div class="field-label">
+                                                <div class="field-title">Cron expression</div>
+                                                <div class="field-description">For example, */2 * * * * checks every two
+                                                    minutes.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <input type="text" x-model="handler.poll_interval_cron"
+                                                    placeholder="*/2 * * * *" />
+                                            </div>
+                                        </div>
+
+                                        <div class="field">
+                                            <div class="field-label">
+                                                <div class="field-title">Routing model</div>
+                                                <div class="field-description">Utility is faster. Chat is more capable
+                                                    when routing gets nuanced.</div>
+                                            </div>
+                                            <div class="field-control">
+                                                <select x-model="handler.dispatcher_model">
+                                                    <option value="utility">Utility</option>
+                                                    <option value="chat">Chat</option>
+                                                </select>
+                                            </div>
+                                        </div>
+
+                                    </div>
+                                </details>
                             </div>
                         </template>
                     </div>
                 </template>
 
-                <button class="btn btn-field" @click="add_handler()" style="margin-top: 8px;">
-                    Add Handler
-                </button>
+                <template x-if="$store.emailConfig.handlers.length > 0">
+                    <button class="btn btn-field email-add-another" @click="$store.emailConfig.addHandler()">
+                        Connect another inbox
+                    </button>
+                </template>
             </div>
         </template>
     </div>
+
+    <style>
+        .email-settings {
+            display: flex;
+            flex-direction: column;
+            gap: 0.9rem;
+        }
+
+        .email-advanced summary {
+            cursor: pointer;
+            list-style: none;
+            font-weight: 700;
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .email-advanced summary::-webkit-details-marker {
+            display: none;
+        }
+
+        .email-advanced summary {
+            padding: 0.95rem 1rem;
+        }
+
+        .email-advanced-chevron {
+            margin-left: auto;
+            flex: 0 0 auto;
+            transition: transform 0.18s ease, opacity 0.18s ease;
+            opacity: 0.72;
+        }
+
+        .email-advanced[open] .email-advanced-chevron {
+            transform: rotate(180deg);
+            opacity: 1;
+        }
+
+        .email-guide-card {
+            border: 1px solid color-mix(in srgb, var(--color-border) 80%, white 20%);
+            border-radius: 12px;
+            padding: 0.9rem 1rem;
+            background: color-mix(in srgb, var(--color-background) 88%, white 12%);
+        }
+
+        .email-guide-title {
+            font-weight: 700;
+            margin-bottom: 0.55rem;
+        }
+
+        .email-guide-list {
+            margin: 0;
+            padding-left: 1.1rem;
+            color: var(--color-text-secondary);
+            line-height: 1.55;
+        }
+
+        .email-empty {
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background: color-mix(in srgb, var(--color-background) 94%, white 6%);
+        }
+
+        .email-empty-title {
+            font-size: 1.05rem;
+            font-weight: 700;
+        }
+
+        .email-empty-copy {
+            margin-top: 0.35rem;
+            margin-bottom: 0.9rem;
+            color: var(--color-text-secondary);
+            line-height: 1.5;
+        }
+
+        .email-card {
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .email-card-header {
+            display: flex;
+            justify-content: space-between;
+            gap: 1rem;
+            align-items: flex-start;
+            padding: var(--spacing-sm) 0;
+            border-bottom: 1px solid var(--color-border);
+            cursor: pointer;
+        }
+
+        .email-card-heading {
+            min-width: 0;
+            flex: 1 1 auto;
+        }
+
+        .email-card-title {
+            font-weight: 700;
+            font-size: 1rem;
+            line-height: 1.35;
+            overflow-wrap: anywhere;
+        }
+
+        .email-card-subtitle {
+            margin-top: 0.3rem;
+            color: var(--color-text-secondary);
+            font-size: var(--font-size-small);
+            line-height: 1.45;
+        }
+
+        .email-card-actions {
+            display: flex;
+            align-items: center;
+            gap: 0.45rem;
+            flex: 0 0 auto;
+        }
+
+        .email-card-chevron {
+            transition: transform 0.18s ease;
+            opacity: 0.7;
+        }
+
+        .email-card-chevron.is-open {
+            transform: rotate(180deg);
+        }
+
+        .email-intro-copy {
+            margin: 1rem 0;
+            padding: 0.85rem 0.95rem;
+            border-radius: 12px;
+            background: color-mix(in srgb, #3b82f6 12%, var(--color-background) 88%);
+            color: var(--color-text-secondary);
+            line-height: 1.5;
+        }
+
+        .email-intro-link {
+            display: inline-flex;
+            margin-top: 0.55rem;
+            color: var(--color-highlight);
+            font-weight: 600;
+            text-decoration: none;
+        }
+
+        .email-intro-link:hover {
+            text-decoration: underline;
+        }
+
+        .email-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 0.85rem;
+        }
+
+        .email-note,
+        .email-missing {
+            margin-top: 0.2rem;
+            margin-bottom: 0.85rem;
+            padding: 0.8rem 0.9rem;
+            border-radius: 12px;
+            font-size: var(--font-size-small);
+            line-height: 1.5;
+        }
+
+        .email-note {
+            background: color-mix(in srgb, var(--color-background) 82%, white 18%);
+            color: var(--color-text-secondary);
+        }
+
+        .email-missing {
+            background: color-mix(in srgb, #f59e0b 14%, var(--color-background) 86%);
+            color: var(--color-text-secondary);
+        }
+
+        .email-advanced {
+            margin-top: 0.95rem;
+            border: 1px solid color-mix(in srgb, var(--color-border) 88%, white 12%);
+            border-radius: 14px;
+            overflow: hidden;
+        }
+
+        .email-advanced summary {
+            padding: 0.9rem 1rem;
+            background: color-mix(in srgb, var(--color-background) 88%, white 12%);
+        }
+
+        .email-advanced-body {
+            padding: 1rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.2rem;
+        }
+
+        .email-test-panel {
+            margin-top: 1rem;
+            padding: var(--spacing-xs) 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        .email-test-copy {
+            min-width: 0;
+        }
+
+        .email-test-title {
+            font-weight: 700;
+            margin-bottom: 0.25rem;
+        }
+
+        .email-test-description {
+            color: var(--color-text-secondary);
+            line-height: 1.5;
+            font-size: var(--font-size-small);
+        }
+
+        .email-results {
+            margin-top: 0.9rem;
+            border-radius: 14px;
+            border: 1px solid color-mix(in srgb, #22c55e 28%, var(--color-border) 72%);
+            background: color-mix(in srgb, #22c55e 8%, var(--color-background) 92%);
+            padding: 0.35rem 0.9rem;
+        }
+
+        .email-results.is-error {
+            border-color: color-mix(in srgb, #ef4444 28%, var(--color-border) 72%);
+            background: color-mix(in srgb, #ef4444 8%, var(--color-background) 92%);
+        }
+
+        .email-result-row {
+            display: flex;
+            align-items: flex-start;
+            gap: 0.8rem;
+            padding: 0.7rem 0;
+        }
+
+        .email-result-row+.email-result-row {
+            border-top: 1px solid color-mix(in srgb, var(--color-border) 85%, white 15%);
+        }
+
+        .email-result-icon {
+            width: 1.25rem;
+            font-weight: 800;
+            line-height: 1.3;
+        }
+
+        .email-result-copy {
+            min-width: 0;
+        }
+
+        .email-result-title {
+            font-weight: 700;
+            margin-bottom: 0.18rem;
+        }
+
+        .email-result-message {
+            color: var(--color-text-secondary);
+            line-height: 1.5;
+            font-size: var(--font-size-small);
+            overflow-wrap: anywhere;
+        }
+
+        .email-status-pill {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 5.25rem;
+            padding: 0.35rem 0.7rem;
+            border-radius: 999px;
+            font-size: 0.8rem;
+            font-weight: 700;
+            letter-spacing: 0.01em;
+        }
+
+        .email-status-pill.tone-success {
+            background: rgba(34, 197, 94, 0.14);
+            color: #7ee7a4;
+        }
+
+        .email-status-pill.tone-ready {
+            background: rgba(59, 130, 246, 0.16);
+            color: #93c5fd;
+        }
+
+        .email-status-pill.tone-warning {
+            background: rgba(245, 158, 11, 0.16);
+            color: #fcd34d;
+        }
+
+        .email-status-pill.tone-muted {
+            background: rgba(148, 163, 184, 0.14);
+            color: #cbd5e1;
+        }
+
+        .email-add-another {
+            align-self: flex-start;
+        }
+
+        @media (max-width: 900px) {
+
+            .email-guide-body,
+            .email-grid {
+                grid-template-columns: minmax(0, 1fr);
+            }
+        }
+
+        @media (max-width: 640px) {
+
+            .email-card-header,
+            .email-test-panel {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            .email-card-actions {
+                justify-content: space-between;
+                width: 100%;
+            }
+
+            .email-status-pill {
+                min-width: 0;
+            }
+        }
+    </style>
 </body>
 
 </html>

--- a/plugins/_email_integration/webui/email-config-store.js
+++ b/plugins/_email_integration/webui/email-config-store.js
@@ -1,0 +1,404 @@
+import { createStore } from "/js/AlpineStore.js";
+import * as API from "/js/api.js";
+
+const API_BASE = "/plugins/_email_integration";
+const GMAIL_APP_PASSWORDS_URL = "https://support.google.com/mail/answer/185833?hl=en";
+const PRESETS = {
+  "": {
+    label: "Choose a provider",
+    account_type: "imap",
+    imap_server: "",
+    imap_port: 993,
+    smtp_server: "",
+    smtp_port: 587,
+  },
+  gmail: {
+    label: "Gmail",
+    account_type: "imap",
+    imap_server: "imap.gmail.com",
+    imap_port: 993,
+    smtp_server: "smtp.gmail.com",
+    smtp_port: 587,
+  },
+  icloud: {
+    label: "iCloud Mail",
+    account_type: "imap",
+    imap_server: "imap.mail.me.com",
+    imap_port: 993,
+    smtp_server: "smtp.mail.me.com",
+    smtp_port: 587,
+  },
+  microsoft365: {
+    label: "Outlook / Microsoft 365",
+    account_type: "imap",
+    imap_server: "outlook.office365.com",
+    imap_port: 993,
+    smtp_server: "smtp.office365.com",
+    smtp_port: 587,
+  },
+  yahoo: {
+    label: "Yahoo Mail",
+    account_type: "imap",
+    imap_server: "imap.mail.yahoo.com",
+    imap_port: 993,
+    smtp_server: "smtp.mail.yahoo.com",
+    smtp_port: 587,
+  },
+  exchange: {
+    label: "Exchange",
+    account_type: "exchange",
+    imap_server: "outlook.office365.com",
+    imap_port: 993,
+    smtp_server: "smtp.office365.com",
+    smtp_port: 587,
+  },
+  "custom-imap": {
+    label: "Custom IMAP",
+    account_type: "imap",
+    imap_server: "",
+    imap_port: 993,
+    smtp_server: "",
+    smtp_port: 587,
+  },
+};
+
+function ensureConfig(config) {
+  if (!config || typeof config !== "object") return;
+  if (!Array.isArray(config.handlers)) config.handlers = [];
+}
+
+export const store = createStore("emailConfig", {
+  config: null,
+  context: null,
+  editing: null,
+  testing: null,
+  testResults: null,
+  testResultsFor: null,
+  guideOpen: false,
+  didInit: false,
+  projects: [],
+  presets: PRESETS,
+
+  get handlers() {
+    ensureConfig(this.config);
+    return Array.isArray(this.config?.handlers) ? this.config.handlers : [];
+  },
+
+  async init(config, context = null) {
+    this.config = config || null;
+    this.context = context;
+    this.didInit = false;
+    ensureConfig(this.config);
+    this.editing = this.handlers.length === 1 ? 0 : null;
+    this.testing = null;
+    this.testResults = null;
+    this.testResultsFor = null;
+    this.guideOpen = this.handlers.length === 0 && window.innerWidth > 720;
+    if (this.handlers.length === 0) this._startInitialHandlerFlow();
+    this.didInit = true;
+
+    try {
+      const response = await API.callJsonApi("projects", { action: "list" });
+      this.projects = response.data || [];
+    } catch (_) {
+      this.projects = [];
+    }
+  },
+
+  cleanup() {
+    this.config = null;
+    this.context = null;
+    this.editing = null;
+    this.testing = null;
+    this.testResults = null;
+    this.testResultsFor = null;
+    this.guideOpen = false;
+    this.didInit = false;
+  },
+
+  newHandler() {
+    return {
+      name: "",
+      enabled: false,
+      account_type: "imap",
+      imap_server: "",
+      imap_port: 993,
+      smtp_server: "",
+      smtp_port: 587,
+      username: "",
+      password: "",
+      poll_mode: "seconds",
+      poll_interval_seconds: 60,
+      poll_interval_cron: "*/2 * * * *",
+      process_unread_days: 0,
+      sender_whitelist: [],
+      project: "",
+      dispatcher_model: "utility",
+      dispatcher_instructions: "",
+      agent_instructions: "",
+    };
+  },
+
+  addHandler() {
+    ensureConfig(this.config);
+    this.config.handlers.push(this.newHandler());
+    this.editing = this.config.handlers.length - 1;
+    this.testResults = null;
+    this.testResultsFor = null;
+  },
+
+  removeHandler(idx) {
+    this.handlers.splice(idx, 1);
+    if (this.editing === idx) this.editing = null;
+    if (this.editing !== null && this.editing > idx) this.editing -= 1;
+    if (this.testResultsFor === idx) {
+      this.testResults = null;
+      this.testResultsFor = null;
+    }
+  },
+
+  toggleEditing(idx) {
+    this.editing = this.editing === idx ? null : idx;
+    if (this.testResultsFor !== idx) {
+      this.testResults = null;
+      this.testResultsFor = null;
+    }
+  },
+
+  providerValue(handler) {
+    const incoming = String(handler.imap_server || "").trim().toLowerCase();
+    const outgoing = String(handler.smtp_server || "").trim().toLowerCase();
+    const accountType = handler.account_type || "imap";
+
+    if (!incoming && !outgoing && !handler.username && !handler.password) return "";
+    if (accountType === "exchange") return "exchange";
+    if (incoming === "imap.gmail.com" || outgoing === "smtp.gmail.com") return "gmail";
+    if (incoming === "imap.mail.me.com" || outgoing === "smtp.mail.me.com") return "icloud";
+    if (incoming === "outlook.office365.com" || outgoing === "smtp.office365.com") return "microsoft365";
+    if (incoming === "imap.mail.yahoo.com" || outgoing === "smtp.mail.yahoo.com") return "yahoo";
+    return "custom-imap";
+  },
+
+  providerLabel(value) {
+    return this.presets[value]?.label || "Custom IMAP";
+  },
+
+  applyProvider(handler, value) {
+    const preset = this.presets[value];
+    if (!preset) return;
+    const previous = this.providerValue(handler);
+
+    handler.account_type = preset.account_type;
+
+    if (value === "custom-imap") {
+      if (previous !== "custom-imap") {
+        handler.imap_server = "";
+        handler.smtp_server = "";
+      }
+      if (!handler.imap_port) handler.imap_port = 993;
+      if (!handler.smtp_port) handler.smtp_port = 587;
+      return;
+    }
+
+    handler.imap_server = preset.imap_server;
+    handler.imap_port = preset.imap_port;
+    handler.smtp_server = preset.smtp_server;
+    handler.smtp_port = preset.smtp_port;
+  },
+
+  providerHint(handler) {
+    const provider = this.providerValue(handler);
+    if (provider === "gmail") return "Use a Google App Password. A regular Gmail password usually will not work here.";
+    if (provider === "icloud") return "Use an app-specific password from your Apple account settings.";
+    if (provider === "microsoft365") return "Most Outlook and Microsoft 365 inboxes work with this preset.";
+    if (provider === "yahoo") return "Yahoo Mail usually works best with an app password.";
+    if (provider === "exchange") return "Choose Exchange only if your organization requires it. For the simplest setup, try Outlook / Microsoft 365 first.";
+    if (provider === "custom-imap") return "Bring your own incoming and outgoing mail server details.";
+    return "How to start: turn on inbox, pick your provider, then add your email address and password.";
+  },
+
+  providerHelpUrl(handler) {
+    return this.providerValue(handler) === "gmail" ? GMAIL_APP_PASSWORDS_URL : "";
+  },
+
+  providerHelpLabel(handler) {
+    if (this.providerValue(handler) !== "gmail") return "";
+    return "Google's guide to create a Gmail App Password";
+  },
+
+  showManualServers(handler) {
+    return this.providerValue(handler) === "custom-imap";
+  },
+
+  showExchangeServer(handler) {
+    return this.providerValue(handler) === "exchange";
+  },
+
+  incomingLabel(handler) {
+    return this.showExchangeServer(handler) ? "Exchange server" : "Incoming mail server";
+  },
+
+  incomingDescription(handler) {
+    return this.showExchangeServer(handler)
+      ? "The Exchange or Microsoft 365 server for this inbox"
+      : "The IMAP server for incoming mail";
+  },
+
+  incomingPlaceholder(handler) {
+    return this.showExchangeServer(handler) ? "outlook.office365.com" : "imap.your-provider.com";
+  },
+
+  scheduleLabel(handler) {
+    const value = this.frequencyValue(handler);
+    if (value === "15") return "Checks every 15 seconds";
+    if (value === "30") return "Checks every 30 seconds";
+    if (value === "60") return "Checks every minute";
+    if (value === "300") return "Checks every 5 minutes";
+    if (value === "900") return "Checks every 15 minutes";
+    return "Uses a custom schedule";
+  },
+
+  frequencyValue(handler) {
+    if (handler.poll_mode !== "seconds") return "custom";
+    const seconds = Number(handler.poll_interval_seconds || 0);
+    if ([15, 30, 60, 300, 900].includes(seconds)) return String(seconds);
+    return "custom";
+  },
+
+  applyFrequency(handler, value) {
+    if (value === "custom") {
+      if (handler.poll_mode !== "cron") handler.poll_mode = "seconds";
+      if (!handler.poll_interval_seconds) handler.poll_interval_seconds = 60;
+      return;
+    }
+    handler.poll_mode = "seconds";
+    handler.poll_interval_seconds = Number(value);
+  },
+
+  frequencyHint(handler) {
+    return this.frequencyValue(handler) === "custom"
+      ? "You are using a custom schedule. You can change the raw timing in Advanced."
+      : this.scheduleLabel(handler);
+  },
+
+  whitelistText(handler) {
+    return (handler.sender_whitelist || []).join(", ");
+  },
+
+  setWhitelist(handler, value) {
+    handler.sender_whitelist = value
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry);
+  },
+
+  slugify(value) {
+    return String(value || "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "");
+  },
+
+  maybeAutoname(handler) {
+    const current = String(handler.name || "").trim();
+    if (current && !/^handler_\d+$/.test(current)) return;
+    const email = String(handler.username || "").trim();
+    const localPart = email.split("@")[0] || "";
+    const nextName = this.slugify(localPart);
+    if (nextName) handler.name = nextName;
+  },
+
+  missingBits(handler) {
+    const missing = [];
+    const provider = this.providerValue(handler);
+    if (!provider) missing.push("provider");
+    if (!handler.username) missing.push("email address");
+    if (!handler.password) missing.push("password");
+    if ((this.showManualServers(handler) || this.showExchangeServer(handler)) && !handler.imap_server) {
+      missing.push(this.showExchangeServer(handler) ? "Exchange server" : "incoming server");
+    }
+    if (this.showManualServers(handler) && !handler.smtp_server) missing.push("outgoing server");
+    return missing;
+  },
+
+  canTest(handler) {
+    return this.missingBits(handler).length === 0;
+  },
+
+  statusLabel(handler) {
+    if (!handler.username && !this.providerValue(handler)) return "New";
+    if (handler.enabled && this.canTest(handler)) return "Live";
+    if (this.canTest(handler)) return "Ready";
+    return "Needs info";
+  },
+
+  statusTone(handler) {
+    if (!handler.username && !this.providerValue(handler)) return "muted";
+    if (handler.enabled && this.canTest(handler)) return "success";
+    if (this.canTest(handler)) return "ready";
+    return "warning";
+  },
+
+  handlerTitle(handler, idx) {
+    return handler.username || handler.name || `Inbox ${idx + 1}`;
+  },
+
+  handlerSubtitle(handler) {
+    const pieces = [];
+    const provider = this.providerValue(handler);
+    if (provider) pieces.push(this.providerLabel(provider));
+    pieces.push(this.scheduleLabel(handler).replace("Checks ", ""));
+    if (handler.project) pieces.push(`Project: ${handler.project}`);
+    return pieces.join(" · ");
+  },
+
+  testButtonLabel(handler, idx) {
+    if (this.testing === idx) return "Checking...";
+    if (this.canTest(handler)) return "Check setup";
+    return "Fill in the basics first";
+  },
+
+  testIntro(handler) {
+    if (this.providerValue(handler) === "exchange") {
+      return "We will check the inbox, check outgoing mail, then send a test email to this address.";
+    }
+    return "We will check incoming mail, check outgoing mail, then send a test email to this inbox.";
+  },
+
+  resultTitle(result) {
+    return result.test || "Check";
+  },
+
+  resultMessage(result) {
+    return result.message || (result.ok ? "Done." : "Something went wrong.");
+  },
+
+  _startInitialHandlerFlow() {
+    this.addHandler();
+    if (!this.context) return;
+    const toComparableJson = typeof this.context._toComparableJson === "function"
+      ? this.context._toComparableJson.bind(this.context)
+      : JSON.stringify;
+    this.context.settingsSnapshotJson = toComparableJson(this.context.settings);
+  },
+
+  async testConnection(idx) {
+    const handler = this.handlers[idx];
+    if (!handler || !this.canTest(handler)) return;
+
+    this.testing = idx;
+    this.testResults = null;
+    this.testResultsFor = idx;
+
+    try {
+      this.testResults = await API.callJsonApi(`${API_BASE}/test_connection`, { handler });
+    } catch (error) {
+      this.testResults = {
+        success: false,
+        results: [{ test: "Connection", ok: false, message: String(error) }],
+      };
+    }
+
+    this.testing = null;
+  },
+});

--- a/plugins/_email_integration/webui/email-config-store.js
+++ b/plugins/_email_integration/webui/email-config-store.js
@@ -77,6 +77,7 @@ export const store = createStore("emailConfig", {
   guideOpen: false,
   didInit: false,
   projects: [],
+  modelPresets: [],
   presets: PRESETS,
 
   get handlers() {
@@ -97,12 +98,15 @@ export const store = createStore("emailConfig", {
     if (this.handlers.length === 0) this._startInitialHandlerFlow();
     this.didInit = true;
 
-    try {
-      const response = await API.callJsonApi("projects", { action: "list" });
-      this.projects = response.data || [];
-    } catch (_) {
-      this.projects = [];
-    }
+    const [projectsResult, presetsResult] = await Promise.allSettled([
+      API.callJsonApi("projects", { action: "list" }),
+      API.callJsonApi("/plugins/_model_config/model_presets", { action: "get" }),
+    ]);
+
+    this.projects = projectsResult.status === "fulfilled" ? (projectsResult.value.data || []) : [];
+    this.modelPresets = presetsResult.status === "fulfilled" && Array.isArray(presetsResult.value.presets)
+      ? presetsResult.value.presets
+      : [];
   },
 
   cleanup() {
@@ -134,6 +138,7 @@ export const store = createStore("emailConfig", {
       sender_whitelist: [],
       project: "",
       dispatcher_model: "utility",
+      chat_model_preset: "",
       dispatcher_instructions: "",
       agent_instructions: "",
     };

--- a/plugins/_telegram_integration/README.md
+++ b/plugins/_telegram_integration/README.md
@@ -17,6 +17,9 @@ This plugin connects one or more Telegram bots to Agent Zero. Each bot runs inde
 - **Per-user chat sessions**
   - Each Telegram user gets a dedicated `AgentContext`, persisted across restarts via a JSON state file.
   - `/start` creates a context; `/clear` resets it.
+  - `/project <name>` switches the active project for the current chat.
+  - `/config <preset>` switches the active model preset for the current chat.
+  - `/send` or `/queue send` flushes the queued messages for the current chat.
 - **Group support**
   - Three modes: `mention` (respond only when @mentioned or replied to), `all` (respond to every message), `off` (private only).
   - Optional welcome message for new members.

--- a/plugins/_telegram_integration/api/test_connection.py
+++ b/plugins/_telegram_integration/api/test_connection.py
@@ -12,9 +12,9 @@ class TestConnection(ApiHandler):
 
         if not token:
             results.append({
-                "test": "Token",
+                "test": "Bot token",
                 "ok": False,
-                "message": "No bot token provided",
+                "message": "Add your bot token first.",
             })
             return {"success": False, "results": results}
 
@@ -23,15 +23,15 @@ class TestConnection(ApiHandler):
             from plugins._telegram_integration.helpers.bot_manager import test_token
             ok, message = await test_token(token)
             results.append({
-                "test": "Bot Token",
+                "test": "Telegram bot",
                 "ok": ok,
-                "message": message,
+                "message": "Telegram accepted the bot token." if ok else message,
             })
         except Exception as e:
             results.append({
-                "test": "Bot Token",
+                "test": "Telegram bot",
                 "ok": False,
-                "message": format_error(e),
+                "message": f"Could not validate the bot token: {format_error(e)}",
             })
 
         return {"success": all(r["ok"] for r in results), "results": results}

--- a/plugins/_telegram_integration/extensions/python/job_loop/_10_telegram_bot.py
+++ b/plugins/_telegram_integration/extensions/python/job_loop/_10_telegram_bot.py
@@ -84,6 +84,7 @@ class TelegramBotManager(Extension):
                     on_message=_on_message,
                     on_command_start=_on_start,
                     on_command_clear=_on_clear,
+                    on_command_control=_on_message,
                     on_callback_query=_on_callback,
                     on_new_members=_on_new_members,
                     group_mode=bot_cfg.get("group_mode", "mention"),

--- a/plugins/_telegram_integration/helpers/bot_manager.py
+++ b/plugins/_telegram_integration/helpers/bot_manager.py
@@ -45,6 +45,7 @@ def create_bot(
     on_message: Callable[..., Awaitable],
     on_command_start: Callable[..., Awaitable],
     on_command_clear: Callable[..., Awaitable],
+    on_command_control: Callable[..., Awaitable] | None = None,
     on_callback_query: Callable[..., Awaitable] | None = None,
     on_new_members: Callable[..., Awaitable] | None = None,
     group_mode: str = "mention",
@@ -56,6 +57,11 @@ def create_bot(
     # Register command handlers
     router.message.register(on_command_start, CommandStart())
     router.message.register(on_command_clear, Command("clear"))
+    if on_command_control:
+        router.message.register(
+            on_command_control,
+            Command(commands=["project", "config", "preset", "queue", "send"]),
+        )
 
     if on_callback_query:
         router.callback_query.register(on_callback_query)

--- a/plugins/_telegram_integration/helpers/handler.py
+++ b/plugins/_telegram_integration/helpers/handler.py
@@ -13,6 +13,7 @@ from aiogram.types import Message as TgMessage, CallbackQuery
 from agent import AgentContext, UserMessage
 from helpers import plugins, files, projects
 from helpers import message_queue as mq
+from helpers import integration_commands
 from helpers.notification import NotificationManager, NotificationType, NotificationPriority
 from helpers.persist_chat import save_tmp_chat
 from helpers.print_style import PrintStyle
@@ -139,7 +140,8 @@ async def handle_start(message: TgMessage, bot_name: str, bot_cfg: dict):
         instance.bot.token, message.chat.id,
         f"\U0001f44b Hello {user.first_name}! I'm connected to Agent Zero.\n\n"
         "Send me a message and I'll process it.\n"
-        "Use /clear to reset the conversation.",
+        "Use /clear to reset the conversation.\n"
+        "Use /project, /config, or /send to control the current chat.",
         parse_mode=None,
     )
 
@@ -201,19 +203,23 @@ async def handle_message(message: TgMessage, bot_name: str, bot_cfg: dict):
     if not instance:
         return
 
-    # Start persistent typing indicator (thread-based, works across event loops)
-    typing_stop = _start_typing(instance.bot.token, message.chat.id)
-
-    # Get or create agent context
+    text = _extract_message_content(message)
     context = await _get_or_create_context(bot_name, bot_cfg, message)
     if not context:
-        typing_stop.set()
         await _send_with_temp_bot(
             instance.bot.token, message.chat.id,
             "Failed to create chat session.",
             parse_mode=None,
         )
         return
+
+    command_reply = integration_commands.try_handle_command(context, text)
+    if command_reply is not None:
+        await _send_with_temp_bot(instance.bot.token, message.chat.id, command_reply, parse_mode=None)
+        return
+
+    # Start persistent typing indicator (thread-based, works across event loops)
+    typing_stop = _start_typing(instance.bot.token, message.chat.id)
 
     # Store stop event so send_telegram_reply can cancel typing
     context.data[CTX_TG_TYPING_STOP] = typing_stop
@@ -226,9 +232,6 @@ async def handle_message(message: TgMessage, bot_name: str, bot_cfg: dict):
                 and message.reply_to_message.from_user.id == instance.bot_info.id):
             reply_to_id = message.message_id
     context.data[CTX_TG_REPLY_TO] = reply_to_id
-
-    # Build user message text
-    text = _extract_message_content(message)
 
     # Use temp bot for downloads (cross-event-loop safe)
     async with _temp_bot(instance.bot.token) as dl_bot:
@@ -287,6 +290,13 @@ async def handle_callback_query(query: CallbackQuery, bot_name: str, bot_cfg: di
         bot_name, bot_cfg, user.id, user.username, query.message.chat.id,
     )
     if not context:
+        return
+
+    command_reply = integration_commands.try_handle_command(context, text)
+    if command_reply is not None:
+        instance = get_bot(bot_name)
+        if instance:
+            await _send_with_temp_bot(instance.bot.token, query.message.chat.id, command_reply, parse_mode=None)
         return
 
     agent = context.agent0

--- a/plugins/_telegram_integration/webui/config.html
+++ b/plugins/_telegram_integration/webui/config.html
@@ -1,4 +1,5 @@
 <html>
+
 <head>
   <title>Telegram Integration</title>
   <script type="module">
@@ -7,446 +8,672 @@
 </head>
 
 <body>
-  <div x-data x-init="$store.telegramConfig.init()">
+  <div x-data x-init="$store.telegramConfig.init(config, context)" x-destroy="$store.telegramConfig.cleanup()">
     <template x-if="config">
       <div class="tg-page">
-        <div class="section-title">Telegram Integration</div>
-        <div class="section-description">
-          Configure Telegram bots to communicate with Agent Zero via Telegram.
-        </div>
+        <div class="section-title">Telegram</div>
 
-        <!-- Quick Start Guide (collapsible) -->
-        <details class="tg-guide">
-          <summary class="tg-guide-toggle">Quick Start Guide</summary>
-          <div class="tg-guide-body">
-            <div class="tg-guide-section tg-guide-section-first">
-              <div class="tg-guide-row">
-                <div class="tg-guide-steps">
-                  <div class="tg-guide-section-title">Get Bot Token</div>
-                  <ol>
-                    <li>Click <a href="https://t.me/BotFather" target="_blank" rel="noopener">@BotFather</a> or scan the QR code on your mobile device, or search <strong>@BotFather</strong> in Telegram</li>
-                    <li>Send <strong>/newbot</strong> and follow the prompts to create a bot</li>
-                    <li>Copy the API token provided by BotFather</li>
-                    <li>Click <strong>Add Bot</strong> below, paste the token, and save</li>
-                  </ol>
-                </div>
-                <img class="tg-qr" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHQAAAB0AQAAAAB84SuKAAAA50lEQVR4nMWVQWoFMQxDnz+zl2/w73+suYF8Aheni98ux1BqglEgQjOx7ETzM+r1awt/v4+ILCAHLPjqJivLAx7zLwjh7Dxg+T/pKj84/4nr5FHPgxb6bRLjAY/50QE6sED3Uz79HZrr7/ZzPiM/X2B7w/cw263uFZ+2sOb6rMf8iyZNNiqt6lfFG1fembHxzxszKQ1a9a8SO26STf9RU8MUqUX/0DLSmULSpn4T6Kx+zn+d+cMdJrWYP4zvxjy91SeSt6mKjf51cinGgOznsVP2rn7dksaEU8uF/yPAGvsu/B///H59AYlVhAI4J5PTAAAAAElFTkSuQmCC"
-                     alt="Scan to open @BotFather" title="@BotFather" />
-              </div>
+        <template x-if="$store.telegramConfig.didInit && $store.telegramConfig.bots.length === 0">
+          <div class="tg-empty">
+            <div class="tg-empty-title">Start with one bot</div>
+            <div class="tg-empty-copy">
+              Most setups only need a bot token, one allowed user, and the default polling mode.
             </div>
-            <div class="tg-guide-section">
-              <div class="tg-guide-row">
-                <div class="tg-guide-steps">
-                  <div class="tg-guide-section-title">Set Allowed Users</div>
-                  <ol>
-                    <li>Enter your Telegram handle (e.g. <strong>@yourname</strong>) in the <strong>Allowed Users</strong> field below.</li>
-                    <li>If you don't know your handle, click <a href="https://t.me/userinfobot" target="_blank" rel="noopener">@userinfobot</a> or scan the QR code, then send <strong>/start</strong> to get your numeric ID</li>
-                  </ol>
-                </div>
-                <img class="tg-qr" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHQAAAB0AQAAAAB84SuKAAAA5klEQVR4nMWVUWrEQAxDn5f+yzfY+x8rN7BPoOLZhW0/Yyg1A6OBOJbHihLmZ/Tj1xH+/hwRGUEesMiXjSs4YMMnkqaGQG77UVJ14/lPfL331Gtf1HfRVdSA2/nhubkDG3Td5+/XW3TAQj/RmYWahPvzDydUUmEC366P36tkrFroTzkKpHtEuJjfVdEJfmqhX6a0LSGrXKt8kCnDqn9kkSZKG/6qo9waGW74T0zmsLif/zi2czmfJN76D32NhbDqH830zhC84H9CTak6l/5TgccJtPSfLOdYwEq/oDM/1eL7i3/+f30Di2x7PjI9e0cAAAAASUVORK5CYII="
-                     alt="Scan to open @userinfobot" title="@userinfobot" />
-              </div>
-            </div>
-            <div class="tg-guide-note">
-              <strong>Group chats:</strong> To let the bot respond to all group messages (not just @mentions),
-              go to @BotFather → <em>/mybots</em> → select your bot → <em>Bot Settings</em> →
-              <em>Group Privacy</em> → <em>Turn off</em>.
-            </div>
+            <button class="btn btn-field" @click="$store.telegramConfig.addBot()">
+              Connect a bot
+            </button>
           </div>
-        </details>
+        </template>
 
-        <!-- Bot cards -->
-        <template x-for="(bot, idx) in (config.bots || [])" :key="idx">
-          <div class="bot-card">
-            <div class="bot-card-header" @click="$store.telegramConfig.toggle(idx)">
-              <span class="material-symbols-outlined bot-expand-icon"
-                    :class="{ 'expanded': $store.telegramConfig.expandedIdx === idx }">chevron_right</span>
-              <span class="bot-card-name" x-text="bot.name || '(unnamed)'"></span>
-              <span class="bot-card-summary" x-show="$store.telegramConfig.expandedIdx !== idx"
-                    x-text="bot.enabled ? 'Enabled' : 'Disabled'"></span>
-              <button class="text-button bot-delete-btn"
-                      @click.stop="$confirmClick($event, () => $store.telegramConfig.removeBot(config, idx))"
-                      title="Remove bot">
-                <span class="material-symbols-outlined">close</span>
-              </button>
+        <template x-for="(bot, idx) in $store.telegramConfig.bots" :key="idx">
+          <div class="tg-card">
+            <div class="tg-card-header" @click="$store.telegramConfig.toggleEditing(idx)">
+              <div class="tg-card-heading">
+                <div class="tg-card-title" x-text="$store.telegramConfig.botTitle(bot, idx)"></div>
+                <div class="tg-card-subtitle" x-text="$store.telegramConfig.botSubtitle(bot)"></div>
+              </div>
+              <div class="tg-card-actions">
+                <span class="tg-status-pill" :class="'tone-' + $store.telegramConfig.botStatusTone(bot)"
+                  x-text="$store.telegramConfig.botStatusLabel(bot)"></span>
+                <button class="btn btn-action delete"
+                  @click.stop="$confirmClick($event, () => $store.telegramConfig.removeBot(idx))" title="Remove bot">
+                  <span class="material-symbols-outlined">delete</span>
+                </button>
+                <span class="material-symbols-outlined tg-card-chevron"
+                  :class="{ 'is-open': $store.telegramConfig.editing === idx }">expand_more</span>
+              </div>
             </div>
 
-            <div class="bot-card-body" x-show="$store.telegramConfig.expandedIdx === idx" x-transition.opacity>
-
-              <div class="field">
-                <div class="field-label">
-                  <div class="field-title">Enabled</div>
-                  <div class="field-description">Enable or disable this Telegram bot</div>
-                </div>
-                <div class="field-control">
-                  <label class="toggle">
-                    <input type="checkbox" x-model="bot.enabled" />
-                    <span class="toggler"></span>
-                  </label>
-                </div>
-              </div>
-
-              <div class="field">
-                <div class="field-label">
-                  <div class="field-title">Message Notifications</div>
-                  <div class="field-description">Show a WebUI notification for each incoming Telegram message</div>
-                </div>
-                <div class="field-control">
-                  <label class="toggle">
-                    <input type="checkbox" x-model="bot.notify_messages" />
-                    <span class="toggler"></span>
-                  </label>
-                </div>
-              </div>
-
-              <div class="field">
-                <div class="field-label">
-                  <div class="field-title">Bot Name</div>
-                  <div class="field-description">Unique identifier for this bot configuration</div>
-                </div>
-                <div class="field-control">
-                  <input type="text" x-model="bot.name" placeholder="e.g. my_bot" />
-                </div>
-              </div>
-
-              <div class="field">
-                <div class="field-label">
-                  <div class="field-title">Bot Token</div>
-                  <div class="field-description">Token from @BotFather on Telegram</div>
-                </div>
-                <div class="field-control">
-                  <input type="password" x-model="bot.token" placeholder="123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11" />
-                </div>
-              </div>
-
-              <div class="field">
-                <div class="field-label">
-                  <div class="field-title">Mode</div>
-                  <div class="field-description">Polling: no public IP required. Webhook: needs HTTPS URL</div>
-                </div>
-                <div class="field-control">
-                  <select x-model="bot.mode">
-                    <option value="polling">Polling</option>
-                    <option value="webhook">Webhook</option>
-                  </select>
-                </div>
-              </div>
-
-              <div class="field" x-show="bot.mode === 'webhook'">
-                <div class="field-label">
-                  <div class="field-title">Webhook URL</div>
-                  <div class="field-description">Your Agent Zero base URL, e.g. https://yourdomain.com</div>
-                </div>
-                <div class="field-control">
-                  <input type="text" x-model="bot.webhook_url" placeholder="https://yourdomain.com" />
-                </div>
-              </div>
-
-              <div class="field" x-show="bot.mode === 'webhook'">
-                <div class="field-label">
-                  <div class="field-title">Webhook Secret</div>
-                  <div class="field-description">Optional shared secret for webhook verification</div>
-                </div>
-                <div class="field-control">
-                  <input type="password" x-model="bot.webhook_secret" />
-                </div>
-              </div>
-
-              <div class="field">
-                <div class="field-label">
-                  <div class="field-title">Allowed Users</div>
-                  <div class="field-description">Comma-separated user IDs or @usernames. Empty = anyone can use</div>
-                </div>
-                <div class="field-control">
-                  <input type="text"
-                         x-effect="if (document.activeElement !== $el) $el.value = $store.telegramConfig.whitelistText(bot)"
-                         @change="$store.telegramConfig.setWhitelist(bot, $event.target.value)"
-                         placeholder="123456789, @username" />
-                </div>
-              </div>
-
-              <div class="field">
-                <div class="field-label">
-                  <div class="field-title">Group Mode</div>
-                  <div class="field-description">How the bot responds in group chats</div>
-                </div>
-                <div class="field-control">
-                  <select x-model="bot.group_mode">
-                    <option value="mention">Respond when @mentioned or replied to</option>
-                    <option value="all">Respond to every message</option>
-                    <option value="off">Ignore group messages</option>
-                  </select>
-                </div>
-              </div>
-
-              <div class="field" x-show="bot.group_mode !== 'off'">
-                <div class="field-label">
-                  <div class="field-title">Welcome New Members</div>
-                  <div class="field-description">Send a greeting when someone joins the group</div>
-                </div>
-                <div class="field-control">
-                  <label class="toggle">
-                    <input type="checkbox" x-model="bot.welcome_enabled" />
-                    <span class="toggler"></span>
-                  </label>
-                </div>
-              </div>
-
-              <div class="field" x-show="bot.group_mode !== 'off' && bot.welcome_enabled">
-                <div class="field-label">
-                  <div class="field-title">Welcome Message</div>
-                  <div class="field-description">Use {name} for the new member's name</div>
-                </div>
-                <div class="field-control">
-                  <input type="text" x-model="bot.welcome_message" placeholder="Welcome, {name}!" />
-                </div>
-              </div>
-
-              <div class="field">
-                <div class="field-label">
-                  <div class="field-title">User Project Mapping</div>
-                  <div class="field-description">Map user IDs to projects: user_id=project, separate by comma</div>
-                </div>
-                <div class="field-control">
-                  <input type="text"
-                         x-effect="if (document.activeElement !== $el) $el.value = $store.telegramConfig.userProjectsText(bot)"
-                         @change="$store.telegramConfig.setUserProjects(bot, $event.target.value)"
-                         placeholder="123456=my_project, 789012=other_project" />
-                </div>
-              </div>
-
-              <div class="field">
-                <div class="field-label">
-                  <div class="field-title">Default Project</div>
-                  <div class="field-description">Fallback project if user not in the mapping above</div>
-                </div>
-                <div class="field-control">
-                  <select x-effect="void $store.telegramConfig.projects; $nextTick(() => $el.value = bot.default_project)"
-                          @change="bot.default_project = $event.target.value">
-                    <option value="">No project</option>
-                    <template x-for="proj in $store.telegramConfig.projects" :key="proj.name">
-                      <option :value="proj.name" x-text="proj.title || proj.name"></option>
+            <template x-if="$store.telegramConfig.editing === idx">
+              <div class="tg-card-body">
+                <div class="tg-step-header">
+                  <div class="tg-step-copy">
+                    <div class="tg-step-title" x-text="$store.telegramConfig.currentStepMeta().title"></div>
+                    <div class="tg-step-description" x-text="$store.telegramConfig.currentStepMeta().description"></div>
+                  </div>
+                  <div class="tg-step-dots" aria-hidden="true">
+                    <template x-for="(step, stepIdx) in $store.telegramConfig.steps" :key="step.title">
+                      <button type="button" class="tg-step-dot"
+                        :class="{ 'is-active': $store.telegramConfig.currentStep === stepIdx }"
+                        @click="$store.telegramConfig.setStep(stepIdx)"></button>
                     </template>
-                  </select>
+                  </div>
                 </div>
-              </div>
 
-              <div class="field">
-                <div class="field-label">
-                  <div class="field-title">Attachment Max Age</div>
-                  <div class="field-description">Hours before attachments auto-delete. 0 = keep forever</div>
-                </div>
-                <div class="field-control">
-                  <input type="number" x-model.number="bot.attachment_max_age_hours" min="0" step="1" placeholder="0" />
-                </div>
-              </div>
+                <template x-if="$store.telegramConfig.currentStep === 0">
+                  <div class="tg-step-panel">
+                    <div class="tg-token-row">
+                      <div class="tg-qr-card">
+                        <div class="tg-qr-title">Scan to open @BotFather</div>
+                        <img class="tg-qr-image" :src="$store.telegramConfig.botFatherQr"
+                          alt="Scan to open @BotFather" />
+                      </div>
 
-              <div class="field">
-                <div class="field-label">
-                  <div class="field-title">Agent Instructions</div>
-                  <div class="field-description">Extra instructions for the agent in Telegram chats</div>
-                </div>
-                <div class="field-control">
-                  <textarea x-model="bot.agent_instructions" rows="3" placeholder="e.g. Always respond concisely for mobile..."></textarea>
-                </div>
-              </div>
+                      <div class="tg-token-card">
+                        <div class="tg-token-steps">
+                          <div class="tg-token-steps-title">Create your bot</div>
+                          <ol class="tg-token-steps-list">
+                            <li>Open <a href="https://t.me/BotFather" target="_blank" rel="noopener">@BotFather</a></li>
+                            <li>Send <strong>/newbot</strong> and follow the prompts</li>
+                            <li>Paste the token here</li>
+                          </ol>
+                        </div>
 
-              <!-- Test connection + results -->
-              <div class="bot-test-row">
-                <button class="btn btn-field"
-                        @click.stop="$store.telegramConfig.testConnection(config, idx)"
-                        :disabled="$store.telegramConfig.testing === idx">
-                  <span x-show="$store.telegramConfig.testing !== idx">Test Connection</span>
-                  <span x-show="$store.telegramConfig.testing === idx">Testing...</span>
-                </button>
-                <template x-if="$store.telegramConfig.testResults && $store.telegramConfig.expandedIdx === idx">
-                  <div class="bot-test-results">
-                    <template x-for="r in $store.telegramConfig.testResults.results" :key="r.test">
-                      <div class="bot-test-result-row">
-                        <span class="bot-test-icon"
-                              x-text="r.ok ? '✓' : '✗'"
-                              :class="r.ok ? 'ok' : 'fail'"></span>
-                        <span class="bot-test-label" x-text="r.test"></span>
-                        <span class="bot-test-msg" x-text="r.message"></span>
+                        <div class="field">
+                          <div class="field-label">
+                            <div class="field-title">Bot token</div>
+                            <div class="field-description">Paste the token you got from @BotFather.</div>
+                          </div>
+                          <div class="field-control">
+                            <input type="password" x-model="bot.token"
+                              placeholder="123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11" />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </template>
+
+                <template x-if="$store.telegramConfig.currentStep === 1">
+                  <div class="tg-step-panel">
+                    <div class="field">
+                      <div class="field-label">
+                        <div class="field-title">Turn on this bot</div>
+                        <div class="field-description">Enable message polling when you are ready for the bot to go live.
+                        </div>
+                      </div>
+                      <div class="field-control">
+                        <label class="toggle">
+                          <input type="checkbox" x-model="bot.enabled" />
+                          <span class="toggler"></span>
+                        </label>
+                      </div>
+                    </div>
+
+                    <div class="field">
+                      <div class="field-label">
+                        <div class="field-title">Bot name</div>
+                        <div class="field-description">A friendly internal label so you can tell bots apart.</div>
+                      </div>
+                      <div class="field-control">
+                        <input type="text" x-model="bot.name" placeholder="support_bot" />
+                      </div>
+                    </div>
+
+                    <div class="field">
+                      <div class="field-label">
+                        <div class="field-title">Delivery mode</div>
+                        <div class="field-description">Polling is the simplest option. Webhook is for public HTTPS
+                          setups.</div>
+                      </div>
+                      <div class="field-control">
+                        <select x-model="bot.mode">
+                          <option value="polling">Polling</option>
+                          <option value="webhook">Webhook</option>
+                        </select>
+                      </div>
+                    </div>
+
+                    <div class="field" x-show="bot.mode === 'webhook'">
+                      <div class="field-label">
+                        <div class="field-title">Webhook URL</div>
+                        <div class="field-description">Your public Agent Zero base URL, for example
+                          https://yourdomain.com.</div>
+                      </div>
+                      <div class="field-control">
+                        <input type="text" x-model="bot.webhook_url" placeholder="https://yourdomain.com" />
+                      </div>
+                    </div>
+
+                    <div class="field">
+                      <div class="field-label">
+                        <div class="field-title">Allowed users</div>
+                        <div class="field-description">Comma-separated @usernames or numeric IDs. Leave empty only if
+                          you truly want open access.</div>
+                      </div>
+                      <div class="field-control">
+                        <input type="text" :value="$store.telegramConfig.whitelistText(bot)"
+                          @input="$store.telegramConfig.setWhitelist(bot, $event.target.value)"
+                          placeholder="@yourname, 123456789" />
+                      </div>
+                    </div>
+
+                    <div class="tg-warning" x-show="$store.telegramConfig.accessWarning(bot)">
+                      <span x-text="$store.telegramConfig.accessWarning(bot)"></span>
+                    </div>
+
+                    <div class="field">
+                      <div class="field-label">
+                        <div class="field-title">Default project</div>
+                        <div class="field-description">Optional fallback project for conversations from this bot.</div>
+                      </div>
+                      <div class="field-control">
+                        <select :value="bot.default_project" @change="bot.default_project = $event.target.value">
+                          <option value="">No project</option>
+                          <template x-for="proj in $store.telegramConfig.projects" :key="proj.name">
+                            <option :value="proj.name" x-text="proj.title || proj.name"
+                              :selected="bot.default_project === proj.name"></option>
+                          </template>
+                        </select>
+                      </div>
+                    </div>
+                  </div>
+                </template>
+
+                <template x-if="$store.telegramConfig.currentStep === 2">
+                  <div class="tg-step-panel">
+                    <div class="field">
+                      <div class="field-label">
+                        <div class="field-title">Group behavior</div>
+                        <div class="field-description">Choose whether the bot replies only when invited into the
+                          conversation or to everything in a group.</div>
+                      </div>
+                      <div class="field-control">
+                        <select x-model="bot.group_mode">
+                          <option value="mention">Reply when @mentioned or replied to</option>
+                          <option value="all">Reply to every group message</option>
+                          <option value="off">Ignore group messages</option>
+                        </select>
+                      </div>
+                    </div>
+
+                    <div class="field" x-show="bot.group_mode !== 'off'">
+                      <div class="field-label">
+                        <div class="field-title">Welcome new members</div>
+                        <div class="field-description">Send a greeting when someone joins the group.</div>
+                      </div>
+                      <div class="field-control">
+                        <label class="toggle">
+                          <input type="checkbox" x-model="bot.welcome_enabled" />
+                          <span class="toggler"></span>
+                        </label>
+                      </div>
+                    </div>
+
+                    <div class="field" x-show="bot.group_mode !== 'off' && bot.welcome_enabled">
+                      <div class="field-label">
+                        <div class="field-title">Welcome message</div>
+                        <div class="field-description">Use {name} for the new member's name.</div>
+                      </div>
+                      <div class="field-control">
+                        <input type="text" x-model="bot.welcome_message" placeholder="Welcome, {name}!" />
+                      </div>
+                    </div>
+
+                    <div class="field">
+                      <div class="field-label">
+                        <div class="field-title">Agent instructions</div>
+                        <div class="field-description">Extra guidance for how the agent should reply in Telegram chats.
+                        </div>
+                      </div>
+                      <div class="field-control">
+                        <textarea x-model="bot.agent_instructions" rows="3"
+                          placeholder="Reply in a concise, mobile-friendly way."></textarea>
+                      </div>
+                    </div>
+                  </div>
+                </template>
+
+                <div class="tg-test-panel">
+                  <div class="tg-test-copy">
+                    <div class="tg-test-title">Check the connection</div>
+                    <div class="tg-test-description" x-text="$store.telegramConfig.testIntro()"></div>
+                  </div>
+                  <button class="btn btn-field" @click.stop="$store.telegramConfig.testConnection(idx)"
+                    :disabled="$store.telegramConfig.testing === idx || !$store.telegramConfig.canTest(bot)">
+                    <span x-text="$store.telegramConfig.testButtonLabel(bot, idx)"></span>
+                  </button>
+                </div>
+
+                <template x-if="$store.telegramConfig.testResults && $store.telegramConfig.testResultsFor === idx">
+                  <div class="tg-results" :class="{ 'is-error': !$store.telegramConfig.testResults.success }">
+                    <template x-for="result in $store.telegramConfig.testResults.results"
+                      :key="result.test + result.message">
+                      <div class="tg-result-row">
+                        <span class="tg-result-icon" x-text="result.ok ? '✓' : '✗'"></span>
+                        <div class="tg-result-copy">
+                          <div class="tg-result-title" x-text="$store.telegramConfig.resultTitle(result)"></div>
+                          <div class="tg-result-message" x-text="$store.telegramConfig.resultMessage(result)"></div>
+                        </div>
                       </div>
                     </template>
                   </div>
                 </template>
-              </div>
 
-            </div>
+                <template x-if="$store.telegramConfig.currentStep > 0">
+                  <details class="tg-advanced">
+                    <summary>
+                      <span>Advanced</span>
+                      <span class="material-symbols-outlined tg-advanced-chevron"
+                        aria-hidden="true">keyboard_arrow_down</span>
+                    </summary>
+                    <div class="tg-advanced-body">
+                      <div class="field" x-show="bot.mode === 'webhook'">
+                        <div class="field-label">
+                          <div class="field-title">Webhook secret</div>
+                          <div class="field-description">Optional shared secret for webhook verification.</div>
+                        </div>
+                        <div class="field-control">
+                          <input type="password" x-model="bot.webhook_secret" />
+                        </div>
+                      </div>
+
+                      <div class="field">
+                        <div class="field-label">
+                          <div class="field-title">Message notifications</div>
+                          <div class="field-description">Show a WebUI notification for each incoming Telegram message.
+                          </div>
+                        </div>
+                        <div class="field-control">
+                          <label class="toggle">
+                            <input type="checkbox" x-model="bot.notify_messages" />
+                            <span class="toggler"></span>
+                          </label>
+                        </div>
+                      </div>
+
+                      <div class="field">
+                        <div class="field-label">
+                          <div class="field-title">User project mapping</div>
+                          <div class="field-description">Map specific Telegram user IDs to projects with user_id=project
+                            entries.</div>
+                        </div>
+                        <div class="field-control">
+                          <input type="text" :value="$store.telegramConfig.userProjectsText(bot)"
+                            @input="$store.telegramConfig.setUserProjects(bot, $event.target.value)"
+                            placeholder="123456=my_project, 789012=other_project" />
+                        </div>
+                      </div>
+
+                      <div class="field">
+                        <div class="field-label">
+                          <div class="field-title">Attachment max age</div>
+                          <div class="field-description">How long to keep downloaded attachments. Use 0 to keep them
+                            forever.</div>
+                        </div>
+                        <div class="field-control">
+                          <input type="number" x-model.number="bot.attachment_max_age_hours" min="0" step="1"
+                            placeholder="0" />
+                        </div>
+                      </div>
+
+                    </div>
+                  </details>
+                </template>
+              </div>
+            </template>
           </div>
         </template>
 
-        <button class="text-button bot-add-btn" @click="$store.telegramConfig.addBot(config)">
-          <span class="material-symbols-outlined">add</span>
-          <span>Add Bot</span>
-        </button>
+        <template x-if="$store.telegramConfig.bots.length > 0">
+          <button class="btn btn-field tg-add-btn" @click="$store.telegramConfig.addBot()">
+            Connect another bot
+          </button>
+        </template>
       </div>
     </template>
   </div>
 
   <style>
-  .tg-page {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-  .tg-guide {
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    font-size: 0.85rem;
-  }
-  .tg-guide-toggle {
-    padding: 8px 10px;
-    cursor: pointer;
-    opacity: 0.8;
-  }
-  .tg-guide-toggle:hover {
-    opacity: 1;
-  }
-  .tg-guide-body {
-    padding: 4px 12px 12px;
-    border-top: 1px solid var(--color-border);
-  }
-  .tg-guide-section {
-    margin-top: 10px;
-  }
-  .tg-guide-section-first {
-    margin-top: 15px;
-  }
-  .tg-guide-steps {
-    flex: 1;
-  }
-  .tg-guide-section-title {
-    font-weight: 600;
-    font-size: 0.85rem;
-    margin-bottom: 4px;
-    opacity: 0.9;
-  }
-  .tg-guide-body ol {
-    margin: 4px 0;
-    padding-left: 20px;
-  }
-  .tg-guide-body li {
-    margin-bottom: 4px;
-  }
-  .tg-guide-body a {
-    color: var(--color-highlight);
-  }
-  .tg-guide-note {
-    margin-top: 15px;
-    padding: 6px 10px;
-    background: var(--color-background-hover, rgba(255,255,255,0.04));
-    border-radius: 4px;
-    font-size: 0.8rem;
-    opacity: 0.85;
-  }
-  .tg-guide-row {
-    display: flex;
-    align-items: flex-start;
-    gap: 12px;
-  }
-  .tg-guide-row ol {
-    flex: 1;
-  }
-  .tg-qr {
-    width: 88px;
-    height: 88px;
-    border-radius: 4px;
-    flex-shrink: 0;
-    image-rendering: pixelated;
-  }
-  .bot-card {
-    border: 1px solid var(--color-border);
-    border-radius: 6px;
-    overflow: hidden;
-  }
-  .bot-card-header {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 8px 10px;
-    cursor: pointer;
-    font-size: 0.85rem;
-  }
-  .bot-card-header:hover {
-    background: var(--color-background-hover, rgba(255,255,255,0.04));
-  }
-  .bot-expand-icon {
-    font-size: 16px;
-    transition: transform 0.15s ease;
-  }
-  .bot-expand-icon.expanded {
-    transform: rotate(90deg);
-  }
-  .bot-card-name {
-    font-weight: 500;
-  }
-  .bot-card-summary {
-    flex: 1;
-    text-align: right;
-    opacity: 0.5;
-    font-size: 0.75rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .bot-delete-btn {
-    margin-left: auto;
-    opacity: 0.5;
-    padding: 2px !important;
-  }
-  .bot-delete-btn:hover {
-    opacity: 1;
-    color: var(--color-error, #f44) !important;
-  }
-  .bot-delete-btn .material-symbols-outlined {
-    font-size: 16px;
-  }
-  .bot-card-body {
-    padding: 4px 12px 12px;
-    border-top: 1px solid var(--color-border);
-  }
-  .bot-add-btn {
-    margin-top: 4px;
-    width: fit-content;
-  }
-  .bot-test-row {
-    margin-top: 12px;
-    display: flex;
-    align-items: flex-start;
-    gap: 12px;
-    flex-wrap: wrap;
-  }
-  .bot-test-results {
-    padding: 4px 0;
-    font-size: 0.85rem;
-    flex: 1;
-    min-width: 200px;
-  }
-  .bot-test-result-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 4px 0;
-  }
-  .bot-test-icon {
-    font-weight: bold;
-  }
-  .bot-test-icon.ok {
-    color: #4caf50;
-  }
-  .bot-test-icon.fail {
-    color: #f44336;
-  }
-  .bot-test-label {
-    font-weight: 500;
-    min-width: 80px;
-  }
-  .bot-test-msg {
-    opacity: 0.8;
-  }
+    .tg-page {
+      display: flex;
+      flex-direction: column;
+      gap: 0.9rem;
+    }
+
+    .tg-advanced summary {
+      cursor: pointer;
+      list-style: none;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .tg-advanced summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .tg-guide-card,
+    .tg-empty,
+    .tg-card {
+      border-radius: 0.5rem;
+    }
+
+    .tg-empty-title,
+    .tg-step-title,
+    .tg-test-title,
+    .tg-qr-title {
+      font-weight: 700;
+    }
+
+    .tg-empty-copy,
+    .tg-step-description,
+    .tg-info-box,
+    .tg-test-description,
+    .tg-result-message,
+    .tg-card-subtitle {
+      color: var(--color-text-secondary);
+      line-height: 1.5;
+    }
+
+    .tg-empty {
+      padding: 1rem;
+    }
+
+    .tg-empty-copy {
+      margin-top: 0.35rem;
+      margin-bottom: 0.9rem;
+    }
+
+    .tg-card-header {
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      align-items: flex-start;
+      padding: var(--spacing-sm) 0;
+      border-bottom: 1px solid var(--color-border);
+      cursor: pointer;
+    }
+
+    .tg-card-heading {
+      min-width: 0;
+      flex: 1 1 auto;
+    }
+
+    .tg-card-title {
+      font-weight: 700;
+      line-height: 1.35;
+      overflow-wrap: anywhere;
+    }
+
+    .tg-card-subtitle {
+      margin-top: 0.3rem;
+      font-size: var(--font-size-small);
+    }
+
+    .tg-card-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.45rem;
+      flex: 0 0 auto;
+    }
+
+    .tg-card-chevron {
+      transition: transform 0.18s ease;
+      opacity: 0.7;
+    }
+
+    .tg-card-chevron.is-open {
+      transform: rotate(180deg);
+    }
+
+    .tg-card-body {
+      border-top: 1px solid color-mix(in srgb, var(--color-border) 88%, white 12%);
+    }
+
+    .tg-step-header {
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      align-items: flex-start;
+      margin: 1rem 0;
+    }
+
+    .tg-step-dots {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      align-items: center;
+    }
+
+    .tg-step-dot {
+      width: 0.85rem;
+      height: 0.85rem;
+      border-radius: 999px;
+      border: 1px solid var(--color-border);
+      background: transparent;
+      cursor: pointer;
+      padding: 0;
+    }
+
+    .tg-step-dot.is-active {
+      background: rgba(59, 130, 246, 0.9);
+      border-color: rgba(59, 130, 246, 0.9);
+    }
+
+    .tg-step-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 0.2rem;
+    }
+
+    .tg-token-row {
+      display: grid;
+      grid-template-columns: minmax(12rem, 16rem) minmax(0, 1fr);
+      gap: 1rem;
+      align-items: stretch;
+    }
+
+    .tg-qr-card,
+    .tg-token-card {
+      border-radius: 0.5rem;
+      background: color-mix(in srgb, var(--color-background) 90%, white 10%);
+      padding: 1rem;
+    }
+
+    .tg-qr-card {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      gap: 0.8rem;
+    }
+
+    .tg-qr-image {
+      width: 150px;
+      height: 150px;
+      border-radius: 0.5rem;
+      image-rendering: pixelated;
+    }
+
+    .tg-token-steps {
+      margin-bottom: 0.9rem;
+    }
+
+    .tg-token-steps-title {
+      font-weight: 700;
+      margin-bottom: 0.45rem;
+    }
+
+    .tg-token-steps-list {
+      margin: 0;
+      padding-left: 1.15rem;
+      color: var(--color-text-secondary);
+      line-height: 1.55;
+    }
+
+    .tg-token-steps-list a {
+      color: var(--color-highlight);
+    }
+
+    .tg-info-box,
+    .tg-warning {
+      margin-bottom: 0.9rem;
+      padding: 0.8rem 0.9rem;
+      border-radius: 12px;
+      font-size: var(--font-size-small);
+    }
+
+    .tg-info-box {
+      background: color-mix(in srgb, #3b82f6 12%, var(--color-background) 88%);
+    }
+
+    .tg-warning {
+      background: color-mix(in srgb, #f59e0b 14%, var(--color-background) 86%);
+    }
+
+    .tg-advanced {
+      margin-top: 0.95rem;
+      border: 1px solid color-mix(in srgb, var(--color-border) 88%, white 12%);
+      border-radius: 14px;
+      overflow: hidden;
+    }
+
+    .tg-advanced summary {
+      padding: 0.9rem 1rem;
+      background: color-mix(in srgb, var(--color-background) 88%, white 12%);
+    }
+
+    .tg-advanced-chevron {
+      margin-left: auto;
+      flex: 0 0 auto;
+      transition: transform 0.18s ease, opacity 0.18s ease;
+      opacity: 0.72;
+    }
+
+    .tg-advanced[open] .tg-advanced-chevron {
+      transform: rotate(180deg);
+      opacity: 1;
+    }
+
+    .tg-advanced-body {
+      padding: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.2rem;
+    }
+
+    .tg-test-panel {
+      margin-top: 1rem;
+      padding: var(--spacing-xs) 0;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .tg-test-copy,
+    .tg-result-copy {
+      min-width: 0;
+    }
+
+    .tg-results {
+      margin-top: 0.9rem;
+      border-radius: 14px;
+      border: 1px solid color-mix(in srgb, #22c55e 28%, var(--color-border) 72%);
+      background: color-mix(in srgb, #22c55e 8%, var(--color-background) 92%);
+      padding: 0.35rem 0.9rem;
+    }
+
+    .tg-results.is-error {
+      border-color: color-mix(in srgb, #ef4444 28%, var(--color-border) 72%);
+      background: color-mix(in srgb, #ef4444 8%, var(--color-background) 92%);
+    }
+
+    .tg-result-row {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.8rem;
+      padding: 0.7rem 0;
+    }
+
+    .tg-result-row+.tg-result-row {
+      border-top: 1px solid color-mix(in srgb, var(--color-border) 85%, white 15%);
+    }
+
+    .tg-result-icon {
+      width: 1.25rem;
+      font-weight: 800;
+      line-height: 1.3;
+    }
+
+    .tg-result-title {
+      font-weight: 700;
+      margin-bottom: 0.18rem;
+    }
+
+    .tg-status-pill {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 5.25rem;
+      padding: 0.35rem 0.7rem;
+      border-radius: 999px;
+      font-size: 0.8rem;
+      font-weight: 700;
+    }
+
+    .tg-status-pill.tone-success {
+      background: rgba(34, 197, 94, 0.14);
+      color: #7ee7a4;
+    }
+
+    .tg-status-pill.tone-ready {
+      background: rgba(59, 130, 246, 0.16);
+      color: #93c5fd;
+    }
+
+    .tg-status-pill.tone-warning {
+      background: rgba(245, 158, 11, 0.16);
+      color: #fcd34d;
+    }
+
+    .tg-status-pill.tone-muted {
+      background: rgba(148, 163, 184, 0.14);
+      color: #cbd5e1;
+    }
+
+    .tg-add-btn {
+      align-self: flex-start;
+    }
+
+    @media (max-width: 900px) {
+      .tg-token-row {
+        grid-template-columns: minmax(0, 1fr);
+      }
+    }
+
+    @media (max-width: 640px) {
+
+      .tg-card-header,
+      .tg-step-header,
+      .tg-test-panel {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .tg-card-actions,
+      .tg-step-dots {
+        width: 100%;
+        justify-content: space-between;
+      }
+
+      .tg-status-pill {
+        min-width: 0;
+      }
+    }
   </style>
 </body>
 

--- a/plugins/_telegram_integration/webui/telegram-config-store.js
+++ b/plugins/_telegram_integration/webui/telegram-config-store.js
@@ -1,30 +1,129 @@
 import { createStore } from "/js/AlpineStore.js";
+import * as API from "/js/api.js";
 
 const API_BASE = "/plugins/_telegram_integration";
+const STEPS = [
+  {
+    title: "Connect your bot",
+    description: "Start with BotFather, then paste the bot token here.",
+  },
+  {
+    title: "Choose who can use it",
+    description: "Finish the core setup, choose access, and decide how messages arrive.",
+  },
+  {
+    title: "Shape the conversation",
+    description: "Choose how the bot behaves in groups and how the agent should reply.",
+  },
+];
+
+const BOTFATHER_QR =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHQAAAB0AQAAAAB84SuKAAAA50lEQVR4nMWVQWoFMQxDnz+zl2/w73+suYF8Aheni98ux1BqglEgQjOx7ETzM+r1awt/v4+ILCAHLPjqJivLAx7zLwjh7Dxg+T/pKj84/4nr5FHPgxb6bRLjAY/50QE6sED3Uz79HZrr7/ZzPiM/X2B7w/cw263uFZ+2sOb6rMf8iyZNNiqt6lfFG1fembHxzxszKQ1a9a8SO26STf9RU8MUqUX/0DLSmULSpn4T6Kx+zn+d+cMdJrWYP4zvxjy91SeSt6mKjf51cinGgOznsVP2rn7dksaEU8uF/yPAGvsu/B///H59AYlVhAI4J5PTAAAAAElFTkSuQmCC";
+
+function ensureConfig(config) {
+  if (!config || typeof config !== "object") return;
+  if (!Array.isArray(config.bots)) config.bots = [];
+}
 
 export const store = createStore("telegramConfig", {
+  config: null,
   projects: [],
-  expandedIdx: null,
+  editing: null,
   testing: null,
   testResults: null,
-  _loaded: false,
+  testResultsFor: null,
+  botSteps: [],
+  didInit: false,
+  steps: STEPS,
+  botFatherQr: BOTFATHER_QR,
+  _projectsLoaded: false,
+  context: null,
 
-  async init() {
-    if (this._loaded) return;
+  get bots() {
+    ensureConfig(this.config);
+    return Array.isArray(this.config?.bots) ? this.config.bots : [];
+  },
+
+  get activeIndex() {
+    return typeof this.editing === "number" ? this.editing : -1;
+  },
+
+  get activeBot() {
+    return this.activeIndex >= 0 ? this.bots[this.activeIndex] || null : null;
+  },
+
+  get showFooterNav() {
+    return this.activeIndex >= 0;
+  },
+
+  get currentStep() {
+    return this.activeIndex >= 0 && typeof this.botSteps[this.activeIndex] === "number"
+      ? this.botSteps[this.activeIndex]
+      : 0;
+  },
+
+  get isFirstStep() {
+    return this.currentStep === 0;
+  },
+
+  get isLastStep() {
+    return this.currentStep >= this.steps.length - 1;
+  },
+
+  get nextDisabled() {
+    return !!this.stepBlockedReason();
+  },
+
+  get nextButtonLabel() {
+    return this.isLastStep ? "Done" : "Next";
+  },
+
+  get footerStepLabel() {
+    return `Step ${this.currentStep + 1} of ${this.steps.length}`;
+  },
+
+  async init(config, context = null) {
+    this.config = config || null;
+    this.context = context;
+    this.didInit = false;
+    ensureConfig(this.config);
+    this.editing = this.bots.length === 1 ? 0 : null;
+    this.testing = null;
+    this.testResults = null;
+    this.testResultsFor = null;
+    this.botSteps = this.bots.map((bot) => this.initialStepForBot(bot));
+    if (this.bots.length === 0) this._startInitialBotFlow();
+    this._installWizardFooter();
+    this.didInit = true;
+
+    if (this._projectsLoaded) return;
     try {
-      const { callJsonApi } = await import("/js/api.js");
-      const res = await callJsonApi("projects", { action: "list" });
-      this.projects = res.data || [];
+      const response = await API.callJsonApi("projects", { action: "list" });
+      this.projects = response.data || [];
     } catch (_) {
       this.projects = [];
     }
-    this._loaded = true;
+    this._projectsLoaded = true;
+  },
+
+  cleanup() {
+    if (this.context?.wizardFooter?.owner === "telegramConfig") {
+      this.context.wizardFooter = null;
+    }
+    this.config = null;
+    this.context = null;
+    this.editing = null;
+    this.testing = null;
+    this.testResults = null;
+    this.testResultsFor = null;
+    this.botSteps = [];
+    this.didInit = false;
   },
 
   defaultBot() {
     return {
       name: "",
-      enabled: true,
+      enabled: false,
       notify_messages: false,
       token: "",
       mode: "polling",
@@ -41,71 +140,208 @@ export const store = createStore("telegramConfig", {
     };
   },
 
-  addBot(config) {
-    if (!config.bots) config.bots = [];
-    const bot = this.defaultBot();
-    bot.name = "bot_" + (config.bots.length + 1);
-    config.bots.push(bot);
-    this.expandedIdx = config.bots.length - 1;
-  },
-
-  removeBot(config, idx) {
-    config.bots.splice(idx, 1);
-    this.expandedIdx = null;
-  },
-
-  toggle(idx) {
-    this.expandedIdx = this.expandedIdx === idx ? null : idx;
+  addBot() {
+    ensureConfig(this.config);
+    this.config.bots.push(this.defaultBot());
+    this.botSteps.push(0);
+    this.editing = this.config.bots.length - 1;
     this.testResults = null;
+    this.testResultsFor = null;
+  },
+
+  removeBot(idx) {
+    this.bots.splice(idx, 1);
+    this.botSteps.splice(idx, 1);
+    if (this.editing === idx) this.editing = null;
+    if (this.editing !== null && this.editing > idx) this.editing -= 1;
+    if (this.testResultsFor === idx) {
+      this.testResults = null;
+      this.testResultsFor = null;
+    }
+  },
+
+  toggleEditing(idx) {
+    this.editing = this.editing === idx ? null : idx;
+    if (this.editing !== null && typeof this.botSteps[this.editing] !== "number") {
+      this.botSteps[this.editing] = this.initialStepForBot(this.bots[this.editing]);
+    }
+    if (this.testResultsFor !== idx) {
+      this.testResults = null;
+      this.testResultsFor = null;
+    }
+  },
+
+  currentStepMeta() {
+    return this.steps[this.currentStep] || this.steps[0];
+  },
+
+  setStep(step) {
+    if (this.activeIndex < 0) return;
+    const next = Math.max(0, Math.min(this.steps.length - 1, Number(step) || 0));
+    this.botSteps[this.activeIndex] = next;
+  },
+
+  previousStep() {
+    if (this.isFirstStep) return;
+    this.setStep(this.currentStep - 1);
+  },
+
+  nextStep() {
+    if (this.stepBlockedReason()) return;
+    if (this.isLastStep) {
+      this.editing = null;
+      return;
+    }
+    this.setStep(this.currentStep + 1);
+  },
+
+  stepBlockedReason() {
+    const bot = this.activeBot;
+    if (!bot) return "";
+    if (this.currentStep === 0 && !String(bot.token || "").trim()) {
+      return "Add your bot token first.";
+    }
+    if (this.currentStep === 1 && bot.mode === "webhook" && !String(bot.webhook_url || "").trim()) {
+      return "Add your webhook URL first.";
+    }
+    return "";
+  },
+
+  canTest(bot) {
+    if (!bot) return false;
+    if (!String(bot.token || "").trim()) return false;
+    if (bot.mode === "webhook" && !String(bot.webhook_url || "").trim()) return false;
+    return true;
+  },
+
+  botStatusLabel(bot) {
+    if (!String(bot?.token || "").trim()) return "New";
+    if (bot?.mode === "webhook" && !String(bot?.webhook_url || "").trim()) return "Needs URL";
+    if (bot?.enabled && this.canTest(bot)) return "Live";
+    if (this.canTest(bot)) return "Ready";
+    return "Needs info";
+  },
+
+  botStatusTone(bot) {
+    const label = this.botStatusLabel(bot);
+    if (label === "Live") return "success";
+    if (label === "Ready") return "ready";
+    if (label === "New") return "muted";
+    return "warning";
+  },
+
+  botTitle(bot, idx) {
+    return String(bot?.name || "").trim() || `Bot ${idx + 1}`;
+  },
+
+  botSubtitle(bot) {
+    const pieces = [bot.mode === "webhook" ? "Webhook" : "Polling"];
+    pieces.push(Array.isArray(bot.allowed_users) && bot.allowed_users.length > 0 ? "Private access" : "Open access");
+    if (bot.default_project) pieces.push(`Project: ${bot.default_project}`);
+    return pieces.join(" · ");
   },
 
   whitelistText(bot) {
     return (bot.allowed_users || []).join(", ");
   },
 
-  setWhitelist(bot, val) {
-    bot.allowed_users = val
+  setWhitelist(bot, value) {
+    bot.allowed_users = value
       .split(",")
-      .map((s) => s.trim())
-      .filter((s) => s);
+      .map((item) => item.trim())
+      .filter((item) => item);
   },
 
   userProjectsText(bot) {
-    const up = bot.user_projects || {};
-    return Object.entries(up)
-      .map(([k, v]) => k + "=" + v)
+    return Object.entries(bot.user_projects || {})
+      .map(([userId, project]) => `${userId}=${project}`)
       .join(", ");
   },
 
-  setUserProjects(bot, val) {
-    const obj = {};
-    val
+  setUserProjects(bot, value) {
+    const mapping = {};
+    value
       .split(",")
-      .map((s) => s.trim())
-      .filter((s) => s)
+      .map((item) => item.trim())
+      .filter((item) => item)
       .forEach((item) => {
-        const parts = item.split("=").map((p) => p.trim());
-        const k = parts[0];
-        if (k) obj[k] = parts[1] || "";
+        const [userId, project] = item.split("=").map((part) => part.trim());
+        if (userId) mapping[userId] = project || "";
       });
-    bot.user_projects = obj;
+    bot.user_projects = mapping;
   },
 
-  async testConnection(config, idx) {
+  accessWarning(bot) {
+    if (!bot?.enabled) return "";
+    if (Array.isArray(bot.allowed_users) && bot.allowed_users.length > 0) return "";
+    return "Allowed users is empty. Anyone who finds this bot can reach your Agent Zero.";
+  },
+
+  async testConnection(idx) {
+    const bot = this.bots[idx];
+    if (!this.canTest(bot)) return;
+
     this.testing = idx;
     this.testResults = null;
+    this.testResultsFor = idx;
+
     try {
-      const { callJsonApi } = await import("/js/api.js");
-      const res = await callJsonApi(`${API_BASE}/test_connection`, {
-        bot: config.bots[idx],
-      });
-      this.testResults = res;
-    } catch (e) {
+      this.testResults = await API.callJsonApi(`${API_BASE}/test_connection`, { bot });
+    } catch (error) {
       this.testResults = {
         success: false,
-        results: [{ test: "Connection", ok: false, message: String(e) }],
+        results: [{ test: "Telegram bot", ok: false, message: String(error) }],
       };
     }
+
     this.testing = null;
+  },
+
+  testButtonLabel(bot, idx) {
+    if (this.testing === idx) return "Checking...";
+    if (this.canTest(bot)) return "Check Telegram connection";
+    return "Fill in the basics first";
+  },
+
+  testIntro() {
+    return "We will validate the bot token with Telegram so you know this bot can connect.";
+  },
+
+  resultTitle(result) {
+    return result.test || "Check";
+  },
+
+  resultMessage(result) {
+    return result.message || (result.ok ? "Done." : "Something went wrong.");
+  },
+
+  initialStepForBot(bot) {
+    return String(bot?.token || "").trim() ? 1 : 0;
+  },
+
+  _startInitialBotFlow() {
+    this.addBot();
+    if (!this.context) return;
+    const toComparableJson = typeof this.context._toComparableJson === "function"
+      ? this.context._toComparableJson.bind(this.context)
+      : JSON.stringify;
+    this.context.settingsSnapshotJson = toComparableJson(this.context.settings);
+  },
+
+  _installWizardFooter() {
+    if (!this.context) return;
+    this.context.wizardFooter = {
+      owner: "telegramConfig",
+      visible: () => this.showFooterNav,
+      canGoBack: () => !this.isFirstStep,
+      backLabel: () => "Back",
+      note: () => this.footerStepLabel,
+      showNext: () => this.showFooterNav && !this.isLastStep,
+      nextLabel: () => this.nextButtonLabel,
+      nextDisabled: () => this.nextDisabled,
+      showSave: () => this.showFooterNav && this.isLastStep,
+      onBack: () => this.previousStep(),
+      onNext: () => this.nextStep(),
+    };
   },
 });

--- a/plugins/_whatsapp_integration/README.md
+++ b/plugins/_whatsapp_integration/README.md
@@ -24,6 +24,7 @@ Dependencies are auto-installed on first bridge start if missing.
 2. Configure allowed phone numbers
 3. Click Show QR Code and scan with WhatsApp on your phone
 4. Send a message from an allowed number to start a chat
+5. Use `/project <name>`, `/config <preset>`, or `/send` in WhatsApp to control the active chat directly
 
 The WhatsApp session persists across restarts in `tmp/whatsapp/session/`. No re-pairing needed unless you disconnect via settings.
 Be careful: if you use your personal number and leave `allowed_numbers` open, other people could misuse your Agent Zero.

--- a/plugins/_whatsapp_integration/api/test_connection.py
+++ b/plugins/_whatsapp_integration/api/test_connection.py
@@ -32,19 +32,19 @@ class TestConnection(ApiHandler):
 
             if status == "connected":
                 results.append({
-                    "test": "Bridge",
+                    "test": "WhatsApp bridge",
                     "ok": True,
-                    "message": f"Connected (uptime: {uptime:.0f}s, queue: {queue})",
+                    "message": f"Connected and ready (uptime: {uptime:.0f}s, queue: {queue})",
                 })
             else:
                 results.append({
-                    "test": "Bridge",
+                    "test": "WhatsApp bridge",
                     "ok": False,
-                    "message": f"Bridge running but status: {status}",
+                    "message": f"The bridge is running, but WhatsApp is not fully connected yet (status: {status}).",
                 })
         except Exception as e:
             results.append({
-                "test": "Bridge",
+                "test": "WhatsApp bridge",
                 "ok": False,
-                "message": f"Bridge not reachable: {format_error(e)}",
+                "message": f"Could not reach the local WhatsApp bridge: {format_error(e)}",
             })

--- a/plugins/_whatsapp_integration/helpers/handler.py
+++ b/plugins/_whatsapp_integration/helpers/handler.py
@@ -13,6 +13,7 @@ import uuid
 from agent import Agent, AgentContext, UserMessage
 from helpers import plugins, files, runtime
 from helpers import message_queue as mq
+from helpers import integration_commands
 from helpers.persist_chat import save_tmp_chat
 from helpers.print_style import PrintStyle
 from helpers.errors import format_error
@@ -120,15 +121,15 @@ async def _dispatch_message(config: dict, msg: dict) -> None:
             PrintStyle.debug(f"WhatsApp: skipping group message (not mentioned or replied to)")
             return
 
-    # Show typing indicator immediately so user sees activity
-    port = int(config.get("bridge_port", 3100))
-    base_url = bridge_manager.get_bridge_url(port)
-    await wa_client.send_typing(base_url, chat_id)
-
     existing = _find_chats_by_jid(chat_id)
 
     if existing:
         # Continue most recent chat for this JID
+        if await _handle_control_message(config, msg, existing[0]):
+            return
+        port = int(config.get("bridge_port", 3100))
+        base_url = bridge_manager.get_bridge_url(port)
+        await wa_client.send_typing(base_url, chat_id)
         await _route_to_chat(msg, existing[0])
     else:
         await _start_new_chat(config, msg)
@@ -162,6 +163,13 @@ async def _start_new_chat(config: dict, msg: dict) -> None:
         projects.activate_project(context.id, project)
 
     save_tmp_chat(context)
+
+    if await _handle_control_message(config, msg, context.id, context=context):
+        return
+
+    port = int(config.get("bridge_port", 3100))
+    base_url = bridge_manager.get_bridge_url(port)
+    await wa_client.send_typing(base_url, chat_id)
 
     user_msg = _build_user_message(context.agent0, msg)
     system_ctx = context.agent0.read_prompt("fw.wa.system_context.md")
@@ -210,6 +218,38 @@ async def _route_to_chat(
 
     save_tmp_chat(context)
     PrintStyle.info(f"WhatsApp: continuing chat {context_id}")
+
+
+async def _handle_control_message(
+    config: dict,
+    msg: dict,
+    context_id: str,
+    *,
+    context: AgentContext | None = None,
+) -> bool:
+    text = msg.get("body", "") or ""
+    parsed = integration_commands.parse_command(text)
+    if not parsed:
+        return False
+
+    context = context or AgentContext.get(context_id)
+    if not context:
+        return False
+
+    response = integration_commands.try_handle_command(context, text)
+    if response is None:
+        return False
+
+    port = int(config.get("bridge_port", 3100))
+    base_url = bridge_manager.get_bridge_url(port)
+    chat_id = context.data.get(CTX_WA_CHAT_ID, "") or msg.get("chatId", "")
+    reply_to = msg.get("messageId", "") if context.data.get(CTX_WA_IS_GROUP) else ""
+
+    await wa_client.send_message(base_url, chat_id, response, reply_to=reply_to)
+    await wa_client.send_typing(base_url, chat_id, paused=True)
+    context.data[CTX_WA_TYPING_ACTIVE] = False
+    PrintStyle.info(f"WhatsApp: handled control command in chat {context.id}")
+    return True
 
 
 # ------------------------------------------------------------------

--- a/plugins/_whatsapp_integration/webui/config.html
+++ b/plugins/_whatsapp_integration/webui/config.html
@@ -1,337 +1,617 @@
 <html>
+
 <head>
     <title>WhatsApp Integration</title>
+    <script type="module">
+        import { store } from "/plugins/_whatsapp_integration/webui/whatsapp-config-store.js";
+    </script>
 </head>
 
 <body>
-    <div x-data="{
-        testing: false,
-        test_results: null,
-        projects: [],
-
-        qr_visible: false,
-        qr_status: '',
-        qr_message: '',
-        qr_data_url: null,
-        qr_poll_timer: null,
-
-        disconnecting: false,
-        disconnect_message: '',
-
-        async init() {
-            try {
-                const { callJsonApi } = await import('/js/api.js');
-                const res = await callJsonApi('projects', { action: 'list' });
-                this.projects = res.data || [];
-            } catch (e) { this.projects = []; }
-        },
-        allowed_text() {
-            const value = config?.allowed_numbers;
-            if (Array.isArray(value)) return value.join(', ');
-            return typeof value === 'string' ? value : '';
-        },
-        allowed_is_empty() {
-            const value = config?.allowed_numbers;
-            if (Array.isArray(value)) return value.length === 0;
-            return !String(value || '').trim();
-        },
-        set_allowed(val) {
-            config.allowed_numbers = val.split(',')
-                .map(s => s.trim())
-                .filter(s => s);
-        },
-        async test_connection() {
-            this.testing = true;
-            this.test_results = null;
-            try {
-                const { callJsonApi } = await import('/js/api.js');
-                const res = await callJsonApi('/plugins/_whatsapp_integration/test_connection', {
-                    config: { bridge_port: config.bridge_port }
-                });
-                this.test_results = res;
-            } catch (e) {
-                this.test_results = { success: false, results: [{ test: 'Connection', ok: false, message: String(e) }] };
-            }
-            this.testing = false;
-        },
-
-        async show_qr() {
-            this.qr_visible = true;
-            this.qr_status = 'loading';
-            this.qr_message = 'Starting bridge...';
-            this.qr_data_url = null;
-            await this.poll_qr();
-            this.qr_poll_timer = setInterval(() => this.poll_qr(), 3000);
-        },
-        hide_qr() {
-            this.qr_visible = false;
-            this.qr_data_url = null;
-            this.qr_status = '';
-            if (this.qr_poll_timer) {
-                clearInterval(this.qr_poll_timer);
-                this.qr_poll_timer = null;
-            }
-        },
-        async poll_qr() {
-            try {
-                const { callJsonApi } = await import('/js/api.js');
-                const res = await callJsonApi('/plugins/_whatsapp_integration/qr_code', {});
-                this.qr_status = res.status || 'error';
-                this.qr_message = res.message || '';
-                this.qr_data_url = res.qr || null;
-
-                if (res.status === 'connected') {
-                    if (this.qr_poll_timer) {
-                        clearInterval(this.qr_poll_timer);
-                        this.qr_poll_timer = null;
-                    }
-                }
-            } catch (e) {
-                this.qr_status = 'error';
-                this.qr_message = String(e);
-                this.qr_data_url = null;
-            }
-        },
-        async disconnect_account() {
-            if (!confirm('Disconnect this WhatsApp account? You will need to scan a new QR code to reconnect.')) return;
-            this.disconnecting = true;
-            this.disconnect_message = '';
-            try {
-                const { callJsonApi } = await import('/js/api.js');
-                const res = await callJsonApi('/plugins/_whatsapp_integration/disconnect', {});
-                this.disconnect_message = res.success ? 'Account disconnected' : (res.message || 'Failed');
-            } catch (e) {
-                this.disconnect_message = String(e);
-            }
-            this.disconnecting = false;
-        }
-    }">
+    <div x-data x-init="$store.whatsappConfig.init(config, context)" x-destroy="$store.whatsappConfig.cleanup()">
         <template x-if="config">
-            <div>
-                <div class="section-title">WhatsApp Integration</div>
+            <div class="wa-page">
+                <div class="section-title">WhatsApp</div>
 
-
-                <div class="field">
-                    <div class="field-label">
-                        <div class="field-title">Enabled</div>
-                        <div class="field-description">Enable WhatsApp bridge and message polling</div>
+                <template x-if="config.enabled && $store.whatsappConfig.hasMeaningfulConfig()">
+                    <div class="wa-summary-card">
+                        <div class="wa-summary-copy">
+                            <div class="wa-summary-title">Current setup</div>
+                            <div class="wa-summary-subtitle"
+                                x-text="$store.whatsappConfig.modeSummary() + ' · ' + $store.whatsappConfig.projectSummary()">
+                            </div>
+                        </div>
+                        <span class="wa-status-pill" :class="'tone-' + $store.whatsappConfig.statusTone()"
+                            x-text="$store.whatsappConfig.statusLabel()"></span>
                     </div>
-                    <div class="field-control">
-                        <label class="toggle">
-                            <input type="checkbox" x-model="config.enabled" />
-                            <span class="toggler"></span>
-                        </label>
-                    </div>
-                </div>
+                </template>
 
-                <!-- WhatsApp Account (shown when enabled) -->
-                <template x-if="config.enabled">
-                    <div>
-                        <div class="field">
-                            <div class="field-label">
-                                <div class="field-title">WhatsApp Account</div>
-                                <div class="field-description">
-                                    <span x-show="!disconnect_message">Pair or switch your WhatsApp account</span>
-                                    <span x-show="disconnect_message" x-text="disconnect_message"
-                                          :style="'color:' + (disconnect_message === 'Account disconnected' ? '#4caf50' : '#f44336')"></span>
+                <div class="wa-wizard-card">
+                    <div class="wa-step-header">
+                        <div class="wa-step-copy">
+                            <div class="wa-step-title" x-text="$store.whatsappConfig.currentStepMeta().title"></div>
+                            <div class="wa-step-description"
+                                x-text="$store.whatsappConfig.currentStepMeta().description"></div>
+                        </div>
+                        <div class="wa-step-dots" aria-hidden="true">
+                            <template x-for="(step, idx) in $store.whatsappConfig.steps" :key="step.title">
+                                <button type="button" class="wa-step-dot"
+                                    :class="{ 'is-active': $store.whatsappConfig.currentStep === idx }"
+                                    @click="$store.whatsappConfig.setStep(idx)"></button>
+                            </template>
+                        </div>
+                    </div>
+
+                    <template x-if="$store.whatsappConfig.currentStep === 0">
+                        <div class="wa-step-panel">
+
+                            <div class="field">
+                                <div class="field-label">
+                                    <div class="field-title">Turn on WhatsApp</div>
+                                    <div class="field-description">Enable the local bridge to start.</div>
+                                </div>
+                                <div class="field-control">
+                                    <label class="toggle">
+                                        <input type="checkbox"
+                                               x-model="config.enabled"
+                                               @change="$store.whatsappConfig.onEnabledChange()" />
+                                        <span class="toggler"></span>
+                                    </label>
                                 </div>
                             </div>
-                            <div class="field-control" style="display: flex; gap: 8px;">
-                                <button class="btn btn-field" @click="show_qr()">
-                                    Show QR Code
-                                </button>
-                                <button class="btn btn-field" @click="disconnect_account()" :disabled="disconnecting">
-                                    <span x-show="!disconnecting">Disconnect</span>
-                                    <span x-show="disconnecting">Disconnecting...</span>
-                                </button>
-                            </div>
-                        </div>
 
-                        <!-- QR Code panel -->
-                        <template x-if="qr_visible">
-                            <div style="margin-top: 8px; padding: 16px; border-radius: 8px;
-                                        border: 1px solid var(--border-color, #333);
-                                        text-align: center;">
-
-                                <!-- Connected state -->
-                                <template x-if="qr_status === 'connected'">
-                                    <div>
-                                        <div style="font-size: 1.5rem; margin-bottom: 8px;">&#10003;</div>
-                                        <div style="font-weight: 500; color: #4caf50;" x-text="qr_message"></div>
-                                        <button class="btn btn-field" @click="hide_qr()" style="margin-top: 12px;">
-                                            Close
-                                        </button>
-                                    </div>
-                                </template>
-
-                                <!-- QR code ready -->
-                                <template x-if="qr_status === 'waiting_scan' && qr_data_url">
-                                    <div>
-                                        <div style="font-weight: 500; margin-bottom: 12px;">
-                                            Scan with WhatsApp on your phone
+                            <template x-if="config.enabled">
+                                <div>
+                                    <div class="field">
+                                        <div class="field-label">
+                                            <div class="field-title">WhatsApp account</div>
+                                            <div class="field-description">
+                                                <span x-show="!$store.whatsappConfig.disconnectMessage">Click "Show QR code" to pair your WhatsApp account.</span>
+                                                <span x-show="$store.whatsappConfig.disconnectMessage"
+                                                      x-text="$store.whatsappConfig.disconnectMessage"></span>
+                                            </div>
                                         </div>
-                                        <img :src="qr_data_url" alt="WhatsApp QR Code"
-                                             style="width: 256px; height: 256px; border-radius: 8px;
-                                                    background: white; padding: 4px;" />
-                                        <div style="margin-top: 8px; font-size: 0.8rem; opacity: 0.6;">
-                                            QR code refreshes automatically
+                                        <div class="field-control wa-inline-actions">
+                                            <button class="btn btn-field" @click="$store.whatsappConfig.showQr()">
+                                                Show QR code
+                                            </button>
+                                            <button class="btn btn-field" @click="$store.whatsappConfig.disconnectAccount()"
+                                                :disabled="$store.whatsappConfig.disconnecting">
+                                                <span x-show="!$store.whatsappConfig.disconnecting">Disconnect</span>
+                                                <span x-show="$store.whatsappConfig.disconnecting">Disconnecting...</span>
+                                            </button>
                                         </div>
-                                        <button class="btn btn-field" @click="hide_qr()" style="margin-top: 12px;">
-                                            Cancel
-                                        </button>
                                     </div>
-                                </template>
 
-                                <!-- Loading / waiting for QR -->
-                                <template x-if="qr_status !== 'connected' && !(qr_status === 'waiting_scan' && qr_data_url)">
-                                    <div>
-                                        <div style="font-weight: 500; margin-bottom: 8px;" x-text="qr_message || 'Connecting...'"></div>
-                                        <div style="font-size: 0.85rem; opacity: 0.6;">
-                                            <template x-if="qr_status === 'error'">
-                                                <span style="color: #f44336;" x-text="qr_message"></span>
+                                    <template x-if="$store.whatsappConfig.qrVisible">
+                                        <div class="wa-qr-panel">
+                                            <template x-if="$store.whatsappConfig.qrStatus === 'connected'">
+                                                <div>
+                                                    <div class="wa-qr-status ok">Connected</div>
+                                                    <div class="wa-qr-message" x-text="$store.whatsappConfig.qrMessage"></div>
+                                                    <button class="btn btn-field" @click="$store.whatsappConfig.hideQr()"
+                                                        style="margin-top: 12px;">
+                                                        Close
+                                                    </button>
+                                                </div>
                                             </template>
-                                            <template x-if="qr_status !== 'error'">
-                                                <span>Please wait...</span>
+
+                                            <template
+                                                x-if="$store.whatsappConfig.qrStatus === 'waiting_scan' && $store.whatsappConfig.qrDataUrl">
+                                                <div>
+                                                    <div class="wa-qr-status">Scan with WhatsApp on your phone</div>
+                                                    <img :src="$store.whatsappConfig.qrDataUrl" alt="WhatsApp QR Code"
+                                                        class="wa-qr-image" />
+                                                    <div class="wa-qr-help">The QR code refreshes automatically.</div>
+                                                    <button class="btn btn-field" @click="$store.whatsappConfig.hideQr()"
+                                                        style="margin-top: 12px;">
+                                                        Cancel
+                                                    </button>
+                                                </div>
+                                            </template>
+
+                                            <template
+                                                x-if="$store.whatsappConfig.qrStatus !== 'connected' && !($store.whatsappConfig.qrStatus === 'waiting_scan' && $store.whatsappConfig.qrDataUrl)">
+                                                <div>
+                                                    <div class="wa-qr-status"
+                                                        x-text="$store.whatsappConfig.qrMessage || 'Connecting...'"></div>
+                                                    <div class="wa-qr-help"
+                                                        x-show="$store.whatsappConfig.qrStatus !== 'error'">
+                                                        Please wait...</div>
+                                                    <div class="wa-qr-help error"
+                                                        x-show="$store.whatsappConfig.qrStatus === 'error'"
+                                                        x-text="$store.whatsappConfig.qrMessage"></div>
+                                                    <button class="btn btn-field" @click="$store.whatsappConfig.hideQr()"
+                                                        style="margin-top: 12px;">
+                                                        Cancel
+                                                    </button>
+                                                </div>
                                             </template>
                                         </div>
-                                        <button class="btn btn-field" @click="hide_qr()" style="margin-top: 12px;">
-                                            Cancel
-                                        </button>
-                                    </div>
-                                </template>
-                            </div>
-                        </template>
-                    </div>
-                </template>
-
-                <div class="field">
-                    <div class="field-label">
-                        <div class="field-title">Mode</div>
-                        <div class="field-description">
-                            <span x-show="config.mode === 'self-chat'">
-                                Use your personal number. You can message yourself to talk to the agent, and the agent can also handle messages that other people send to your number.
-                            </span>
-                            <span x-show="config.mode !== 'self-chat'">
-                                Use a separate WhatsApp number dedicated to Agent Zero conversations.
-                            </span>
-                        </div>
-                    </div>
-                    <div class="field-control">
-                        <select x-model="config.mode">
-                            <option value="self-chat">Personal number (self-chat)</option>
-                            <option value="dedicated">Separate number (dedicated)</option>
-                        </select>
-                    </div>
-                </div>
-
-                <template x-if="config.enabled && allowed_is_empty()">
-                    <div style="margin: 8px 0 20px; padding: 12px 14px; border-radius: 10px;
-                                border: 1px solid rgba(255, 170, 0, 0.45);
-                                background: rgba(255, 170, 0, 0.12);
-                                color: var(--color-warning-text);">
-                        <div style="font-weight: 600; display: flex; align-items: center; gap: 8px;">
-                            <span aria-hidden="true">&#9888;</span>
-                            <span>Warning</span>
-                        </div>
-                        <div style="margin-top: 4px; line-height: 1.45;">
-                            Allowed Numbers is empty. If other people can message this WhatsApp number, they can use your Agent Zero.
-                        </div>
-                    </div>
-                </template>
-
-                <div class="field">
-                    <div class="field-label">
-                        <div class="field-title">Allowed Numbers</div>
-                        <div class="field-description">Comma-separated phone numbers. Matching is normalized by the backend, so punctuation and + prefixes are okay. Empty = allow all.</div>
-                    </div>
-                    <div class="field-control">
-                        <input type="text" :value="allowed_text()" @change="set_allowed($event.target.value)" placeholder="+1 (415) 555-1234, +44 7911 123456" />
-                    </div>
-                </div>
-
-                <div class="field">
-                    <div class="field-label">
-                        <div class="field-title">Allow Group</div>
-                        <div class="field-description">Respond in group chats when mentioned or replied to</div>
-                    </div>
-                    <div class="field-control">
-                        <label class="toggle">
-                            <input type="checkbox" x-model="config.allow_group" />
-                            <span class="toggler"></span>
-                        </label>
-                    </div>
-                </div>
-
-                <div class="field">
-                    <div class="field-label">
-                        <div class="field-title">Project</div>
-                        <div class="field-description">Project to activate for WhatsApp chats</div>
-                    </div>
-                    <div class="field-control">
-                        <select :value="config.project" @change="config.project = $event.target.value">
-                            <option value="">No project</option>
-                            <template x-for="proj in projects" :key="proj.name">
-                                <option :value="proj.name" x-text="proj.title || proj.name" :selected="config.project === proj.name"></option>
+                                    </template>
+                                </div>
                             </template>
-                        </select>
-                    </div>
-                </div>
 
-                <div class="field">
-                    <div class="field-label">
-                        <div class="field-title">Agent Instructions</div>
-                        <div class="field-description">Extra instructions for the agent in WhatsApp chats</div>
-                    </div>
-                    <div class="field-control">
-                        <textarea x-model="config.agent_instructions" rows="3" placeholder="e.g. Always respond concisely..."></textarea>
-                    </div>
-                </div>
-
-                <div class="field">
-                    <div class="field-label">
-                        <div class="field-title">Bridge Port</div>
-                        <div class="field-description">Local port for the WhatsApp bridge HTTP server</div>
-                    </div>
-                    <div class="field-control">
-                        <input type="number" x-model.number="config.bridge_port" placeholder="3100" />
-                    </div>
-                </div>
-
-                <div class="field">
-                    <div class="field-label">
-                        <div class="field-title">Poll Interval (seconds)</div>
-                        <div class="field-description">How often to check for new messages (minimum 2)</div>
-                    </div>
-                    <div class="field-control">
-                        <input type="number" x-model.number="config.poll_interval_seconds" min="2" placeholder="3" />
-                    </div>
-                </div>
-
-                <!-- Test connection -->
-                <div style="margin-top: 16px; display: flex; align-items: center; gap: 12px;">
-                    <button class="btn btn-field" @click="test_connection()" :disabled="testing">
-                        <span x-show="!testing">Test Connection</span>
-                        <span x-show="testing">Testing...</span>
-                    </button>
-                </div>
-
-                <!-- Test results -->
-                <template x-if="test_results">
-                    <div style="margin-top: 8px; padding: 8px 12px; border-radius: 6px; font-size: 0.85rem;
-                                border: 1px solid var(--border-color, #333);">
-                        <template x-for="r in test_results.results" :key="r.test">
-                            <div style="display: flex; align-items: center; gap: 8px; padding: 4px 0;">
-                                <span x-text="r.ok ? '✓' : '✗'"
-                                      :style="'font-weight: bold; color:' + (r.ok ? '#4caf50' : '#f44336')"></span>
-                                <span style="font-weight: 500; min-width: 50px;" x-text="r.test"></span>
-                                <span style="opacity: 0.8;" x-text="r.message"></span>
+                            <div class="wa-note" x-show="!config.enabled">
+                                Turn on WhatsApp to pair or switch your account.
                             </div>
-                        </template>
+
+                            <div class="field">
+                                <div class="field-label">
+                                    <div class="field-title">Mode</div>
+                                    <div class="field-description">
+                                        <span x-show="config.mode === 'self-chat'">
+                                            Use your own number. You can message yourself to talk to the agent.
+                                        </span>
+                                        <span x-show="config.mode !== 'self-chat'">
+                                            Use a separate number dedicated to Agent Zero conversations.
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="field-control">
+                                    <select x-model="config.mode">
+                                        <option value="self-chat">Personal number (self-chat)</option>
+                                        <option value="dedicated">Separate number (dedicated)</option>
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div class="wa-mode-note">
+                                <strong>Good to know:</strong> Self-chat uses your own number. Dedicated is better for
+                                shared or public access. You can pair now or come back to it later.
+                            </div>
+
+                            <div class="wa-warning" x-show="$store.whatsappConfig.accessWarning()">
+                                <div class="wa-warning-title">
+                                    <span aria-hidden="true">&#9888;</span>
+                                    <span>Warning</span>
+                                </div>
+                                <div class="wa-warning-body" x-text="$store.whatsappConfig.accessWarning()"></div>
+                            </div>
+
+                            <div class="field">
+                                <div class="field-label">
+                                    <div class="field-title">Allowed numbers</div>
+                                    <div class="field-description">Comma-separated phone numbers. Punctuation and +
+                                        prefixes are okay. Leave empty only if you want open access.</div>
+                                </div>
+                                <div class="field-control">
+                                    <input type="text" :value="$store.whatsappConfig.allowedText()"
+                                        @input="$store.whatsappConfig.setAllowed($event.target.value)"
+                                        placeholder="+1 (415) 555-1234, +44 7911 123456" />
+                                </div>
+                            </div>
+
+                            <div class="field">
+                                <div class="field-label">
+                                    <div class="field-title">Allow groups</div>
+                                    <div class="field-description">Reply in group chats when mentioned or replied to.
+                                    </div>
+                                </div>
+                                <div class="field-control">
+                                    <label class="toggle">
+                                        <input type="checkbox" x-model="config.allow_group" />
+                                        <span class="toggler"></span>
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+
+                    <template x-if="$store.whatsappConfig.currentStep === 1">
+                        <div class="wa-step-panel">
+                            <div class="field">
+                                <div class="field-label">
+                                    <div class="field-title">Project</div>
+                                    <div class="field-description">Optional project to activate for WhatsApp
+                                        conversations.</div>
+                                </div>
+                                <div class="field-control">
+                                    <select :value="config.project" @change="config.project = $event.target.value">
+                                        <option value="">No project</option>
+                                        <template x-for="proj in $store.whatsappConfig.projects" :key="proj.name">
+                                            <option :value="proj.name" x-text="proj.title || proj.name"
+                                                :selected="config.project === proj.name"></option>
+                                        </template>
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div class="field">
+                                <div class="field-label">
+                                    <div class="field-title">Agent instructions</div>
+                                    <div class="field-description">Extra guidance for how the agent should reply in
+                                        WhatsApp chats.</div>
+                                </div>
+                                <div class="field-control">
+                                    <textarea x-model="config.agent_instructions" rows="3"
+                                        placeholder="Reply briefly and naturally, like a mobile conversation."></textarea>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+
+                    <div class="wa-test-panel">
+                        <div class="wa-test-copy">
+                            <div class="wa-test-title">Check the connection</div>
+                            <div class="wa-test-description">We will check whether the local WhatsApp bridge is up and
+                                connected.</div>
+                        </div>
+                        <button class="btn btn-field" @click="$store.whatsappConfig.testConnection()"
+                            :disabled="$store.whatsappConfig.testing">
+                            <span x-text="$store.whatsappConfig.testButtonLabel()"></span>
+                        </button>
                     </div>
-                </template>
+
+                    <template x-if="$store.whatsappConfig.testResults">
+                        <div class="wa-results" :class="{ 'is-error': !$store.whatsappConfig.testResults.success }">
+                            <template x-for="result in $store.whatsappConfig.testResults.results"
+                                :key="result.test + result.message">
+                                <div class="wa-result-row">
+                                    <span class="wa-result-icon" x-text="result.ok ? '✓' : '✗'"></span>
+                                    <div class="wa-result-copy">
+                                        <div class="wa-result-title" x-text="result.test"></div>
+                                        <div class="wa-result-message" x-text="result.message"></div>
+                                    </div>
+                                </div>
+                            </template>
+                        </div>
+                    </template>
+
+                    <template x-if="$store.whatsappConfig.currentStep > 0">
+                        <details class="wa-advanced">
+                            <summary>
+                                <span>Advanced</span>
+                                <span class="material-symbols-outlined wa-advanced-chevron"
+                                    aria-hidden="true">keyboard_arrow_down</span>
+                            </summary>
+                            <div class="wa-advanced-body">
+                                <div class="wa-info-box">
+                                    These settings are here when you need them, but the defaults are fine for most
+                                    setups.
+                                </div>
+
+                                <div class="field">
+                                    <div class="field-label">
+                                        <div class="field-title">Bridge port</div>
+                                        <div class="field-description">Local port for the WhatsApp bridge HTTP server.
+                                        </div>
+                                    </div>
+                                    <div class="field-control">
+                                        <input type="number" x-model.number="config.bridge_port" placeholder="3100" />
+                                    </div>
+                                </div>
+
+                                <div class="field">
+                                    <div class="field-label">
+                                        <div class="field-title">Poll interval (seconds)</div>
+                                        <div class="field-description">How often to check for new messages. The minimum
+                                            is 2 seconds.</div>
+                                    </div>
+                                    <div class="field-control">
+                                        <input type="number" x-model.number="config.poll_interval_seconds" min="2"
+                                            placeholder="3" />
+                                    </div>
+                                </div>
+
+                            </div>
+                        </details>
+                    </template>
+                </div>
             </div>
         </template>
     </div>
+
+    <style>
+        .wa-page {
+            display: flex;
+            flex-direction: column;
+            gap: 0.9rem;
+        }
+
+        .wa-summary-card,
+        .wa-wizard-card {
+            border-radius: 0.5rem;
+        }
+
+        .wa-advanced summary {
+            cursor: pointer;
+            list-style: none;
+            font-weight: 700;
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .wa-advanced summary::-webkit-details-marker {
+            display: none;
+        }
+
+        .wa-summary-title,
+        .wa-step-title,
+        .wa-test-title {
+            font-weight: 700;
+        }
+
+        .wa-summary-subtitle,
+        .wa-step-description,
+        .wa-note,
+        .wa-mode-note,
+        .wa-test-description,
+        .wa-result-message {
+            color: var(--color-text-secondary);
+            line-height: 1.5;
+        }
+
+        .wa-summary-card {
+            padding: 1rem;
+            border: 1px solid var(--color-border);
+            display: flex;
+            justify-content: space-between;
+            gap: 1rem;
+            align-items: center;
+        }
+
+        .wa-step-header {
+            display: flex;
+            justify-content: space-between;
+            gap: 1rem;
+            align-items: flex-start;
+            margin-bottom: 1rem;
+        }
+
+        .wa-step-dots {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+            align-items: center;
+        }
+
+        .wa-step-dot {
+            width: 0.85rem;
+            height: 0.85rem;
+            border-radius: 999px;
+            border: 1px solid var(--color-border);
+            background: transparent;
+            cursor: pointer;
+            padding: 0;
+        }
+
+        .wa-step-dot.is-active {
+            background: rgba(59, 130, 246, 0.9);
+            border-color: rgba(59, 130, 246, 0.9);
+        }
+
+        .wa-step-panel {
+            display: flex;
+            flex-direction: column;
+            gap: 0.2rem;
+        }
+
+        .wa-info-box,
+        .wa-note {
+            margin-bottom: 0.9rem;
+            padding: 0.8rem 0.9rem;
+            border-radius: 12px;
+            font-size: var(--font-size-small);
+        }
+
+        .wa-info-box {
+            background: color-mix(in srgb, #3b82f6 12%, var(--color-background) 88%);
+        }
+
+        .wa-note {
+            background: color-mix(in srgb, var(--color-background) 88%, white 12%);
+        }
+
+        .wa-warning {
+            margin: 0.5rem 0 1.25rem;
+            padding: 0.75rem 0.9rem;
+            border-radius: 10px;
+            border: 1px solid rgba(255, 170, 0, 0.45);
+            background: rgba(255, 170, 0, 0.12);
+            color: var(--color-warning-text);
+            font-size: var(--font-size-small);
+        }
+
+        .wa-warning-title {
+            font-weight: 600;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .wa-warning-body {
+            margin-top: 0.25rem;
+            line-height: 1.45;
+        }
+
+        .wa-mode-note {
+            margin-top: -0.2rem;
+            margin-bottom: 0.9rem;
+            font-size: var(--font-size-small);
+        }
+
+        .wa-inline-actions {
+            display: flex;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .wa-qr-panel {
+            margin-top: 0.25rem;
+            padding: 1rem;
+            border-radius: 14px;
+            border: 1px solid color-mix(in srgb, var(--color-border) 88%, white 12%);
+            background: color-mix(in srgb, var(--color-background) 90%, white 10%);
+            text-align: center;
+        }
+
+        .wa-qr-status {
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+        }
+
+        .wa-qr-status.ok {
+            color: #7ee7a4;
+        }
+
+        .wa-qr-message,
+        .wa-qr-help {
+            color: var(--color-text-secondary);
+            line-height: 1.5;
+        }
+
+        .wa-qr-help {
+            font-size: var(--font-size-small);
+            margin-top: 0.4rem;
+        }
+
+        .wa-qr-help.error {
+            color: #fca5a5;
+        }
+
+        .wa-qr-image {
+            width: 256px;
+            height: 256px;
+            max-width: 100%;
+            border-radius: 8px;
+            background: white;
+            padding: 4px;
+        }
+
+        .wa-advanced {
+            margin-top: 1rem;
+            border: 1px solid color-mix(in srgb, var(--color-border) 88%, white 12%);
+            border-radius: 14px;
+            overflow: hidden;
+        }
+
+        .wa-advanced summary {
+            padding: 0.9rem 1rem;
+            background: color-mix(in srgb, var(--color-background) 88%, white 12%);
+        }
+
+        .wa-advanced-chevron {
+            margin-left: auto;
+            flex: 0 0 auto;
+            transition: transform 0.18s ease, opacity 0.18s ease;
+            opacity: 0.72;
+        }
+
+        .wa-advanced[open] .wa-advanced-chevron {
+            transform: rotate(180deg);
+            opacity: 1;
+        }
+
+        .wa-advanced-body {
+            padding: 1rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.2rem;
+        }
+
+        .wa-test-panel {
+            margin-top: 1rem;
+            padding: var(--spacing-xs) 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        .wa-test-copy,
+        .wa-result-copy {
+            min-width: 0;
+        }
+
+        .wa-results {
+            margin-top: 0.9rem;
+            border-radius: 14px;
+            border: 1px solid color-mix(in srgb, #22c55e 28%, var(--color-border) 72%);
+            background: color-mix(in srgb, #22c55e 8%, var(--color-background) 92%);
+            padding: 0.35rem 0.9rem;
+        }
+
+        .wa-results.is-error {
+            border-color: color-mix(in srgb, #ef4444 28%, var(--color-border) 72%);
+            background: color-mix(in srgb, #ef4444 8%, var(--color-background) 92%);
+        }
+
+        .wa-result-row {
+            display: flex;
+            align-items: flex-start;
+            gap: 0.8rem;
+            padding: 0.7rem 0;
+        }
+
+        .wa-result-row+.wa-result-row {
+            border-top: 1px solid color-mix(in srgb, var(--color-border) 85%, white 15%);
+        }
+
+        .wa-result-icon {
+            width: 1.25rem;
+            font-weight: 800;
+            line-height: 1.3;
+        }
+
+        .wa-result-title {
+            font-weight: 700;
+            margin-bottom: 0.18rem;
+        }
+
+        .wa-status-pill {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 5.25rem;
+            padding: 0.35rem 0.7rem;
+            border-radius: 999px;
+            font-size: 0.8rem;
+            font-weight: 700;
+        }
+
+        .wa-status-pill.tone-success {
+            background: rgba(34, 197, 94, 0.14);
+            color: #7ee7a4;
+        }
+
+        .wa-status-pill.tone-ready {
+            background: rgba(59, 130, 246, 0.16);
+            color: #93c5fd;
+        }
+
+        .wa-status-pill.tone-warning {
+            background: rgba(245, 158, 11, 0.16);
+            color: #fcd34d;
+        }
+
+        .wa-status-pill.tone-muted {
+            background: rgba(148, 163, 184, 0.14);
+            color: #cbd5e1;
+        }
+
+        @media (max-width: 640px) {
+
+            .wa-summary-card,
+            .wa-step-header,
+            .wa-test-panel {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            .wa-step-dots {
+                width: 100%;
+                justify-content: space-between;
+            }
+
+            .wa-status-pill {
+                min-width: 0;
+                align-self: flex-start;
+            }
+        }
+    </style>
 </body>
 
 </html>

--- a/plugins/_whatsapp_integration/webui/whatsapp-config-store.js
+++ b/plugins/_whatsapp_integration/webui/whatsapp-config-store.js
@@ -1,0 +1,273 @@
+import { createStore } from "/js/AlpineStore.js";
+import * as API from "/js/api.js";
+
+const API_BASE = "/plugins/_whatsapp_integration";
+const STEPS = [
+  {
+    title: "Pair your account and set access",
+    description: "Turn on WhatsApp, connect the account, and choose who can reach it.",
+  },
+  {
+    title: "Choose where conversations go",
+    description: "Pick a project if you want one and shape how the agent should reply.",
+  },
+];
+
+function ensureConfig(config) {
+  if (!config || typeof config !== "object") return;
+  if (typeof config.enabled !== "boolean") config.enabled = false;
+  if (!config.mode) config.mode = "self-chat";
+  if (!config.bridge_port) config.bridge_port = 3100;
+  if (!config.poll_interval_seconds) config.poll_interval_seconds = 3;
+  if (typeof config.allow_group !== "boolean") config.allow_group = false;
+
+  if (Array.isArray(config.allowed_numbers)) return;
+  if (typeof config.allowed_numbers === "string") {
+    config.allowed_numbers = config.allowed_numbers
+      .split(",")
+      .map((item) => item.trim())
+      .filter((item) => item);
+    return;
+  }
+  config.allowed_numbers = [];
+}
+
+export const store = createStore("whatsappConfig", {
+  config: null,
+  projects: [],
+  guideOpen: false,
+  currentStep: 0,
+  testing: false,
+  testResults: null,
+  qrVisible: false,
+  qrStatus: "",
+  qrMessage: "",
+  qrDataUrl: null,
+  qrPollTimer: null,
+  disconnecting: false,
+  disconnectMessage: "",
+  steps: STEPS,
+  _projectsLoaded: false,
+  context: null,
+
+  get showFooterNav() {
+    return true;
+  },
+
+  get isFirstStep() {
+    return this.currentStep === 0;
+  },
+
+  get isLastStep() {
+    return this.currentStep >= this.steps.length - 1;
+  },
+
+  get nextButtonLabel() {
+    return this.isLastStep ? "Done" : "Next";
+  },
+
+  get footerStepLabel() {
+    return `Step ${this.currentStep + 1} of ${this.steps.length}`;
+  },
+
+  async init(config, context = null) {
+    this.config = config || null;
+    this.context = context;
+    ensureConfig(this.config);
+    this.guideOpen = !this.hasMeaningfulConfig() && window.innerWidth > 720;
+    this.currentStep = 0;
+    this.testing = false;
+    this.testResults = null;
+    this._installWizardFooter();
+
+    if (this._projectsLoaded) return;
+    try {
+      const response = await API.callJsonApi("projects", { action: "list" });
+      this.projects = response.data || [];
+    } catch (_) {
+      this.projects = [];
+    }
+    this._projectsLoaded = true;
+  },
+
+  cleanup() {
+    if (this.context?.wizardFooter?.owner === "whatsappConfig") {
+      this.context.wizardFooter = null;
+    }
+    this.hideQr();
+    this.config = null;
+    this.context = null;
+    this.guideOpen = false;
+    this.currentStep = 0;
+    this.testing = false;
+    this.testResults = null;
+    this.disconnecting = false;
+    this.disconnectMessage = "";
+  },
+
+  currentStepMeta() {
+    return this.steps[this.currentStep] || this.steps[0];
+  },
+
+  setStep(step) {
+    this.currentStep = Math.max(0, Math.min(this.steps.length - 1, Number(step) || 0));
+  },
+
+  nextStep() {
+    if (!this.isLastStep) this.currentStep += 1;
+  },
+
+  previousStep() {
+    if (!this.isFirstStep) this.currentStep -= 1;
+  },
+
+  hasMeaningfulConfig() {
+    if (!this.config) return false;
+    return !!(
+      this.config.enabled
+      || String(this.config.project || "").trim()
+      || String(this.config.agent_instructions || "").trim()
+      || (Array.isArray(this.config.allowed_numbers) && this.config.allowed_numbers.length > 0)
+    );
+  },
+
+  allowedText() {
+    ensureConfig(this.config);
+    return (this.config?.allowed_numbers || []).join(", ");
+  },
+
+  allowedIsEmpty() {
+    ensureConfig(this.config);
+    return (this.config?.allowed_numbers || []).length === 0;
+  },
+
+  setAllowed(value) {
+    ensureConfig(this.config);
+    this.config.allowed_numbers = value
+      .split(",")
+      .map((item) => item.trim())
+      .filter((item) => item);
+  },
+
+  onEnabledChange() {
+    if (this.config?.enabled) return;
+    this.hideQr();
+  },
+
+  accessWarning() {
+    if (!this.config?.enabled) return "";
+    if (!this.allowedIsEmpty()) return "";
+    return "Allowed numbers is empty. If other people can message this number, they can reach your Agent Zero.";
+  },
+
+  statusLabel() {
+    if (!this.config?.enabled) return "Off";
+    if (this.qrStatus === "connected") return "Live";
+    if (this.allowedIsEmpty()) return "Open access";
+    return "Ready";
+  },
+
+  statusTone() {
+    const label = this.statusLabel();
+    if (label === "Live") return "success";
+    if (label === "Ready") return "ready";
+    if (label === "Off") return "muted";
+    return "warning";
+  },
+
+  modeSummary() {
+    if (!this.config) return "";
+    return this.config.mode === "self-chat" ? "Self-chat" : "Dedicated number";
+  },
+
+  projectSummary() {
+    return this.config?.project ? `Project: ${this.config.project}` : "No project";
+  },
+
+  async testConnection() {
+    this.testing = true;
+    this.testResults = null;
+    try {
+      this.testResults = await API.callJsonApi(`${API_BASE}/test_connection`, {
+        config: { bridge_port: this.config?.bridge_port },
+      });
+    } catch (error) {
+      this.testResults = {
+        success: false,
+        results: [{ test: "WhatsApp", ok: false, message: String(error) }],
+      };
+    }
+    this.testing = false;
+  },
+
+  testButtonLabel() {
+    return this.testing ? "Checking..." : "Check WhatsApp connection";
+  },
+
+  async showQr() {
+    this.qrVisible = true;
+    this.qrStatus = "loading";
+    this.qrMessage = "Starting the WhatsApp bridge...";
+    this.qrDataUrl = null;
+    await this.pollQr();
+    this.qrPollTimer = setInterval(() => this.pollQr(), 3000);
+  },
+
+  hideQr() {
+    this.qrVisible = false;
+    this.qrDataUrl = null;
+    this.qrStatus = "";
+    if (this.qrPollTimer) {
+      clearInterval(this.qrPollTimer);
+      this.qrPollTimer = null;
+    }
+  },
+
+  async pollQr() {
+    try {
+      const response = await API.callJsonApi(`${API_BASE}/qr_code`, {});
+      this.qrStatus = response.status || "error";
+      this.qrMessage = response.message || "";
+      this.qrDataUrl = response.qr || null;
+
+      if (response.status === "connected" && this.qrPollTimer) {
+        clearInterval(this.qrPollTimer);
+        this.qrPollTimer = null;
+      }
+    } catch (error) {
+      this.qrStatus = "error";
+      this.qrMessage = String(error);
+      this.qrDataUrl = null;
+    }
+  },
+
+  async disconnectAccount() {
+    if (!window.confirm("Disconnect this WhatsApp account? You will need to scan a new QR code to reconnect.")) return;
+    this.disconnecting = true;
+    this.disconnectMessage = "";
+    try {
+      const response = await API.callJsonApi(`${API_BASE}/disconnect`, {});
+      this.disconnectMessage = response.success ? "Account disconnected" : (response.message || "Disconnect failed");
+    } catch (error) {
+      this.disconnectMessage = String(error);
+    }
+    this.disconnecting = false;
+  },
+
+  _installWizardFooter() {
+    if (!this.context) return;
+    this.context.wizardFooter = {
+      owner: "whatsappConfig",
+      visible: () => this.showFooterNav,
+      canGoBack: () => !this.isFirstStep,
+      backLabel: () => "Back",
+      note: () => this.footerStepLabel,
+      showNext: () => !this.isLastStep,
+      nextLabel: () => this.nextButtonLabel,
+      nextDisabled: () => false,
+      showSave: () => this.isLastStep,
+      onBack: () => this.previousStep(),
+      onNext: () => this.nextStep(),
+    };
+  },
+});

--- a/webui/components/plugins/plugin-settings-store.js
+++ b/webui/components/plugins/plugin-settings-store.js
@@ -19,6 +19,7 @@ const model = {
 
     // plugin settings data (plugins bind their fields here)
     settings: {},
+    wizardFooter: null,
 
     settingsSnapshotJson: "",
     previousProjectName: "",
@@ -80,6 +81,7 @@ const model = {
         this.pluginMeta = pluginMeta || null;
         this.settings = {};
         this.settingsSnapshotJson = "";
+        this.wizardFooter = null;
         this.error = null;
         this.projectName = projectName;
         this.agentProfileKey = agentProfileKey;
@@ -373,6 +375,7 @@ const model = {
         this.agentProfileKey = "";
         this.settings = {};
         this.settingsSnapshotJson = "";
+        this.wizardFooter = null;
         this.previousProjectName = "";
         this.previousAgentProfileKey = "";
         this.loadedPath = "";

--- a/webui/components/plugins/plugin-settings.html
+++ b/webui/components/plugins/plugin-settings.html
@@ -114,21 +114,42 @@
             </div>
 
             <!-- Footer (pinned outside scroll area) -->
-            <div class="modal-footer" data-modal-footer>
-                <button class="btn btn-ok"
-                        @click="context.save()"
-                        :disabled="context?.isSaving || context?.isLoading">
-                    Save
-                </button>
-                <button class="btn"
-                        @click="context.resetToDefault()"
-                        :disabled="context?.isSaving || context?.isLoading">
-                    Default
-                </button>
-                <button class="btn btn-cancel"
-                        @click="window.closeModal?.()">
-                    Cancel
-                </button>
+            <div class="modal-footer plugin-settings-footer" data-modal-footer>
+                <div class="plugin-settings-footer-nav"
+                     x-show="context.wizardFooter?.visible?.()">
+                    <div class="plugin-settings-footer-nav-row">
+                        <button class="btn"
+                                @click="context.wizardFooter?.onBack?.()"
+                                :disabled="!context.wizardFooter?.canGoBack?.()">
+                            <span x-text="context.wizardFooter?.backLabel?.() || 'Back'"></span>
+                        </button>
+                        <div class="plugin-settings-footer-note" x-text="context.wizardFooter?.note?.() || ''"></div>
+                    </div>
+                </div>
+
+                <div class="plugin-settings-footer-actions">
+                    <button class="btn"
+                            @click="context.resetToDefault()"
+                            :disabled="context?.isSaving || context?.isLoading">
+                        Default
+                    </button>
+                    <button class="btn btn-cancel"
+                            @click="window.closeModal?.()">
+                        Cancel
+                    </button>
+                    <button class="btn btn-field"
+                            x-show="context.wizardFooter?.showNext?.()"
+                            @click="context.wizardFooter?.onNext?.()"
+                            :disabled="context.wizardFooter?.nextDisabled?.()">
+                        <span x-text="context.wizardFooter?.nextLabel?.() || 'Next'"></span>
+                    </button>
+                    <button class="btn btn-ok"
+                            x-show="!context.wizardFooter || context.wizardFooter?.showSave?.()"
+                            @click="context.save()"
+                            :disabled="context?.isSaving || context?.isLoading">
+                        Save
+                    </button>
+                </div>
             </div>
             </div>
         </template>
@@ -213,6 +234,39 @@
             min-height: 4rem;
         }
 
+        .plugin-settings-footer {
+            justify-content: space-between;
+            gap: 1rem;
+            flex-wrap: wrap;
+        }
+
+        .plugin-settings-footer-nav {
+            flex: 1 1 22rem;
+            min-width: 18rem;
+        }
+
+        .plugin-settings-footer-nav-row {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            width: 100%;
+        }
+
+        .plugin-settings-footer-note {
+            color: var(--color-text-secondary);
+            font-size: var(--font-size-small);
+            line-height: 1.4;
+            flex: 1 1 auto;
+            min-width: 0;
+        }
+
+        .plugin-settings-footer-actions {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            margin-left: auto;
+        }
+
         .spinning {
             animation: spin 1s linear infinite;
         }
@@ -281,6 +335,21 @@
                 margin-left: 0;
                 justify-content: flex-start;
                 white-space: normal;
+            }
+
+            .plugin-settings-footer-nav {
+                width: 100%;
+                min-width: 0;
+            }
+
+            .plugin-settings-footer-nav-row {
+                flex-wrap: wrap;
+            }
+
+            .plugin-settings-footer-actions {
+                width: 100%;
+                justify-content: flex-end;
+                margin-left: 0;
             }
         }
     </style>

--- a/webui/css/settings.css
+++ b/webui/css/settings.css
@@ -3,7 +3,7 @@
 /* Field Styles */
 .field {
   display: grid;
-  grid-template-columns: 60% 1fr;
+  grid-template-columns: 55% 1fr;
   align-items: center;
   margin-block: 1rem;
   padding: var(--spacing-xs) 0;


### PR DESCRIPTION
Redesign the email, Telegram, and WhatsApp integrations with a clearer setup flow, a more polished configuration experience, and native chat-side controls for day-to-day use.

- simplify the email panel by surfacing the essentials first, moving advanced scheduling behind Advanced, and making connection checks more visible
- redesign Telegram and WhatsApp as step-based setup flows with clearer status states, safer access warnings, richer test feedback, and more responsive layouts
- add shared plugin-settings wizard footer support, extract WhatsApp state into its own store, and align test-connection messages with the new UX
- improve first-run setup by opening Telegram and email directly into the initial configuration flow, skipping the Telegram QR/setup step when a bot is already configured, and adding the official Gmail app-password help link
- restore the WhatsApp access warning styling and only show QR/disconnect controls when the bridge is enabled
- add native `/project`, `/config`, `/send`, and `/queue` chat controls for Telegram and WhatsApp, plus matching control handling for email threads
- add an optional email conversation preset selector backed by Model Configuration presets for new chats created from each inbox