### PR TITLE
fix: prevent path traversal in save_text_file

### DIFF
--- a/helpers/file_browser.py
+++ b/helpers/file_browser.py
@@ -169,7 +169,7 @@ class FileBrowser:
                 raise ValueError("File exceeds 1 MB and cannot be edited")
 
             full_path = (self.base_dir / file_path).resolve()
-            if not str(full_path).startswith(str(self.base_dir)):
+            if not full_path.is_relative_to(self.base_dir.resolve()):
                 raise ValueError("Invalid path")
             if full_path.exists() and full_path.is_dir():
                 raise ValueError("Target is a directory")


### PR DESCRIPTION
Fix path traversal vulnerability in save_text_file
Fixes #1541
The previous check used startswith() which can be bypassed when base_dir is /. Replaced with is_relative_to() for proper path validation.