### PR TITLE
docs: clarify scheduler context choice

### DIFF
--- a/docs/guides/usage.md
+++ b/docs/guides/usage.md
@@ -517,11 +517,13 @@ For **Planned Tasks**, add specific execution times:
 - Prevents context pollution between tasks
 - Better for independent, recurring workflows
 - Default for UI-created tasks
+- Use `wait_for_task` or open the task's chat context when you want to inspect its result from another chat
 
 **Shared Context**:
 - Task shares a chat context (useful for agent-created tasks)
 - Can build on previous task executions
 - Useful for sequential, related operations
+- Better when you expect to ask follow-up questions in the same chat after the task finishes
 
 #### Execution Flow
 

--- a/prompts/agent.system.tool.scheduler.md
+++ b/prompts/agent.system.tool.scheduler.md
@@ -4,6 +4,8 @@ rules:
 - before `scheduler:create_*` or `scheduler:run_task`, inspect existing tasks with `scheduler:find_task_by_name` or `scheduler:list_tasks`
 - do not manually run a task just because it is scheduled or planned unless user asks to run now
 - do not create recursive task prompts that schedule more tasks
+- use the current chat context when the user will likely ask follow-up questions about the task result
+- use `dedicated_context` for independent background jobs whose results should stay in their own task chat
 methods:
 - `scheduler:list_tasks`: optional `state[]`, `type[]`, `next_run_within`, `next_run_after`
 - `scheduler:find_task_by_name`: `name`


### PR DESCRIPTION
Summary
- clarify when scheduler tasks should stay in the current chat context
- document when `dedicated_context` is better and how to inspect those task results
- add the same rule to the scheduler tool prompt so agent-created tasks pick the right context more often

Validation
- `git diff --check`

Fixes #1588
