### PR TITLE
fix: pass embedding kwargs (trust_remote_code) in preload_embedding()

### DIFF
--- a/preload.py
+++ b/preload.py
@@ -22,8 +22,9 @@ async def preload():
                 from plugins._model_config.helpers.model_config import get_embedding_model_config_object
                 emb_cfg = get_embedding_model_config_object()
                 if emb_cfg.provider.lower() == "huggingface":
+                    emb_kwargs = getattr(emb_cfg, "kwargs", {}) or {}
                     emb_mod = models.get_embedding_model(
-                        "huggingface", emb_cfg.name
+                        "huggingface", emb_cfg.name, **emb_kwargs
                     )
                     emb_txt = await emb_mod.aembed_query("test")
                     return emb_txt


### PR DESCRIPTION
## Bug

`preload_embedding()` in `preload.py` calls `models.get_embedding_model()` without forwarding the `kwargs` from the embedding config object. This causes HuggingFace models that require `trust_remote_code=True` (e.g., `nomic-ai/nomic-bert-2048`) to fail during startup preloading with:

```
Error in preload_embedding: nomic-ai/nomic-bert-2048 ... Please pass trust_remote_code=True
```

## Root Cause

The config schema supports a `kwargs` field, and `get_embedding_model()` already accepts `**kwargs` and passes them through — but `preload_embedding()` never forwards them. The feature is half-implemented.

## Fix

Extract `kwargs` from the config object with a safe default and forward them:

```python
emb_kwargs = getattr(emb_cfg, "kwargs", {}) or {}
emb_mod = models.get_embedding_model("huggingface", emb_cfg.name, **emb_kwargs)
```

Two-line change to `preload.py`.

## Impact

- Fully backward compatible — `**{}` is a no-op for configs without kwargs
- No config changes required
- Affects any HuggingFace embedding model requiring `trust_remote_code` (increasingly common)

## Testing

Deployed and verified across 5 production Agent Zero instances (Docker). All instances show successful preload with `All keys matched successfully` and zero `Error in preload_embedding` messages.
