### PR TITLE
fix: MCP call_tool threading.Lock held across await deadlocks event loop

### DIFF
--- a/helpers/mcp_handler.py
+++ b/helpers/mcp_handler.py
@@ -232,11 +232,13 @@ class MCPServerRemote(BaseModel):
     disabled: bool = Field(default=False)
 
     __lock: ClassVar[threading.Lock] = PrivateAttr(default=threading.Lock())
+    __async_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
     __client: Optional["MCPClientRemote"] = PrivateAttr(default=None)
 
     def __init__(self, config: dict[str, Any]):
         super().__init__()
         self.__client = MCPClientRemote(self)
+        self.__async_lock = asyncio.Lock()
         self.update(config)
 
     def get_error(self) -> str:
@@ -261,8 +263,9 @@ class MCPServerRemote(BaseModel):
         self, tool_name: str, input_data: Dict[str, Any]
     ) -> CallToolResult:
         """Call a tool with the given input data"""
-        with self.__lock:
-            # We already run in an event loop, dont believe Pylance
+        # Use asyncio.Lock here — threading.Lock must not be held across an await,
+        # as it blocks the event loop thread and freezes all other coroutines.
+        async with self.__async_lock:
             return await self.__client.call_tool(tool_name, input_data)  # type: ignore
 
     def update(self, config: dict[str, Any]) -> "MCPServerRemote":
@@ -310,11 +313,13 @@ class MCPServerLocal(BaseModel):
     disabled: bool = Field(default=False)
 
     __lock: ClassVar[threading.Lock] = PrivateAttr(default=threading.Lock())
+    __async_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
     __client: Optional["MCPClientLocal"] = PrivateAttr(default=None)
 
     def __init__(self, config: dict[str, Any]):
         super().__init__()
         self.__client = MCPClientLocal(self)
+        self.__async_lock = asyncio.Lock()
         self.update(config)
 
     def get_error(self) -> str:
@@ -339,8 +344,7 @@ class MCPServerLocal(BaseModel):
         self, tool_name: str, input_data: Dict[str, Any]
     ) -> CallToolResult:
         """Call a tool with the given input data"""
-        with self.__lock:
-            # We already run in an event loop, dont believe Pylance
+        async with self.__async_lock:
             return await self.__client.call_tool(tool_name, input_data)  # type: ignore
 
     def update(self, config: dict[str, Any]) -> "MCPServerLocal":
@@ -970,11 +974,11 @@ class MCPClientBase(ABC):
 
         async def call_tool_op(current_session: ClientSession):
             set = settings.get_settings()
-            # PrintStyle(font_color="cyan").print(f"MCPClientBase ({self.server.name}): Executing 'call_tool' for '{tool_name}' via MCP session...")
+            tool_timeout = self.server.tool_timeout or set["mcp_client_tool_timeout"]
             response: CallToolResult = await current_session.call_tool(
                 tool_name,
                 input_data,
-                read_timeout_seconds=timedelta(seconds=set["mcp_client_tool_timeout"]),
+                read_timeout_seconds=timedelta(seconds=tool_timeout),
             )
             # PrintStyle(font_color="green").print(f"MCPClientBase ({self.server.name}): Tool '{tool_name}' call successful via session.")
             return response

--- a/helpers/mcp_handler.py
+++ b/helpers/mcp_handler.py
@@ -802,11 +802,15 @@ class MCPConfig(BaseModel):
         if "." not in tool_name:
             raise ValueError(f"Tool {tool_name} not found")
         server_name_part, tool_name_part = tool_name.split(".")
+        target_server = None
         with self.__lock:
             for server in self.servers:
                 if server.name == server_name_part and server.has_tool(tool_name_part):
-                    return await server.call_tool(tool_name_part, input_data)
+                    target_server = server
+                    break
+        if target_server is None:
             raise ValueError(f"Tool {tool_name} not found")
+        return await target_server.call_tool(tool_name_part, input_data)
 
 
 T = TypeVar("T")


### PR DESCRIPTION
Fixes #1553

## Problem

Three `threading.Lock` instances in `helpers/mcp_handler.py` are held across `await` calls. A `threading.Lock` is an OS-level blocking mutex — holding it across an `await` suspends the coroutine while keeping the lock acquired. Any other coroutine that tries to acquire the same lock blocks the **entire event loop thread**, making Agent Zero completely unresponsive to new chats while a slow MCP tool (e.g. Perplexity deep research) is running.

A secondary bug: `MCPClientBase.call_tool` always used the global `mcp_client_tool_timeout`, ignoring per-server `tool_timeout` overrides.

## Changes

**`helpers/mcp_handler.py`** — 3 fixes, 1 file:

1. **`MCPServerRemote.call_tool`**: add `asyncio.Lock` instance (`__async_lock`), use `async with self.__async_lock` instead of `with self.__lock`. Sync methods (`get_error`, `get_tools`, `has_tool`, `update`) keep `threading.Lock` — correct, they're called from sync context.

2. **`MCPServerLocal.call_tool`**: same fix as above.

3. **`MCPConfig.call_tool`**: resolve the target server under `threading.Lock` (sync, instant list lookup), release the lock, then `await server.call_tool()` outside it. This is the outermost and most impactful site — it's the dispatcher that all MCP tool calls pass through.

4. **`MCPClientBase.call_tool`**: `tool_timeout = self.server.tool_timeout or set["mcp_client_tool_timeout"]` — per-server override now takes precedence over global default.

## Tests

Verified on a live Agent Zero instance (Proxmox LXC, Docker):
- Triggered Perplexity deep research (1200s timeout configured)
- Opened new chat while research was running → **responded immediately** (previously: no response until timeout)
- Research completed successfully after ~3 minutes
- No regressions observed on sqlite, sequential-thinking, deep-wiki MCP servers

Existing test suite: `pytest` — no new failures introduced.

## Notes

- No new dependencies
- No breaking changes
- `threading.Lock` is intentionally kept for all sync accessors — only the async `call_tool` path is changed