### PR TITLE
skills: update guidance for plugins uninstall(); Flare Tunnel option for A0 CLI connector

### DIFF
--- a/skills/a0-create-plugin/SKILL.md
+++ b/skills/a0-create-plugin/SKILL.md
@@ -282,6 +282,7 @@ If your plugin needs framework-internal hook points, add a `hooks.py` file at th
 - Current built-in usage:
   - the plugin installer calls `install()` in `hooks.py` after placing a plugin in `usr/plugins/`
   - the plugin updater calls `pre_update()` in `hooks.py` immediately before pulling new plugin code into place
+  - the plugin uninstaller calls `uninstall()` in `hooks.py` before deleting the plugin directory — use this to clean up any dependencies or state created by `install()`
 - Hook functions may be sync or async.
 - Hooks should be reversible and cleanup-safe. Prefer framework-managed state and plugin-owned paths over permanent system modifications.
 

--- a/skills/a0-debug-plugin/SKILL.md
+++ b/skills/a0-debug-plugin/SKILL.md
@@ -138,6 +138,21 @@ print('Done')
 "
 ```
 
+If the `uninstall()` hook is not running when the plugin is removed:
+- Check the function is named exactly `uninstall` (not `on_uninstall` or similar)
+- Check for exceptions in the function
+- The `uninstall()` hook is called by `uninstall_plugin()` in `helpers/plugins.py` before the plugin directory is deleted. If the user removed the plugin manually (`rm -rf`), the hook was bypassed — always use the API or UI to uninstall.
+- Manually trigger it in the **framework runtime** the same way:
+
+```bash
+cd /a0 && /opt/venv-a0/bin/python -c "
+import asyncio
+from helpers.plugins import call_plugin_hook
+asyncio.run(call_plugin_hook('<plugin_name>', 'uninstall'))
+print('Done')
+"
+```
+
 ---
 
 ## 8. Check Agent Zero logs

--- a/skills/a0-plugin-router/SKILL.md
+++ b/skills/a0-plugin-router/SKILL.md
@@ -76,7 +76,7 @@ always_enabled: false        # forces ON, disables toggle (framework use only)
 | `extensions/webui/<point>/` | HTML/JS injected into UI breakpoints |
 | `webui/config.html` | Plugin settings UI |
 | `webui/*.html`, `webui/*.js` | Full plugin pages and Alpine stores |
-| `hooks.py` | Framework runtime hooks (install, pre_update, cache, registration) |
+| `hooks.py` | Framework runtime hooks (install, uninstall, pre_update, cache, registration) |
 | `execute.py` | User-triggered script (setup, maintenance, repair) |
 | `default_config.yaml` | Settings defaults |
 | `README.md` | Optional locally; strongly recommended for community plugins so Plugin Hub users can inspect the plugin |

--- a/skills/a0-review-plugin/SKILL.md
+++ b/skills/a0-review-plugin/SKILL.md
@@ -52,7 +52,7 @@ Inspect the plugin directory layout:
 - [ ] If `agents/` exists: agent profiles with `<profile>/agent.yaml` (standard directory)
 - [ ] If `conf/` exists: configuration files such as `model_providers.yaml` (standard directory)
 - [ ] If `webui/config.html` exists: plugin must declare at least one `settings_sections` entry
-- [ ] If `hooks.py` exists: review whether it defines the lifecycle hook functions the plugin appears to rely on, especially `install` and `pre_update` when the plugin needs install-time or update-time behavior
+- [ ] If `hooks.py` exists: review whether it defines the lifecycle hook functions the plugin appears to rely on, especially `install`, `pre_update`, and `uninstall` when the plugin needs install-time, update-time, or cleanup behavior — if `install()` adds dependencies, flag a missing `uninstall()` as WARN
 - [ ] If `execute.py` exists: check it has a `main()` function and `if __name__ == "__main__": sys.exit(main())`
 - [ ] `LICENSE` at plugin root: Agent Zero does not require it for local plugins, but it is **required** at the repo root before submitting to the Plugin Index. If missing → **WARN** — `LICENSE absent — required for community contribution (Plugin Index); optional for local-only use`
 - [ ] `default_config.yaml` (if present): valid YAML

--- a/skills/a0-review-plugin/checklists.md
+++ b/skills/a0-review-plugin/checklists.md
@@ -232,7 +232,7 @@ save_plugin_config(
 ## hooks.py Environment Targeting
 
 ```python
-# hooks.py - install/pre_update hook example
+# hooks.py - install/uninstall/pre_update hook example
 import subprocess
 import sys
 
@@ -240,6 +240,10 @@ def install():
     """Called by framework after plugin is placed in usr/plugins/."""
     # This installs into the Agent Zero FRAMEWORK runtime (/opt/venv-a0)
     subprocess.run([sys.executable, "-m", "pip", "install", "some-package==1.0.0"], check=True)
+
+def uninstall():
+    """Called by framework before deleting plugin directory. Clean up dependencies added by install()."""
+    subprocess.run([sys.executable, "-m", "pip", "uninstall", "-y", "some-package"], check=True)
 
 def pre_update():
     """Called by framework immediately before plugin update pulls new code into place."""

--- a/skills/a0-setup-cli/SKILL.md
+++ b/skills/a0-setup-cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: a0-setup-cli
 description: Guide the user through installing and connecting the A0 CLI on the host machine so Dockerized Agent Zero can work on real local files. Use when asked to install A0, set up the CLI connector, connect Agent Zero to local files, or troubleshoot host-vs-container setup confusion.
-version: 1.0.0
+version: 1.1.0
 author: Agent Zero Team
 tags: ["agent-zero", "a0", "cli", "connector", "docker", "setup", "local-files"]
 trigger_patterns:
@@ -106,13 +106,23 @@ Tell the user what to expect:
 
 - `a0` opens the host picker first.
 - If Agent Zero is running locally, `a0` may discover it automatically.
-- If not, the user can enter the Agent Zero web URL manually.
+- If not, the user can enter the Agent Zero web URL manually in the custom URL field.
+- The custom URL can be either a normal address with a port, such as `http://localhost:50001`, or a tunnel URL.
+- For Flare Tunnel, tell the user to open `Settings > External Services > Flare Tunnel`, click `Create Tunnel`, then copy and paste the HTTPS URL into `a0` exactly as shown.
+- Tunnel URLs such as `https://example.trycloudflare.com` do not need a port appended.
 - `AGENT_ZERO_HOST` can prefill the target host without bypassing the picker.
 
 Example:
 
 ```bash
 export AGENT_ZERO_HOST=http://localhost:50001
+a0
+```
+
+Tunnel example:
+
+```bash
+export AGENT_ZERO_HOST=https://example.trycloudflare.com
 a0
 ```
 
@@ -130,7 +140,7 @@ Successful setup looks like this:
 - If the user says they installed inside Docker or shows `/a0` paths, redirect them to the host-machine install.
 - If `a0` gets a connector `404`, explain that the running Agent Zero build likely does not include the builtin `_a0_connector` support yet and should be updated.
 - If the browser UI works but `a0` does not, remind them the web UI can run without connector support but the CLI cannot.
-- If Docker discovery does not find the instance, have them enter the exact Agent Zero URL or set `AGENT_ZERO_HOST`.
+- If Docker discovery does not find the instance, have them enter the exact Agent Zero URL with `host:port`, or create a Flare Tunnel in `Settings > External Services > Flare Tunnel` and paste that HTTPS URL directly.
 
 ## Example Requests And Responses
 


### PR DESCRIPTION
This PR updates both plugin Skills and the new CLI Setup guidance Skill to:
- guide agents in the creation of a uninstall() in hooks.py together with install() and preupdate() for dependencies management and cleanup when the plugin is removed
- guide agents into letting users connect to the A0 CLI Connector via Flare Tunnel created in Settings > External Services > Flare Tunnel