### PR TITLE
fix: prevent AttributeError in _apply_settings when context has no agent0

### DIFF
--- a/helpers/settings.py
+++ b/helpers/settings.py
@@ -501,7 +501,7 @@ def _apply_settings(previous: Settings | None):
             config = initialize_agent(override_settings={"agent_profile": profile})
             ctx.config = config  # reinitialize context config with new settings
             # apply config to agents
-            agent = ctx.agent0
+            agent = getattr(ctx, 'agent0', None)
             while agent:
                 agent.config = ctx.config
                 agent = agent.get_data(agent.DATA_NAME_SUBORDINATE)


### PR DESCRIPTION
## Summary

`_apply_settings` crashes with `AttributeError: 'AgentContext' object has no attribute 'agent0'` in contexts where `agent0` has not been initialized yet (e.g. during early startup or in lightweight contexts created for settings application before the agent loop starts).

## Root Cause

```python
# Before
agent = ctx.agent0  # AttributeError if agent0 not set on ctx
```

`AgentContext` does not guarantee `agent0` is set at the point `_apply_settings` is called. The attribute access raises `AttributeError` instead of gracefully handling the missing agent.

## Fix

```python
# After
agent = getattr(ctx, 'agent0', None)
```

One-line change. `getattr` with a default of `None` matches the existing null-check pattern already used downstream in the same function.

## Impact

- Prevents a crash during settings application in contexts without an initialized agent
- No behavior change when `agent0` is present
- Consistent with how other optional context attributes are accessed in the codebase