### PR TITLE
feat: allow disabling prompt caching per model via a0_explicit_caching kwarg

### DIFF
--- a/models.py
+++ b/models.py
@@ -498,6 +498,10 @@ class LiteLLMChatWrapper(SimpleChatModel):
         if user_message:
             messages.append(HumanMessage(content=user_message))
 
+        # Allow model kwargs to disable explicit caching (for models that don't support it)
+        if self.kwargs.get("a0_explicit_caching") is False or kwargs.get("a0_explicit_caching") is False:
+            explicit_caching = False
+
         # convert to litellm format
         msgs_conv = self._convert_messages(messages, explicit_caching=explicit_caching)
 
@@ -510,6 +514,7 @@ class LiteLLMChatWrapper(SimpleChatModel):
         call_kwargs: dict[str, Any] = _without_stream_kwarg({**self.kwargs, **kwargs})
         max_retries: int = int(call_kwargs.pop("a0_retry_attempts", 2))
         retry_delay_s: float = float(call_kwargs.pop("a0_retry_delay_seconds", 1.5))
+        call_kwargs.pop("a0_explicit_caching", None)  # strip before passing to LiteLLM
         stream = reasoning_callback is not None or response_callback is not None or tokens_callback is not None
 
         # results


### PR DESCRIPTION
## Problem

Models that don't support prompt caching (e.g. NVIDIA Nemotron on AWS Bedrock) fail with `403 Forbidden` errors because Agent Zero unconditionally adds `cache_control: {type: 'ephemeral'}` markers to messages via `explicit_caching=True` in `call_chat_model()`.

The Bedrock error message is:
> "You invoked an unsupported model or your request did not allow prompt caching."

## Solution

Add support for a new model kwarg `a0_explicit_caching` that, when set to `false`, disables prompt caching for that specific model. This allows users to configure it in their preset's Additional Settings:

```
a0_explicit_caching=false
```

Or in `presets.yaml`:
```yaml
kwargs:
  a0_explicit_caching: false
```

## Implementation

- Read `a0_explicit_caching` from model kwargs **before** `_convert_messages()` is called (critical ordering — must happen before cache_control markers are injected)
- If the value is `False`, override `explicit_caching` to `False` for that call
- Strip the kwarg from `call_kwargs` before passing to LiteLLM

## Example Use Case

NVIDIA Nemotron on Bedrock preset:
```yaml
kwargs:
  aws_region_name: us-east-2
  fake_stream: true
  a0_explicit_caching: false
```

This follows the same pattern as existing A0-specific kwargs (`a0_retry_attempts`, `a0_retry_delay_seconds`) that are stripped before reaching LiteLLM.

## Testing

- Verified NVIDIA Nemotron (`nvidia.nemotron-super-3-120b`) responds successfully with this fix
- Confirmed no impact on Claude models (which continue to use prompt caching by default)
- The fix is backwards-compatible: existing presets without this kwarg behave identically