### PR TITLE
fix: model config settings lost after scope change (fixes #1518)

### DIFF
--- a/plugins/_model_config/webui/config.html
+++ b/plugins/_model_config/webui/config.html
@@ -14,6 +14,8 @@
          await $store.modelConfig.refreshApiKeyStatus();
          $store.modelConfig.initConfigFields(config);
          $store.modelConfig.installSettingsHooks(context, config);
+         $watch('context.projectName', () => $store.modelConfig.initConfigFields(config));
+         $watch('context.agentProfileKey', () => $store.modelConfig.initConfigFields(config));
        ">
     <template x-if="config && $store.modelConfig._loaded">
       <div class="model-config-sections">
@@ -21,7 +23,7 @@
         <!-- Model Sections (Main, Utility, Embedding) -->
         <template x-for="section in $store.modelConfig.MODEL_SECTIONS" :key="section.key">
           <div class="model-section"
-               x-data="{ model: config[section.key], modelType: section.key.replace('_model', ''), providers: $store.modelConfig.getProviders(section.key), searchType: $store.modelConfig.getSearchType(section.key), apiKeyMode: 'store' }">
+               x-data="{ get model() { return config[section.key]; }, modelType: section.key.replace('_model', ''), providers: $store.modelConfig.getProviders(section.key), searchType: $store.modelConfig.getSearchType(section.key), apiKeyMode: 'store' }">
             <div class="section-title" x-text="section.title"></div>
             <div class="section-description" x-text="section.desc"></div>
             <x-component path="/plugins/_model_config/webui/model-field.html"></x-component>


### PR DESCRIPTION
## Problem

When changing the Project/Agent Profile scope in **Settings → Model Configuration**, user edits are silently discarded. The scoped `config.json` file is created at the correct path, but it contains the unchanged fallback/global config instead of the user's modifications.

For example: selecting Project + Agent Profile, changing Main Model from Opus → Sonnet, and clicking Save results in a config file that still shows Opus.

Fixes #1518

## Root Cause

In `plugins/_model_config/webui/config.html`, each model section captures a static reference at render time:

```html
x-data="{ model: config[section.key], ... }"
```

When the user changes scope (Project/Agent Profile), `plugin-settings-store.js` calls `loadSettings()` which **replaces** `context.settings` with a new object:

```javascript
this.settings = result.ok ? (result.data || {}) : {};
```

The `model` variable in the child `x-data` scope still references the **old** object. User edits via `x-model="model.name"` modify the stale object, while `save()` serializes the new (unmodified) object.

A secondary issue: `initConfigFields(config)` only runs once in `x-init`, so `_kwargs_text` fields are never re-initialized after a scope change.

## Fix

Two changes to `plugins/_model_config/webui/config.html`:

1. **Use a getter** so `model` always resolves from the current `config` object:

```diff
- x-data="{ model: config[section.key], modelType: ...
+ x-data="{ get model() { return config[section.key]; }, modelType: ...
```

2. **Add a `$watch`** to re-initialize kwargs text fields when config changes after scope switch:

```diff
  $store.modelConfig.installSettingsHooks(context, config);
+ $watch('config', (val) => $store.modelConfig.initConfigFields(val));
```

## Testing

1. Open Settings → Config Models
2. Select a Project + Agent Profile combination that has no existing scoped config
3. Observe the "Settings do not yet exist for this combination" info message
4. Change the Main Model name to something distinctive (e.g., Opus → Sonnet)
5. Click Save
6. Reopen Settings → Config Models
7. Re-select the same Project + Agent Profile
8. **Before fix:** Model reverts to the global value (Opus)
9. **After fix:** Model shows the saved value (Sonnet) and the info message is gone

Also verified:

- Global scope save still works correctly (no regression)
- Advanced Settings kwargs fields re-initialize properly after scope change
- Per-Chat Override toggle persists correctly at scoped level