### PR TITLE
fix: prevent path traversal in save_file_b64

### DIFF
--- a/helpers/file_browser.py
+++ b/helpers/file_browser.py
@@ -42,7 +42,7 @@ class FileBrowser:
         try:
             # Resolve the target directory path
             target_file = (self.base_dir / current_path / filename).resolve()
-            if not str(target_file).startswith(str(self.base_dir)):
+            if not target_file.is_relative_to(self.base_dir.resolve()):
                 raise ValueError("Invalid target directory")
 
             os.makedirs(target_file.parent, exist_ok=True)


### PR DESCRIPTION
Fix path traversal vulnerability in save_file_b64
Fixes #1540
The previous check used startswith() which can be bypassed. Replaced with is_relative_to() for proper path validation.