### PR TITLE
🧹 Fix token source mismatch in MCP settings

### DIFF
--- a/helpers/settings.py
+++ b/helpers/settings.py
@@ -317,6 +317,7 @@ def set_settings(settings: Settings, apply: bool = True):
     previous = _settings
     _settings = normalize_settings(settings)
     _write_settings_file(_settings)
+    _settings["mcp_server_token"] = create_auth_token()
     if apply:
         _apply_settings(previous)
     return reload_settings()
@@ -570,9 +571,7 @@ def _apply_settings(previous: Settings | None):
             )  # TODO overkill, replace with background task
 
         # update token in mcp server
-        current_token = (
-            create_auth_token()
-        )  # TODO - ugly, token in settings is generated from dotenv and does not always correspond
+        current_token = _settings["mcp_server_token"]
         if not previous or current_token != previous["mcp_server_token"]:
 
             async def update_mcp_token(token: str):


### PR DESCRIPTION
🎯 What: Ensure `_settings["mcp_server_token"]` uses the updated token after user/password fields are saved to `.env`. Removed the manual call to `create_auth_token` in `_apply_settings()`. 💡 

Why: `normalize_settings()` runs before `_write_settings_file()`, so `_settings` contained the token using the old password/login combo. This required a workaround in `_apply_settings()`. This change fixes the root issue, so the ugly workaround can be removed, which improves clarity and maintainability. ✅ 

Verification: Ran pytest tests related to `mcp_server_token` in WS security, and ran general sanity tests in the project. The changes do not introduce regressions. ✨ 

Result: Cleaned up code health issue without altering functionality.