### PR TITLE
fix: always check project-level plugin config as fallback (fixes #1548)

### DIFF
--- a/helpers/plugins.py
+++ b/helpers/plugins.py
@@ -752,13 +752,12 @@ def find_plugin_assets(
             )
             if _collect(path, project_name, agent_profile):
                 return results
-        if not agent_profile or agent_profile == "*":
-            # project/.a0proj/plugins/<plugin_name>/...
-            path = projects.get_project_meta(
-                project_name, files.PLUGINS_DIR, plugin_name, *subpaths
-            )
-            if _collect(path, project_name, ""):
-                return results
+        # project/.a0proj/plugins/<plugin_name>/... (always check as fallback, even when agent_profile is set)
+        path = projects.get_project_meta(
+            project_name, files.PLUGINS_DIR, plugin_name, *subpaths
+        )
+        if _collect(path, project_name, ""):
+            return results
 
     # usr/agents/<profile>/plugins/<plugin_name>/...
     if agent_profile:


### PR DESCRIPTION
Fixes #1548

## Problem

When `agent_profile` is set to a concrete value (e.g. `"agent0"`), the `find_plugin_assets()` function in `helpers/plugins.py` skips the project-level plugin config (`<project>/.a0proj/plugins/<plugin>/config.json`). This is caused by an overly restrictive guard condition on line 755:

```python
if not agent_profile or agent_profile == "*":
    # project/.a0proj/plugins/<plugin_name>/...
```

Only wildcard/empty profiles could reach the project-level config, making per-project plugin overrides (including `_model_config` for per-project chat/utility/embedding model selection) silently ineffective for all normal agent runs.

## Solution

Remove the `if not agent_profile or agent_profile == "*":` guard, so the project-level config is always checked as a fallback after the profile-scoped project path. The search precedence is preserved:

1. `project/.a0proj/agents/<profile>/plugins/<plugin>/config.json` (profile-scoped project)
2. `project/.a0proj/plugins/<plugin>/config.json` (project-level) ← was skipped, now always checked
3. `usr/agents/<profile>/plugins/<plugin>/config.json` (profile-scoped global)
4. `usr/plugins/<plugin>/config.json` (global fallback)

## Testing

Verified locally: creating a per-project `_model_config/config.json` with a different model than the global config now correctly applies the override when a new chat is started with that project active.