### PR TITLE
fix: coerce schedule fields to str to prevent ValidationError with integer inputs

### DIFF
--- a/helpers/task_scheduler.py
+++ b/helpers/task_scheduler.py
@@ -1035,11 +1035,11 @@ def parse_task_schedule(schedule_data: Dict[str, str]) -> TaskSchedule:
     """Parse dictionary into TaskSchedule with validation."""
     try:
         return TaskSchedule(
-            minute=schedule_data.get('minute', '*'),
-            hour=schedule_data.get('hour', '*'),
-            day=schedule_data.get('day', '*'),
-            month=schedule_data.get('month', '*'),
-            weekday=schedule_data.get('weekday', '*'),
+            minute=str(schedule_data.get('minute', '*')),
+            hour=str(schedule_data.get('hour', '*')),
+            day=str(schedule_data.get('day', '*')),
+            month=str(schedule_data.get('month', '*')),
+            weekday=str(schedule_data.get('weekday', '*')),
             timezone=schedule_data.get('timezone', Localization.get().get_timezone())
         )
     except Exception as e:

--- a/tools/scheduler.py
+++ b/tools/scheduler.py
@@ -156,11 +156,11 @@ class SchedulerTool(Tool):
         dedicated_context: bool = kwargs.get("dedicated_context", False)
 
         task_schedule = TaskSchedule(
-            minute=schedule.get("minute", "*"),
-            hour=schedule.get("hour", "*"),
-            day=schedule.get("day", "*"),
-            month=schedule.get("month", "*"),
-            weekday=schedule.get("weekday", "*"),
+            minute=str(schedule.get("minute", "*")),
+            hour=str(schedule.get("hour", "*")),
+            day=str(schedule.get("day", "*")),
+            month=str(schedule.get("month", "*")),
+            weekday=str(schedule.get("weekday", "*")),
         )
 
         # Validate cron expression, agent might hallucinate


### PR DESCRIPTION
Fixes #1473

## Problem

When an LLM outputs numeric values (e.g. `0`, `9`) for cron schedule fields instead of strings, `create_scheduled_task` crashes with a `pydantic_core.ValidationError`:

```
ValidationError: 2 validation errors for TaskSchedule
minute
  Input should be a valid string [type=string_type, input_value=0, input_type=int]
hour
  Input should be a valid string [type=string_type, input_value=9, input_type=int]
```

Pydantic v2 does not auto-coerce `int` → `str`, and LLMs frequently output integers for numeric cron fields (e.g. `0` instead of `"0"`).

## Solution

Wrap all schedule field values with `str()` at both construction sites:

- `tools/scheduler.py` — `create_scheduled_task()`: coerce each cron field before passing to `TaskSchedule`
- `helpers/task_scheduler.py` — `parse_task_schedule()`: same coercion when parsing a schedule dict

This is a non-breaking, minimal fix. `str(int)` and `str(str)` both produce the correct string value, so there is no behavior change for already-valid inputs.

## Testing

The fix can be verified manually:
```python
from helpers.task_scheduler import TaskSchedule
# Previously raised ValidationError; now works correctly
schedule = TaskSchedule(minute=str(0), hour=str(9), day=str("*"), month=str("*"), weekday=str("*"))
print(schedule.to_crontab())  # "0 9 * * *"
```