### PR TITLE
Fix Time Travel stale index.lock cleanup and await progress updates

### DIFF
--- a/plugins/_code_execution/tools/code_execution_tool.py
+++ b/plugins/_code_execution/tools/code_execution_tool.py
@@ -278,7 +278,7 @@ class CodeExecution(Tool):
             if partial_output:
                 PrintStyle(font_color="#85C1E9").stream(partial_output)
                 truncated_output = self.fix_full_output(full_output)
-                self.set_progress(truncated_output)
+                await self.set_progress(truncated_output)
                 heading = self.get_heading_from_output(truncated_output, 0)
                 self.log.update(content=prefix + truncated_output, heading=heading)
                 last_output_time = now
@@ -397,7 +397,7 @@ class CodeExecution(Tool):
                 return None
             raise
         truncated_output = self.fix_full_output(full_output)
-        self.set_progress(truncated_output)
+        await self.set_progress(truncated_output)
         heading = self.get_heading_from_output(truncated_output, 0)
 
         last_lines = (

--- a/plugins/_time_travel/helpers/time_travel.py
+++ b/plugins/_time_travel/helpers/time_travel.py
@@ -1104,17 +1104,36 @@ class TimeTravelService:
         env["GIT_OPTIONAL_LOCKS"] = "0"
         return env
 
+    def _cleanup_git_index_lock(self) -> None:
+        """Remove a stale Git index lock after a killed Git subprocess.
+
+        subprocess timeouts terminate Git before it can always release
+        repo.git/index.lock. Leaving that lock in place poisons all later
+        snapshot attempts for the workspace, so cleanup is best-effort and
+        intentionally preserves the original timeout/error path.
+        """
+        lock_path = self.workspace.repo_git_path / "index.lock"
+        try:
+            if lock_path.exists():
+                lock_path.unlink()
+        except OSError:
+            pass
+
     def _run_git_dir(self, *args: str, check: bool = False) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(
-            ["git", f"--git-dir={self.workspace.repo_git_path}", *args],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            env=self._git_env(),
-            timeout=GIT_TIMEOUT_SECONDS,
-            check=check,
-        )
+        try:
+            return subprocess.run(
+                ["git", f"--git-dir={self.workspace.repo_git_path}", *args],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                env=self._git_env(),
+                timeout=GIT_TIMEOUT_SECONDS,
+                check=check,
+            )
+        except subprocess.TimeoutExpired:
+            self._cleanup_git_index_lock()
+            raise
 
     def _shadow_repo_valid(self) -> bool:
         if not self.workspace.repo_git_path.is_dir():
@@ -1202,24 +1221,28 @@ class TimeTravelService:
 
     def _git(self, *args: str, input: str | None = None, env: dict[str, str] | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
         self.workspace.shadow_path.mkdir(parents=True, exist_ok=True)
-        completed = subprocess.run(
-            [
-                "git",
-                f"--git-dir={self.workspace.repo_git_path}",
-                f"--work-tree={self.workspace.real_path}",
-                "-c",
-                "core.bare=false",
-                *args,
-            ],
-            input=input,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            env=env or self._git_env(),
-            cwd=str(self.workspace.real_path) if self.workspace.real_path.exists() else None,
-            timeout=GIT_TIMEOUT_SECONDS,
-        )
+        try:
+            completed = subprocess.run(
+                [
+                    "git",
+                    f"--git-dir={self.workspace.repo_git_path}",
+                    f"--work-tree={self.workspace.real_path}",
+                    "-c",
+                    "core.bare=false",
+                    *args,
+                ],
+                input=input,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                env=env or self._git_env(),
+                cwd=str(self.workspace.real_path) if self.workspace.real_path.exists() else None,
+                timeout=GIT_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            self._cleanup_git_index_lock()
+            raise
         if check and completed.returncode != 0:
             raise GitCommandError(
                 (completed.stderr or completed.stdout or "Git command failed.").strip(),
@@ -1230,21 +1253,25 @@ class TimeTravelService:
 
     def _git_bytes(self, *args: str, input: bytes | None = None, check: bool = True) -> subprocess.CompletedProcess[bytes]:
         self.workspace.shadow_path.mkdir(parents=True, exist_ok=True)
-        completed = subprocess.run(
-            [
-                "git",
-                f"--git-dir={self.workspace.repo_git_path}",
-                f"--work-tree={self.workspace.real_path}",
-                "-c",
-                "core.bare=false",
-                *args,
-            ],
-            input=input,
-            capture_output=True,
-            env=self._git_env(),
-            cwd=str(self.workspace.real_path) if self.workspace.real_path.exists() else None,
-            timeout=GIT_TIMEOUT_SECONDS,
-        )
+        try:
+            completed = subprocess.run(
+                [
+                    "git",
+                    f"--git-dir={self.workspace.repo_git_path}",
+                    f"--work-tree={self.workspace.real_path}",
+                    "-c",
+                    "core.bare=false",
+                    *args,
+                ],
+                input=input,
+                capture_output=True,
+                env=self._git_env(),
+                cwd=str(self.workspace.real_path) if self.workspace.real_path.exists() else None,
+                timeout=GIT_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            self._cleanup_git_index_lock()
+            raise
         if check and completed.returncode != 0:
             stderr = completed.stderr.decode("utf-8", errors="replace")
             stdout = completed.stdout.decode("utf-8", errors="replace")


### PR DESCRIPTION
## Summary

This PR fixes two small stability issues observed in Agent Zero runtime paths:

1. Time Travel can leave a stale `repo.git/index.lock` when a Git subprocess is killed by `subprocess.TimeoutExpired`, poisoning later snapshots for that workspace.
2. `code_execution_tool` calls async `Tool.set_progress()` without `await` in two output-progress paths, producing coroutine warnings and potential progress/update instability under load.

## Changes

### Time Travel

Adds a best-effort `_cleanup_git_index_lock()` helper and calls it when Git subprocesses time out in:

- `_run_git_dir()`
- `_git()`
- `_git_bytes()`

The timeout exception is re-raised. The patch does not change `GIT_TIMEOUT_SECONDS`, does not suppress errors, and does not alter normal successful Git behavior.

### Code execution tool

Changes two bare calls:

```python
self.set_progress(truncated_output)
```

to:

```python
await self.set_progress(truncated_output)
```

## Why

If a Time Travel Git command times out, the killed Git process may leave `index.lock` behind. Later snapshot attempts then fail with:

```text
fatal: Unable to create '.../repo.git/index.lock': File exists.
```

Cleaning the lock after timeout prevents one failed snapshot from permanently poisoning that workspace.

The `set_progress` calls are in async functions and should await the coroutine.

## Validation

Validated locally with:

```bash
python -m py_compile plugins/_time_travel/helpers/time_travel.py
python -m py_compile plugins/_code_execution/tools/code_execution_tool.py
```

Also validated in a live Agent Zero environment with a Time Travel stability guard after remediation:

```json
{
  "verdict": "PASS",
  "workspace_count": 9
}
```

No current stale Time Travel `index.lock` files remained after the fix.

## Notes

This is intentionally minimal defensive cleanup. It does not disable Time Travel, change timeout values, or add environment-specific behavior.
