### PR TITLE
feat(webui): add chats-header-controls x-extension hook point

### DIFF
--- a/webui/components/sidebar/chats/chats-list.html
+++ b/webui/components/sidebar/chats/chats-list.html
@@ -17,6 +17,7 @@
           <button id="newChat" class="btn-icon-action chat-list-action-btn" @click="$store.chats.newChat()" aria-label="New Chat" title="New Chat" data-bs-placement="top" data-bs-trigger="hover">
             <span class="material-symbols-outlined">chat_add_on</span>
           </button>
+          <x-extension id="chats-header-controls"></x-extension>
         </div>
 
 


### PR DESCRIPTION
Adds a new x-extension hook point to the chats list section-header-row, enabling plugins to inject controls into the chats header area. Follows the established x-extension pattern. One line change.