### PR TITLE
Fix message queue persistence after auto-send

### DIFF
--- a/api/message_queue_send.py
+++ b/api/message_queue_send.py
@@ -19,6 +19,8 @@ class MessageQueueSend(ApiHandler):
 
         if send_all:
             count = mq.send_all_aggregated(context)
+            if count:
+                mark_dirty_for_context(context.id, reason="message_queue_send_all")
             return {"ok": True, "sent_count": count}
 
         # Send single item

--- a/extensions/python/process_chain_end/_50_process_queue.py
+++ b/extensions/python/process_chain_end/_50_process_queue.py
@@ -2,6 +2,7 @@ import asyncio
 from helpers.extension import Extension
 from helpers import message_queue as mq
 from agent import AgentContext, Agent, LoopData
+from helpers.state_monitor_integration import mark_dirty_for_context
 
 
 class ProcessQueue(Extension):
@@ -34,4 +35,5 @@ class ProcessQueue(Extension):
         
         # Send next queued message if task is not running
         if not context.is_running():
-            mq.send_next(context)
+            if mq.send_next(context):
+                mark_dirty_for_context(context.id, reason="message_queue_auto_send")


### PR DESCRIPTION
## Summary
- Mark chat context dirty after automatic queued-message send so the emptied queue is persisted.
- Mark context dirty after `send_all` queue sends.

## Problem
Queued messages could remain visible in `output_data.message_queue` even after the backend consumed `data.message_queue`, making the UI show stale queued messages although the LLM had already replied.

## Testing
- `python3 -m py_compile extensions/python/process_chain_end/_50_process_queue.py api/message_queue_send.py`