### PR TITLE
fix: catch TimeoutError in memory recall wait extension

### DIFF
--- a/plugins/_memory/extensions/python/message_loop_prompts_after/_91_recall_wait.py
+++ b/plugins/_memory/extensions/python/message_loop_prompts_after/_91_recall_wait.py
@@ -1,5 +1,7 @@
+import asyncio
 from helpers.extension import Extension
 from agent import LoopData
+from helpers.print_style import PrintStyle
 from plugins._memory.extensions.python.message_loop_prompts_after._50_recall_memories import DATA_NAME_TASK as DATA_NAME_TASK_MEMORIES, DATA_NAME_ITER as DATA_NAME_ITER_MEMORIES
 from helpers import plugins
 
@@ -27,4 +29,7 @@ class RecallWait(Extension):
                     return
 
             # otherwise await the task
-            await task
+            try:
+                await task
+            except (TimeoutError, asyncio.TimeoutError):
+                PrintStyle.standard("Memory recall timed out, skipping")


### PR DESCRIPTION
## Summary

The memory recall wait extension crashes the entire monologue loop when the embedding query takes longer than the 30-second SEARCH_TIMEOUT.

The _50_recall_memories.py extension correctly wraps the search in asyncio.wait_for(timeout=30), but _91_recall_wait.py awaits the resulting task without catching TimeoutError, causing an unhandled exception that kills the agent loop.

## Changes

- Added import asyncio and from helpers.print_style import PrintStyle
- Wrapped await task in try/except (TimeoutError, asyncio.TimeoutError) with a log message
- The agent now gracefully skips memories for that turn instead of crashing

## Before

    # otherwise await the task
    await task

## After

    # otherwise await the task
    try:
        await task
    except (TimeoutError, asyncio.TimeoutError):
        PrintStyle.standard("Memory recall timed out, skipping")

## Testing

This fix has been running in production for several days with no issues. The timeout still fires occasionally (slow embedding calls), but the agent continues normally instead of crashing.

## Files Changed

- plugins/_memory/extensions/python/message_loop_prompts_after/_91_recall_wait.py
