### PR TITLE
fix: normalize tool_args before validation in process_tools

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -875,6 +875,11 @@ class Agent:
         # Only validate when extraction produced an object; None means no JSON tool
         # block was found — the misformat warning path below handles that.
         if tool_request is not None:
+            # Normalize: map 'args' -> 'tool_args', default to empty dict
+            if "tool_args" not in tool_request:
+                tool_request["tool_args"] = tool_request.get("args", {})
+            if not isinstance(tool_request["tool_args"], dict):
+                tool_request["tool_args"] = {}
             await self.validate_tool_request(tool_request)
 
         if tool_request is not None:


### PR DESCRIPTION
## Fix for #1512

### Problem
`validate_tool_request()` crashes with `ValueError` when an LLM outputs `"args"` instead of `"tool_args"` in the tool request JSON.

### Solution
Add normalization before calling `validate_tool_request()`:
- Map `"args"` → `"tool_args"` if `"tool_args"` is missing
- Default `"tool_args"` to empty dict if not a dict type

### Changes
- `agent.py`: Added 4-line normalization block before `validate_tool_request()` call in `process_tools()`

### Testing
- Handles `{"tool_name": "x", "args": {}}` → normalizes to `{"tool_name": "x", "tool_args": {}}`
- Correctly formatted requests pass unchanged
- Non-dict values defaulted to `{}`

Closes #1512