### PR TITLE
fix: await set_progress() coroutine in code_execution_tool

### DIFF
--- a/plugins/_code_execution/tools/code_execution_tool.py
+++ b/plugins/_code_execution/tools/code_execution_tool.py
@@ -256,7 +256,7 @@ class CodeExecution(Tool):
             if partial_output:
                 PrintStyle(font_color="#85C1E9").stream(partial_output)
                 truncated_output = self.fix_full_output(full_output)
-                self.set_progress(truncated_output)
+                await self.set_progress(truncated_output)
                 heading = self.get_heading_from_output(truncated_output, 0)
                 self.log.update(content=prefix + truncated_output, heading=heading)
                 last_output_time = now
@@ -368,7 +368,7 @@ class CodeExecution(Tool):
             timeout=1, reset_full_output=reset_full_output
         )
         truncated_output = self.fix_full_output(full_output)
-        self.set_progress(truncated_output)
+        await self.set_progress(truncated_output)
         heading = self.get_heading_from_output(truncated_output, 0)
 
         last_lines = (


### PR DESCRIPTION
Fix: await set_progress() coroutine in code_execution_tool
Fixes #1543
set_progress() is defined as async def in helpers/tool.py but was called without await at lines 259 and 371 in code_execution_tool.py. This caused progress updates to silently fail with a RuntimeWarning, making the agent appear stalled in the WebUI. Added await at both locations to fix this.