### PR TITLE
fix: push agent state to all WS connections and sync sidebar in backg…

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -300,6 +300,11 @@ class AgentContext:
             return response
         except Exception as e:
             await self.handle_exception("process_chain", e)
+        finally:
+            # Push updated running state to ALL connections when agent finishes.
+            # Without this, non-active tabs don't see running:false until they click.
+            from helpers.state_monitor_integration import mark_dirty_all
+            mark_dirty_all(reason="agent.AgentContext._process_chain completed")
 
     @extension.extensible
     async def handle_exception(self, location: str, exception: Exception):

--- a/webui/components/chat/message-queue/message-queue-store.js
+++ b/webui/components/chat/message-queue/message-queue-store.js
@@ -47,8 +47,15 @@ const model = {
   },
 
   // Combined items for display: confirmed first, then pending at the end
+  // Deduplicate by id to prevent Alpine "Duplicate key" errors during
+  // the race between server poll updates and pending item cleanup.
   get allItems() {
-    return [...this.items, ...this.pendingItems];
+    const seen = new Set();
+    return [...this.items, ...this.pendingItems].filter((item) => {
+      if (seen.has(item.id)) return false;
+      seen.add(item.id);
+      return true;
+    });
   },
 
   async addToQueue(text, attachments = []) {

--- a/webui/components/sidebar/chats/chats-list.html
+++ b/webui/components/sidebar/chats/chats-list.html
@@ -24,7 +24,7 @@
 
         <ul class="config-list chats-config-list no-scrollbar" x-show="$store.chats.contexts.length > 0">
           <template x-for="context in $store.chats.contexts" :key="context.id">
-            <li>
+            <li :data-chat-id="context.id">
               <div :class="{'chat-container': true, 'chat-selected': context.id === $store.chats.selected}"
                 @click="$store.chats.selectChat(context.id)">
                 <div class="chat-list-button">

--- a/webui/index.js
+++ b/webui/index.js
@@ -314,6 +314,13 @@ export async function applySnapshot(snapshot, options = {}) {
     return { updated: false };
   }
 
+  // Update chats/tasks list BEFORE context check so background chat
+  // state changes (running, etc.) are always reflected in the sidebar.
+  let contexts = snapshot.contexts || [];
+  chatsStore.applyContexts(contexts);
+  let tasks = snapshot.tasks || [];
+  tasksStore.applyTasks(tasks);
+
   if (
     snapshot.context != context &&
     context !== null
@@ -369,14 +376,6 @@ export async function applySnapshot(snapshot, options = {}) {
   if (touchConnectionStatus) {
     setConnectionStatus(true);
   }
-
-  // Update chats list using store
-  let contexts = snapshot.contexts || [];
-  chatsStore.applyContexts(contexts);
-
-  // Update tasks list using store
-  let tasks = snapshot.tasks || [];
-  tasksStore.applyTasks(tasks);
 
   // Make sure the active context is properly selected in both lists
   if (context) {


### PR DESCRIPTION
Description:

Problem
Background tabs don't update — When an agent finishes running, non-active browser tabs don't see running: false until the user clicks on them
Alpine "Duplicate key" console errors — The allItems getter can return duplicate items during the race between server poll updates and pending item cleanup
Sidebar stale in background tabs — chatsStore.applyContexts() runs after the context-equality check, so background chat state changes never reach the sidebar
Changes
agent.py — Added a finally block to _process_chain() that calls mark_dirty_all(). When any agent chain completes, the updated running state is pushed to all WebSocket connections.

message-queue-store.js — Deduplicate allItems by id using a Set to prevent Alpine "Duplicate key" errors during server-poll vs pending-item race.

chats-list.html — Added :data-chat-id="context.id" to the <li> element for DOM-based targeting by extensions.

index.js — Moved chatsStore.applyContexts() and tasksStore.applyTasks() before the context-equality early-return in applySnapshot(). Background state changes now always reach the sidebar.