### PR TITLE
fix(plugins): restore list defaults and remove turtle import

### DIFF
--- a/api/plugins_list.py
+++ b/api/plugins_list.py
@@ -3,10 +3,10 @@ from helpers import plugins
 
 class PluginsList(ApiHandler):
     async def process(self, input: Input, request: Request) -> Output:
-        filter = input.get("filter", {})
+        filter = input.get("filter") or {}
 
-        custom = filter.get("custom", False)
-        builtin = filter.get("builtin", False)
+        custom = filter.get("custom", True)
+        builtin = filter.get("builtin", True)
 
         plugin_list = plugins.get_enhanced_plugins_list(custom=custom, builtin=builtin)
         

--- a/plugins/_plugin_installer/helpers/install.py
+++ b/plugins/_plugin_installer/helpers/install.py
@@ -4,7 +4,6 @@ from datetime import datetime, timezone
 import json
 import os
 import time
-from turtle import stamp
 import urllib.request
 import uuid
 import zipfile


### PR DESCRIPTION
## Summary
- Restore plugin list API defaults so calls without an explicit filter return both custom and builtin plugins.
- Remove accidental `from turtle import stamp` import from the plugin installer helper, which imports Tkinter and breaks headless/Docker environments without `_tkinter`.

## Validation
- `python -m py_compile api/plugins_list.py plugins/_plugin_installer/helpers/install.py plugins/_plugin_installer/api/plugin_install.py`
- Smoke-tested dynamic loading of `plugins/_plugin_installer/api/plugin_install.py`.
- Smoke-tested import of `api.plugins_list.PluginsList`.

## Context
On current `origin/main`, `/api/plugins_list` defaults both `custom` and `builtin` to `False`, so an empty or missing filter returns an empty plugin list. Also the plugin installer endpoint can fail on import in headless environments because `turtle` imports `tkinter`, which requires `_tkinter`.
