### PR TITLE
Fix UI restart hanging before response flush

### DIFF
--- a/api/health.py
+++ b/api/health.py
@@ -13,7 +13,7 @@ class HealthCheck(ApiHandler):
 
     @classmethod
     def get_methods(cls) -> list[str]:
-        return ["GET", "POST"]
+        return ["GET", "POST", "HEAD"]
 
     async def process(self, input: dict, request: Request) -> dict | Response:
         gitinfo = None

--- a/api/restart.py
+++ b/api/restart.py
@@ -1,8 +1,22 @@
+import threading
+import time
+
 from helpers.api import ApiHandler, Request, Response
 
 from helpers import process
 
 class Restart(ApiHandler):
     async def process(self, input: dict, request: Request) -> dict | Response:
-        process.reload()
-        return Response(status=200)
+        def delayed_reload():
+            # Let the HTTP response flush to the browser before the server process
+            # is stopped/re-executed. Without this delay the Web UI can be left
+            # waiting forever on a request whose connection was cut mid-flight.
+            time.sleep(0.35)
+            process.reload()
+
+        threading.Thread(
+            target=delayed_reload,
+            daemon=True,
+            name="UiRestartExit",
+        ).start()
+        return {"success": True, "message": "Restart scheduled."}

--- a/helpers/process.py
+++ b/helpers/process.py
@@ -1,8 +1,14 @@
 import os
+import subprocess
 import sys
 import threading
+from pathlib import Path
 
 from helpers.print_style import PrintStyle
+
+SELF_UPDATE_TRIGGER_PATH = Path("/exe/a0-self-update.yaml")
+SYSTEMD_MARKER_PATH = Path("/run/systemd/system")
+SYSTEMD_SERVICE_NAME = os.environ.get("A0_SYSTEMD_SERVICE", "agent-zero.service")
 
 _server = None
 _reload_lock = threading.Lock()
@@ -22,6 +28,41 @@ def stop_server():
         _server.shutdown()
         _server = None
 
+def has_pending_self_update():
+    return SELF_UPDATE_TRIGGER_PATH.exists()
+
+def request_systemd_restart_for_self_update():
+    if not SYSTEMD_MARKER_PATH.exists():
+        return False
+
+    try:
+        active = subprocess.run(
+            ["systemctl", "is-active", "--quiet", SYSTEMD_SERVICE_NAME],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+            check=False,
+        )
+    except Exception as exc:
+        PrintStyle.warning(f"Could not check systemd service state: {exc}")
+        return False
+
+    if active.returncode != 0:
+        return False
+
+    try:
+        subprocess.Popen(
+            ["systemctl", "restart", "--no-block", SYSTEMD_SERVICE_NAME],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception as exc:
+        PrintStyle.warning(f"Could not request systemd restart: {exc}")
+        return False
+
+    return True
+
 def reload():
     global _reloading
     with _reload_lock:
@@ -31,6 +72,19 @@ def reload():
         _reloading = True
 
     stop_server()
+
+    if has_pending_self_update():
+        PrintStyle.standard(
+            "Pending self-update detected; handing restart back to the native supervisor..."
+        )
+        if request_systemd_restart_for_self_update():
+            PrintStyle.standard("Systemd restart requested for self-update handoff.")
+        else:
+            PrintStyle.hint(
+                "Systemd restart was not available; exiting for the native supervisor handoff."
+            )
+        exit_process()
+
     restart_process()
 
 def restart_process():

--- a/helpers/process.py
+++ b/helpers/process.py
@@ -1,9 +1,12 @@
 import os
 import sys
-from helpers import runtime
+import threading
+
 from helpers.print_style import PrintStyle
 
 _server = None
+_reload_lock = threading.Lock()
+_reloading = False
 
 def set_server(server):
     global _server
@@ -20,11 +23,15 @@ def stop_server():
         _server = None
 
 def reload():
+    global _reloading
+    with _reload_lock:
+        if _reloading:
+            PrintStyle.hint("Reload already in progress; ignoring duplicate request.")
+            return
+        _reloading = True
+
     stop_server()
-    if runtime.is_dockerized():
-        exit_process()
-    else:
-        restart_process()
+    restart_process()
 
 def restart_process():
     PrintStyle.standard("Restarting process...")
@@ -33,4 +40,4 @@ def restart_process():
 
 def exit_process():
     PrintStyle.standard("Exiting process...")
-    sys.exit(0)
+    os._exit(0)

--- a/tests/test_process_reload.py
+++ b/tests/test_process_reload.py
@@ -1,0 +1,171 @@
+import subprocess
+
+import pytest
+
+from helpers import process
+
+
+@pytest.fixture(autouse=True)
+def reset_reload_state():
+    process._reloading = False
+    yield
+    process._reloading = False
+
+
+def test_reload_restarts_process_when_no_self_update(monkeypatch):
+    called = {"stop": False, "restart": False, "exit": False, "systemd": False}
+
+    monkeypatch.setattr(process, "stop_server", lambda: called.__setitem__("stop", True))
+    monkeypatch.setattr(process, "restart_process", lambda: called.__setitem__("restart", True))
+    monkeypatch.setattr(process, "has_pending_self_update", lambda: False)
+    monkeypatch.setattr(
+        process,
+        "request_systemd_restart_for_self_update",
+        lambda: called.__setitem__("systemd", True),
+    )
+    monkeypatch.setattr(process.os, "_exit", lambda code: called.__setitem__("exit", True))
+
+    process.reload()
+
+    assert called == {"stop": True, "restart": True, "exit": False, "systemd": False}
+
+
+def test_reload_exits_for_native_handoff_when_self_update_pending_without_systemd(monkeypatch):
+    called = {"stop": False, "restart": False, "systemd": False, "exit_code": None}
+
+    def fake_exit(code):
+        called["exit_code"] = code
+        raise SystemExit(code)
+
+    def fake_systemd_restart():
+        called["systemd"] = True
+        return False
+
+    monkeypatch.setattr(process, "stop_server", lambda: called.__setitem__("stop", True))
+    monkeypatch.setattr(process, "restart_process", lambda: called.__setitem__("restart", True))
+    monkeypatch.setattr(process, "has_pending_self_update", lambda: True)
+    monkeypatch.setattr(process, "request_systemd_restart_for_self_update", fake_systemd_restart)
+    monkeypatch.setattr(process.os, "_exit", fake_exit)
+
+    with pytest.raises(SystemExit) as exc_info:
+        process.reload()
+
+    assert exc_info.value.code == 0
+    assert called == {"stop": True, "restart": False, "systemd": True, "exit_code": 0}
+
+
+def test_reload_requests_systemd_restart_when_self_update_pending(monkeypatch):
+    called = {"stop": False, "restart": False, "systemd": False, "exit_code": None}
+
+    def fake_exit(code):
+        called["exit_code"] = code
+        raise SystemExit(code)
+
+    def fake_systemd_restart():
+        called["systemd"] = True
+        return True
+
+    monkeypatch.setattr(process, "stop_server", lambda: called.__setitem__("stop", True))
+    monkeypatch.setattr(process, "restart_process", lambda: called.__setitem__("restart", True))
+    monkeypatch.setattr(process, "has_pending_self_update", lambda: True)
+    monkeypatch.setattr(process, "request_systemd_restart_for_self_update", fake_systemd_restart)
+    monkeypatch.setattr(process.os, "_exit", fake_exit)
+
+    with pytest.raises(SystemExit) as exc_info:
+        process.reload()
+
+    assert exc_info.value.code == 0
+    assert called == {"stop": True, "restart": False, "systemd": True, "exit_code": 0}
+
+
+def test_reload_ignores_duplicate_request(monkeypatch):
+    process._reloading = True
+    called = {"stop": False, "restart": False, "exit": False}
+
+    monkeypatch.setattr(process, "stop_server", lambda: called.__setitem__("stop", True))
+    monkeypatch.setattr(process, "restart_process", lambda: called.__setitem__("restart", True))
+    monkeypatch.setattr(process.os, "_exit", lambda code: called.__setitem__("exit", True))
+
+    process.reload()
+
+    assert called == {"stop": False, "restart": False, "exit": False}
+
+
+def test_has_pending_self_update_checks_trigger_path(monkeypatch):
+    monkeypatch.setattr(
+        process,
+        "SELF_UPDATE_TRIGGER_PATH",
+        type("Trigger", (), {"exists": staticmethod(lambda: True)})(),
+    )
+
+    assert process.has_pending_self_update() is True
+
+
+def test_request_systemd_restart_returns_false_without_systemd(monkeypatch):
+    monkeypatch.setattr(
+        process,
+        "SYSTEMD_MARKER_PATH",
+        type("Marker", (), {"exists": staticmethod(lambda: False)})(),
+    )
+
+    assert process.request_systemd_restart_for_self_update() is False
+
+
+def test_request_systemd_restart_starts_unit_when_active(monkeypatch):
+    calls = {"run": None, "popen": None}
+
+    class Completed:
+        returncode = 0
+
+    def fake_run(args, **kwargs):
+        calls["run"] = args
+        return Completed()
+
+    def fake_popen(args, **kwargs):
+        calls["popen"] = args
+        return object()
+
+    monkeypatch.setattr(
+        process,
+        "SYSTEMD_MARKER_PATH",
+        type("Marker", (), {"exists": staticmethod(lambda: True)})(),
+    )
+    monkeypatch.setattr(process.subprocess, "run", fake_run)
+    monkeypatch.setattr(process.subprocess, "Popen", fake_popen)
+
+    assert process.request_systemd_restart_for_self_update() is True
+    assert calls["run"] == ["systemctl", "is-active", "--quiet", "agent-zero.service"]
+    assert calls["popen"] == ["systemctl", "restart", "--no-block", "agent-zero.service"]
+
+
+def test_request_systemd_restart_returns_false_when_unit_inactive(monkeypatch):
+    calls = {"popen": False}
+
+    class Completed:
+        returncode = 3
+
+    monkeypatch.setattr(
+        process,
+        "SYSTEMD_MARKER_PATH",
+        type("Marker", (), {"exists": staticmethod(lambda: True)})(),
+    )
+    monkeypatch.setattr(process.subprocess, "run", lambda *a, **kw: Completed())
+    monkeypatch.setattr(process.subprocess, "Popen", lambda *a, **kw: calls.__setitem__("popen", True))
+
+    assert process.request_systemd_restart_for_self_update() is False
+    assert calls["popen"] is False
+
+
+def test_request_systemd_restart_returns_false_on_systemctl_error(monkeypatch):
+    monkeypatch.setattr(
+        process,
+        "SYSTEMD_MARKER_PATH",
+        type("Marker", (), {"exists": staticmethod(lambda: True)})(),
+    )
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args=args, timeout=5)
+
+    monkeypatch.setattr(process.subprocess, "run", fake_run)
+
+    assert process.request_systemd_restart_for_self_update() is False

--- a/tests/test_restart_api.py
+++ b/tests/test_restart_api.py
@@ -1,0 +1,57 @@
+import asyncio
+
+from api import restart
+from api.health import HealthCheck
+from api.restart import Restart
+
+
+class FakeThread:
+    created = []
+
+    def __init__(self, *, target, daemon, name):
+        self.target = target
+        self.daemon = daemon
+        self.name = name
+        self.started = False
+        self.created.append(self)
+
+    def start(self):
+        self.started = True
+
+
+def test_restart_returns_before_reloading(monkeypatch):
+    FakeThread.created = []
+    monkeypatch.setattr(restart.threading, "Thread", FakeThread)
+
+    handler = Restart(app=None, thread_lock=None)
+    response = asyncio.run(handler.process({}, request=None))
+
+    assert response == {"success": True, "message": "Restart scheduled."}
+    assert len(FakeThread.created) == 1
+    thread = FakeThread.created[0]
+    assert thread.name == "UiRestartExit"
+    assert thread.daemon is True
+    assert thread.started is True
+
+
+def test_restart_thread_runs_delayed_reload(monkeypatch):
+    called = False
+
+    def reload():
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(restart.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(restart.process, "reload", reload)
+    monkeypatch.setattr(restart.threading, "Thread", FakeThread)
+
+    FakeThread.created = []
+    handler = Restart(app=None, thread_lock=None)
+    asyncio.run(handler.process({}, request=None))
+
+    FakeThread.created[0].target()
+    assert called is True
+
+
+def test_health_allows_head_probes():
+    assert "HEAD" in HealthCheck.get_methods()


### PR DESCRIPTION
## Summary
- Make `/api/restart` return immediately and schedule the actual reload in a delayed daemon thread.
- Prevent duplicate reload requests while one is already in progress.
- Use in-process restart via `os.execv()` for normal UI restarts, so the response can flush cleanly.
- Detect pending native self-updates via `/exe/a0-self-update.yaml` and hand control back to the native supervisor instead of re-execing `run_ui.py`.
- When running under systemd, request `systemctl restart --no-block agent-zero.service` so the service wrapper can consume the self-update trigger.
- Allow `HEAD /api/health` for readiness probes.

## Why
The Web UI restart flow could hang because `/api/restart` called `process.reload()` before the HTTP response was reliably flushed. In Docker/LXC this could terminate or interrupt the request, leaving the UI polling/waiting indefinitely.

A follow-up issue was found with self-update: if `/exe/a0-self-update.yaml` was pending, the new UI restart path could directly re-exec `run_ui.py` and bypass the native wrapper/self-update manager that applies the update. In systemd deployments, the active UI process can also be a child process rather than the service `MainPID`, so simply exiting the UI process may not restart the whole service. The restart helper now detects this pending self-update case and asks systemd to restart the service before exiting, with a supervisor-exit fallback when systemd is unavailable.

## Validation
- Rebased on current `origin/main` / `v1.14`.
- `python -m py_compile api/restart.py api/health.py helpers/process.py tests/test_restart_api.py tests/test_process_reload.py`
- `python -m pytest -q tests/test_restart_api.py tests/test_process_reload.py` → 12 passed
