### PR TITLE
⚡ performance improvement: replace synchronous sleep with asyncio.sle…

### DIFF
--- a/api/mcp_servers_apply.py
+++ b/api/mcp_servers_apply.py
@@ -1,4 +1,4 @@
-import time
+import asyncio
 from helpers.api import ApiHandler, Request, Response
 
 from typing import Any
@@ -15,7 +15,7 @@ class McpServersApply(ApiHandler):
             set_settings_delta({"mcp_servers": "[]"}) # to force reinitialization
             set_settings_delta({"mcp_servers": mcp_servers})
 
-            time.sleep(1) # wait at least a second
+            await asyncio.sleep(1) # wait at least a second
             # MCPConfig.wait_for_lock() # wait until config lock is released
             status = MCPConfig.get_instance().get_servers_status()
             return {"success": True, "status": status}


### PR DESCRIPTION
…ep in mcp_servers_apply

💡 What: Replaced time.sleep(1) with await asyncio.sleep(1) inside the async process function of McpServersApply.
🎯 Why: time.sleep is blocking and stalls the asyncio event loop, causing concurrent tasks to execute sequentially rather than concurrently.
📊 Measured Improvement: A benchmark simulation showed that running 5 concurrent requests dropped from 5.0 seconds (sequential) to 1.0 second (concurrent), eliminating event-loop blocking.