### PR TITLE
Return proper 400 / 500 responses from speech API endpoints

### DIFF
--- a/api/synthesize.py
+++ b/api/synthesize.py
@@ -15,9 +15,6 @@ class Synthesize(ApiHandler):
         if ctxid:
             self.use_context(ctxid)
 
-        # if not await kokoro_tts.is_downloaded():
-        #     context.log.log(type="info", content="Kokoro TTS model is currently being initialized, please wait...")
-
         try:
             # # Clean and chunk text for long responses
             # cleaned_text = self._clean_text(text)

--- a/api/synthesize.py
+++ b/api/synthesize.py
@@ -2,15 +2,18 @@
 
 from helpers.api import ApiHandler, Request, Response
 
-from helpers import runtime, settings, kokoro_tts
+from helpers import kokoro_tts
 
 class Synthesize(ApiHandler):
-    async def process(self, input: dict, request: Request) -> dict | Response:
-        text = input.get("text", "")
-        ctxid = input.get("ctxid", "")
+    async def process(self, payload: dict, _request: Request) -> dict | Response:
+        text = payload.get("text", "")
+        ctxid = payload.get("ctxid", "")
+
+        if not text:
+            return Response("Missing 'text'.", 400)
         
         if ctxid:
-            context = self.use_context(ctxid)
+            self.use_context(ctxid)
 
         # if not await kokoro_tts.is_downloaded():
         #     context.log.log(type="info", content="Kokoro TTS model is currently being initialized, please wait...")
@@ -36,7 +39,7 @@ class Synthesize(ApiHandler):
             audio = await kokoro_tts.synthesize_sentences([text])
             return {"audio": audio, "success": True}
         except Exception as e:
-            return {"error": str(e), "success": False}
+            return Response(str(e), 500)
     
     # def _clean_text(self, text: str) -> str:
     #     """Clean text by removing markdown, tables, code blocks, and other formatting"""

--- a/api/transcribe.py
+++ b/api/transcribe.py
@@ -13,9 +13,6 @@ class Transcribe(ApiHandler):
         if ctxid:
             self.use_context(ctxid)
 
-        # if not await whisper.is_downloaded():
-        #     context.log.log(type="info", content="Whisper STT model is currently being initialized, please wait...")
-
         try:
             settings_data = settings.get_settings()
             result = await whisper.transcribe(settings_data["stt_model_size"], audio) # type: ignore

--- a/api/transcribe.py
+++ b/api/transcribe.py
@@ -1,18 +1,24 @@
 from helpers.api import ApiHandler, Request, Response
 
-from helpers import runtime, settings, whisper
+from helpers import settings, whisper
 
 class Transcribe(ApiHandler):
-    async def process(self, input: dict, request: Request) -> dict | Response:
-        audio = input.get("audio")
-        ctxid = input.get("ctxid", "")
+    async def process(self, payload: dict, _request: Request) -> dict | Response:
+        audio = payload.get("audio")
+        ctxid = payload.get("ctxid", "")
+
+        if not audio:
+            return Response("Missing 'audio'.", 400)
 
         if ctxid:
-            context = self.use_context(ctxid)
+            self.use_context(ctxid)
 
         # if not await whisper.is_downloaded():
         #     context.log.log(type="info", content="Whisper STT model is currently being initialized, please wait...")
 
-        set = settings.get_settings()
-        result = await whisper.transcribe(set["stt_model_size"], audio) # type: ignore
-        return result
+        try:
+            settings_data = settings.get_settings()
+            result = await whisper.transcribe(settings_data["stt_model_size"], audio) # type: ignore
+            return result
+        except Exception as e:
+            return Response(str(e), 500)

--- a/tests/test_speech_api_http_contract.py
+++ b/tests/test_speech_api_http_contract.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TRANSCRIBE_PATH = PROJECT_ROOT / "api" / "transcribe.py"
+SYNTHESIZE_PATH = PROJECT_ROOT / "api" / "synthesize.py"
+
+
+class StubResponse:
+    def __init__(self, response=None, status=200, mimetype=None):
+        self.response = response
+        self.status_code = status
+        self.mimetype = mimetype
+
+    def get_data(self, as_text: bool = False):
+        if as_text:
+            if self.response is None:
+                return ""
+            return self.response if isinstance(self.response, str) else str(self.response)
+
+        if self.response is None:
+            return b""
+        if isinstance(self.response, bytes):
+            return self.response
+        return str(self.response).encode()
+
+
+class StubApiHandler:
+    def __init__(self, app=None, thread_lock=None):
+        self.app = app
+        self.thread_lock = thread_lock
+
+    def use_context(self, ctxid: str, create_if_not_exists: bool = True):
+        return {"ctxid": ctxid, "create_if_not_exists": create_if_not_exists}
+
+
+def _install_speech_stubs(
+    monkeypatch,
+    *,
+    transcribe_impl=None,
+    synthesize_impl=None,
+    settings_data=None,
+):
+    helpers_pkg = types.ModuleType("helpers")
+    helpers_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "helpers", helpers_pkg)
+
+    api_mod = types.ModuleType("helpers.api")
+    api_mod.ApiHandler = StubApiHandler
+    api_mod.Request = object
+    api_mod.Response = StubResponse
+    monkeypatch.setitem(sys.modules, "helpers.api", api_mod)
+
+    runtime_mod = types.ModuleType("helpers.runtime")
+    monkeypatch.setitem(sys.modules, "helpers.runtime", runtime_mod)
+
+    settings_mod = types.ModuleType("helpers.settings")
+    settings_mod.get_settings = lambda: settings_data or {"stt_model_size": "base"}
+    monkeypatch.setitem(sys.modules, "helpers.settings", settings_mod)
+
+    whisper_mod = types.ModuleType("helpers.whisper")
+
+    async def default_transcribe(model_name, audio):
+        return {"text": f"{model_name}:{audio}"}
+
+    whisper_mod.transcribe = transcribe_impl or default_transcribe
+    monkeypatch.setitem(sys.modules, "helpers.whisper", whisper_mod)
+
+    kokoro_mod = types.ModuleType("helpers.kokoro_tts")
+
+    async def default_synthesize(chunks):
+        return "|".join(chunks)
+
+    kokoro_mod.synthesize_sentences = synthesize_impl or default_synthesize
+    monkeypatch.setitem(sys.modules, "helpers.kokoro_tts", kokoro_mod)
+
+    helpers_pkg.runtime = runtime_mod
+    helpers_pkg.settings = settings_mod
+    helpers_pkg.whisper = whisper_mod
+    helpers_pkg.kokoro_tts = kokoro_mod
+
+
+def _load_module(monkeypatch, module_path: Path, **stub_kwargs):
+    _install_speech_stubs(monkeypatch, **stub_kwargs)
+
+    spec = importlib.util.spec_from_file_location(
+        f"test_{module_path.stem}_{module_path.stat().st_size}",
+        module_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_transcribe_missing_audio_returns_400(monkeypatch):
+    module = _load_module(monkeypatch, TRANSCRIBE_PATH)
+
+    response = asyncio.run(module.Transcribe(None, None).process({}, None))
+
+    assert response.status_code == 400
+    assert response.get_data(as_text=True) == "Missing 'audio'."
+
+
+def test_transcribe_backend_failure_returns_500(monkeypatch):
+    async def failing_transcribe(model_name, audio):
+        raise RuntimeError("stt exploded")
+
+    module = _load_module(monkeypatch, TRANSCRIBE_PATH, transcribe_impl=failing_transcribe)
+
+    response = asyncio.run(module.Transcribe(None, None).process({"audio": "abc"}, None))
+
+    assert response.status_code == 500
+    assert response.get_data(as_text=True) == "stt exploded"
+
+
+def test_transcribe_success_keeps_json_payload(monkeypatch):
+    async def transcribe_ok(model_name, audio):
+        return {"text": f"decoded:{model_name}:{audio}"}
+
+    module = _load_module(
+        monkeypatch,
+        TRANSCRIBE_PATH,
+        transcribe_impl=transcribe_ok,
+        settings_data={"stt_model_size": "tiny"},
+    )
+
+    response = asyncio.run(module.Transcribe(None, None).process({"audio": "abc"}, None))
+
+    assert response == {"text": "decoded:tiny:abc"}
+
+
+def test_synthesize_missing_text_returns_400(monkeypatch):
+    module = _load_module(monkeypatch, SYNTHESIZE_PATH)
+
+    response = asyncio.run(module.Synthesize(None, None).process({}, None))
+
+    assert response.status_code == 400
+    assert response.get_data(as_text=True) == "Missing 'text'."
+
+
+def test_synthesize_backend_failure_returns_500(monkeypatch):
+    async def failing_synthesize(chunks):
+        raise RuntimeError("tts exploded")
+
+    module = _load_module(monkeypatch, SYNTHESIZE_PATH, synthesize_impl=failing_synthesize)
+
+    response = asyncio.run(module.Synthesize(None, None).process({"text": "hello"}, None))
+
+    assert response.status_code == 500
+    assert response.get_data(as_text=True) == "tts exploded"
+
+
+def test_synthesize_success_keeps_json_payload(monkeypatch):
+    async def synthesize_ok(_chunks):
+        return "audio-bytes"
+
+    module = _load_module(monkeypatch, SYNTHESIZE_PATH, synthesize_impl=synthesize_ok)
+
+    response = asyncio.run(module.Synthesize(None, None).process({"text": "hello"}, None))
+
+    assert response == {"audio": "audio-bytes", "success": True}


### PR DESCRIPTION
# PR description draft: Fix speech API HTTP error contract

## Suggested title

Return proper `400` / `500` responses from speech API endpoints

## Summary

This change makes the speech endpoints return explicit HTTP error responses for invalid input and backend failures, while preserving the existing JSON success payloads on success.

## Problem

The WebUI JSON client in `webui/js/api.js` throws on non-2xx responses and uses `response.text()` as the thrown error message. The existing speech endpoints did not consistently follow that contract:

- missing required input was not validated early enough;
- backend failures could be returned as JSON payloads inside `200 OK` responses.

That makes speech failures look like transport success and weakens frontend error handling.

These handlers are consumed by the built-in WebUI speech flows through `sendJsonData(...)`, so this change is intended as an internal contract correction rather than a redesign of a documented external API.

## What changed

### `api/transcribe.py`

- validate that `audio` is present;
- return `Response("Missing 'audio'.", 400)` when it is absent;
- wrap backend transcription in `try/except`;
- return `Response(str(e), 500)` on backend failure;
- preserve the current success payload on successful transcription.

### `api/synthesize.py`

- validate that `text` is present;
- return `Response("Missing 'text'.", 400)` when it is absent;
- return `Response(str(e), 500)` on backend synthesis failure instead of `{ success: false, error: ... }` with an OK status;
- preserve the current success payload `{ "audio": ..., "success": true }` on success.

## Why this is safe

- success responses are unchanged;
- only failure semantics are corrected;
- the change aligns the handlers with the behavior the frontend client already expects.
- the change removes misleading `200 OK` responses on failure paths instead of expanding the API surface.

## Tests

Added `tests/test_speech_api_http_contract.py` covering:

- `400` on missing `audio`;
- `500` on STT backend exception;
- success payload passthrough for transcription;
- `400` on missing `text`;
- `500` on TTS backend exception;
- success payload passthrough for synthesis.

The tests are intentionally isolated at the handler-contract level so they can assert precise HTTP status/body behavior without needing a full Flask/runtime bootstrap.

## Validation

Run locally in clean worktree:

- `pytest tests/test_speech_api_http_contract.py -q`
- Result: `6 passed`

## Reviewer notes

The intended observable behavior change is only on failure paths: speech API consumers now receive actual HTTP error responses instead of mixed success/error semantics.

When opening the PR, call out explicitly that:

- built-in success payloads are unchanged;
- the WebUI already treats non-2xx as the standard error path;
- this fixes incorrect `200`-on-error behavior rather than introducing a new API contract.
