### PR TITLE
fix: tool request validation crash on non-canonical field names

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -872,18 +872,20 @@ class Agent:
         # search for tool usage requests in agent message
         tool_request = extract_tools.json_parse_dirty(msg)
 
+        raw_tool_name = ""
+        tool_args = {}
+
         # Only validate when extraction produced an object; None means no JSON tool
-        # block was found — the misformat warning path below handles that.
+        # block was found - the misformat warning path below handles that.
         if tool_request is not None:
             try:
-                await self.validate_tool_request(tool_request)
+                raw_tool_name, tool_args = extract_tools.normalize_tool_request(
+                    tool_request
+                )
             except ValueError:
                 tool_request = None  # treat structural validation errors as misformat
 
         if tool_request is not None:
-            raw_tool_name = tool_request.get("tool_name", tool_request.get("tool",""))  # Get the raw tool name
-            tool_args = tool_request.get("tool_args", tool_request.get("args", {}))
-
             tool_name = raw_tool_name  # Initialize tool_name with raw_tool_name
             tool_method = None  # Initialize tool_method
 
@@ -977,14 +979,7 @@ class Agent:
 
     @extension.extensible
     async def validate_tool_request(self, tool_request: Any):
-        if not isinstance(tool_request, dict):
-            raise ValueError("Tool request must be a dictionary")
-        tool_name = tool_request.get("tool_name") or tool_request.get("tool")
-        if not tool_name or not isinstance(tool_name, str):
-            raise ValueError("Tool request must have a tool_name (type string) field")
-        tool_args = tool_request.get("tool_args", tool_request.get("args"))
-        if tool_args is None or not isinstance(tool_args, dict):
-            raise ValueError("Tool request must have a tool_args (type dictionary) field")
+        extract_tools.normalize_tool_request(tool_request)
 
 
 

--- a/agent.py
+++ b/agent.py
@@ -875,7 +875,10 @@ class Agent:
         # Only validate when extraction produced an object; None means no JSON tool
         # block was found — the misformat warning path below handles that.
         if tool_request is not None:
-            await self.validate_tool_request(tool_request)
+            try:
+                await self.validate_tool_request(tool_request)
+            except ValueError:
+                tool_request = None  # treat structural validation errors as misformat
 
         if tool_request is not None:
             raw_tool_name = tool_request.get("tool_name", tool_request.get("tool",""))  # Get the raw tool name
@@ -976,9 +979,11 @@ class Agent:
     async def validate_tool_request(self, tool_request: Any):
         if not isinstance(tool_request, dict):
             raise ValueError("Tool request must be a dictionary")
-        if not tool_request.get("tool_name") or not isinstance(tool_request.get("tool_name"), str):
+        tool_name = tool_request.get("tool_name") or tool_request.get("tool")
+        if not tool_name or not isinstance(tool_name, str):
             raise ValueError("Tool request must have a tool_name (type string) field")
-        if "tool_args" not in tool_request or not isinstance(tool_request.get("tool_args"), dict):
+        tool_args = tool_request.get("tool_args", tool_request.get("args"))
+        if tool_args is None or not isinstance(tool_args, dict):
             raise ValueError("Tool request must have a tool_args (type dictionary) field")
 
 

--- a/helpers/extract_tools.py
+++ b/helpers/extract_tools.py
@@ -19,6 +19,23 @@ def json_parse_dirty(json: str) -> dict[str, Any] | None:
             return None
     return None
 
+
+def normalize_tool_request(tool_request: Any) -> tuple[str, dict]:
+    if not isinstance(tool_request, dict):
+        raise ValueError("Tool request must be a dictionary")
+    tool_name = tool_request.get("tool_name")
+    if not tool_name or not isinstance(tool_name, str):
+        tool_name = tool_request.get("tool")
+    if not tool_name or not isinstance(tool_name, str):
+        raise ValueError("Tool request must have a tool_name (type string) field")
+    tool_args = tool_request.get("tool_args")
+    if not isinstance(tool_args, dict):
+        tool_args = tool_request.get("args")
+    if not isinstance(tool_args, dict):
+        raise ValueError("Tool request must have a tool_args (type dictionary) field")
+    return tool_name, tool_args
+
+
 def extract_json_root_string(content: str) -> str | None:
     if not content or not isinstance(content, str):
         return None
@@ -81,5 +98,3 @@ def fix_json_string(json_string):
         r'(?<=: ")(.*?)(?=")', replace_unescaped_newlines, json_string, flags=re.DOTALL
     )
     return fixed_string
-
-

--- a/tests/test_tool_request_normalization.py
+++ b/tests/test_tool_request_normalization.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from helpers.extract_tools import normalize_tool_request
+
+
+def test_normalize_tool_request_accepts_fallback_keys() -> None:
+    assert normalize_tool_request({"tool": "response", "args": {"text": "ok"}}) == (
+        "response",
+        {"text": "ok"},
+    )
+
+
+def test_normalize_tool_request_uses_fallback_when_canonical_name_is_empty() -> None:
+    assert normalize_tool_request(
+        {"tool_name": "", "tool": "response", "args": {"text": "ok"}}
+    ) == ("response", {"text": "ok"})
+
+
+def test_normalize_tool_request_uses_fallback_when_canonical_args_are_invalid() -> None:
+    assert normalize_tool_request(
+        {"tool_name": "response", "tool_args": None, "args": {"text": "ok"}}
+    ) == ("response", {"text": "ok"})
+
+
+def test_normalize_tool_request_rejects_missing_args() -> None:
+    with pytest.raises(ValueError, match="tool_args"):
+        normalize_tool_request({"tool_name": "response"})


### PR DESCRIPTION
1. `validate_tool_request` only checks canonical keys `tool_name`/`tool_args`, while `process_tools` already supports dual-key fallback (`tool`/`args`). Valid non-canonical JSON from smaller models is incorrectly rejected at validation, triggering an error.
2. `validate_tool_request` raises `ValueError` instead of `RepairableException`, escalating a recoverable format error into a conversation-ending crash.

Fix:

- Align validation logic with `process_tools` fallback — `validate_tool_request` now accepts `tool`/`args` as valid alternative keys.
- On validation failure, set `tool_request` to `None` to fall through to the existing misformat branch — logs a warning and continues the loop instead of crashing.