### PR TITLE
fix(docker): use git commit comparison for volume update detection

### DIFF
--- a/docker/run/fs/ins/copy_A0.sh
+++ b/docker/run/fs/ins/copy_A0.sh
@@ -5,8 +5,24 @@ set -e
 SOURCE_DIR="/git/agent-zero"
 TARGET_DIR="/a0"
 
-# Copy repository files if run_ui.py is missing in /a0 (if the volume is mounted)
+# Get the git commit hash from the image's bundled source
+IMAGE_COMMIT=$(git -C "$SOURCE_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")
+
+# Get the git commit hash from the mounted volume (if it exists and has a git repo)
+VOLUME_COMMIT=$(git -C "$TARGET_DIR" rev-parse HEAD 2>/dev/null || echo "none")
+
 if [ ! -f "$TARGET_DIR/run_ui.py" ]; then
-    echo "Copying files from $SOURCE_DIR to $TARGET_DIR..."
+    # Volume is empty / first run — do initial copy
+    echo "No existing installation found. Copying files from $SOURCE_DIR to $TARGET_DIR..."
     cp -rn --no-preserve=ownership,mode "$SOURCE_DIR/." "$TARGET_DIR"
+elif [ "$IMAGE_COMMIT" != "$VOLUME_COMMIT" ] && [ "$IMAGE_COMMIT" != "unknown" ]; then
+    # Image ships a different (newer) commit than what the volume contains — sync code files
+    echo "Image commit ($IMAGE_COMMIT) differs from volume commit ($VOLUME_COMMIT)."
+    echo "Updating $TARGET_DIR with new image code from $SOURCE_DIR..."
+    # Use rsync-style copy: overwrite existing files, but preserve user data not in the source
+    # --no-preserve keeps ownership/mode from causing permission issues on the bind mount
+    cp -r --no-preserve=ownership,mode "$SOURCE_DIR/." "$TARGET_DIR"
+    echo "Update complete."
+else
+    echo "Volume is up to date with image (commit: $IMAGE_COMMIT). Skipping copy."
 fi


### PR DESCRIPTION
## Summary

- Replace the naive "file exists" check in `copy_A0.sh` with git commit hash comparison so Docker image updates automatically sync code to the mounted volume.

## Problem

Previously, once `/a0/run_ui.py` existed the copy was skipped forever, leaving stale code on the volume after image upgrades. Users had to manually delete the volume to get updated code.

## Changes

**`docker/run/fs/ins/copy_A0.sh`**:
- First run (empty volume): initial copy (unchanged behavior)
- Image commit ≠ volume commit: overwrite code files while preserving user data not in the source
- Commits match: skip copy (fast startup)