### PR TITLE
fix: accept 'args' alias and null value in validate_tool_request

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -978,10 +978,9 @@ class Agent:
             raise ValueError("Tool request must be a dictionary")
         if not tool_request.get("tool_name") or not isinstance(tool_request.get("tool_name"), str):
             raise ValueError("Tool request must have a tool_name (type string) field")
-        if "tool_args" not in tool_request or not isinstance(tool_request.get("tool_args"), dict):
+        tool_args_value = tool_request.get("tool_args", tool_request.get("args"))
+        if tool_args_value is not None and not isinstance(tool_args_value, dict):
             raise ValueError("Tool request must have a tool_args (type dictionary) field")
-
-
 
     async def handle_reasoning_stream(self, stream: str):
         await self.handle_intervention()


### PR DESCRIPTION
## Problem

`validate_tool_request` raises a `ValueError` intermittently when the LLM emits `"args"` instead of `"tool_args"` in its JSON response:

```
ValueError: Tool request must have a tool_args (type dictionary) field
```

The bug is a mismatch between validation and processing:

- **`process_tools`** already handles the `"args"` alias: `.get("tool_args", .get("args", {}))`
- **`validate_tool_request`** only accepted `"tool_args"` — rejecting `"args"` before `process_tools` could normalize it

Also, a `null` / missing `tool_args` value raised erroneously, even though `process_tools` already defaults it to `{}`.

## Fix

```python
# Before
if "tool_args" not in tool_request or not isinstance(tool_request.get("tool_args"), dict):
    raise ValueError("Tool request must have a tool_args (type dictionary) field")

# After
tool_args_value = tool_request.get("tool_args", tool_request.get("args"))
if tool_args_value is not None and not isinstance(tool_args_value, dict):
    raise ValueError("Tool request must have a tool_args (type dictionary) field")
```

- Accepts `"args"` as an alias for `"tool_args"` (matches what `process_tools` already does)
- Tolerates `null` / missing value (downstream already defaults to `{}`)
- Still raises if the value is present but not a dict (genuine malformat)

## Impact

- Eliminates intermittent `ValueError` crashes when models use non-standard field names
- No behaviour change for well-formed requests
- 2-line change, no new dependencies