### PR TITLE
Add extensible OAuth providers

### DIFF
--- a/plugins/_model_config/provider_metadata.yaml
+++ b/plugins/_model_config/provider_metadata.yaml
@@ -1,18 +1,10 @@
 chat:
-  codex_oauth:
-    api_key_mode: oauth
-  github_copilot_oauth:
-    api_key_mode: oauth
-  gemini_api_oauth:
-    api_key_mode: oauth
   lm_studio:
     api_key_mode: none
   ollama:
     api_key_mode: none
   other:
     api_key_mode: optional
-  xai_grok_oauth:
-    api_key_mode: oauth
 
 embedding:
   huggingface:

--- a/plugins/_model_config/provider_metadata.yaml
+++ b/plugins/_model_config/provider_metadata.yaml
@@ -1,12 +1,18 @@
 chat:
   codex_oauth:
     api_key_mode: oauth
+  github_copilot_oauth:
+    api_key_mode: oauth
+  gemini_api_oauth:
+    api_key_mode: oauth
   lm_studio:
     api_key_mode: none
   ollama:
     api_key_mode: none
   other:
     api_key_mode: optional
+  xai_grok_oauth:
+    api_key_mode: oauth
 
 embedding:
   huggingface:

--- a/plugins/_oauth/AGENTS.md
+++ b/plugins/_oauth/AGENTS.md
@@ -1,0 +1,59 @@
+# OAuth Plugin DOX
+
+## Purpose
+
+- Own account-backed OAuth model-provider connections for Agent Zero.
+- Provide local OpenAI-compatible proxy endpoints for connectable account providers.
+- Keep provider-specific OAuth behavior inside this plugin, not in core model code.
+- Preserve Codex/ChatGPT compatibility while allowing additional providers through the provider registry.
+
+## Ownership
+
+- `plugin.yaml`, `default_config.yaml`, and `README.md` own the plugin manifest, settings defaults, and user-facing connection notes.
+- `conf/model_providers.yaml` owns OAuth-backed model provider definitions and their `api_key_mode: oauth` metadata.
+- `api/` owns provider-aware settings modal endpoints such as status, login start, polling, manual callback, models, and disconnect.
+- `helpers/providers/` owns provider implementations, provider metadata, registry wiring, token storage helpers, and provider-specific endpoint validation.
+- `helpers/routes.py` owns local OAuth callback and OpenAI-compatible proxy routes mounted by the route bootstrap extension.
+- `webui/config.html` and `webui/oauth-config-store.js` own the OAuth Connections settings UI.
+- `extensions/python/_functions/models/get_api_key/end/` owns the dummy API-key extension used by OAuth model providers.
+- `tests/test_oauth_*.py` own provider contract, security, static UI, and compatibility regressions.
+
+## Local Contracts
+
+- Core model code such as `models.py` must stay provider-agnostic. Do not add Codex, GitHub Copilot, Gemini, xAI, or other OAuth provider knowledge outside plugin-owned config or plugin hooks.
+- Add OAuth model providers in `_oauth/conf/model_providers.yaml`, not `_model_config/provider_metadata.yaml`.
+- Provider cards and model slot actions must be driven by backend provider status. Do not reintroduce hardcoded frontend provider lists or fallback provider catalogs.
+- `helpers/providers/registry.py` is the source of truth for connectable OAuth providers.
+- Usage-plan metadata belongs only to connectable providers. Do not add metadata-only subscription families for providers this plugin cannot connect.
+- API handlers should remain provider-aware. Missing or blank `provider_id` defaults to Codex only for existing backward compatibility; falsey non-string IDs must not silently default.
+- Codex success contracts must preserve legacy fields such as `account_id` while allowing newer fields such as `account_label`.
+- Do not modify Codex chat-to-responses multimodal conversion without preserving the image/text regression coverage in `tests/test_oauth_codex.py`.
+- Token files are password-equivalent credentials. Store them under plugin-owned `usr/plugins/_oauth/<provider>/auth.json` paths with private permissions, and do not share rotating refresh-token files with external CLIs.
+- Stored upstream base URLs and OAuth token endpoints must be validated against provider-owned allowlists before sending bearer or refresh tokens.
+- Browser callback providers must support manual callback paste when the browser cannot reach the local callback route.
+- Local proxy routes must remain loopback or token protected and must not add broad CORS access.
+
+## Work Guidance
+
+- When adding a connectable provider, add the provider class, registry entry, model-provider config, default settings, route registration, UI support when needed, tests, and README/DOX updates together.
+- Keep provider classes explicit about their auth endpoints, scopes, refresh behavior, and safe API hosts.
+- Use shared helpers only for duplicated mechanics such as callback parsing, attempt lookup, model-list parsing, and JSON/error helpers.
+- Keep provider policy visible in each provider module; avoid abstracting away endpoint validation or billing/quota caveats.
+- Prefer plugin-local imports such as `plugins._oauth.helpers...` for bundled plugin code.
+- Keep `_oauth` account providers separate from API-key providers in core configuration.
+- Treat Gemini API OAuth as a Google Cloud OAuth-client flow. Do not conflate it with Antigravity, Gemini Code Assist, Gemini CLI, Google AI Pro, or Google AI Ultra subscription quota.
+- Treat Claude Code subscription auth and Antigravity product auth as non-connectable unless their vendors provide an explicit third-party provider contract.
+- Keep user-facing errors safe: report setup or tier restrictions without exposing tokens, callback secrets, or raw auth payloads.
+
+## Verification
+
+- Run `pytest tests/test_oauth_*.py` after backend provider, route, token, or UI contract changes.
+- Run `pytest tests/test_plugin_scan_prompt.py` after plugin structure, extension, or docs changes.
+- Run onboarding or model-config tests when provider metadata, `api_key_mode`, or model-provider config changes.
+- Run `git diff --check` before committing.
+- For security-sensitive changes, include regressions that prove bearer tokens are not sent to malicious stored endpoints.
+- For Codex changes, include `tests/test_oauth_codex.py` and preserve `account_id` and multimodal image bridge regressions.
+
+## Child DOX Index
+
+No child DOX files.

--- a/plugins/_oauth/README.md
+++ b/plugins/_oauth/README.md
@@ -2,11 +2,53 @@
 
 Generic local OAuth bridge for Agent Zero.
 
-The first provider is `Codex/ChatGPT Account`:
-
-- signs in with OpenAI's Codex device-code flow
-- writes credentials to an Agent Zero-owned `auth.json` file
-- refreshes local tokens when needed
-- exposes a loopback OpenAI-compatible wrapper at `/oauth/codex/v1`
-
 Tokens in `auth.json` are password-equivalent credentials. Keep this plugin on trusted local machines only. Do not configure `auth_file_path` to share a rotating refresh-token file with Codex CLI or another client.
+
+## Providers
+
+### Codex/ChatGPT (`codex_oauth`)
+
+- Uses the existing Codex device-code flow.
+- Writes Codex-compatible credentials to an Agent Zero-owned `auth.json` file.
+- Refreshes local tokens when needed.
+- Exposes the local OpenAI-compatible wrapper at `/oauth/codex/v1`.
+
+### GitHub Copilot (`github_copilot_oauth`)
+
+- Uses GitHub's OAuth device flow.
+- Exchanges the GitHub access token for a Copilot API token.
+- Stores credentials under `usr/plugins/_oauth/github_copilot/auth.json`.
+
+### Google Gemini API (`gemini_api_oauth`)
+
+- Uses Google's OAuth authorization-code flow with PKCE.
+- Requires a user-provided Google Cloud OAuth client with the Generative Language API enabled.
+- Proxies the official Gemini OpenAI-compatible endpoint at `/oauth/gemini-api/v1`.
+- Stores credentials under `usr/plugins/_oauth/gemini_api/auth.json`.
+- Uses Gemini API billing and quotas. It does not use Antigravity, Gemini Code Assist, Gemini CLI, Google AI Pro, or Google AI Ultra subscription quota.
+
+### xAI Grok (`xai_grok_oauth`)
+
+- Uses xAI's browser-based PKCE flow.
+- Supports manual callback paste for remote hosts where the browser cannot reach the local callback directly.
+- Stores credentials under `usr/plugins/_oauth/xai_grok/auth.json`.
+
+### Claude Code and Antigravity Product OAuth
+
+Claude Code subscription OAuth and Antigravity product OAuth are intentionally metadata-only. They are product-specific login flows rather than third-party provider contracts for Agent Zero to route model traffic through.
+
+## Usage Plan Metadata
+
+The status API exposes `usage_plan_catalog` for subscription and billing context. It covers the implemented Codex, GitHub Copilot, Google Gemini API, and xAI providers, plus nearby Claude Code and Google Gemini / Antigravity plan families.
+
+Google Gemini API OAuth is implemented through a user-provided Google Cloud OAuth client. Google Gemini / Antigravity subscription metadata remains separate because Antigravity and Gemini Code Assist product OAuth are not third-party model-provider contracts.
+
+## Remote xAI Callback
+
+When Agent Zero is running on a remote host, the browser may complete the xAI authorization step somewhere other than the machine serving the local callback route. In that case, paste the callback value into the xAI card.
+
+The xAI card accepts any of these formats:
+
+- Full callback URL.
+- Query string such as `?code=...&state=...`.
+- Bare authorization code.

--- a/plugins/_oauth/README.md
+++ b/plugins/_oauth/README.md
@@ -33,15 +33,9 @@ Tokens in `auth.json` are password-equivalent credentials. Keep this plugin on t
 - Supports manual callback paste for remote hosts where the browser cannot reach the local callback directly.
 - Stores credentials under `usr/plugins/_oauth/xai_grok/auth.json`.
 
-### Claude Code and Antigravity Product OAuth
-
-Claude Code subscription OAuth and Antigravity product OAuth are intentionally metadata-only. They are product-specific login flows rather than third-party provider contracts for Agent Zero to route model traffic through.
-
 ## Usage Plan Metadata
 
-The status API exposes `usage_plan_catalog` for subscription and billing context. It covers the implemented Codex, GitHub Copilot, Google Gemini API, and xAI providers, plus nearby Claude Code and Google Gemini / Antigravity plan families.
-
-Google Gemini API OAuth is implemented through a user-provided Google Cloud OAuth client. Google Gemini / Antigravity subscription metadata remains separate because Antigravity and Gemini Code Assist product OAuth are not third-party model-provider contracts.
+The status API exposes `usage_plan_catalog` for subscription and billing context. It covers only connectable providers: Codex, GitHub Copilot, Google Gemini API, and xAI Grok.
 
 ## Remote xAI Callback
 

--- a/plugins/_oauth/api/manual_callback.py
+++ b/plugins/_oauth/api/manual_callback.py
@@ -4,23 +4,11 @@ from helpers.api import ApiHandler, Request
 from plugins._oauth.helpers.providers import CODEX_PROVIDER_ID, get_provider
 
 
-class Disconnect(ApiHandler):
+class ManualCallback(ApiHandler):
     async def process(self, input: dict, request: Request) -> dict:
-        del request
         raw_provider_id = _provider_id(input)
         try:
-            provider = get_provider(raw_provider_id)
-            result = provider.disconnect()
-            response = {
-                "ok": True,
-                "provider_id": provider.provider_id,
-                "result": result,
-                "provider": provider.status(),
-                **result,
-            }
-            if provider.provider_id == CODEX_PROVIDER_ID:
-                response["codex"] = response["provider"]
-            return response
+            return get_provider(raw_provider_id).manual_callback(input, request).to_dict()
         except Exception as exc:
             return {
                 "ok": False,

--- a/plugins/_oauth/api/models.py
+++ b/plugins/_oauth/api/models.py
@@ -1,13 +1,37 @@
 from __future__ import annotations
 
 from helpers.api import ApiHandler, Request
-from plugins._oauth.helpers import codex
+from plugins._oauth.helpers.providers import CODEX_PROVIDER_ID, get_provider
 
 
 class Models(ApiHandler):
     async def process(self, input: dict, request: Request) -> dict:
+        del request
+        raw_provider_id = _provider_id(input)
         try:
-            models = codex.fetch_models()
-            return {"ok": True, "models": models}
+            provider = get_provider(raw_provider_id)
+            models = provider.models()
+            return {"ok": True, "provider_id": provider.provider_id, "models": models}
         except Exception as exc:
-            return {"ok": False, "error": str(exc), "models": []}
+            return {
+                "ok": False,
+                "provider_id": _provider_id_label(raw_provider_id),
+                "error": str(exc),
+                "models": [],
+            }
+
+
+def _provider_id(input: dict) -> object:
+    if "provider_id" not in input or input.get("provider_id") is None:
+        return CODEX_PROVIDER_ID
+    value = input.get("provider_id")
+    if isinstance(value, str) and not value.strip():
+        return CODEX_PROVIDER_ID
+    return value
+
+
+def _provider_id_label(value: object) -> str:
+    if value is None:
+        return CODEX_PROVIDER_ID
+    text = str(value).strip()
+    return text or CODEX_PROVIDER_ID

--- a/plugins/_oauth/api/poll_device_login.py
+++ b/plugins/_oauth/api/poll_device_login.py
@@ -1,35 +1,33 @@
 from __future__ import annotations
 
 from helpers.api import ApiHandler, Request
-from plugins._oauth.helpers import codex
-from plugins._oauth.helpers.state import get_device_attempt, pop_device_attempt
+from plugins._oauth.helpers.providers import CODEX_PROVIDER_ID, get_provider
 
 
 class PollDeviceLogin(ApiHandler):
     async def process(self, input: dict, request: Request) -> dict:
-        attempt_id = str(input.get("attempt_id") or "").strip()
-        if not attempt_id:
-            return {"ok": False, "error": "Missing device authorization attempt."}
-
-        attempt = get_device_attempt(attempt_id)
-        if attempt is None:
-            return {"ok": False, "expired": True, "error": "Device authorization expired."}
-
+        raw_provider_id = _provider_id(input)
         try:
-            result = codex.poll_device_authorization(
-                attempt.device_auth_id,
-                attempt.user_code,
-            )
+            return get_provider(raw_provider_id).poll_login(input, request).to_dict()
         except Exception as exc:
-            return {"ok": False, "error": str(exc)}
+            return {
+                "ok": False,
+                "provider_id": _provider_id_label(raw_provider_id),
+                "error": str(exc),
+            }
 
-        if result.get("completed"):
-            pop_device_attempt(attempt_id)
-            return {"ok": True, "completed": True, "account_id": result.get("account_id", "")}
 
-        return {
-            "ok": True,
-            "completed": False,
-            "interval": attempt.interval,
-            "expires_at": attempt.expires_at,
-        }
+def _provider_id(input: dict) -> object:
+    if "provider_id" not in input or input.get("provider_id") is None:
+        return CODEX_PROVIDER_ID
+    value = input.get("provider_id")
+    if isinstance(value, str) and not value.strip():
+        return CODEX_PROVIDER_ID
+    return value
+
+
+def _provider_id_label(value: object) -> str:
+    if value is None:
+        return CODEX_PROVIDER_ID
+    text = str(value).strip()
+    return text or CODEX_PROVIDER_ID

--- a/plugins/_oauth/api/start_device_login.py
+++ b/plugins/_oauth/api/start_device_login.py
@@ -1,36 +1,9 @@
 from __future__ import annotations
 
-import secrets
-
 from helpers.api import ApiHandler, Request
-from plugins._oauth.helpers import codex
-from plugins._oauth.helpers.config import codex_config
-from plugins._oauth.helpers.state import put_device_attempt
+from plugins._oauth.helpers.providers import CODEX_PROVIDER_ID, get_provider
 
 
 class StartDeviceLogin(ApiHandler):
     async def process(self, input: dict, request: Request) -> dict:
-        cfg = codex_config()
-        if not cfg["enabled"]:
-            return {"ok": False, "error": "Codex/ChatGPT account connection is disabled."}
-
-        try:
-            device = codex.request_device_code()
-            attempt_id = secrets.token_urlsafe(24)
-            attempt = put_device_attempt(
-                attempt_id,
-                device["device_auth_id"],
-                device["user_code"],
-                device["interval"],
-                device["expires_at"],
-            )
-            return {
-                "ok": True,
-                "attempt_id": attempt.attempt_id,
-                "verification_url": device["verification_url"],
-                "user_code": attempt.user_code,
-                "interval": attempt.interval,
-                "expires_at": attempt.expires_at,
-            }
-        except Exception as exc:
-            return {"ok": False, "error": str(exc)}
+        return get_provider(CODEX_PROVIDER_ID).start_login(input, request).to_dict()

--- a/plugins/_oauth/api/start_login.py
+++ b/plugins/_oauth/api/start_login.py
@@ -1,54 +1,44 @@
 from __future__ import annotations
 
-import webbrowser
-
 from helpers.api import ApiHandler, Request
-from plugins._oauth.helpers import codex
-from plugins._oauth.helpers.config import codex_config
-from plugins._oauth.helpers.state import put_attempt
+from plugins._oauth.helpers.providers import CODEX_PROVIDER_ID, get_provider
 
 
 class StartLogin(ApiHandler):
     async def process(self, input: dict, request: Request) -> dict:
-        cfg = codex_config()
-        if not cfg["enabled"]:
-            return {"ok": False, "error": "Codex/ChatGPT account connection is disabled."}
-
-        redirect_uri = _redirect_uri(request, cfg["callback_path"])
-        pkce = codex.generate_pkce()
-        state = codex.generate_state()
-        attempt = put_attempt(state, pkce.verifier, redirect_uri)
-        auth_url = codex.build_authorize_url(redirect_uri, state, pkce)
-
-        if cfg["open_browser_from_server"]:
+        if "provider_id" not in input:
+            raw_provider_id = CODEX_PROVIDER_ID
             try:
-                webbrowser.open(auth_url)
-            except Exception:
-                pass
+                provider = get_provider(CODEX_PROVIDER_ID)
+                start_browser_login = getattr(provider, "start_browser_login", None)
+                if callable(start_browser_login):
+                    return start_browser_login(input, request).to_dict()
+                return provider.start_login(input, request).to_dict()
+            except Exception as exc:
+                return {"ok": False, "provider_id": CODEX_PROVIDER_ID, "error": str(exc)}
 
-        return {
-            "ok": True,
-            "auth_url": auth_url,
-            "redirect_uri": redirect_uri,
-            "expires_at": attempt.expires_at,
-        }
+        raw_provider_id = _provider_id(input)
+        try:
+            return get_provider(raw_provider_id).start_login(input, request).to_dict()
+        except Exception as exc:
+            return {
+                "ok": False,
+                "provider_id": _provider_id_label(raw_provider_id),
+                "error": str(exc),
+            }
 
 
-def _redirect_uri(request: Request, callback_path: str) -> str:
-    origin = (request.headers.get("Origin") or "").rstrip("/")
-    if not _is_local_origin(origin):
-        origin = request.url_root.rstrip("/")
-    return f"{origin}{callback_path}"
+def _provider_id(input: dict) -> object:
+    if "provider_id" not in input or input.get("provider_id") is None:
+        return CODEX_PROVIDER_ID
+    value = input.get("provider_id")
+    if isinstance(value, str) and not value.strip():
+        return CODEX_PROVIDER_ID
+    return value
 
 
-def _is_local_origin(origin: str) -> bool:
-    if not origin:
-        return False
-    return (
-        origin.startswith("http://localhost:")
-        or origin == "http://localhost"
-        or origin.startswith("http://127.0.0.1:")
-        or origin == "http://127.0.0.1"
-        or origin.startswith("http://[::1]:")
-        or origin == "http://[::1]"
-    )
+def _provider_id_label(value: object) -> str:
+    if value is None:
+        return CODEX_PROVIDER_ID
+    text = str(value).strip()
+    return text or CODEX_PROVIDER_ID

--- a/plugins/_oauth/api/status.py
+++ b/plugins/_oauth/api/status.py
@@ -1,22 +1,32 @@
 from __future__ import annotations
 
 from helpers.api import ApiHandler, Request
-from plugins._oauth.helpers import codex
-from plugins._oauth.helpers.config import codex_config
 from plugins._oauth.helpers.route_bootstrap import is_installed
+from plugins._oauth.helpers.providers import CODEX_PROVIDER_ID, provider_registry
+from plugins._oauth.helpers.usage_plans import usage_plan_catalog
 
 
 class Status(ApiHandler):
     async def process(self, input: dict, request: Request) -> dict:
-        cfg = codex_config()
+        del input, request
+        providers = [_provider_status(provider) for provider in provider_registry().values()]
+        provider_map = {provider["provider_id"]: provider for provider in providers}
         return {
             "ok": True,
             "routes_installed": is_installed(),
-            "codex": {
-                **codex.status(),
-                "enabled": cfg["enabled"],
-                "proxy_base_path": cfg["proxy_base_path"],
-                "callback_path": cfg["callback_path"],
-                "v1_base_path": f'{cfg["proxy_base_path"]}/v1',
-            },
+            "providers": providers,
+            "provider_map": provider_map,
+            "usage_plan_catalog": usage_plan_catalog(),
+            "codex": provider_map.get(CODEX_PROVIDER_ID, {}),
+        }
+
+
+def _provider_status(provider) -> dict:
+    try:
+        return provider.status()
+    except Exception as exc:
+        return {
+            "provider_id": str(getattr(provider, "provider_id", "")),
+            "connected": False,
+            "error": str(exc),
         }

--- a/plugins/_oauth/conf/model_providers.yaml
+++ b/plugins/_oauth/conf/model_providers.yaml
@@ -2,6 +2,7 @@ chat:
   codex_oauth:
     name: Codex/ChatGPT Account
     litellm_provider: openai
+    api_key_mode: oauth
     models_list:
       endpoint_url: "/models"
     kwargs:
@@ -10,6 +11,7 @@ chat:
   github_copilot_oauth:
     name: GitHub Copilot Account
     litellm_provider: openai
+    api_key_mode: oauth
     models_list:
       endpoint_url: "/models"
     kwargs:
@@ -18,6 +20,7 @@ chat:
   gemini_api_oauth:
     name: Google Gemini API Account
     litellm_provider: openai
+    api_key_mode: oauth
     models_list:
       endpoint_url: "/models"
     kwargs:
@@ -26,6 +29,7 @@ chat:
   xai_grok_oauth:
     name: xAI Grok Account
     litellm_provider: openai
+    api_key_mode: oauth
     models_list:
       endpoint_url: "/models"
     kwargs:

--- a/plugins/_oauth/conf/model_providers.yaml
+++ b/plugins/_oauth/conf/model_providers.yaml
@@ -7,3 +7,27 @@ chat:
     kwargs:
       api_base: "http://127.0.0.1/oauth/codex/v1"
       api_key: "oauth"
+  github_copilot_oauth:
+    name: GitHub Copilot Account
+    litellm_provider: openai
+    models_list:
+      endpoint_url: "/models"
+    kwargs:
+      api_base: "http://127.0.0.1/oauth/github-copilot/v1"
+      api_key: "oauth"
+  gemini_api_oauth:
+    name: Google Gemini API Account
+    litellm_provider: openai
+    models_list:
+      endpoint_url: "/models"
+    kwargs:
+      api_base: "http://127.0.0.1/oauth/gemini-api/v1"
+      api_key: "oauth"
+  xai_grok_oauth:
+    name: xAI Grok Account
+    litellm_provider: openai
+    models_list:
+      endpoint_url: "/models"
+    kwargs:
+      api_base: "http://127.0.0.1/oauth/xai-grok/v1"
+      api_key: "oauth"

--- a/plugins/_oauth/default_config.yaml
+++ b/plugins/_oauth/default_config.yaml
@@ -1,4 +1,4 @@
-# Generic OAuth connection settings. Only Codex is implemented for now.
+# Generic OAuth connection settings.
 codex:
   enabled: true
 
@@ -31,3 +31,25 @@ codex:
   callback_path: "/auth/callback"
   require_proxy_token: false
   proxy_token: ""
+
+github_copilot:
+  enabled: true
+  enterprise_domain: ""
+
+gemini_api:
+  enabled: true
+  client_id: ""
+  client_secret: ""
+  quota_project_id: ""
+  scopes:
+    - openid
+    - email
+    - profile
+    - https://www.googleapis.com/auth/cloud-platform
+    - https://www.googleapis.com/auth/generative-language.retriever
+  api_base_url: "https://generativelanguage.googleapis.com/v1beta/openai"
+  proxy_base_path: "/oauth/gemini-api"
+  callback_path: "/oauth/gemini-api/callback"
+
+xai_grok:
+  enabled: true

--- a/plugins/_oauth/extensions/python/_functions/models/get_api_key/end/_20_codex_account_dummy_key.py
+++ b/plugins/_oauth/extensions/python/_functions/models/get_api_key/end/_20_codex_account_dummy_key.py
@@ -1,26 +1,24 @@
 from __future__ import annotations
 
 from helpers.extension import Extension
-
-
-DUMMY_API_KEY = "oauth"
-PROVIDERS = {"codex_oauth"}
+from plugins._oauth.helpers.providers import DUMMY_API_KEY, oauth_provider_ids
 
 
 class CodexAccountDummyKey(Extension):
     def execute(self, data: dict | None = None, **kwargs):
+        del kwargs
         if not isinstance(data, dict):
             return
 
         args = data.get("args")
         call_kwargs = data.get("kwargs")
         service = ""
-        if isinstance(args, tuple) and args:
+        if isinstance(args, (list, tuple)) and args:
             service = str(args[0] or "")
         elif isinstance(call_kwargs, dict):
             service = str(call_kwargs.get("service") or "")
 
-        if service.lower() not in PROVIDERS:
+        if service.lower() not in oauth_provider_ids():
             return
 
         result = str(data.get("result") or "").strip()

--- a/plugins/_oauth/extensions/python/_functions/models/get_api_key/end/_20_oauth_account_dummy_key.py
+++ b/plugins/_oauth/extensions/python/_functions/models/get_api_key/end/_20_oauth_account_dummy_key.py
@@ -4,7 +4,7 @@ from helpers.extension import Extension
 from plugins._oauth.helpers.providers import DUMMY_API_KEY, oauth_provider_ids
 
 
-class CodexAccountDummyKey(Extension):
+class OAuthAccountDummyKey(Extension):
     def execute(self, data: dict | None = None, **kwargs):
         del kwargs
         if not isinstance(data, dict):

--- a/plugins/_oauth/helpers/config.py
+++ b/plugins/_oauth/helpers/config.py
@@ -19,6 +19,14 @@ DEFAULT_CODEX_SCOPES = [
     "api.connectors.read",
     "api.connectors.invoke",
 ]
+DEFAULT_GEMINI_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
+DEFAULT_GEMINI_API_SCOPES = [
+    "openid",
+    "email",
+    "profile",
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/generative-language.retriever",
+]
 
 
 def oauth_config() -> dict[str, Any]:
@@ -48,6 +56,23 @@ def codex_config(config: dict[str, Any] | None = None) -> dict[str, Any]:
         "callback_path": _normalize_base_path(raw.get("callback_path"), "/auth/callback"),
         "require_proxy_token": _as_bool(raw.get("require_proxy_token"), False),
         "proxy_token": _as_str(raw.get("proxy_token")),
+    }
+
+
+def gemini_api_config(config: dict[str, Any] | None = None) -> dict[str, Any]:
+    source = config if isinstance(config, dict) else oauth_config()
+    raw = source.get("gemini_api", {}) if isinstance(source, dict) else {}
+    raw = raw if isinstance(raw, dict) else {}
+
+    return {
+        "enabled": _as_bool(raw.get("enabled"), True),
+        "client_id": _as_str(raw.get("client_id")),
+        "client_secret": _as_str(raw.get("client_secret")),
+        "scopes": _as_str_list(raw.get("scopes")) or DEFAULT_GEMINI_API_SCOPES,
+        "quota_project_id": _as_str(raw.get("quota_project_id")),
+        "api_base_url": _trim_url(raw.get("api_base_url"), DEFAULT_GEMINI_API_BASE_URL),
+        "proxy_base_path": _normalize_base_path(raw.get("proxy_base_path"), "/oauth/gemini-api"),
+        "callback_path": _normalize_base_path(raw.get("callback_path"), "/oauth/gemini-api/callback"),
     }
 
 

--- a/plugins/_oauth/helpers/providers/__init__.py
+++ b/plugins/_oauth/helpers/providers/__init__.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from plugins._oauth.helpers.providers.base import (
+    CODEX_PROVIDER_ID,
+    DUMMY_API_KEY,
+    GEMINI_API_PROVIDER_ID,
+    GITHUB_COPILOT_PROVIDER_ID,
+    XAI_GROK_PROVIDER_ID,
+    CallbackResult,
+    LoginPollResult,
+    LoginStartResult,
+    OAuthProvider,
+    OAuthProviderMetadata,
+    ProviderError,
+    provider_auth_path,
+    provider_data_dir,
+    public_error,
+    read_json_file,
+    write_private_json,
+)
+from plugins._oauth.helpers.providers.registry import (
+    get_provider,
+    oauth_provider_ids,
+    provider_registry,
+)
+
+__all__ = [
+    "CODEX_PROVIDER_ID",
+    "DUMMY_API_KEY",
+    "GEMINI_API_PROVIDER_ID",
+    "GITHUB_COPILOT_PROVIDER_ID",
+    "XAI_GROK_PROVIDER_ID",
+    "CallbackResult",
+    "LoginPollResult",
+    "LoginStartResult",
+    "OAuthProvider",
+    "OAuthProviderMetadata",
+    "ProviderError",
+    "get_provider",
+    "oauth_provider_ids",
+    "provider_auth_path",
+    "provider_data_dir",
+    "provider_registry",
+    "public_error",
+    "read_json_file",
+    "write_private_json",
+]

--- a/plugins/_oauth/helpers/providers/base.py
+++ b/plugins/_oauth/helpers/providers/base.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import importlib
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+
+CODEX_PROVIDER_ID = "codex_oauth"
+GITHUB_COPILOT_PROVIDER_ID = "github_copilot_oauth"
+GEMINI_API_PROVIDER_ID = "gemini_api_oauth"
+XAI_GROK_PROVIDER_ID = "xai_grok_oauth"
+DUMMY_API_KEY = "oauth"
+
+
+class ProviderError(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "provider_error",
+        status: int = 400,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.status = status
+        self.details = dict(details or {})
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "ok": False,
+            "error": self.message,
+            "code": self.code,
+            "status": self.status,
+        }
+        if self.details:
+            result["details"] = self.details
+        return result
+
+
+@dataclass(frozen=True)
+class OAuthProviderMetadata:
+    provider_id: str
+    display_name: str
+    short_name: str
+    model_provider_id: str
+    icon: str
+    auth_flow: str
+    default_model: str
+    default_models: list[str] = field(default_factory=list)
+    proxy_base_path: str = ""
+    callback_path: str = ""
+    supports_manual_callback: bool = False
+    supports_enterprise_domain: bool = False
+    supports_oauth_client_config: bool = False
+    supports_quota_project: bool = False
+    note: str = ""
+    warning: str = ""
+    usage_plans: list[dict[str, Any]] = field(default_factory=list)
+    usage_plan_notes: list[str] = field(default_factory=list)
+    usage_plan_sources: list[dict[str, str]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LoginStartResult:
+    ok: bool
+    provider_id: str
+    flow: str
+    auth_url: str = ""
+    redirect_uri: str = ""
+    attempt_id: str = ""
+    verification_url: str = ""
+    user_code: str = ""
+    interval: int = 5
+    expires_at: float = 0
+    message: str = ""
+    error: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LoginPollResult:
+    ok: bool
+    provider_id: str
+    completed: bool = False
+    account_label: str = ""
+    account_id: str = ""
+    interval: int = 5
+    expires_at: float = 0
+    expired: bool = False
+    error: str = ""
+    warning: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class CallbackResult:
+    ok: bool
+    provider_id: str
+    account_label: str = ""
+    account_id: str = ""
+    error: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class OAuthProvider(Protocol):
+    provider_id: str
+
+    def metadata(self) -> OAuthProviderMetadata:
+        ...
+
+    def status(self) -> dict[str, Any]:
+        ...
+
+    def start_login(self, input: dict[str, Any] | None = None, request: Any = None) -> LoginStartResult:
+        ...
+
+    def poll_login(self, input: dict[str, Any] | None = None, request: Any = None) -> LoginPollResult:
+        ...
+
+    def complete_callback(self, args: dict[str, Any], request: Any) -> CallbackResult:
+        ...
+
+    def manual_callback(self, input: dict[str, Any], request: Any) -> LoginPollResult:
+        ...
+
+    def models(self) -> list[str]:
+        ...
+
+    def disconnect(self) -> dict[str, Any]:
+        ...
+
+    def api_key(self) -> str:
+        ...
+
+    def register_routes(self, app: Any) -> None:
+        ...
+
+
+def provider_data_dir(provider_slug: str) -> Path:
+    if not _valid_provider_slug(provider_slug):
+        raise ProviderError(
+            "Invalid OAuth provider storage slug.",
+            code="invalid_provider_slug",
+        )
+
+    files = importlib.import_module("helpers.files")
+
+    path = Path(
+        files.get_abs_path(
+            files.USER_DIR,
+            files.PLUGINS_DIR,
+            "_oauth",
+            provider_slug,
+        )
+    )
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def provider_auth_path(provider_slug: str) -> Path:
+    return provider_data_dir(provider_slug) / "auth.json"
+
+
+def _valid_provider_slug(provider_slug: str) -> bool:
+    if not isinstance(provider_slug, str):
+        return False
+    if not provider_slug or provider_slug in {".", ".."}:
+        return False
+    if "/" in provider_slug or "\\" in provider_slug:
+        return False
+    return all(char.isalnum() or char in {"_", "-"} for char in provider_slug)
+
+
+def read_json_file(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except FileNotFoundError:
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    return payload
+
+
+def write_private_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_name = ""
+    try:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=str(path.parent),
+        )
+        os.chmod(tmp_name, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    except Exception:
+        if tmp_name:
+            Path(tmp_name).unlink(missing_ok=True)
+        raise
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def public_error(exc: Exception) -> str:
+    return str(exc) or exc.__class__.__name__

--- a/plugins/_oauth/helpers/providers/base.py
+++ b/plugins/_oauth/helpers/providers/base.py
@@ -61,9 +61,6 @@ class OAuthProviderMetadata:
     supports_quota_project: bool = False
     note: str = ""
     warning: str = ""
-    usage_plans: list[dict[str, Any]] = field(default_factory=list)
-    usage_plan_notes: list[str] = field(default_factory=list)
-    usage_plan_sources: list[dict[str, str]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/plugins/_oauth/helpers/providers/codex.py
+++ b/plugins/_oauth/helpers/providers/codex.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import secrets
+import webbrowser
+from typing import Any
+
+from plugins._oauth.helpers.providers.base import (
+    CODEX_PROVIDER_ID,
+    DUMMY_API_KEY,
+    CallbackResult,
+    LoginPollResult,
+    LoginStartResult,
+    OAuthProviderMetadata,
+)
+from plugins._oauth.helpers.usage_plans import (
+    usage_plan_notes_for,
+    usage_plan_sources_for,
+    usage_plans_for,
+)
+from plugins._oauth.helpers.state import (
+    get_device_attempt,
+    pop_device_attempt,
+    put_attempt,
+    put_device_attempt,
+)
+
+
+CODEX_DEFAULT_MODELS = ["gpt-5.2-codex", "gpt-5.2"]
+CODEX_FALLBACK_CONFIG = {
+    "enabled": True,
+    "models": [],
+    "proxy_base_path": "/oauth/codex",
+    "callback_path": "/auth/callback",
+    "open_browser_from_server": False,
+}
+
+
+class CodexOAuthProvider:
+    provider_id = CODEX_PROVIDER_ID
+
+    def metadata(self) -> OAuthProviderMetadata:
+        cfg = _codex_config()
+        models = cfg["models"] or CODEX_DEFAULT_MODELS
+        return OAuthProviderMetadata(
+            provider_id=CODEX_PROVIDER_ID,
+            display_name="Codex/ChatGPT",
+            short_name="Codex",
+            model_provider_id=CODEX_PROVIDER_ID,
+            icon="openai",
+            auth_flow="device_code",
+            default_model=models[0] if models else "gpt-5.2-codex",
+            default_models=models,
+            proxy_base_path=cfg["proxy_base_path"],
+            callback_path=cfg["callback_path"],
+            usage_plans=usage_plans_for(CODEX_PROVIDER_ID),
+            usage_plan_notes=usage_plan_notes_for(CODEX_PROVIDER_ID),
+            usage_plan_sources=usage_plan_sources_for(CODEX_PROVIDER_ID),
+        )
+
+    def status(self) -> dict[str, Any]:
+        from plugins._oauth.helpers import codex
+
+        cfg = _codex_config()
+        return {
+            **self.metadata().to_dict(),
+            **codex.status(),
+            "enabled": cfg["enabled"],
+            "proxy_base_path": cfg["proxy_base_path"],
+            "callback_path": cfg["callback_path"],
+            "v1_base_path": f'{cfg["proxy_base_path"]}/v1',
+        }
+
+    def start_login(self, input: dict[str, Any] | None = None, request: Any = None) -> LoginStartResult:
+        del input, request
+        from plugins._oauth.helpers import codex
+
+        cfg = _codex_config()
+        if not cfg["enabled"]:
+            return LoginStartResult(
+                ok=False,
+                provider_id=CODEX_PROVIDER_ID,
+                flow="device_code",
+                error="Codex/ChatGPT account connection is disabled.",
+            )
+
+        try:
+            device = codex.request_device_code()
+            attempt_id = secrets.token_urlsafe(24)
+            attempt = put_device_attempt(
+                attempt_id,
+                device["device_auth_id"],
+                device["user_code"],
+                device["interval"],
+                device["expires_at"],
+                provider_id=CODEX_PROVIDER_ID,
+            )
+        except Exception as exc:
+            return LoginStartResult(
+                ok=False,
+                provider_id=CODEX_PROVIDER_ID,
+                flow="device_code",
+                error=str(exc),
+            )
+
+        return LoginStartResult(
+            ok=True,
+            provider_id=CODEX_PROVIDER_ID,
+            flow="device_code",
+            attempt_id=attempt.attempt_id,
+            verification_url=device["verification_url"],
+            user_code=attempt.user_code,
+            interval=attempt.interval,
+            expires_at=attempt.expires_at,
+        )
+
+    def start_browser_login(
+        self,
+        input: dict[str, Any] | None = None,
+        request: Any = None,
+    ) -> LoginStartResult:
+        del input
+        cfg = _codex_config()
+        if not cfg["enabled"]:
+            return LoginStartResult(
+                ok=False,
+                provider_id=CODEX_PROVIDER_ID,
+                flow="browser_pkce",
+                error="Codex/ChatGPT account connection is disabled.",
+            )
+
+        from plugins._oauth.helpers import codex
+
+        redirect_uri = _redirect_uri(request, cfg["callback_path"])
+        pkce = codex.generate_pkce()
+        state = codex.generate_state()
+        attempt = put_attempt(
+            state,
+            pkce.verifier,
+            redirect_uri,
+            provider_id=CODEX_PROVIDER_ID,
+        )
+        auth_url = codex.build_authorize_url(redirect_uri, state, pkce)
+
+        if cfg["open_browser_from_server"]:
+            try:
+                webbrowser.open(auth_url)
+            except Exception:
+                pass
+
+        return LoginStartResult(
+            ok=True,
+            provider_id=CODEX_PROVIDER_ID,
+            flow="browser_pkce",
+            auth_url=auth_url,
+            redirect_uri=redirect_uri,
+            expires_at=attempt.expires_at,
+        )
+
+    def poll_login(self, input: dict[str, Any] | None = None, request: Any = None) -> LoginPollResult:
+        del request
+        data = input or {}
+        attempt_id = str(data.get("attempt_id") or "").strip()
+        if not attempt_id:
+            return LoginPollResult(
+                ok=False,
+                provider_id=CODEX_PROVIDER_ID,
+                error="Missing device authorization attempt.",
+            )
+
+        attempt = get_device_attempt(attempt_id)
+        if attempt is None:
+            return LoginPollResult(
+                ok=False,
+                provider_id=CODEX_PROVIDER_ID,
+                expired=True,
+                error="Device authorization expired.",
+            )
+        if attempt.provider_id != CODEX_PROVIDER_ID:
+            return LoginPollResult(
+                ok=False,
+                provider_id=CODEX_PROVIDER_ID,
+                error="Device authorization provider mismatch.",
+            )
+
+        try:
+            from plugins._oauth.helpers import codex
+
+            result = codex.poll_device_authorization(
+                attempt.device_auth_id,
+                attempt.user_code,
+            )
+        except Exception as exc:
+            return LoginPollResult(ok=False, provider_id=CODEX_PROVIDER_ID, error=str(exc))
+
+        if result.get("completed"):
+            pop_device_attempt(attempt_id)
+            account_id = str(result.get("account_id") or "")
+            return LoginPollResult(
+                ok=True,
+                provider_id=CODEX_PROVIDER_ID,
+                completed=True,
+                account_label=str(result.get("account_label") or account_id),
+                account_id=account_id,
+            )
+
+        return LoginPollResult(
+            ok=True,
+            provider_id=CODEX_PROVIDER_ID,
+            completed=False,
+            interval=attempt.interval,
+            expires_at=attempt.expires_at,
+        )
+
+    def complete_callback(
+        self,
+        args: dict[str, Any],
+        request: Any = None,
+    ) -> CallbackResult:
+        del args, request
+        return CallbackResult(
+            ok=False,
+            provider_id=CODEX_PROVIDER_ID,
+            error="Codex OAuth callback is handled by compatibility routes.",
+        )
+
+    def manual_callback(
+        self,
+        input: dict[str, Any],
+        request: Any = None,
+    ) -> LoginPollResult:
+        del input, request
+        return LoginPollResult(
+            ok=False,
+            provider_id=CODEX_PROVIDER_ID,
+            error="Codex uses device-code login in this UI.",
+        )
+
+    def models(self) -> list[str]:
+        from plugins._oauth.helpers import codex
+
+        return codex.fetch_models()
+
+    def disconnect(self) -> dict[str, Any]:
+        from plugins._oauth.helpers import codex
+
+        return codex.disconnect_auth()
+
+    def api_key(self) -> str:
+        return DUMMY_API_KEY
+
+    def register_routes(self, app: Any) -> None:
+        del app
+        return None
+
+
+def _redirect_uri(request: Any, callback_path: str) -> str:
+    origin = ""
+    if request is not None:
+        origin = (getattr(request, "headers", {}).get("Origin") or "").rstrip("/")
+        if not _is_local_origin(origin):
+            origin = getattr(request, "url_root", "").rstrip("/")
+    return f"{origin}{callback_path}"
+
+
+def _codex_config() -> dict[str, Any]:
+    try:
+        from plugins._oauth.helpers.config import codex_config
+
+        return codex_config()
+    except ModuleNotFoundError as exc:
+        if exc.name and exc.name.startswith("plugins._oauth"):
+            raise
+        return dict(CODEX_FALLBACK_CONFIG)
+
+
+def _is_local_origin(origin: str) -> bool:
+    if not origin:
+        return False
+    return (
+        origin.startswith("http://localhost:")
+        or origin == "http://localhost"
+        or origin.startswith("http://127.0.0.1:")
+        or origin == "http://127.0.0.1"
+        or origin.startswith("http://[::1]:")
+        or origin == "http://[::1]"
+    )

--- a/plugins/_oauth/helpers/providers/codex.py
+++ b/plugins/_oauth/helpers/providers/codex.py
@@ -12,11 +12,6 @@ from plugins._oauth.helpers.providers.base import (
     LoginStartResult,
     OAuthProviderMetadata,
 )
-from plugins._oauth.helpers.usage_plans import (
-    usage_plan_notes_for,
-    usage_plan_sources_for,
-    usage_plans_for,
-)
 from plugins._oauth.helpers.state import (
     get_device_attempt,
     pop_device_attempt,
@@ -52,9 +47,6 @@ class CodexOAuthProvider:
             default_models=models,
             proxy_base_path=cfg["proxy_base_path"],
             callback_path=cfg["callback_path"],
-            usage_plans=usage_plans_for(CODEX_PROVIDER_ID),
-            usage_plan_notes=usage_plan_notes_for(CODEX_PROVIDER_ID),
-            usage_plan_sources=usage_plan_sources_for(CODEX_PROVIDER_ID),
         )
 
     def status(self) -> dict[str, Any]:

--- a/plugins/_oauth/helpers/providers/common.py
+++ b/plugins/_oauth/helpers/providers/common.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from plugins._oauth.helpers import state as state_store
+
+
+def parse_manual_callback(raw: Any) -> dict[str, str | None] | None:
+    text = "" if raw is None else str(raw).strip()
+    if not text:
+        return None
+
+    if text.startswith("http://") or text.startswith("https://"):
+        query = urlparse(text).query
+    elif text.startswith("?"):
+        query = text[1:]
+    elif "=" in text or "&" in text:
+        query = text
+    else:
+        return {
+            "code": text,
+            "state": None,
+            "error": None,
+            "error_description": None,
+        }
+
+    parsed = parse_qs(query, keep_blank_values=True)
+    return {
+        "code": first_query_value(parsed, "code"),
+        "state": first_query_value(parsed, "state"),
+        "error": first_query_value(parsed, "error"),
+        "error_description": first_query_value(parsed, "error_description"),
+    }
+
+
+def latest_attempt(provider_id: str):
+    state_store.cleanup_expired()
+    with state_store._lock:
+        attempts = [
+            attempt
+            for attempt in state_store._attempts.values()
+            if attempt.provider_id == provider_id and not attempt.expired()
+        ]
+    if not attempts:
+        return None
+    return max(attempts, key=lambda attempt: attempt.created_at)
+
+
+def models_from_payload(payload: Any) -> list[str]:
+    values: list[Any]
+    if isinstance(payload, dict) and isinstance(payload.get("data"), list):
+        values = payload["data"]
+    elif isinstance(payload, dict) and isinstance(payload.get("models"), list):
+        values = payload["models"]
+    elif isinstance(payload, list):
+        values = payload
+    else:
+        return []
+
+    models: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        model_id = ""
+        if isinstance(value, str):
+            model_id = value
+        elif isinstance(value, dict):
+            model_id = str(value.get("id") or value.get("name") or "")
+        model_id = model_id.strip()
+        if model_id.startswith("models/"):
+            model_id = model_id.split("/", 1)[1]
+        if model_id and model_id not in seen:
+            seen.add(model_id)
+            models.append(model_id)
+    return models
+
+
+def json_payload(response: Any) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except Exception:
+        payload = {}
+    if not isinstance(payload, dict):
+        return {}
+    return payload
+
+
+def error_message(payload: dict[str, Any], fallback: str) -> str:
+    error = payload.get("error")
+    if isinstance(error, dict):
+        return str(error.get("message") or error.get("status") or fallback)
+    return str(payload.get("error_description") or payload.get("error") or fallback)
+
+
+def first_query_value(parsed: dict[str, list[str]], key: str) -> str | None:
+    values = parsed.get(key) or []
+    if not values:
+        return None
+    return values[0]
+
+
+def as_optional_string(value: Any) -> str | None:
+    if isinstance(value, list):
+        value = value[0] if value else None
+    text = "" if value is None else str(value).strip()
+    return text or None
+
+
+def expires_ms(payload: dict[str, Any]) -> int:
+    if payload.get("expires_at") is not None:
+        try:
+            value = float(payload["expires_at"])
+            if value < 1_000_000_000_000:
+                value *= 1000
+            return int(value)
+        except (TypeError, ValueError):
+            pass
+    try:
+        return int((time.time() + float(payload.get("expires_in") or 0)) * 1000)
+    except (TypeError, ValueError):
+        return 0
+
+
+def as_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default

--- a/plugins/_oauth/helpers/providers/gemini_api.py
+++ b/plugins/_oauth/helpers/providers/gemini_api.py
@@ -5,7 +5,7 @@ import json
 import time
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import urlencode, urlparse
 
 from plugins._oauth.helpers.providers.base import (
     DUMMY_API_KEY,
@@ -19,12 +19,16 @@ from plugins._oauth.helpers.providers.base import (
     read_json_file,
     write_private_json,
 )
-from plugins._oauth.helpers.usage_plans import (
-    usage_plan_notes_for,
-    usage_plan_sources_for,
-    usage_plans_for,
+from plugins._oauth.helpers.providers.common import (
+    as_int as _as_int,
+    as_optional_string as _as_optional_string,
+    error_message as _error_message,
+    expires_ms as _expires_ms,
+    json_payload as _json_payload,
+    latest_attempt,
+    models_from_payload as _models_from_payload,
+    parse_manual_callback,
 )
-from plugins._oauth.helpers import state as state_store
 from plugins._oauth.helpers.state import get_attempt, pop_attempt, put_attempt
 
 
@@ -46,34 +50,6 @@ CLIENT_CONFIG_NOTE = (
     "This uses Gemini API billing/quotas, not Antigravity or Gemini Code Assist subscription quota."
 )
 REFRESH_MARGIN_MS = 60_000
-
-
-def parse_manual_callback(raw: Any) -> dict[str, str | None] | None:
-    text = "" if raw is None else str(raw).strip()
-    if not text:
-        return None
-
-    if text.startswith("http://") or text.startswith("https://"):
-        query = urlparse(text).query
-    elif text.startswith("?"):
-        query = text[1:]
-    elif "=" in text or "&" in text:
-        query = text
-    else:
-        return {
-            "code": text,
-            "state": None,
-            "error": None,
-            "error_description": None,
-        }
-
-    parsed = parse_qs(query, keep_blank_values=True)
-    return {
-        "code": _first_query_value(parsed, "code"),
-        "state": _first_query_value(parsed, "state"),
-        "error": _first_query_value(parsed, "error"),
-        "error_description": _first_query_value(parsed, "error_description"),
-    }
 
 
 class GeminiApiOAuthProvider:
@@ -106,9 +82,6 @@ class GeminiApiOAuthProvider:
             supports_oauth_client_config=True,
             supports_quota_project=True,
             note=CLIENT_CONFIG_NOTE,
-            usage_plans=usage_plans_for(GEMINI_API_PROVIDER_ID),
-            usage_plan_notes=usage_plan_notes_for(GEMINI_API_PROVIDER_ID),
-            usage_plan_sources=usage_plan_sources_for(GEMINI_API_PROVIDER_ID),
         )
 
     def status(self) -> dict[str, Any]:
@@ -302,7 +275,7 @@ class GeminiApiOAuthProvider:
         if state:
             attempt = get_attempt(state)
             if attempt is None:
-                if _latest_gemini_attempt() is not None:
+                if latest_attempt(GEMINI_API_PROVIDER_ID) is not None:
                     return LoginPollResult(
                         ok=False,
                         provider_id=GEMINI_API_PROVIDER_ID,
@@ -321,7 +294,7 @@ class GeminiApiOAuthProvider:
                     error="OAuth state mismatch. Return to Agent Zero and start a new Google Gemini API connection.",
                 )
         elif allow_missing_state:
-            attempt = _latest_gemini_attempt()
+            attempt = latest_attempt(GEMINI_API_PROVIDER_ID)
             if attempt is None:
                 return LoginPollResult(
                     ok=False,
@@ -642,78 +615,6 @@ def _validate_google_token_endpoint(value: str) -> None:
         )
 
 
-def _latest_gemini_attempt():
-    state_store.cleanup_expired()
-    with state_store._lock:
-        attempts = [
-            attempt
-            for attempt in state_store._attempts.values()
-            if attempt.provider_id == GEMINI_API_PROVIDER_ID and not attempt.expired()
-        ]
-    if not attempts:
-        return None
-    return max(attempts, key=lambda attempt: attempt.created_at)
-
-
-def _models_from_payload(payload: Any) -> list[str]:
-    values: list[Any]
-    if isinstance(payload, dict) and isinstance(payload.get("data"), list):
-        values = payload["data"]
-    elif isinstance(payload, dict) and isinstance(payload.get("models"), list):
-        values = payload["models"]
-    elif isinstance(payload, list):
-        values = payload
-    else:
-        return []
-
-    models: list[str] = []
-    seen: set[str] = set()
-    for value in values:
-        model_id = ""
-        if isinstance(value, str):
-            model_id = value
-        elif isinstance(value, dict):
-            model_id = str(value.get("id") or value.get("name") or "")
-        model_id = model_id.strip()
-        if model_id.startswith("models/"):
-            model_id = model_id.split("/", 1)[1]
-        if model_id and model_id not in seen:
-            seen.add(model_id)
-            models.append(model_id)
-    return models
-
-
-def _json_payload(response: Any) -> dict[str, Any]:
-    try:
-        payload = response.json()
-    except Exception:
-        payload = {}
-    if not isinstance(payload, dict):
-        return {}
-    return payload
-
-
-def _error_message(payload: dict[str, Any], fallback: str) -> str:
-    error = payload.get("error")
-    if isinstance(error, dict):
-        return str(error.get("message") or error.get("status") or fallback)
-    return str(payload.get("error_description") or payload.get("error") or fallback)
-
-
-def _first_query_value(parsed: dict[str, list[str]], key: str) -> str | None:
-    values = parsed.get(key) or []
-    if not values:
-        return None
-    return values[0]
-
-
-def _as_optional_string(value: Any) -> str | None:
-    if isinstance(value, list):
-        value = value[0] if value else None
-    text = "" if value is None else str(value).strip()
-    return text or None
-
-
 def _account_label(auth: dict[str, Any]) -> str:
     claims = _jwt_claims(str(auth.get("id_token") or ""))
     return str(claims.get("email") or auth.get("account_label") or "Google Gemini API")
@@ -730,28 +631,6 @@ def _jwt_claims(token: str) -> dict[str, Any]:
     except Exception:
         return {}
     return parsed if isinstance(parsed, dict) else {}
-
-
-def _expires_ms(payload: dict[str, Any]) -> int:
-    if payload.get("expires_at") is not None:
-        try:
-            value = float(payload["expires_at"])
-            if value < 1_000_000_000_000:
-                value *= 1000
-            return int(value)
-        except (TypeError, ValueError):
-            pass
-    try:
-        return int((time.time() + float(payload.get("expires_in") or 0)) * 1000)
-    except (TypeError, ValueError):
-        return 0
-
-
-def _as_int(value: Any, default: int) -> int:
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return default
 
 
 def _codex_helper():

--- a/plugins/_oauth/helpers/providers/gemini_api.py
+++ b/plugins/_oauth/helpers/providers/gemini_api.py
@@ -1,0 +1,786 @@
+from __future__ import annotations
+
+import base64
+import json
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+from plugins._oauth.helpers.providers.base import (
+    DUMMY_API_KEY,
+    GEMINI_API_PROVIDER_ID,
+    CallbackResult,
+    LoginPollResult,
+    LoginStartResult,
+    OAuthProviderMetadata,
+    ProviderError,
+    provider_auth_path,
+    read_json_file,
+    write_private_json,
+)
+from plugins._oauth.helpers.usage_plans import (
+    usage_plan_notes_for,
+    usage_plan_sources_for,
+    usage_plans_for,
+)
+from plugins._oauth.helpers import state as state_store
+from plugins._oauth.helpers.state import get_attempt, pop_attempt, put_attempt
+
+
+GOOGLE_AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+GEMINI_OPENAI_API_BASE = "https://generativelanguage.googleapis.com/v1beta/openai"
+CURATED_MODELS = [
+    "gemini-3.5-flash",
+    "gemini-3.1-pro-preview",
+    "gemini-3-flash-preview",
+    "gemini-3.1-flash-lite",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
+]
+NOT_CONNECTED_MESSAGE = "Google Gemini API OAuth is not connected yet."
+CLIENT_CONFIG_NOTE = (
+    "Requires a Google Cloud OAuth client with the Generative Language API enabled. "
+    "This uses Gemini API billing/quotas, not Antigravity or Gemini Code Assist subscription quota."
+)
+REFRESH_MARGIN_MS = 60_000
+
+
+def parse_manual_callback(raw: Any) -> dict[str, str | None] | None:
+    text = "" if raw is None else str(raw).strip()
+    if not text:
+        return None
+
+    if text.startswith("http://") or text.startswith("https://"):
+        query = urlparse(text).query
+    elif text.startswith("?"):
+        query = text[1:]
+    elif "=" in text or "&" in text:
+        query = text
+    else:
+        return {
+            "code": text,
+            "state": None,
+            "error": None,
+            "error_description": None,
+        }
+
+    parsed = parse_qs(query, keep_blank_values=True)
+    return {
+        "code": _first_query_value(parsed, "code"),
+        "state": _first_query_value(parsed, "state"),
+        "error": _first_query_value(parsed, "error"),
+        "error_description": _first_query_value(parsed, "error_description"),
+    }
+
+
+class GeminiApiOAuthProvider:
+    provider_id = GEMINI_API_PROVIDER_ID
+
+    def auth_path(self) -> Path:
+        return provider_auth_path("gemini_api")
+
+    def read_auth(self) -> dict[str, Any]:
+        return read_json_file(self.auth_path())
+
+    def write_auth(self, data: dict[str, Any]) -> None:
+        write_private_json(self.auth_path(), data)
+
+    def metadata(self) -> OAuthProviderMetadata:
+        cfg = _gemini_api_config()
+        base_path = cfg["proxy_base_path"]
+        return OAuthProviderMetadata(
+            provider_id=GEMINI_API_PROVIDER_ID,
+            display_name="Google Gemini API",
+            short_name="Gemini API",
+            model_provider_id=GEMINI_API_PROVIDER_ID,
+            icon="google",
+            auth_flow="browser_pkce",
+            default_model="gemini-3.5-flash",
+            default_models=list(CURATED_MODELS),
+            proxy_base_path=base_path,
+            callback_path=cfg["callback_path"],
+            supports_manual_callback=True,
+            supports_oauth_client_config=True,
+            supports_quota_project=True,
+            note=CLIENT_CONFIG_NOTE,
+            usage_plans=usage_plans_for(GEMINI_API_PROVIDER_ID),
+            usage_plan_notes=usage_plan_notes_for(GEMINI_API_PROVIDER_ID),
+            usage_plan_sources=usage_plan_sources_for(GEMINI_API_PROVIDER_ID),
+        )
+
+    def status(self) -> dict[str, Any]:
+        cfg = _gemini_api_config()
+        auth = self.read_auth()
+        access = str(auth.get("access") or "")
+        refresh = str(auth.get("refresh") or "")
+        client_id = str(cfg.get("client_id") or auth.get("client_id") or "")
+        quota_project_id = str(cfg.get("quota_project_id") or auth.get("quota_project_id") or "")
+        result = {
+            **self.metadata().to_dict(),
+            "enabled": cfg["enabled"],
+            "connected": bool(access and refresh),
+            "account_label": _account_label(auth) if access or refresh else "",
+            "client_id": client_id,
+            "client_secret_configured": bool(cfg.get("client_secret") or auth.get("client_secret")),
+            "quota_project_id": quota_project_id,
+            "base_url": safe_api_base_url(auth.get("base_url") or cfg.get("api_base_url")),
+            "auth_file_path": str(self.auth_path()),
+            "v1_base_path": f'{cfg["proxy_base_path"]}/v1',
+        }
+        if access and refresh and _as_int(auth.get("expires"), 0) <= int(time.time() * 1000):
+            result["warning"] = "Google Gemini API OAuth access token is expired and will be refreshed on the next request."
+        return result
+
+    def start_login(self, input: dict[str, Any] | None = None, request: Any = None) -> LoginStartResult:
+        data = input or {}
+        cfg = _gemini_api_config()
+        if not cfg["enabled"]:
+            return LoginStartResult(
+                ok=False,
+                provider_id=GEMINI_API_PROVIDER_ID,
+                flow="browser_pkce",
+                error="Google Gemini API OAuth connection is disabled.",
+            )
+
+        try:
+            client = _client_config(data, cfg)
+            codex = _codex_helper()
+            pkce = codex.generate_pkce()
+            state = codex.generate_state()
+            redirect_uri = _redirect_uri(request, cfg["callback_path"])
+            attempt = put_attempt(
+                state,
+                pkce.verifier,
+                redirect_uri,
+                provider_id=GEMINI_API_PROVIDER_ID,
+                extra={
+                    "client_id": client["client_id"],
+                    "client_secret": client["client_secret"],
+                    "quota_project_id": client["quota_project_id"],
+                    "scope": " ".join(cfg["scopes"]),
+                    "code_challenge": pkce.challenge,
+                    "token_endpoint": GOOGLE_TOKEN_ENDPOINT,
+                    "api_base_url": safe_api_base_url(cfg["api_base_url"]),
+                },
+            )
+            query = {
+                "response_type": "code",
+                "client_id": client["client_id"],
+                "redirect_uri": redirect_uri,
+                "scope": " ".join(cfg["scopes"]),
+                "code_challenge": pkce.challenge,
+                "code_challenge_method": "S256",
+                "state": state,
+                "access_type": "offline",
+                "prompt": "consent",
+                "include_granted_scopes": "true",
+            }
+            auth_url = f"{GOOGLE_AUTHORIZATION_ENDPOINT}?{urlencode(query)}"
+        except Exception as exc:
+            return LoginStartResult(
+                ok=False,
+                provider_id=GEMINI_API_PROVIDER_ID,
+                flow="browser_pkce",
+                error=str(exc),
+                message=str(exc),
+            )
+
+        return LoginStartResult(
+            ok=True,
+            provider_id=GEMINI_API_PROVIDER_ID,
+            flow="browser_pkce",
+            auth_url=auth_url,
+            redirect_uri=redirect_uri,
+            expires_at=attempt.expires_at,
+        )
+
+    def poll_login(self, input: dict[str, Any] | None = None, request: Any = None) -> LoginPollResult:
+        del input, request
+        return LoginPollResult(
+            ok=False,
+            provider_id=GEMINI_API_PROVIDER_ID,
+            error="Google Gemini API OAuth uses browser callback login.",
+        )
+
+    def exchange_code(
+        self,
+        token_endpoint: str,
+        code: str,
+        redirect_uri: str,
+        code_verifier: str,
+        client_id: str,
+        client_secret: str,
+    ) -> dict[str, Any]:
+        import requests
+
+        _validate_google_token_endpoint(token_endpoint)
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": client_id,
+            "code_verifier": code_verifier,
+        }
+        if client_secret:
+            data["client_secret"] = client_secret
+
+        response = requests.post(
+            token_endpoint,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            data=data,
+            timeout=30,
+        )
+        payload = _json_payload(response)
+        if not response.ok:
+            raise ProviderError(
+                _error_message(payload, f"Google Gemini API token exchange failed with status {response.status_code}."),
+                code="token_exchange_failed",
+                status=response.status_code,
+            )
+        _validate_token_payload(payload, require_refresh=True)
+        return payload
+
+    def manual_callback(self, input: dict[str, Any], request: Any = None) -> LoginPollResult:
+        del request
+        raw = input.get("callback")
+        if raw is None:
+            raw = input.get("callback_url")
+        return self._complete_from_callback(parse_manual_callback(raw), allow_missing_state=True)
+
+    def complete_callback(
+        self,
+        args: dict[str, Any],
+        request: Any = None,
+    ) -> CallbackResult:
+        del request
+        callback = {
+            "code": _as_optional_string(args.get("code")),
+            "state": _as_optional_string(args.get("state")),
+            "error": _as_optional_string(args.get("error")),
+            "error_description": _as_optional_string(args.get("error_description")),
+        }
+        result = self._complete_from_callback(callback, allow_missing_state=False)
+        return CallbackResult(
+            ok=result.ok,
+            provider_id=GEMINI_API_PROVIDER_ID,
+            account_label=result.account_label,
+            account_id=result.account_id,
+            error=result.error,
+        )
+
+    def _complete_from_callback(
+        self,
+        callback: dict[str, str | None] | None,
+        *,
+        allow_missing_state: bool,
+    ) -> LoginPollResult:
+        if not callback:
+            return LoginPollResult(ok=False, provider_id=GEMINI_API_PROVIDER_ID, error="Missing OAuth callback.")
+        if callback.get("error"):
+            return LoginPollResult(
+                ok=False,
+                provider_id=GEMINI_API_PROVIDER_ID,
+                error=str(callback.get("error_description") or callback.get("error")),
+            )
+
+        code = str(callback.get("code") or "").strip()
+        if not code:
+            return LoginPollResult(
+                ok=False,
+                provider_id=GEMINI_API_PROVIDER_ID,
+                error="The OAuth callback did not include an authorization code.",
+            )
+
+        state = str(callback.get("state") or "").strip()
+        attempt = None
+        if state:
+            attempt = get_attempt(state)
+            if attempt is None:
+                if _latest_gemini_attempt() is not None:
+                    return LoginPollResult(
+                        ok=False,
+                        provider_id=GEMINI_API_PROVIDER_ID,
+                        error="OAuth state mismatch. Return to Agent Zero and start a new Google Gemini API connection.",
+                    )
+                return LoginPollResult(
+                    ok=False,
+                    provider_id=GEMINI_API_PROVIDER_ID,
+                    expired=True,
+                    error="OAuth sign-in expired. Return to Agent Zero and start a new Google Gemini API connection.",
+                )
+            if attempt.provider_id != GEMINI_API_PROVIDER_ID:
+                return LoginPollResult(
+                    ok=False,
+                    provider_id=GEMINI_API_PROVIDER_ID,
+                    error="OAuth state mismatch. Return to Agent Zero and start a new Google Gemini API connection.",
+                )
+        elif allow_missing_state:
+            attempt = _latest_gemini_attempt()
+            if attempt is None:
+                return LoginPollResult(
+                    ok=False,
+                    provider_id=GEMINI_API_PROVIDER_ID,
+                    error="No active Google Gemini API sign-in attempt was found.",
+                )
+            state = attempt.state
+        else:
+            return LoginPollResult(
+                ok=False,
+                provider_id=GEMINI_API_PROVIDER_ID,
+                error="The OAuth callback did not include state.",
+            )
+
+        token_endpoint = str(attempt.extra.get("token_endpoint") or GOOGLE_TOKEN_ENDPOINT)
+        client_id = str(attempt.extra.get("client_id") or "")
+        client_secret = str(attempt.extra.get("client_secret") or "")
+        try:
+            payload = self.exchange_code(
+                token_endpoint,
+                code,
+                attempt.redirect_uri,
+                attempt.verifier,
+                client_id,
+                client_secret,
+            )
+            auth = _auth_from_token_payload(
+                payload,
+                token_endpoint,
+                client_id=client_id,
+                client_secret=client_secret,
+                quota_project_id=str(attempt.extra.get("quota_project_id") or ""),
+                api_base_url=str(attempt.extra.get("api_base_url") or GEMINI_OPENAI_API_BASE),
+            )
+            self.write_auth(auth)
+            pop_attempt(state)
+        except Exception as exc:
+            return LoginPollResult(
+                ok=False,
+                provider_id=GEMINI_API_PROVIDER_ID,
+                error=str(exc),
+            )
+
+        label = _account_label(auth)
+        return LoginPollResult(
+            ok=True,
+            provider_id=GEMINI_API_PROVIDER_ID,
+            completed=True,
+            account_label=label,
+            account_id=label,
+        )
+
+    def ensure_fresh_auth(self) -> dict[str, Any]:
+        auth = self.read_auth()
+        refresh = str(auth.get("refresh") or "")
+        if not refresh:
+            return auth
+
+        access = str(auth.get("access") or "")
+        expires = _as_int(auth.get("expires"), 0)
+        if access and expires and expires > int(time.time() * 1000) + REFRESH_MARGIN_MS:
+            return auth
+
+        token_endpoint = str(auth.get("token_endpoint") or GOOGLE_TOKEN_ENDPOINT)
+        _validate_google_token_endpoint(token_endpoint)
+        client_id = str(auth.get("client_id") or "")
+        client_secret = str(auth.get("client_secret") or "")
+        cfg = _gemini_api_config()
+        if cfg.get("client_id"):
+            client_id = str(cfg["client_id"])
+        if cfg.get("client_secret"):
+            client_secret = str(cfg["client_secret"])
+        if not client_id:
+            raise ProviderError(
+                "Google Gemini API OAuth refresh requires the original OAuth client ID.",
+                code="missing_oauth_client",
+                status=401,
+            )
+
+        refreshed = self._refresh_tokens(token_endpoint, refresh, client_id, client_secret, auth)
+        self.write_auth(refreshed)
+        return refreshed
+
+    def _refresh_tokens(
+        self,
+        token_endpoint: str,
+        refresh: str,
+        client_id: str,
+        client_secret: str,
+        existing: dict[str, Any],
+    ) -> dict[str, Any]:
+        import requests
+
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh,
+            "client_id": client_id,
+        }
+        if client_secret:
+            data["client_secret"] = client_secret
+        response = requests.post(
+            token_endpoint,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            data=data,
+            timeout=30,
+        )
+        payload = _json_payload(response)
+        if not response.ok:
+            raise ProviderError(
+                _error_message(payload, f"Google Gemini API token refresh failed with status {response.status_code}."),
+                code="token_refresh_failed",
+                status=response.status_code,
+            )
+        _validate_token_payload(payload, require_refresh=False)
+        merged = dict(existing)
+        merged.update(
+            _auth_from_token_payload(
+                payload,
+                token_endpoint,
+                fallback_refresh=refresh,
+                client_id=client_id,
+                client_secret=client_secret,
+                quota_project_id=str(existing.get("quota_project_id") or ""),
+                api_base_url=str(existing.get("base_url") or GEMINI_OPENAI_API_BASE),
+            )
+        )
+        if not payload.get("id_token") and existing.get("id_token"):
+            merged["id_token"] = existing["id_token"]
+        return merged
+
+    def models(self) -> list[str]:
+        if not self.read_auth():
+            return list(CURATED_MODELS)
+        try:
+            auth = self.ensure_fresh_auth()
+        except Exception:
+            return list(CURATED_MODELS)
+        access = str(auth.get("access") or "")
+        if not access:
+            return list(CURATED_MODELS)
+
+        base_url = safe_api_base_url(auth.get("base_url"))
+        try:
+            import requests
+
+            response = requests.get(
+                f"{base_url}/models",
+                headers=_gemini_headers(auth),
+                timeout=30,
+            )
+            if not response.ok:
+                return list(CURATED_MODELS)
+            parsed = _models_from_payload(response.json())
+            return parsed or list(CURATED_MODELS)
+        except Exception:
+            return list(CURATED_MODELS)
+
+    def disconnect(self) -> dict[str, Any]:
+        path = self.auth_path()
+        existed = path.exists()
+        try:
+            path.unlink(missing_ok=True)
+        except FileNotFoundError:
+            pass
+        return {
+            "disconnected": existed,
+            "removed_auth_files": [str(path)] if existed else [],
+        }
+
+    def api_key(self) -> str:
+        return DUMMY_API_KEY
+
+    def register_routes(self, app: Any) -> None:
+        from plugins._oauth.helpers import routes
+
+        route_defs = [
+            ("/oauth/gemini-api/health", "oauth_gemini_api_health", routes.gemini_api_health, ["GET"]),
+            ("/oauth/gemini-api/callback", "oauth_gemini_api_callback", routes.gemini_api_callback, ["GET"]),
+            (
+                "/oauth/gemini-api/v1/models",
+                "oauth_gemini_api_models",
+                routes.gemini_api_models,
+                ["GET", "OPTIONS"],
+            ),
+            (
+                "/oauth/gemini-api/v1/chat/completions",
+                "oauth_gemini_api_chat_completions",
+                routes.gemini_api_chat_completions,
+                ["POST", "OPTIONS"],
+            ),
+            (
+                "/oauth/gemini-api/v1/responses",
+                "oauth_gemini_api_responses",
+                routes.gemini_api_responses,
+                ["POST", "OPTIONS"],
+            ),
+        ]
+        for rule, endpoint, view_func, methods in route_defs:
+            if endpoint in app.view_functions:
+                continue
+            app.add_url_rule(rule, endpoint, view_func, methods=methods)
+
+
+def _auth_from_token_payload(
+    payload: dict[str, Any],
+    token_endpoint: str,
+    *,
+    fallback_refresh: str = "",
+    client_id: str = "",
+    client_secret: str = "",
+    quota_project_id: str = "",
+    api_base_url: str = GEMINI_OPENAI_API_BASE,
+) -> dict[str, Any]:
+    return {
+        "provider": GEMINI_API_PROVIDER_ID,
+        "type": "oauth",
+        "access": str(payload.get("access_token") or ""),
+        "refresh": str(payload.get("refresh_token") or fallback_refresh or ""),
+        "expires": _expires_ms(payload),
+        "id_token": str(payload.get("id_token") or ""),
+        "token_type": str(payload.get("token_type") or "Bearer"),
+        "scope": str(payload.get("scope") or ""),
+        "token_endpoint": token_endpoint,
+        "base_url": safe_api_base_url(api_base_url),
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "quota_project_id": quota_project_id,
+    }
+
+
+def _validate_token_payload(payload: dict[str, Any], *, require_refresh: bool) -> None:
+    if not isinstance(payload, dict):
+        raise ProviderError("Google Gemini API token endpoint returned a malformed response.", code="token_malformed", status=502)
+    missing = []
+    if not str(payload.get("access_token") or ""):
+        missing.append("access_token")
+    if require_refresh and not str(payload.get("refresh_token") or ""):
+        missing.append("refresh_token")
+    if missing:
+        raise ProviderError(
+            f"Google Gemini API token response is missing: {', '.join(missing)}",
+            code="token_malformed",
+            status=502,
+        )
+
+
+def safe_api_base_url(value: Any) -> str:
+    text = str(value or "").strip().rstrip("/")
+    if not text:
+        return GEMINI_OPENAI_API_BASE
+    parsed = urlparse(text)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme == "https" and host == "generativelanguage.googleapis.com":
+        return text
+    return GEMINI_OPENAI_API_BASE
+
+
+def _gemini_headers(auth: dict[str, Any]) -> dict[str, str]:
+    headers = {
+        "Accept": "application/json",
+        "Authorization": f'Bearer {str(auth.get("access") or "")}',
+    }
+    quota_project_id = str(auth.get("quota_project_id") or "").strip()
+    if quota_project_id:
+        headers["x-goog-user-project"] = quota_project_id
+    return headers
+
+
+def _client_config(data: dict[str, Any], cfg: dict[str, Any]) -> dict[str, str]:
+    client_id = str(data.get("client_id") or cfg.get("client_id") or "").strip()
+    client_secret = str(data.get("client_secret") or cfg.get("client_secret") or "").strip()
+    quota_project_id = str(data.get("quota_project_id") or cfg.get("quota_project_id") or "").strip()
+    if not client_id or not client_secret:
+        raise ProviderError(
+            "Configure a Google OAuth client ID and client secret before connecting Gemini API OAuth.",
+            code="missing_oauth_client",
+        )
+    return {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "quota_project_id": quota_project_id,
+    }
+
+
+def _redirect_uri(request: Any, callback_path: str) -> str:
+    origin = ""
+    if request is not None:
+        origin = (getattr(request, "headers", {}).get("Origin") or "").rstrip("/")
+        if not _is_local_origin(origin):
+            origin = getattr(request, "url_root", "").rstrip("/")
+    return f"{origin}{callback_path}"
+
+
+def _is_local_origin(origin: str) -> bool:
+    if not origin:
+        return False
+    return (
+        origin.startswith("http://localhost:")
+        or origin == "http://localhost"
+        or origin.startswith("http://127.0.0.1:")
+        or origin == "http://127.0.0.1"
+        or origin.startswith("http://[::1]:")
+        or origin == "http://[::1]"
+    )
+
+
+def _validate_google_token_endpoint(value: str) -> None:
+    parsed = urlparse(value)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or host != "oauth2.googleapis.com":
+        raise ProviderError(
+            "Google Gemini API OAuth token endpoint is invalid.",
+            code="invalid_token_endpoint",
+            status=502,
+        )
+
+
+def _latest_gemini_attempt():
+    state_store.cleanup_expired()
+    with state_store._lock:
+        attempts = [
+            attempt
+            for attempt in state_store._attempts.values()
+            if attempt.provider_id == GEMINI_API_PROVIDER_ID and not attempt.expired()
+        ]
+    if not attempts:
+        return None
+    return max(attempts, key=lambda attempt: attempt.created_at)
+
+
+def _models_from_payload(payload: Any) -> list[str]:
+    values: list[Any]
+    if isinstance(payload, dict) and isinstance(payload.get("data"), list):
+        values = payload["data"]
+    elif isinstance(payload, dict) and isinstance(payload.get("models"), list):
+        values = payload["models"]
+    elif isinstance(payload, list):
+        values = payload
+    else:
+        return []
+
+    models: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        model_id = ""
+        if isinstance(value, str):
+            model_id = value
+        elif isinstance(value, dict):
+            model_id = str(value.get("id") or value.get("name") or "")
+        model_id = model_id.strip()
+        if model_id.startswith("models/"):
+            model_id = model_id.split("/", 1)[1]
+        if model_id and model_id not in seen:
+            seen.add(model_id)
+            models.append(model_id)
+    return models
+
+
+def _json_payload(response: Any) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except Exception:
+        payload = {}
+    if not isinstance(payload, dict):
+        return {}
+    return payload
+
+
+def _error_message(payload: dict[str, Any], fallback: str) -> str:
+    error = payload.get("error")
+    if isinstance(error, dict):
+        return str(error.get("message") or error.get("status") or fallback)
+    return str(payload.get("error_description") or payload.get("error") or fallback)
+
+
+def _first_query_value(parsed: dict[str, list[str]], key: str) -> str | None:
+    values = parsed.get(key) or []
+    if not values:
+        return None
+    return values[0]
+
+
+def _as_optional_string(value: Any) -> str | None:
+    if isinstance(value, list):
+        value = value[0] if value else None
+    text = "" if value is None else str(value).strip()
+    return text or None
+
+
+def _account_label(auth: dict[str, Any]) -> str:
+    claims = _jwt_claims(str(auth.get("id_token") or ""))
+    return str(claims.get("email") or auth.get("account_label") or "Google Gemini API")
+
+
+def _jwt_claims(token: str) -> dict[str, Any]:
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+    try:
+        payload = parts[1] + "=" * (-len(parts[1]) % 4)
+        decoded = base64.urlsafe_b64decode(payload.encode("utf-8"))
+        parsed = json.loads(decoded.decode("utf-8"))
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _expires_ms(payload: dict[str, Any]) -> int:
+    if payload.get("expires_at") is not None:
+        try:
+            value = float(payload["expires_at"])
+            if value < 1_000_000_000_000:
+                value *= 1000
+            return int(value)
+        except (TypeError, ValueError):
+            pass
+    try:
+        return int((time.time() + float(payload.get("expires_in") or 0)) * 1000)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _as_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _codex_helper():
+    import importlib
+
+    return importlib.import_module("plugins._oauth.helpers.codex")
+
+
+def _gemini_api_config() -> dict[str, Any]:
+    try:
+        from plugins._oauth.helpers.config import gemini_api_config
+
+        return gemini_api_config()
+    except ModuleNotFoundError as exc:
+        if exc.name and exc.name.startswith("plugins._oauth"):
+            raise
+        return {
+            "enabled": True,
+            "client_id": "",
+            "client_secret": "",
+            "scopes": [
+                "openid",
+                "email",
+                "profile",
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/generative-language.retriever",
+            ],
+            "quota_project_id": "",
+            "api_base_url": GEMINI_OPENAI_API_BASE,
+            "proxy_base_path": "/oauth/gemini-api",
+            "callback_path": "/oauth/gemini-api/callback",
+        }

--- a/plugins/_oauth/helpers/providers/github_copilot.py
+++ b/plugins/_oauth/helpers/providers/github_copilot.py
@@ -18,11 +18,6 @@ from plugins._oauth.helpers.providers.base import (
     read_json_file,
     write_private_json,
 )
-from plugins._oauth.helpers.usage_plans import (
-    usage_plan_notes_for,
-    usage_plan_sources_for,
-    usage_plans_for,
-)
 from plugins._oauth.helpers.state import (
     DeviceAttempt,
     get_device_attempt,
@@ -213,9 +208,6 @@ class GitHubCopilotOAuthProvider:
             proxy_base_path="/oauth/github-copilot",
             supports_enterprise_domain=True,
             note=ENTERPRISE_NOTE,
-            usage_plans=usage_plans_for(GITHUB_COPILOT_PROVIDER_ID),
-            usage_plan_notes=usage_plan_notes_for(GITHUB_COPILOT_PROVIDER_ID),
-            usage_plan_sources=usage_plan_sources_for(GITHUB_COPILOT_PROVIDER_ID),
         )
 
     def status(self) -> dict[str, Any]:

--- a/plugins/_oauth/helpers/providers/github_copilot.py
+++ b/plugins/_oauth/helpers/providers/github_copilot.py
@@ -1,0 +1,673 @@
+from __future__ import annotations
+
+import secrets
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from plugins._oauth.helpers.providers.base import (
+    DUMMY_API_KEY,
+    GITHUB_COPILOT_PROVIDER_ID,
+    CallbackResult,
+    LoginPollResult,
+    LoginStartResult,
+    OAuthProviderMetadata,
+    ProviderError,
+    provider_auth_path,
+    read_json_file,
+    write_private_json,
+)
+from plugins._oauth.helpers.usage_plans import (
+    usage_plan_notes_for,
+    usage_plan_sources_for,
+    usage_plans_for,
+)
+from plugins._oauth.helpers.state import (
+    DeviceAttempt,
+    get_device_attempt,
+    pop_device_attempt,
+    put_device_attempt,
+)
+
+
+CLIENT_ID = "Iv1.b507a08c87ecfe98"
+DEFAULT_DOMAIN = "github.com"
+COPILOT_HEADERS = {
+    "User-Agent": "GitHubCopilotChat/0.35.0",
+    "Editor-Version": "vscode/1.107.0",
+    "Editor-Plugin-Version": "copilot-chat/0.35.0",
+    "Copilot-Integration-Id": "vscode-chat",
+}
+CURATED_MODELS = [
+    "gpt-5.2-codex",
+    "gpt-5.2",
+    "claude-sonnet-4.5",
+    "claude-opus-4.5",
+    "gemini-2.5-pro",
+    "grok-code-fast-1",
+    "gpt-4.1",
+    "gpt-4o",
+]
+NOT_CONNECTED_MESSAGE = "GitHub Copilot OAuth is not connected yet."
+ENTERPRISE_NOTE = "Leave Enterprise domain blank for github.com, or enter a GitHub Enterprise domain."
+DEFAULT_COPILOT_BASE_URL = "https://api.individual.githubcopilot.com"
+DEFAULT_COPILOT_HOST = "api.individual.githubcopilot.com"
+GITHUB_COPILOT_API_HOSTS = {
+    DEFAULT_COPILOT_HOST,
+    "api.githubcopilot.com",
+}
+REFRESH_MARGIN_MS = 60_000
+
+
+def normalize_enterprise_domain(value: Any) -> str:
+    text = "" if value is None else str(value).strip()
+    if not text:
+        return DEFAULT_DOMAIN
+    if any(char.isspace() for char in text):
+        raise ValueError("Invalid GitHub Enterprise URL/domain.")
+
+    parsed = urlparse(text if "://" in text else f"//{text}")
+    if parsed.scheme and parsed.scheme not in {"http", "https"}:
+        raise ValueError("Invalid GitHub Enterprise URL/domain.")
+    if "@" in parsed.netloc:
+        raise ValueError("Invalid GitHub Enterprise URL/domain.")
+
+    host = (parsed.hostname or "").strip().lower().rstrip(".")
+    if not host or "/" in host or "\\" in host:
+        raise ValueError("Invalid GitHub Enterprise URL/domain.")
+    if host.startswith("-") or host.endswith("-") or ".." in host:
+        raise ValueError("Invalid GitHub Enterprise URL/domain.")
+    return host
+
+
+def github_urls(domain: Any) -> dict[str, str]:
+    normalized = normalize_enterprise_domain(domain)
+    web_base = f"https://{normalized}"
+    if normalized == DEFAULT_DOMAIN:
+        copilot_token = "https://api.github.com/copilot_internal/v2/token"
+    else:
+        copilot_token = f"https://{normalized}/api/v3/copilot_internal/v2/token"
+    return {
+        "device_code": f"{web_base}/login/device/code",
+        "access_token": f"{web_base}/login/oauth/access_token",
+        "copilot_token": copilot_token,
+    }
+
+
+def copilot_base_url_from_token(token: str, enterprise_domain: Any = "") -> str:
+    domain = normalize_enterprise_domain(enterprise_domain)
+    for part in str(token or "").split(";"):
+        key, separator, value = part.partition("=")
+        if separator and key.strip() == "proxy-ep":
+            try:
+                return safe_copilot_base_url_from_proxy_endpoint(value, domain)
+            except ProviderError:
+                return DEFAULT_COPILOT_BASE_URL
+    if domain != DEFAULT_DOMAIN:
+        return f"https://copilot-api.{domain}"
+    return DEFAULT_COPILOT_BASE_URL
+
+
+def safe_copilot_base_url(value: Any, enterprise_domain: Any = "") -> str:
+    text = str(value or "").strip().rstrip("/")
+    domain = normalize_enterprise_domain(enterprise_domain)
+    if not text:
+        return _default_copilot_base_url_for_domain(domain)
+
+    parsed = urlparse(text)
+    host = (parsed.hostname or "").strip().lower().rstrip(".")
+    if parsed.scheme == "https" and _is_allowed_copilot_api_host(host, domain):
+        return f"https://{host}"
+    return _default_copilot_base_url_for_domain(domain)
+
+
+def safe_copilot_base_url_from_proxy_endpoint(value: Any, enterprise_domain: Any = "") -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ProviderError("GitHub Copilot token returned an invalid proxy endpoint.", code="invalid_proxy_endpoint", status=502)
+
+    parsed = urlparse(text if "://" in text else f"//{text}")
+    if parsed.scheme and parsed.scheme != "https":
+        raise ProviderError("GitHub Copilot token returned an invalid proxy endpoint.", code="invalid_proxy_endpoint", status=502)
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ProviderError(
+            "GitHub Copilot token returned an invalid proxy endpoint.",
+            code="invalid_proxy_endpoint",
+            status=502,
+        ) from exc
+    if parsed.username or parsed.password or port is not None:
+        raise ProviderError("GitHub Copilot token returned an invalid proxy endpoint.", code="invalid_proxy_endpoint", status=502)
+    if parsed.path not in {"", "/"} or parsed.params or parsed.query or parsed.fragment:
+        raise ProviderError("GitHub Copilot token returned an invalid proxy endpoint.", code="invalid_proxy_endpoint", status=502)
+
+    domain = normalize_enterprise_domain(enterprise_domain)
+    host = (parsed.hostname or "").strip().lower().rstrip(".")
+    if host.startswith("proxy."):
+        host = f"api.{host.removeprefix('proxy.')}"
+    if not _is_allowed_proxy_endpoint_host(host, domain):
+        raise ProviderError("GitHub Copilot token returned an invalid proxy endpoint.", code="invalid_proxy_endpoint", status=502)
+    return f"https://{host}"
+
+
+def _default_copilot_base_url_for_domain(domain: str) -> str:
+    if domain != DEFAULT_DOMAIN:
+        return f"https://copilot-api.{domain}"
+    return DEFAULT_COPILOT_BASE_URL
+
+
+def _is_allowed_copilot_api_host(host: str, enterprise_domain: str) -> bool:
+    if host in GITHUB_COPILOT_API_HOSTS:
+        return True
+    return enterprise_domain != DEFAULT_DOMAIN and host == f"copilot-api.{enterprise_domain}"
+
+
+def _is_allowed_proxy_endpoint_host(host: str, enterprise_domain: str) -> bool:
+    if host.endswith(".githubcopilot.com"):
+        return True
+    return enterprise_domain != DEFAULT_DOMAIN and host == f"copilot-api.{enterprise_domain}"
+
+
+class GitHubCopilotOAuthProvider:
+    provider_id = GITHUB_COPILOT_PROVIDER_ID
+
+    def auth_path(self) -> Path:
+        return provider_auth_path("github_copilot")
+
+    def read_auth(self) -> dict[str, Any]:
+        return read_json_file(self.auth_path())
+
+    def write_auth(self, data: dict[str, Any]) -> None:
+        write_private_json(self.auth_path(), data)
+
+    def ensure_fresh_auth(self) -> dict[str, Any]:
+        auth = self.read_auth()
+        refresh = str(auth.get("refresh") or "")
+        access = str(auth.get("access") or "")
+        if not refresh or not access:
+            return auth
+
+        expires = _as_int(auth.get("expires"), 0)
+        if not expires or expires > int(time.time() * 1000) + REFRESH_MARGIN_MS:
+            return auth
+
+        domain = auth.get("enterprise_domain") or DEFAULT_DOMAIN
+        refreshed = refresh_copilot_token(refresh, domain)
+        if auth.get("models_warning") and not refreshed.get("models_warning"):
+            refreshed["models_warning"] = auth["models_warning"]
+        self.write_auth(refreshed)
+        return refreshed
+
+    def metadata(self) -> OAuthProviderMetadata:
+        return OAuthProviderMetadata(
+            provider_id=GITHUB_COPILOT_PROVIDER_ID,
+            display_name="GitHub Copilot",
+            short_name="GitHub Copilot",
+            model_provider_id=GITHUB_COPILOT_PROVIDER_ID,
+            icon="github",
+            auth_flow="device_code",
+            default_model="gpt-5.2-codex",
+            default_models=list(CURATED_MODELS),
+            proxy_base_path="/oauth/github-copilot",
+            supports_enterprise_domain=True,
+            note=ENTERPRISE_NOTE,
+            usage_plans=usage_plans_for(GITHUB_COPILOT_PROVIDER_ID),
+            usage_plan_notes=usage_plan_notes_for(GITHUB_COPILOT_PROVIDER_ID),
+            usage_plan_sources=usage_plan_sources_for(GITHUB_COPILOT_PROVIDER_ID),
+        )
+
+    def status(self) -> dict[str, Any]:
+        auth = self.read_auth()
+        access = str(auth.get("access") or "")
+        refresh = str(auth.get("refresh") or "")
+        enterprise_domain = str(auth.get("enterprise_domain") or "")
+        domain = enterprise_domain or DEFAULT_DOMAIN
+        result = {
+            **self.metadata().to_dict(),
+            "connected": bool(access and refresh),
+            "account_label": domain,
+            "enterprise_domain": enterprise_domain,
+            "base_url": str(auth.get("base_url") or ""),
+            "auth_file_path": str(self.auth_path()),
+        }
+        if auth.get("models_warning"):
+            result["models_warning"] = str(auth["models_warning"])
+        return result
+
+    def start_login(self, input: dict[str, Any] | None = None, request: Any = None) -> LoginStartResult:
+        del request
+        data = input or {}
+        try:
+            domain = normalize_enterprise_domain(data.get("enterprise_domain", ""))
+            device = _post_device_code(domain)
+            device_code = str(device.get("device_code") or "")
+            user_code = str(device.get("user_code") or "")
+            verification_url = str(
+                device.get("verification_uri")
+                or device.get("verification_url")
+                or "https://github.com/login/device"
+            )
+            if not device_code or not user_code:
+                raise RuntimeError("GitHub device-code response was malformed.")
+            interval = _as_positive_int(device.get("interval"), 5)
+            expires_in = _as_positive_int(device.get("expires_in"), 900)
+            attempt = put_device_attempt(
+                secrets.token_urlsafe(24),
+                device_code,
+                user_code,
+                interval,
+                time.time() + expires_in,
+                provider_id=GITHUB_COPILOT_PROVIDER_ID,
+                extra={"domain": domain},
+            )
+        except Exception as exc:
+            message = str(exc)
+            return LoginStartResult(
+                ok=False,
+                provider_id=GITHUB_COPILOT_PROVIDER_ID,
+                flow="device_code",
+                message=message,
+                error=message,
+            )
+
+        return LoginStartResult(
+            ok=True,
+            provider_id=GITHUB_COPILOT_PROVIDER_ID,
+            flow="device_code",
+            attempt_id=attempt.attempt_id,
+            verification_url=verification_url,
+            user_code=attempt.user_code,
+            interval=attempt.interval,
+            expires_at=attempt.expires_at,
+        )
+
+    def poll_login(self, input: dict[str, Any] | None = None, request: Any = None) -> LoginPollResult:
+        del request
+        data = input or {}
+        attempt_id = str(data.get("attempt_id") or "").strip()
+        if not attempt_id:
+            return LoginPollResult(
+                ok=False,
+                provider_id=GITHUB_COPILOT_PROVIDER_ID,
+                error="Missing device authorization attempt.",
+            )
+
+        attempt = get_device_attempt(attempt_id)
+        if attempt is None:
+            return LoginPollResult(
+                ok=False,
+                provider_id=GITHUB_COPILOT_PROVIDER_ID,
+                expired=True,
+                error="Device authorization expired.",
+            )
+        if attempt.provider_id != GITHUB_COPILOT_PROVIDER_ID:
+            return LoginPollResult(
+                ok=False,
+                provider_id=GITHUB_COPILOT_PROVIDER_ID,
+                error="Device authorization provider mismatch.",
+            )
+
+        domain = normalize_enterprise_domain(attempt.extra.get("domain", ""))
+        try:
+            payload = _post_device_poll(domain, attempt.device_auth_id)
+        except Exception as exc:
+            return LoginPollResult(ok=False, provider_id=GITHUB_COPILOT_PROVIDER_ID, error=str(exc))
+
+        error = str(payload.get("error") or "")
+        if error == "authorization_pending":
+            return LoginPollResult(
+                ok=True,
+                provider_id=GITHUB_COPILOT_PROVIDER_ID,
+                completed=False,
+                interval=attempt.interval,
+                expires_at=attempt.expires_at,
+            )
+        if error == "slow_down":
+            interval = attempt.interval + 5
+            put_device_attempt(
+                attempt.attempt_id,
+                attempt.device_auth_id,
+                attempt.user_code,
+                interval,
+                attempt.expires_at,
+                provider_id=GITHUB_COPILOT_PROVIDER_ID,
+                extra=attempt.extra,
+            )
+            return LoginPollResult(
+                ok=True,
+                provider_id=GITHUB_COPILOT_PROVIDER_ID,
+                completed=False,
+                interval=interval,
+                expires_at=attempt.expires_at,
+            )
+        if error in {"expired_token", "access_denied"}:
+            pop_device_attempt(attempt_id)
+            return LoginPollResult(
+                ok=False,
+                provider_id=GITHUB_COPILOT_PROVIDER_ID,
+                expired=error == "expired_token",
+                error=error,
+            )
+        if error:
+            return LoginPollResult(ok=False, provider_id=GITHUB_COPILOT_PROVIDER_ID, error=error)
+
+        github_access_token = str(payload.get("access_token") or "")
+        if not github_access_token:
+            return LoginPollResult(
+                ok=False,
+                provider_id=GITHUB_COPILOT_PROVIDER_ID,
+                error="GitHub device poll response was malformed.",
+            )
+
+        try:
+            auth = refresh_copilot_token(github_access_token, domain)
+        except Exception as exc:
+            return LoginPollResult(ok=False, provider_id=GITHUB_COPILOT_PROVIDER_ID, error=str(exc))
+
+        warning = ""
+        try:
+            summary = enable_known_models(auth["access"], domain)
+            if summary.get("failed"):
+                auth["models_warning"] = "Some Copilot models could not be enabled."
+                warning = auth["models_warning"]
+        except Exception as exc:
+            auth["models_warning"] = str(exc)
+            warning = str(exc)
+
+        self.write_auth(auth)
+        pop_device_attempt(attempt_id)
+        return LoginPollResult(
+            ok=True,
+            provider_id=GITHUB_COPILOT_PROVIDER_ID,
+            completed=True,
+            account_label=domain,
+            warning=warning,
+        )
+
+    def complete_callback(
+        self,
+        args: dict[str, Any],
+        request: Any = None,
+    ) -> CallbackResult:
+        del args, request
+        return CallbackResult(
+            ok=False,
+            provider_id=GITHUB_COPILOT_PROVIDER_ID,
+            error="GitHub Copilot uses device-code login.",
+        )
+
+    def manual_callback(
+        self,
+        input: dict[str, Any],
+        request: Any = None,
+    ) -> LoginPollResult:
+        del input, request
+        return LoginPollResult(
+            ok=False,
+            provider_id=GITHUB_COPILOT_PROVIDER_ID,
+            error="GitHub Copilot uses device-code login.",
+        )
+
+    def models(self) -> list[str]:
+        try:
+            auth = self.ensure_fresh_auth()
+        except Exception:
+            return list(CURATED_MODELS)
+        access = str(auth.get("access") or "")
+        if not access:
+            return list(CURATED_MODELS)
+
+        try:
+            import requests
+
+            base_url = safe_copilot_base_url(auth.get("base_url"), auth.get("enterprise_domain"))
+            response = requests.get(
+                f"{base_url}/models",
+                headers={
+                    **COPILOT_HEADERS,
+                    "Accept": "application/json",
+                    "Authorization": f"Bearer {access}",
+                },
+                timeout=30,
+            )
+            if not response.ok:
+                return list(CURATED_MODELS)
+            parsed = _models_from_payload(response.json())
+            return parsed or list(CURATED_MODELS)
+        except Exception:
+            return list(CURATED_MODELS)
+
+    def disconnect(self) -> dict[str, Any]:
+        path = self.auth_path()
+        existed = path.exists()
+        try:
+            path.unlink(missing_ok=True)
+        except FileNotFoundError:
+            pass
+        return {
+            "disconnected": existed,
+            "removed_auth_files": [str(path)] if existed else [],
+        }
+
+    def api_key(self) -> str:
+        return DUMMY_API_KEY
+
+    def register_routes(self, app: Any) -> None:
+        from plugins._oauth.helpers import routes
+
+        route_defs = [
+            ("/oauth/github-copilot/health", "oauth_github_copilot_health", routes.github_copilot_health, ["GET"]),
+            (
+                "/oauth/github-copilot/v1/models",
+                "oauth_github_copilot_models",
+                routes.github_copilot_models,
+                ["GET", "OPTIONS"],
+            ),
+            (
+                "/oauth/github-copilot/v1/chat/completions",
+                "oauth_github_copilot_chat_completions",
+                routes.github_copilot_chat_completions,
+                ["POST", "OPTIONS"],
+            ),
+            (
+                "/oauth/github-copilot/v1/responses",
+                "oauth_github_copilot_responses",
+                routes.github_copilot_responses,
+                ["POST", "OPTIONS"],
+            ),
+        ]
+        for rule, endpoint, view_func, methods in route_defs:
+            if endpoint in app.view_functions:
+                continue
+            app.add_url_rule(rule, endpoint, view_func, methods=methods)
+
+    def _store_device_attempt_for_test(
+        self,
+        domain: str,
+        device_code: str,
+        user_code: str,
+        interval: int,
+    ) -> DeviceAttempt:
+        return put_device_attempt(
+            secrets.token_urlsafe(24),
+            device_code,
+            user_code,
+            interval,
+            time.time() + 900,
+            provider_id=GITHUB_COPILOT_PROVIDER_ID,
+            extra={"domain": normalize_enterprise_domain(domain)},
+        )
+
+
+def refresh_copilot_token(refresh: str, domain: Any) -> dict[str, Any]:
+    normalized = normalize_enterprise_domain(domain)
+    import requests
+
+    response = requests.get(
+        github_urls(normalized)["copilot_token"],
+        headers={
+            **COPILOT_HEADERS,
+            "Accept": "application/json",
+            "Authorization": f"Bearer {refresh}",
+        },
+        timeout=30,
+    )
+    if not response.ok:
+        raise RuntimeError(f"GitHub Copilot token refresh failed with status {response.status_code}.")
+
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise RuntimeError("GitHub Copilot token response was malformed.")
+    token = str(payload.get("token") or payload.get("access_token") or "")
+    expires_at = _expires_ms(payload)
+    if not token or not expires_at:
+        raise RuntimeError("GitHub Copilot token response was missing token data.")
+
+    return {
+        "provider": GITHUB_COPILOT_PROVIDER_ID,
+        "type": "oauth",
+        "refresh": refresh,
+        "access": token,
+        "expires": max(0, expires_at - 300_000),
+        "enterprise_domain": "" if normalized == DEFAULT_DOMAIN else normalized,
+        "base_url": copilot_base_url_from_token(token, normalized),
+    }
+
+
+def enable_known_models(token: str, domain: Any) -> dict[str, Any]:
+    base_url = copilot_base_url_from_token(token, domain).rstrip("/")
+    summary: dict[str, Any] = {"attempted": len(CURATED_MODELS), "enabled": 0, "failed": []}
+    try:
+        import requests
+    except Exception as exc:
+        summary["failed"] = [{"model": model, "error": str(exc)} for model in CURATED_MODELS]
+        return summary
+
+    for model in CURATED_MODELS:
+        try:
+            response = requests.post(
+                f"{base_url}/models/{model}/policy",
+                headers={
+                    **COPILOT_HEADERS,
+                    "Accept": "application/json",
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+                json={"state": "enabled"},
+                timeout=30,
+            )
+            if response.ok:
+                summary["enabled"] += 1
+            else:
+                summary["failed"].append({"model": model, "status": response.status_code})
+        except Exception as exc:
+            summary["failed"].append({"model": model, "error": str(exc)})
+    return summary
+
+
+def _post_device_code(domain: str) -> dict[str, Any]:
+    import requests
+
+    response = requests.post(
+        github_urls(domain)["device_code"],
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": COPILOT_HEADERS["User-Agent"],
+        },
+        data={"client_id": CLIENT_ID, "scope": "read:user"},
+        timeout=30,
+    )
+    payload = _json_payload(response)
+    if not response.ok:
+        raise RuntimeError(str(payload.get("error_description") or payload.get("error") or "GitHub device-code request failed."))
+    return payload
+
+
+def _post_device_poll(domain: str, device_code: str) -> dict[str, Any]:
+    import requests
+
+    response = requests.post(
+        github_urls(domain)["access_token"],
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": COPILOT_HEADERS["User-Agent"],
+        },
+        data={
+            "client_id": CLIENT_ID,
+            "device_code": device_code,
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        },
+        timeout=30,
+    )
+    payload = _json_payload(response)
+    if response.ok or payload.get("error"):
+        return payload
+    raise RuntimeError("GitHub device poll request failed.")
+
+
+def _json_payload(response: Any) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except Exception:
+        payload = {}
+    if not isinstance(payload, dict):
+        return {}
+    return payload
+
+
+def _models_from_payload(payload: Any) -> list[str]:
+    values: list[Any]
+    if isinstance(payload, dict) and isinstance(payload.get("data"), list):
+        values = payload["data"]
+    elif isinstance(payload, dict) and isinstance(payload.get("models"), list):
+        values = payload["models"]
+    elif isinstance(payload, list):
+        values = payload
+    else:
+        return []
+
+    models: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        model_id = ""
+        if isinstance(value, str):
+            model_id = value
+        elif isinstance(value, dict):
+            model_id = str(value.get("id") or value.get("name") or "")
+        model_id = model_id.strip()
+        if model_id and model_id not in seen:
+            seen.add(model_id)
+            models.append(model_id)
+    return models
+
+
+def _expires_ms(payload: dict[str, Any]) -> int:
+    raw = payload.get("expires_at")
+    if raw is None and payload.get("expires_in") is not None:
+        return int((time.time() + float(payload["expires_in"])) * 1000)
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 0
+    if value < 1_000_000_000_000:
+        value *= 1000
+    return int(value)
+
+
+def _as_positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _as_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default

--- a/plugins/_oauth/helpers/providers/registry.py
+++ b/plugins/_oauth/helpers/providers/registry.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from plugins._oauth.helpers.providers.base import (
+    CODEX_PROVIDER_ID,
+    OAuthProvider,
+)
+from plugins._oauth.helpers.providers.codex import CodexOAuthProvider
+
+
+def provider_registry() -> dict[str, OAuthProvider]:
+    from plugins._oauth.helpers.providers.gemini_api import GeminiApiOAuthProvider
+    from plugins._oauth.helpers.providers.github_copilot import GitHubCopilotOAuthProvider
+    from plugins._oauth.helpers.providers.xai_grok import XaiGrokOAuthProvider
+
+    providers: list[OAuthProvider] = [
+        CodexOAuthProvider(),
+        GitHubCopilotOAuthProvider(),
+        GeminiApiOAuthProvider(),
+        XaiGrokOAuthProvider(),
+    ]
+    return {provider.provider_id: provider for provider in providers}
+
+
+def get_provider(provider_id: str | None = None) -> OAuthProvider:
+    if provider_id is None:
+        normalized = CODEX_PROVIDER_ID
+    else:
+        normalized = str(provider_id).strip()
+        if not normalized:
+            normalized = CODEX_PROVIDER_ID
+    registry = provider_registry()
+    try:
+        return registry[normalized]
+    except KeyError as exc:
+        raise KeyError(f"Unknown OAuth provider: {normalized}") from exc
+
+
+def oauth_provider_ids() -> set[str]:
+    return set(provider_registry())

--- a/plugins/_oauth/helpers/providers/xai_grok.py
+++ b/plugins/_oauth/helpers/providers/xai_grok.py
@@ -1,0 +1,663 @@
+from __future__ import annotations
+
+import secrets
+import time
+import importlib
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+from plugins._oauth.helpers.providers.base import (
+    DUMMY_API_KEY,
+    XAI_GROK_PROVIDER_ID,
+    CallbackResult,
+    LoginPollResult,
+    LoginStartResult,
+    OAuthProviderMetadata,
+    ProviderError,
+    provider_auth_path,
+    read_json_file,
+    write_private_json,
+)
+from plugins._oauth.helpers.usage_plans import (
+    usage_plan_notes_for,
+    usage_plan_sources_for,
+    usage_plans_for,
+)
+from plugins._oauth.helpers import state as state_store
+from plugins._oauth.helpers.state import get_attempt, pop_attempt, put_attempt
+
+
+XAI_ISSUER = "https://auth.x.ai"
+XAI_DISCOVERY_URL = f"{XAI_ISSUER}/.well-known/openid-configuration"
+XAI_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
+XAI_SCOPE = "openid profile email offline_access grok-cli:access api:access"
+XAI_REDIRECT_URI = "http://127.0.0.1:56121/callback"
+XAI_API_BASE = "https://api.x.ai/v1"
+CURATED_MODELS = [
+    "grok-4.3",
+    "grok-4.20-0309-reasoning",
+    "grok-4.20-0309-non-reasoning",
+    "grok-4.20-multi-agent-0309",
+    "grok-code-fast-1",
+]
+NOT_CONNECTED_MESSAGE = "xAI Grok OAuth is not connected yet."
+OAUTH_TIER_WARNING = (
+    "xAI Grok OAuth API access may be restricted by tier. "
+    "If OAuth token exchange is denied, the separate API-key `xai` provider may work."
+)
+REFRESH_MARGIN_MS = 60_000
+
+
+def parse_manual_callback(raw: Any) -> dict[str, str | None] | None:
+    text = "" if raw is None else str(raw).strip()
+    if not text:
+        return None
+
+    if text.startswith("http://") or text.startswith("https://"):
+        query = urlparse(text).query
+    elif text.startswith("?"):
+        query = text[1:]
+    elif "=" in text or "&" in text:
+        query = text
+    else:
+        return {
+            "code": text,
+            "state": None,
+            "error": None,
+            "error_description": None,
+        }
+
+    parsed = parse_qs(query, keep_blank_values=True)
+    return {
+        "code": _first_query_value(parsed, "code"),
+        "state": _first_query_value(parsed, "state"),
+        "error": _first_query_value(parsed, "error"),
+        "error_description": _first_query_value(parsed, "error_description"),
+    }
+
+
+class XaiGrokOAuthProvider:
+    provider_id = XAI_GROK_PROVIDER_ID
+
+    def auth_path(self) -> Path:
+        return provider_auth_path("xai_grok")
+
+    def read_auth(self) -> dict[str, Any]:
+        return read_json_file(self.auth_path())
+
+    def write_auth(self, data: dict[str, Any]) -> None:
+        write_private_json(self.auth_path(), data)
+
+    def discovery(self) -> dict[str, str]:
+        import requests
+
+        response = requests.get(
+            XAI_DISCOVERY_URL,
+            headers={"Accept": "application/json"},
+            timeout=30,
+        )
+        payload = _json_payload(response)
+        if not response.ok:
+            raise ProviderError(
+                _error_message(payload, f"xAI Grok discovery failed with status {response.status_code}."),
+                code="discovery_failed",
+                status=response.status_code,
+            )
+        authorization_endpoint = str(payload.get("authorization_endpoint") or "").strip()
+        token_endpoint = str(payload.get("token_endpoint") or "").strip()
+        if not authorization_endpoint or not token_endpoint:
+            raise ProviderError(
+                "xAI Grok discovery response was missing OAuth endpoints.",
+                code="discovery_malformed",
+                status=502,
+            )
+        _validate_xai_endpoint(authorization_endpoint)
+        _validate_xai_endpoint(token_endpoint)
+        return {
+            "authorization_endpoint": authorization_endpoint,
+            "token_endpoint": token_endpoint,
+        }
+
+    def metadata(self) -> OAuthProviderMetadata:
+        return OAuthProviderMetadata(
+            provider_id=XAI_GROK_PROVIDER_ID,
+            display_name="xAI Grok",
+            short_name="Grok",
+            model_provider_id=XAI_GROK_PROVIDER_ID,
+            icon="xai",
+            auth_flow="browser_pkce",
+            default_model="grok-4.3",
+            default_models=list(CURATED_MODELS),
+            proxy_base_path="/oauth/xai-grok",
+            callback_path="/oauth/xai-grok/callback",
+            supports_manual_callback=True,
+            warning=OAUTH_TIER_WARNING,
+            usage_plans=usage_plans_for(XAI_GROK_PROVIDER_ID),
+            usage_plan_notes=usage_plan_notes_for(XAI_GROK_PROVIDER_ID),
+            usage_plan_sources=usage_plan_sources_for(XAI_GROK_PROVIDER_ID),
+        )
+
+    def status(self) -> dict[str, Any]:
+        auth = self.read_auth()
+        access = str(auth.get("access") or "")
+        refresh = str(auth.get("refresh") or "")
+        result = {
+            **self.metadata().to_dict(),
+            "connected": bool(access and refresh),
+            "account_label": "xAI Grok" if access or refresh else "",
+            "base_url": str(auth.get("base_url") or XAI_API_BASE),
+            "auth_file_path": str(self.auth_path()),
+        }
+        warning = str(auth.get("warning") or "")
+        if warning:
+            result["warning"] = warning
+        elif access and refresh and _as_int(auth.get("expires"), 0) <= int(time.time() * 1000):
+            result["warning"] = "xAI Grok OAuth access token is expired and will be refreshed on the next request."
+        return result
+
+    def start_login(self, input: dict[str, Any] | None = None, request: Any = None) -> LoginStartResult:
+        del input, request
+        try:
+            codex = importlib.import_module("plugins._oauth.helpers.codex")
+            metadata = self.discovery()
+            pkce = codex.generate_pkce()
+            state = codex.generate_state()
+            nonce = secrets.token_urlsafe(24)
+            attempt = put_attempt(
+                state,
+                pkce.verifier,
+                XAI_REDIRECT_URI,
+                provider_id=XAI_GROK_PROVIDER_ID,
+                extra={
+                    "nonce": nonce,
+                    "code_challenge": pkce.challenge,
+                    "token_endpoint": metadata["token_endpoint"],
+                },
+            )
+            query = {
+                "response_type": "code",
+                "client_id": XAI_CLIENT_ID,
+                "redirect_uri": XAI_REDIRECT_URI,
+                "scope": XAI_SCOPE,
+                "code_challenge": pkce.challenge,
+                "code_challenge_method": "S256",
+                "state": state,
+                "nonce": nonce,
+                "plan": "generic",
+                "referrer": "agent-zero",
+            }
+            auth_url = f'{metadata["authorization_endpoint"]}?{urlencode(query)}'
+        except Exception as exc:
+            return LoginStartResult(
+                ok=False,
+                provider_id=XAI_GROK_PROVIDER_ID,
+                flow="browser_pkce",
+                error=str(exc),
+                message=str(exc),
+            )
+
+        return LoginStartResult(
+            ok=True,
+            provider_id=XAI_GROK_PROVIDER_ID,
+            flow="browser_pkce",
+            auth_url=auth_url,
+            redirect_uri=XAI_REDIRECT_URI,
+            expires_at=attempt.expires_at,
+        )
+
+    def poll_login(self, input: dict[str, Any] | None = None, request: Any = None) -> LoginPollResult:
+        del input, request
+        return LoginPollResult(
+            ok=False,
+            provider_id=XAI_GROK_PROVIDER_ID,
+            error="xAI Grok uses browser callback login.",
+        )
+
+    def exchange_code(
+        self,
+        token_endpoint: str,
+        code: str,
+        redirect_uri: str,
+        code_verifier: str,
+        code_challenge: str,
+    ) -> dict[str, Any]:
+        import requests
+
+        response = requests.post(
+            token_endpoint,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": XAI_CLIENT_ID,
+                "code_verifier": code_verifier,
+                "code_challenge": code_challenge,
+                "code_challenge_method": "S256",
+            },
+            timeout=30,
+        )
+        payload = _json_payload(response)
+        if not response.ok:
+            if response.status_code == 403:
+                raise ProviderError(
+                    OAUTH_TIER_WARNING,
+                    code="oauth_tier_restricted",
+                    status=403,
+                )
+            raise ProviderError(
+                _error_message(payload, f"xAI Grok token exchange failed with status {response.status_code}."),
+                code="token_exchange_failed",
+                status=response.status_code,
+            )
+        _validate_token_payload(payload, require_refresh=True)
+        return payload
+
+    def manual_callback(self, input: dict[str, Any], request: Any = None) -> LoginPollResult:
+        del request
+        raw = input.get("callback")
+        if raw is None:
+            raw = input.get("callback_url")
+        return self._complete_from_callback(parse_manual_callback(raw), allow_missing_state=True)
+
+    def complete_callback(
+        self,
+        args: dict[str, Any],
+        request: Any = None,
+    ) -> CallbackResult:
+        del request
+        callback = {
+            "code": _as_optional_string(args.get("code")),
+            "state": _as_optional_string(args.get("state")),
+            "error": _as_optional_string(args.get("error")),
+            "error_description": _as_optional_string(args.get("error_description")),
+        }
+        result = self._complete_from_callback(callback, allow_missing_state=False)
+        return CallbackResult(
+            ok=result.ok,
+            provider_id=XAI_GROK_PROVIDER_ID,
+            account_label=result.account_label,
+            error=result.error,
+        )
+
+    def _complete_from_callback(
+        self,
+        callback: dict[str, str | None] | None,
+        *,
+        allow_missing_state: bool,
+    ) -> LoginPollResult:
+        if not callback:
+            return LoginPollResult(ok=False, provider_id=XAI_GROK_PROVIDER_ID, error="Missing OAuth callback.")
+        if callback.get("error"):
+            return LoginPollResult(
+                ok=False,
+                provider_id=XAI_GROK_PROVIDER_ID,
+                error=str(callback.get("error_description") or callback.get("error")),
+            )
+
+        code = str(callback.get("code") or "").strip()
+        if not code:
+            return LoginPollResult(
+                ok=False,
+                provider_id=XAI_GROK_PROVIDER_ID,
+                error="The OAuth callback did not include an authorization code.",
+            )
+
+        state = str(callback.get("state") or "").strip()
+        attempt = None
+        if state:
+            attempt = get_attempt(state)
+            if attempt is None:
+                if _latest_xai_attempt() is not None:
+                    return LoginPollResult(
+                        ok=False,
+                        provider_id=XAI_GROK_PROVIDER_ID,
+                        error="OAuth state mismatch. Return to Agent Zero and start a new xAI Grok connection.",
+                    )
+                return LoginPollResult(
+                    ok=False,
+                    provider_id=XAI_GROK_PROVIDER_ID,
+                    expired=True,
+                    error="OAuth sign-in expired. Return to Agent Zero and start a new xAI Grok connection.",
+                )
+            if attempt.provider_id != XAI_GROK_PROVIDER_ID:
+                return LoginPollResult(
+                    ok=False,
+                    provider_id=XAI_GROK_PROVIDER_ID,
+                    error="OAuth state mismatch. Return to Agent Zero and start a new xAI Grok connection.",
+                )
+        elif allow_missing_state:
+            attempt = _latest_xai_attempt()
+            if attempt is None:
+                return LoginPollResult(
+                    ok=False,
+                    provider_id=XAI_GROK_PROVIDER_ID,
+                    error="No active xAI Grok sign-in attempt was found.",
+                )
+            state = attempt.state
+        else:
+            return LoginPollResult(
+                ok=False,
+                provider_id=XAI_GROK_PROVIDER_ID,
+                error="The OAuth callback did not include state.",
+            )
+
+        token_endpoint = str(attempt.extra.get("token_endpoint") or "")
+        if not token_endpoint:
+            token_endpoint = self.discovery()["token_endpoint"]
+        code_challenge = str(attempt.extra.get("code_challenge") or "")
+        try:
+            payload = self.exchange_code(
+                token_endpoint,
+                code,
+                attempt.redirect_uri,
+                attempt.verifier,
+                code_challenge,
+            )
+            auth = _auth_from_token_payload(payload, token_endpoint)
+            self.write_auth(auth)
+            pop_attempt(state)
+        except Exception as exc:
+            return LoginPollResult(
+                ok=False,
+                provider_id=XAI_GROK_PROVIDER_ID,
+                error=str(exc),
+            )
+
+        return LoginPollResult(
+            ok=True,
+            provider_id=XAI_GROK_PROVIDER_ID,
+            completed=True,
+            account_label="xAI Grok",
+        )
+
+    def ensure_fresh_auth(self) -> dict[str, Any]:
+        auth = self.read_auth()
+        access = str(auth.get("access") or "")
+        refresh = str(auth.get("refresh") or "")
+        if not access or not refresh:
+            return auth
+
+        expires = _as_int(auth.get("expires"), 0)
+        if expires and expires > int(time.time() * 1000) + REFRESH_MARGIN_MS:
+            return auth
+
+        token_endpoint = str(auth.get("token_endpoint") or "")
+        if not token_endpoint:
+            token_endpoint = self.discovery()["token_endpoint"]
+        _validate_xai_endpoint(token_endpoint, code="invalid_token_endpoint")
+        try:
+            refreshed = self._refresh_tokens(token_endpoint, refresh, auth)
+        except ProviderError:
+            raise
+        except Exception as exc:
+            raise ProviderError(
+                f"xAI Grok OAuth refresh failed: {exc}",
+                code="auth_refresh_failed",
+                status=401,
+            ) from exc
+        self.write_auth(refreshed)
+        return refreshed
+
+    def _refresh_tokens(self, token_endpoint: str, refresh: str, existing: dict[str, Any]) -> dict[str, Any]:
+        import requests
+
+        response = requests.post(
+            token_endpoint,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh,
+                "client_id": XAI_CLIENT_ID,
+            },
+            timeout=30,
+        )
+        payload = _json_payload(response)
+        if not response.ok:
+            if response.status_code == 403:
+                raise ProviderError(
+                    OAUTH_TIER_WARNING,
+                    code="oauth_tier_restricted",
+                    status=403,
+                )
+            raise ProviderError(
+                _error_message(payload, f"xAI Grok token refresh failed with status {response.status_code}."),
+                code="token_refresh_failed",
+                status=response.status_code,
+            )
+        _validate_token_payload(payload, require_refresh=False)
+        merged = dict(existing)
+        merged.update(_auth_from_token_payload(payload, token_endpoint, fallback_refresh=refresh))
+        if not payload.get("id_token") and existing.get("id_token"):
+            merged["id_token"] = existing["id_token"]
+        if not payload.get("token_type") and existing.get("token_type"):
+            merged["token_type"] = existing["token_type"]
+        return merged
+
+    def models(self) -> list[str]:
+        if not self.read_auth():
+            return list(CURATED_MODELS)
+        try:
+            auth = self.ensure_fresh_auth()
+        except Exception:
+            return list(CURATED_MODELS)
+        access = str(auth.get("access") or "")
+        if not access:
+            return list(CURATED_MODELS)
+
+        base_url = safe_api_base_url(auth.get("base_url"))
+        try:
+            import requests
+
+            response = requests.get(
+                f"{base_url}/models",
+                headers={
+                    "Accept": "application/json",
+                    "Authorization": f"Bearer {access}",
+                },
+                timeout=30,
+            )
+            if not response.ok:
+                return list(CURATED_MODELS)
+            parsed = _models_from_payload(response.json())
+            return parsed or list(CURATED_MODELS)
+        except Exception:
+            return list(CURATED_MODELS)
+
+    def disconnect(self) -> dict[str, Any]:
+        path = self.auth_path()
+        existed = path.exists()
+        try:
+            path.unlink(missing_ok=True)
+        except FileNotFoundError:
+            pass
+        return {
+            "disconnected": existed,
+            "removed_auth_files": [str(path)] if existed else [],
+        }
+
+    def api_key(self) -> str:
+        return DUMMY_API_KEY
+
+    def register_routes(self, app: Any) -> None:
+        from plugins._oauth.helpers import routes
+
+        route_defs = [
+            ("/oauth/xai-grok/health", "oauth_xai_grok_health", routes.xai_grok_health, ["GET"]),
+            ("/oauth/xai-grok/callback", "oauth_xai_grok_callback", routes.xai_grok_callback, ["GET"]),
+            (
+                "/oauth/xai-grok/v1/models",
+                "oauth_xai_grok_models",
+                routes.xai_grok_models,
+                ["GET", "OPTIONS"],
+            ),
+            (
+                "/oauth/xai-grok/v1/chat/completions",
+                "oauth_xai_grok_chat_completions",
+                routes.xai_grok_chat_completions,
+                ["POST", "OPTIONS"],
+            ),
+            (
+                "/oauth/xai-grok/v1/responses",
+                "oauth_xai_grok_responses",
+                routes.xai_grok_responses,
+                ["POST", "OPTIONS"],
+            ),
+        ]
+        for rule, endpoint, view_func, methods in route_defs:
+            if endpoint in app.view_functions:
+                continue
+            app.add_url_rule(rule, endpoint, view_func, methods=methods)
+
+
+def _auth_from_token_payload(
+    payload: dict[str, Any],
+    token_endpoint: str,
+    *,
+    fallback_refresh: str = "",
+) -> dict[str, Any]:
+    return {
+        "provider": XAI_GROK_PROVIDER_ID,
+        "type": "oauth",
+        "access": str(payload.get("access_token") or ""),
+        "refresh": str(payload.get("refresh_token") or fallback_refresh or ""),
+        "expires": _expires_ms(payload),
+        "id_token": str(payload.get("id_token") or ""),
+        "token_type": str(payload.get("token_type") or "Bearer"),
+        "token_endpoint": token_endpoint,
+        "base_url": XAI_API_BASE,
+    }
+
+
+def _validate_token_payload(payload: dict[str, Any], *, require_refresh: bool) -> None:
+    if not isinstance(payload, dict):
+        raise ProviderError("xAI Grok token endpoint returned a malformed response.", code="token_malformed", status=502)
+    missing = []
+    if not str(payload.get("access_token") or ""):
+        missing.append("access_token")
+    if require_refresh and not str(payload.get("refresh_token") or ""):
+        missing.append("refresh_token")
+    if missing:
+        raise ProviderError(
+            f"xAI Grok token response is missing: {', '.join(missing)}",
+            code="token_malformed",
+            status=502,
+        )
+
+
+def safe_api_base_url(value: Any) -> str:
+    text = str(value or "").strip().rstrip("/")
+    if not text:
+        return XAI_API_BASE
+    parsed = urlparse(text)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme == "https" and (host == "api.x.ai" or host.endswith(".api.x.ai")):
+        return text
+    return XAI_API_BASE
+
+
+def _validate_xai_endpoint(value: str, *, code: str = "discovery_invalid_endpoint") -> None:
+    parsed = urlparse(value)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or not (host == "x.ai" or host.endswith(".x.ai")):
+        raise ProviderError(
+            "xAI Grok discovery returned an invalid OAuth endpoint.",
+            code=code,
+            status=502,
+        )
+
+
+def _latest_xai_attempt():
+    state_store.cleanup_expired()
+    with state_store._lock:
+        attempts = [
+            attempt
+            for attempt in state_store._attempts.values()
+            if attempt.provider_id == XAI_GROK_PROVIDER_ID and not attempt.expired()
+        ]
+    if not attempts:
+        return None
+    return max(attempts, key=lambda attempt: attempt.created_at)
+
+
+def _models_from_payload(payload: Any) -> list[str]:
+    values: list[Any]
+    if isinstance(payload, dict) and isinstance(payload.get("data"), list):
+        values = payload["data"]
+    elif isinstance(payload, dict) and isinstance(payload.get("models"), list):
+        values = payload["models"]
+    elif isinstance(payload, list):
+        values = payload
+    else:
+        return []
+
+    models: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        model_id = ""
+        if isinstance(value, str):
+            model_id = value
+        elif isinstance(value, dict):
+            model_id = str(value.get("id") or value.get("name") or "")
+        model_id = model_id.strip()
+        if model_id and model_id not in seen:
+            seen.add(model_id)
+            models.append(model_id)
+    return models
+
+
+def _json_payload(response: Any) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except Exception:
+        payload = {}
+    if not isinstance(payload, dict):
+        return {}
+    return payload
+
+
+def _error_message(payload: dict[str, Any], fallback: str) -> str:
+    return str(payload.get("error_description") or payload.get("error") or fallback)
+
+
+def _first_query_value(parsed: dict[str, list[str]], key: str) -> str | None:
+    values = parsed.get(key) or []
+    if not values:
+        return None
+    return values[0]
+
+
+def _as_optional_string(value: Any) -> str | None:
+    if isinstance(value, list):
+        value = value[0] if value else None
+    text = "" if value is None else str(value).strip()
+    return text or None
+
+
+def _expires_ms(payload: dict[str, Any]) -> int:
+    if payload.get("expires_at") is not None:
+        try:
+            value = float(payload["expires_at"])
+            if value < 1_000_000_000_000:
+                value *= 1000
+            return int(value)
+        except (TypeError, ValueError):
+            pass
+    try:
+        return int((time.time() + float(payload.get("expires_in") or 0)) * 1000)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _as_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default

--- a/plugins/_oauth/helpers/providers/xai_grok.py
+++ b/plugins/_oauth/helpers/providers/xai_grok.py
@@ -5,7 +5,7 @@ import time
 import importlib
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import urlencode, urlparse
 
 from plugins._oauth.helpers.providers.base import (
     DUMMY_API_KEY,
@@ -19,12 +19,16 @@ from plugins._oauth.helpers.providers.base import (
     read_json_file,
     write_private_json,
 )
-from plugins._oauth.helpers.usage_plans import (
-    usage_plan_notes_for,
-    usage_plan_sources_for,
-    usage_plans_for,
+from plugins._oauth.helpers.providers.common import (
+    as_int as _as_int,
+    as_optional_string as _as_optional_string,
+    error_message as _error_message,
+    expires_ms as _expires_ms,
+    json_payload as _json_payload,
+    latest_attempt,
+    models_from_payload as _models_from_payload,
+    parse_manual_callback,
 )
-from plugins._oauth.helpers import state as state_store
 from plugins._oauth.helpers.state import get_attempt, pop_attempt, put_attempt
 
 
@@ -47,34 +51,6 @@ OAUTH_TIER_WARNING = (
     "If OAuth token exchange is denied, the separate API-key `xai` provider may work."
 )
 REFRESH_MARGIN_MS = 60_000
-
-
-def parse_manual_callback(raw: Any) -> dict[str, str | None] | None:
-    text = "" if raw is None else str(raw).strip()
-    if not text:
-        return None
-
-    if text.startswith("http://") or text.startswith("https://"):
-        query = urlparse(text).query
-    elif text.startswith("?"):
-        query = text[1:]
-    elif "=" in text or "&" in text:
-        query = text
-    else:
-        return {
-            "code": text,
-            "state": None,
-            "error": None,
-            "error_description": None,
-        }
-
-    parsed = parse_qs(query, keep_blank_values=True)
-    return {
-        "code": _first_query_value(parsed, "code"),
-        "state": _first_query_value(parsed, "state"),
-        "error": _first_query_value(parsed, "error"),
-        "error_description": _first_query_value(parsed, "error_description"),
-    }
 
 
 class XaiGrokOAuthProvider:
@@ -133,9 +109,6 @@ class XaiGrokOAuthProvider:
             callback_path="/oauth/xai-grok/callback",
             supports_manual_callback=True,
             warning=OAUTH_TIER_WARNING,
-            usage_plans=usage_plans_for(XAI_GROK_PROVIDER_ID),
-            usage_plan_notes=usage_plan_notes_for(XAI_GROK_PROVIDER_ID),
-            usage_plan_sources=usage_plan_sources_for(XAI_GROK_PROVIDER_ID),
         )
 
     def status(self) -> dict[str, Any]:
@@ -312,7 +285,7 @@ class XaiGrokOAuthProvider:
         if state:
             attempt = get_attempt(state)
             if attempt is None:
-                if _latest_xai_attempt() is not None:
+                if latest_attempt(XAI_GROK_PROVIDER_ID) is not None:
                     return LoginPollResult(
                         ok=False,
                         provider_id=XAI_GROK_PROVIDER_ID,
@@ -331,7 +304,7 @@ class XaiGrokOAuthProvider:
                     error="OAuth state mismatch. Return to Agent Zero and start a new xAI Grok connection.",
                 )
         elif allow_missing_state:
-            attempt = _latest_xai_attempt()
+            attempt = latest_attempt(XAI_GROK_PROVIDER_ID)
             if attempt is None:
                 return LoginPollResult(
                     ok=False,
@@ -572,92 +545,3 @@ def _validate_xai_endpoint(value: str, *, code: str = "discovery_invalid_endpoin
             code=code,
             status=502,
         )
-
-
-def _latest_xai_attempt():
-    state_store.cleanup_expired()
-    with state_store._lock:
-        attempts = [
-            attempt
-            for attempt in state_store._attempts.values()
-            if attempt.provider_id == XAI_GROK_PROVIDER_ID and not attempt.expired()
-        ]
-    if not attempts:
-        return None
-    return max(attempts, key=lambda attempt: attempt.created_at)
-
-
-def _models_from_payload(payload: Any) -> list[str]:
-    values: list[Any]
-    if isinstance(payload, dict) and isinstance(payload.get("data"), list):
-        values = payload["data"]
-    elif isinstance(payload, dict) and isinstance(payload.get("models"), list):
-        values = payload["models"]
-    elif isinstance(payload, list):
-        values = payload
-    else:
-        return []
-
-    models: list[str] = []
-    seen: set[str] = set()
-    for value in values:
-        model_id = ""
-        if isinstance(value, str):
-            model_id = value
-        elif isinstance(value, dict):
-            model_id = str(value.get("id") or value.get("name") or "")
-        model_id = model_id.strip()
-        if model_id and model_id not in seen:
-            seen.add(model_id)
-            models.append(model_id)
-    return models
-
-
-def _json_payload(response: Any) -> dict[str, Any]:
-    try:
-        payload = response.json()
-    except Exception:
-        payload = {}
-    if not isinstance(payload, dict):
-        return {}
-    return payload
-
-
-def _error_message(payload: dict[str, Any], fallback: str) -> str:
-    return str(payload.get("error_description") or payload.get("error") or fallback)
-
-
-def _first_query_value(parsed: dict[str, list[str]], key: str) -> str | None:
-    values = parsed.get(key) or []
-    if not values:
-        return None
-    return values[0]
-
-
-def _as_optional_string(value: Any) -> str | None:
-    if isinstance(value, list):
-        value = value[0] if value else None
-    text = "" if value is None else str(value).strip()
-    return text or None
-
-
-def _expires_ms(payload: dict[str, Any]) -> int:
-    if payload.get("expires_at") is not None:
-        try:
-            value = float(payload["expires_at"])
-            if value < 1_000_000_000_000:
-                value *= 1000
-            return int(value)
-        except (TypeError, ValueError):
-            pass
-    try:
-        return int((time.time() + float(payload.get("expires_in") or 0)) * 1000)
-    except (TypeError, ValueError):
-        return 0
-
-
-def _as_int(value: Any, default: int) -> int:
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return default

--- a/plugins/_oauth/helpers/routes.py
+++ b/plugins/_oauth/helpers/routes.py
@@ -9,6 +9,14 @@ from flask import Response, jsonify, request, stream_with_context
 
 from plugins._oauth.helpers import codex
 from plugins._oauth.helpers.config import codex_config
+from plugins._oauth.helpers.providers import (
+    GEMINI_API_PROVIDER_ID,
+    GITHUB_COPILOT_PROVIDER_ID,
+    XAI_GROK_PROVIDER_ID,
+    ProviderError,
+    get_provider,
+    provider_registry,
+)
 from plugins._oauth.helpers.state import pop_attempt
 
 
@@ -38,6 +46,9 @@ def register_oauth_routes(app) -> None:
         if endpoint in app.view_functions:
             continue
         app.add_url_rule(rule, endpoint, view_func, methods=methods)
+
+    for provider in provider_registry().values():
+        provider.register_routes(app)
 
 
 def codex_health():
@@ -91,6 +102,8 @@ def codex_models():
                 ],
             }
         )
+    except ProviderError as exc:
+        return _json_error(str(exc), status=exc.status, code=exc.code)
     except Exception as exc:
         return _json_error(str(exc), status=502, code="upstream_error")
 
@@ -189,6 +202,325 @@ def codex_chat_completions():
     )
 
 
+def github_copilot_health():
+    return jsonify(
+        {
+            "ok": True,
+            "provider": GITHUB_COPILOT_PROVIDER_ID,
+            "base_path": "/oauth/github-copilot",
+        }
+    )
+
+
+def github_copilot_models():
+    if request.method == "OPTIONS":
+        return _options_response()
+    denied = _proxy_denied_response()
+    if denied:
+        return denied
+
+    provider = get_provider(GITHUB_COPILOT_PROVIDER_ID)
+    return jsonify(
+        {
+            "object": "list",
+            "data": [
+                {
+                    "id": model,
+                    "object": "model",
+                    "created": 0,
+                    "owned_by": "github-copilot-oauth",
+                }
+                for model in provider.models()
+            ],
+        }
+    )
+
+
+def github_copilot_chat_completions():
+    if request.method == "OPTIONS":
+        return _options_response()
+    return _github_copilot_json_proxy("/chat/completions")
+
+
+def github_copilot_responses():
+    if request.method == "OPTIONS":
+        return _options_response()
+    return _github_copilot_json_proxy("/responses")
+
+
+def xai_grok_health():
+    return jsonify(
+        {
+            "ok": True,
+            "provider": XAI_GROK_PROVIDER_ID,
+            "base_path": "/oauth/xai-grok",
+        }
+    )
+
+
+def xai_grok_callback():
+    provider = get_provider(XAI_GROK_PROVIDER_ID)
+    result = provider.complete_callback(dict(request.args), request)
+    if result.ok:
+        return _html_page("xAI Grok Connected", result.account_label or "Connected")
+    return _html_page("xAI Grok Sign-In Failed", result.error or "The OAuth callback failed."), 400
+
+
+def xai_grok_models():
+    if request.method == "OPTIONS":
+        return _options_response()
+    denied = _proxy_denied_response()
+    if denied:
+        return denied
+
+    provider = get_provider(XAI_GROK_PROVIDER_ID)
+    return jsonify(
+        {
+            "object": "list",
+            "data": [
+                {
+                    "id": model,
+                    "object": "model",
+                    "created": 0,
+                    "owned_by": "xai-grok-oauth",
+                }
+                for model in provider.models()
+            ],
+        }
+    )
+
+
+def xai_grok_chat_completions():
+    if request.method == "OPTIONS":
+        return _options_response()
+    return _xai_grok_json_proxy("/chat/completions")
+
+
+def xai_grok_responses():
+    if request.method == "OPTIONS":
+        return _options_response()
+    return _xai_grok_json_proxy("/responses")
+
+
+def gemini_api_health():
+    return jsonify(
+        {
+            "ok": True,
+            "provider": GEMINI_API_PROVIDER_ID,
+            "base_path": "/oauth/gemini-api",
+        }
+    )
+
+
+def gemini_api_callback():
+    provider = get_provider(GEMINI_API_PROVIDER_ID)
+    result = provider.complete_callback(dict(request.args), request)
+    if result.ok:
+        return _html_page("Google Gemini API Connected", result.account_label or "Connected")
+    return _html_page("Google Gemini API Sign-In Failed", result.error or "The OAuth callback failed."), 400
+
+
+def gemini_api_models():
+    if request.method == "OPTIONS":
+        return _options_response()
+    denied = _proxy_denied_response()
+    if denied:
+        return denied
+
+    provider = get_provider(GEMINI_API_PROVIDER_ID)
+    return jsonify(
+        {
+            "object": "list",
+            "data": [
+                {
+                    "id": model,
+                    "object": "model",
+                    "created": 0,
+                    "owned_by": "gemini-api-oauth",
+                }
+                for model in provider.models()
+            ],
+        }
+    )
+
+
+def gemini_api_chat_completions():
+    if request.method == "OPTIONS":
+        return _options_response()
+    return _gemini_api_json_proxy("/chat/completions")
+
+
+def gemini_api_responses():
+    if request.method == "OPTIONS":
+        return _options_response()
+    return _gemini_api_json_proxy("/responses")
+
+
+def _github_copilot_json_proxy(path: str):
+    denied = _proxy_denied_response()
+    if denied:
+        return denied
+
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return _json_error("Request body must be a JSON object.")
+
+    provider = get_provider(GITHUB_COPILOT_PROVIDER_ID)
+    ensure_fresh_auth = getattr(provider, "ensure_fresh_auth", None)
+    read_auth = getattr(provider, "read_auth", None)
+    try:
+        if callable(ensure_fresh_auth):
+            auth = ensure_fresh_auth()
+        elif callable(read_auth):
+            auth = read_auth()
+        else:
+            auth = {}
+    except ProviderError as exc:
+        return _json_error(str(exc), status=exc.status, code=exc.code)
+    except Exception as exc:
+        return _json_error(str(exc), status=502, code="upstream_error")
+    access = str(auth.get("access") or "")
+    if not access:
+        return _json_error("GitHub Copilot OAuth is not connected.", status=401, code="not_connected")
+
+    wants_stream = body.get("stream") is True
+    try:
+        import requests
+
+        from plugins._oauth.helpers.providers.github_copilot import COPILOT_HEADERS, safe_copilot_base_url
+
+        base_url = safe_copilot_base_url(auth.get("base_url"), auth.get("enterprise_domain"))
+
+        upstream = requests.post(
+            f"{base_url}{path}",
+            headers={
+                **COPILOT_HEADERS,
+                "Authorization": f"Bearer {access}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+            stream=wants_stream,
+            timeout=120,
+        )
+    except ProviderError as exc:
+        return _json_error(str(exc), status=exc.status, code=exc.code)
+    except Exception as exc:
+        return _json_error(str(exc), status=502, code="upstream_error")
+
+    if wants_stream and upstream.ok:
+        return _stream_upstream_sse(upstream)
+    return _copy_upstream_response(upstream)
+
+
+def _xai_grok_json_proxy(path: str):
+    denied = _proxy_denied_response()
+    if denied:
+        return denied
+
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return _json_error("Request body must be a JSON object.")
+
+    provider = get_provider(XAI_GROK_PROVIDER_ID)
+    ensure_fresh_auth = getattr(provider, "ensure_fresh_auth", None)
+    read_auth = getattr(provider, "read_auth", None)
+    try:
+        if callable(ensure_fresh_auth):
+            auth = ensure_fresh_auth()
+        elif callable(read_auth):
+            auth = read_auth()
+        else:
+            auth = {}
+    except ProviderError as exc:
+        return _json_error(str(exc), status=exc.status, code=exc.code)
+    except Exception as exc:
+        return _json_error(str(exc), status=502, code="upstream_error")
+
+    access = str(auth.get("access") or "")
+    refresh = str(auth.get("refresh") or "")
+    if not access or not refresh:
+        return _json_error("xAI Grok OAuth is not connected.", status=401, code="not_connected")
+
+    from plugins._oauth.helpers.providers.xai_grok import safe_api_base_url
+
+    base_url = safe_api_base_url(auth.get("base_url"))
+    wants_stream = body.get("stream") is True
+    try:
+        import requests
+
+        upstream = requests.post(
+            f"{base_url}{path}",
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {access}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+            stream=wants_stream,
+            timeout=120,
+        )
+    except Exception as exc:
+        return _json_error(str(exc), status=502, code="upstream_error")
+
+    if wants_stream and upstream.ok:
+        return _stream_upstream_sse(upstream)
+    return _copy_upstream_response(upstream)
+
+
+def _gemini_api_json_proxy(path: str):
+    denied = _proxy_denied_response()
+    if denied:
+        return denied
+
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return _json_error("Request body must be a JSON object.")
+
+    provider = get_provider(GEMINI_API_PROVIDER_ID)
+    ensure_fresh_auth = getattr(provider, "ensure_fresh_auth", None)
+    read_auth = getattr(provider, "read_auth", None)
+    try:
+        if callable(ensure_fresh_auth):
+            auth = ensure_fresh_auth()
+        elif callable(read_auth):
+            auth = read_auth()
+        else:
+            auth = {}
+    except ProviderError as exc:
+        return _json_error(str(exc), status=exc.status, code=exc.code)
+    except Exception as exc:
+        return _json_error(str(exc), status=502, code="upstream_error")
+
+    access = str(auth.get("access") or "")
+    refresh = str(auth.get("refresh") or "")
+    if not access or not refresh:
+        return _json_error("Google Gemini API OAuth is not connected.", status=401, code="not_connected")
+
+    from plugins._oauth.helpers.providers.gemini_api import _gemini_headers, safe_api_base_url
+
+    base_url = safe_api_base_url(auth.get("base_url"))
+    wants_stream = body.get("stream") is True
+    try:
+        import requests
+
+        upstream = requests.post(
+            f"{base_url}{path}",
+            headers={
+                **_gemini_headers(auth),
+                "Content-Type": "application/json",
+            },
+            json=body,
+            stream=wants_stream,
+            timeout=120,
+        )
+    except Exception as exc:
+        return _json_error(str(exc), status=502, code="upstream_error")
+
+    if wants_stream and upstream.ok:
+        return _stream_upstream_sse(upstream)
+    return _copy_upstream_response(upstream)
+
+
 def _stream_upstream_sse(upstream):
     headers = codex.response_headers(upstream)
     headers.setdefault("Content-Type", "text/event-stream")
@@ -279,7 +611,7 @@ def _proxy_authorized() -> bool:
         return True
     if cfg["require_proxy_token"]:
         return False
-    return _host_is_local(request.host) or _remote_is_loopback(request.remote_addr)
+    return _remote_is_loopback(request.remote_addr)
 
 
 def _supplied_proxy_token() -> str:

--- a/plugins/_oauth/helpers/routes.py
+++ b/plugins/_oauth/helpers/routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ipaddress
 import json
 import time
-from typing import Any
+from typing import Any, Callable
 
 from flask import Response, jsonify, request, stream_with_context
 
@@ -357,117 +357,63 @@ def gemini_api_responses():
 
 
 def _github_copilot_json_proxy(path: str):
-    denied = _proxy_denied_response()
-    if denied:
-        return denied
+    from plugins._oauth.helpers.providers.github_copilot import COPILOT_HEADERS, safe_copilot_base_url
 
-    body = request.get_json(silent=True)
-    if not isinstance(body, dict):
-        return _json_error("Request body must be a JSON object.")
-
-    provider = get_provider(GITHUB_COPILOT_PROVIDER_ID)
-    ensure_fresh_auth = getattr(provider, "ensure_fresh_auth", None)
-    read_auth = getattr(provider, "read_auth", None)
-    try:
-        if callable(ensure_fresh_auth):
-            auth = ensure_fresh_auth()
-        elif callable(read_auth):
-            auth = read_auth()
-        else:
-            auth = {}
-    except ProviderError as exc:
-        return _json_error(str(exc), status=exc.status, code=exc.code)
-    except Exception as exc:
-        return _json_error(str(exc), status=502, code="upstream_error")
-    access = str(auth.get("access") or "")
-    if not access:
-        return _json_error("GitHub Copilot OAuth is not connected.", status=401, code="not_connected")
-
-    wants_stream = body.get("stream") is True
-    try:
-        import requests
-
-        from plugins._oauth.helpers.providers.github_copilot import COPILOT_HEADERS, safe_copilot_base_url
-
-        base_url = safe_copilot_base_url(auth.get("base_url"), auth.get("enterprise_domain"))
-
-        upstream = requests.post(
-            f"{base_url}{path}",
-            headers={
-                **COPILOT_HEADERS,
-                "Authorization": f"Bearer {access}",
-                "Content-Type": "application/json",
-            },
-            json=body,
-            stream=wants_stream,
-            timeout=120,
-        )
-    except ProviderError as exc:
-        return _json_error(str(exc), status=exc.status, code=exc.code)
-    except Exception as exc:
-        return _json_error(str(exc), status=502, code="upstream_error")
-
-    if wants_stream and upstream.ok:
-        return _stream_upstream_sse(upstream)
-    return _copy_upstream_response(upstream)
+    return _oauth_json_proxy(
+        GITHUB_COPILOT_PROVIDER_ID,
+        path,
+        "GitHub Copilot OAuth is not connected.",
+        lambda auth: safe_copilot_base_url(auth.get("base_url"), auth.get("enterprise_domain")),
+        lambda auth, access: {
+            **COPILOT_HEADERS,
+            "Authorization": f"Bearer {access}",
+            "Content-Type": "application/json",
+        },
+    )
 
 
 def _xai_grok_json_proxy(path: str):
-    denied = _proxy_denied_response()
-    if denied:
-        return denied
-
-    body = request.get_json(silent=True)
-    if not isinstance(body, dict):
-        return _json_error("Request body must be a JSON object.")
-
-    provider = get_provider(XAI_GROK_PROVIDER_ID)
-    ensure_fresh_auth = getattr(provider, "ensure_fresh_auth", None)
-    read_auth = getattr(provider, "read_auth", None)
-    try:
-        if callable(ensure_fresh_auth):
-            auth = ensure_fresh_auth()
-        elif callable(read_auth):
-            auth = read_auth()
-        else:
-            auth = {}
-    except ProviderError as exc:
-        return _json_error(str(exc), status=exc.status, code=exc.code)
-    except Exception as exc:
-        return _json_error(str(exc), status=502, code="upstream_error")
-
-    access = str(auth.get("access") or "")
-    refresh = str(auth.get("refresh") or "")
-    if not access or not refresh:
-        return _json_error("xAI Grok OAuth is not connected.", status=401, code="not_connected")
-
     from plugins._oauth.helpers.providers.xai_grok import safe_api_base_url
 
-    base_url = safe_api_base_url(auth.get("base_url"))
-    wants_stream = body.get("stream") is True
-    try:
-        import requests
-
-        upstream = requests.post(
-            f"{base_url}{path}",
-            headers={
-                "Accept": "application/json",
-                "Authorization": f"Bearer {access}",
-                "Content-Type": "application/json",
-            },
-            json=body,
-            stream=wants_stream,
-            timeout=120,
-        )
-    except Exception as exc:
-        return _json_error(str(exc), status=502, code="upstream_error")
-
-    if wants_stream and upstream.ok:
-        return _stream_upstream_sse(upstream)
-    return _copy_upstream_response(upstream)
+    return _oauth_json_proxy(
+        XAI_GROK_PROVIDER_ID,
+        path,
+        "xAI Grok OAuth is not connected.",
+        lambda auth: safe_api_base_url(auth.get("base_url")),
+        lambda auth, access: {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {access}",
+            "Content-Type": "application/json",
+        },
+        require_refresh=True,
+    )
 
 
 def _gemini_api_json_proxy(path: str):
+    from plugins._oauth.helpers.providers.gemini_api import _gemini_headers, safe_api_base_url
+
+    return _oauth_json_proxy(
+        GEMINI_API_PROVIDER_ID,
+        path,
+        "Google Gemini API OAuth is not connected.",
+        lambda auth: safe_api_base_url(auth.get("base_url")),
+        lambda auth, access: {
+            **_gemini_headers(auth),
+            "Content-Type": "application/json",
+        },
+        require_refresh=True,
+    )
+
+
+def _oauth_json_proxy(
+    provider_id: str,
+    path: str,
+    not_connected_message: str,
+    base_url_for: Callable[[dict[str, Any]], str],
+    headers_for: Callable[[dict[str, Any], str], dict[str, str]],
+    *,
+    require_refresh: bool = False,
+):
     denied = _proxy_denied_response()
     if denied:
         return denied
@@ -476,16 +422,8 @@ def _gemini_api_json_proxy(path: str):
     if not isinstance(body, dict):
         return _json_error("Request body must be a JSON object.")
 
-    provider = get_provider(GEMINI_API_PROVIDER_ID)
-    ensure_fresh_auth = getattr(provider, "ensure_fresh_auth", None)
-    read_auth = getattr(provider, "read_auth", None)
     try:
-        if callable(ensure_fresh_auth):
-            auth = ensure_fresh_auth()
-        elif callable(read_auth):
-            auth = read_auth()
-        else:
-            auth = {}
+        auth = _provider_auth(provider_id)
     except ProviderError as exc:
         return _json_error(str(exc), status=exc.status, code=exc.code)
     except Exception as exc:
@@ -493,32 +431,42 @@ def _gemini_api_json_proxy(path: str):
 
     access = str(auth.get("access") or "")
     refresh = str(auth.get("refresh") or "")
-    if not access or not refresh:
-        return _json_error("Google Gemini API OAuth is not connected.", status=401, code="not_connected")
+    if not access or (require_refresh and not refresh):
+        return _json_error(not_connected_message, status=401, code="not_connected")
 
-    from plugins._oauth.helpers.providers.gemini_api import _gemini_headers, safe_api_base_url
-
-    base_url = safe_api_base_url(auth.get("base_url"))
     wants_stream = body.get("stream") is True
     try:
         import requests
 
+        base_url = base_url_for(auth)
         upstream = requests.post(
             f"{base_url}{path}",
-            headers={
-                **_gemini_headers(auth),
-                "Content-Type": "application/json",
-            },
+            headers=headers_for(auth, access),
             json=body,
             stream=wants_stream,
             timeout=120,
         )
+    except ProviderError as exc:
+        return _json_error(str(exc), status=exc.status, code=exc.code)
     except Exception as exc:
         return _json_error(str(exc), status=502, code="upstream_error")
 
     if wants_stream and upstream.ok:
         return _stream_upstream_sse(upstream)
     return _copy_upstream_response(upstream)
+
+
+def _provider_auth(provider_id: str) -> dict[str, Any]:
+    provider = get_provider(provider_id)
+    ensure_fresh_auth = getattr(provider, "ensure_fresh_auth", None)
+    read_auth = getattr(provider, "read_auth", None)
+    if callable(ensure_fresh_auth):
+        auth = ensure_fresh_auth()
+    elif callable(read_auth):
+        auth = read_auth()
+    else:
+        auth = {}
+    return auth if isinstance(auth, dict) else {}
 
 
 def _stream_upstream_sse(upstream):

--- a/plugins/_oauth/helpers/state.py
+++ b/plugins/_oauth/helpers/state.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 
 LOGIN_TTL_SECONDS = 10 * 60
@@ -14,6 +15,8 @@ class LoginAttempt:
     verifier: str
     redirect_uri: str
     created_at: float
+    provider_id: str = "codex_oauth"
+    extra: dict[str, Any] = field(default_factory=dict)
 
     @property
     def expires_at(self) -> float:
@@ -30,6 +33,8 @@ class DeviceAttempt:
     user_code: str
     interval: int
     expires_at_value: float
+    provider_id: str = "codex_oauth"
+    extra: dict[str, Any] = field(default_factory=dict)
 
     @property
     def expires_at(self) -> float:
@@ -44,16 +49,34 @@ _attempts: dict[str, LoginAttempt] = {}
 _device_attempts: dict[str, DeviceAttempt] = {}
 
 
-def put_attempt(state: str, verifier: str, redirect_uri: str) -> LoginAttempt:
+def put_attempt(
+    state: str,
+    verifier: str,
+    redirect_uri: str,
+    *,
+    provider_id: str = "codex_oauth",
+    extra: dict[str, Any] | None = None,
+) -> LoginAttempt:
     cleanup_expired()
     attempt = LoginAttempt(
         state=state,
         verifier=verifier,
         redirect_uri=redirect_uri,
         created_at=time.time(),
+        provider_id=provider_id,
+        extra=dict(extra or {}),
     )
     with _lock:
         _attempts[state] = attempt
+    return attempt
+
+
+def get_attempt(state: str) -> LoginAttempt | None:
+    cleanup_expired()
+    with _lock:
+        attempt = _attempts.get(state)
+    if attempt is None or attempt.expired():
+        return None
     return attempt
 
 
@@ -72,6 +95,9 @@ def put_device_attempt(
     user_code: str,
     interval: int,
     expires_at: float,
+    *,
+    provider_id: str = "codex_oauth",
+    extra: dict[str, Any] | None = None,
 ) -> DeviceAttempt:
     cleanup_expired()
     attempt = DeviceAttempt(
@@ -80,6 +106,8 @@ def put_device_attempt(
         user_code=user_code,
         interval=interval,
         expires_at_value=expires_at,
+        provider_id=provider_id,
+        extra=dict(extra or {}),
     )
     with _lock:
         _device_attempts[attempt_id] = attempt

--- a/plugins/_oauth/helpers/usage_plans.py
+++ b/plugins/_oauth/helpers/usage_plans.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+CODEX_PROVIDER_ID = "codex_oauth"
+GITHUB_COPILOT_PROVIDER_ID = "github_copilot_oauth"
+CLAUDE_CODE_PROVIDER_ID = "claude_code_oauth"
+GEMINI_API_PROVIDER_ID = "gemini_api_oauth"
+GEMINI_CODE_ASSIST_PROVIDER_ID = "gemini_code_assist_oauth"
+XAI_GROK_PROVIDER_ID = "xai_grok_oauth"
+
+
+USAGE_PLAN_CATALOG: dict[str, dict[str, Any]] = {
+    CODEX_PROVIDER_ID: {
+        "provider_id": CODEX_PROVIDER_ID,
+        "display_name": "OpenAI Codex",
+        "implemented": True,
+        "plans": [
+            {"id": "free", "label": "Free", "billing": "$0/month", "usage": "Quick coding tasks with plan-specific limits."},
+            {"id": "go", "label": "Go", "billing": "$8/month", "usage": "Lightweight coding tasks."},
+            {"id": "plus", "label": "Plus", "billing": "$20/month", "usage": "Focused coding sessions, latest Codex models, and credit extension."},
+            {"id": "pro", "label": "Pro", "billing": "From $100/month", "usage": "Higher Codex limits than Plus, including Pro tiers."},
+            {"id": "business", "label": "Business", "billing": "Pay as you go", "usage": "Standard or usage-based Codex seats, credits, admin controls, and no training by default."},
+            {"id": "enterprise_edu", "label": "Enterprise / Edu", "billing": "Contact sales", "usage": "Enterprise controls, priority processing, audit and usage monitoring."},
+            {"id": "api_key", "label": "API Key", "billing": "Token-based API pricing", "usage": "CLI, SDK, or IDE automation without ChatGPT cloud features."},
+        ],
+        "notes": [
+            "Codex is included across ChatGPT Free, Go, Plus, Pro, Business, Edu, and Enterprise plans.",
+            "The Pro 2x/boost promotion ended on 2026-05-31.",
+            "API-key usage is separate from ChatGPT subscription usage and may receive delayed access to some new Codex models.",
+        ],
+        "sources": [
+            {"label": "OpenAI Codex pricing", "url": "https://developers.openai.com/codex/pricing"},
+            {"label": "Using Codex with your ChatGPT plan", "url": "https://help.openai.com/en/articles/11369540"},
+        ],
+    },
+    GITHUB_COPILOT_PROVIDER_ID: {
+        "provider_id": GITHUB_COPILOT_PROVIDER_ID,
+        "display_name": "GitHub Copilot",
+        "implemented": True,
+        "plans": [
+            {"id": "free", "label": "Copilot Free", "billing": "Free", "usage": "Entry Copilot access with monthly completion limits."},
+            {"id": "student", "label": "Copilot Student", "billing": "Free for eligible users", "usage": "Student-entitled Copilot access."},
+            {"id": "pro", "label": "Copilot Pro", "billing": "$10/month", "usage": "Individual Copilot access with paid entitlements."},
+            {"id": "pro_plus", "label": "Copilot Pro+", "billing": "$39/month", "usage": "Larger individual AI-credit pool."},
+            {"id": "max", "label": "Copilot Max", "billing": "$100/month", "usage": "Highest individual monthly AI-credit allowance and priority model access."},
+            {"id": "business", "label": "Copilot Business", "billing": "$19/seat/month", "usage": "Team and organization plan with centralized management."},
+            {"id": "enterprise", "label": "Copilot Enterprise", "billing": "$39/seat/month", "usage": "Enterprise Cloud plan with larger AI-credit pool and enterprise controls."},
+        ],
+        "notes": [
+            "AI-credit availability and model access can differ by seat and organization policy.",
+            "GitHub docs list new signup pauses for several Copilot plans beginning in April 2026.",
+            "Beginning 2026-06-01, GitHub docs describe Copilot Max as upgrade-only for users with existing Copilot plans.",
+        ],
+        "sources": [
+            {"label": "GitHub Copilot plans", "url": "https://docs.github.com/en/copilot/get-started/plans"},
+        ],
+    },
+    CLAUDE_CODE_PROVIDER_ID: {
+        "provider_id": CLAUDE_CODE_PROVIDER_ID,
+        "display_name": "Claude Code",
+        "implemented": False,
+        "plans": [
+            {"id": "pro", "label": "Pro", "billing": "Subscription", "usage": "Shared Claude and Claude Code usage limits."},
+            {"id": "max_5x", "label": "Max 5x", "billing": "Subscription", "usage": "Higher included usage than Pro."},
+            {"id": "max_20x", "label": "Max 20x", "billing": "Subscription", "usage": "Highest individual Claude Code subscription allocation."},
+            {"id": "team", "label": "Team", "billing": "Seat-based subscription", "usage": "Claude Code included with every Team seat; premium seats add more usage."},
+            {"id": "enterprise_premium", "label": "Enterprise Premium", "billing": "Seat-based subscription", "usage": "Enterprise seat type with Claude Code access."},
+            {"id": "enterprise_usage_based", "label": "Enterprise usage-based", "billing": "API-rate consumption", "usage": "Usage billed by consumption instead of per-seat caps."},
+        ],
+        "notes": [
+            "Claude subscription usage and Anthropic API-key billing are distinct systems.",
+            "An ANTHROPIC_API_KEY can make Claude Code use API billing instead of subscription allocation.",
+        ],
+        "sources": [
+            {"label": "Claude Code with Pro or Max", "url": "https://support.claude.com/en/articles/11145838-use-claude-code-with-your-pro-or-max-plan"},
+            {"label": "Claude Code with Team or Enterprise", "url": "https://support.claude.com/en/articles/11845131-use-claude-code-with-your-team-or-enterprise-plan"},
+        ],
+    },
+    GEMINI_API_PROVIDER_ID: {
+        "provider_id": GEMINI_API_PROVIDER_ID,
+        "display_name": "Google Gemini API",
+        "implemented": True,
+        "plans": [
+            {"id": "oauth_cloud_project", "label": "OAuth Cloud project", "billing": "Google Cloud project", "usage": "Official OAuth access using a user-provided Google Cloud OAuth client."},
+            {"id": "api_key", "label": "API key", "billing": "Gemini API pricing", "usage": "Standard Gemini API key access through Google AI Studio or Google Cloud."},
+            {"id": "vertex_ai", "label": "Vertex AI", "billing": "Google Cloud", "usage": "Enterprise Gemini API access through Vertex AI projects and IAM."},
+        ],
+        "notes": [
+            "Gemini API OAuth requires the Google Generative Language API to be enabled on the user's Cloud project.",
+            "OAuth Gemini API usage is separate from Antigravity, Gemini Code Assist, Gemini CLI, Google AI Pro, and Google AI Ultra subscription quotas.",
+            "A quota project may be required so Google can attribute billing and quota to the correct Cloud project.",
+        ],
+        "sources": [
+            {"label": "Gemini API OAuth", "url": "https://ai.google.dev/gemini-api/docs/oauth"},
+            {"label": "Gemini OpenAI compatibility", "url": "https://ai.google.dev/gemini-api/docs/openai"},
+            {"label": "Gemini API billing", "url": "https://ai.google.dev/gemini-api/docs/billing"},
+        ],
+    },
+    GEMINI_CODE_ASSIST_PROVIDER_ID: {
+        "provider_id": GEMINI_CODE_ASSIST_PROVIDER_ID,
+        "display_name": "Google Gemini / Antigravity",
+        "implemented": False,
+        "implementation_status": "metadata_only",
+        "plans": [
+            {"id": "individual", "label": "Antigravity Individual", "billing": "$0/month", "usage": "Baseline Antigravity quota, unlimited tab completions, and CLI access."},
+            {"id": "google_ai_pro", "label": "Google AI Pro", "billing": "Subscription", "usage": "More generous Antigravity rate limits and AI credit overages."},
+            {"id": "google_ai_ultra", "label": "Google AI Ultra", "billing": "Subscription", "usage": "Highest Antigravity quota, highest weekly limits, and third-party model access."},
+            {"id": "organization", "label": "Organization plan", "billing": "Google Cloud", "usage": "Gemini Enterprise Agent Platform access, Cloud project integration, and consumption pricing."},
+            {"id": "code_assist_standard", "label": "Gemini Code Assist Standard", "billing": "Google Cloud subscription", "usage": "Organization plan for code assistance, agent mode, and Gemini CLI quotas."},
+            {"id": "code_assist_enterprise", "label": "Gemini Code Assist Enterprise", "billing": "Google Cloud subscription", "usage": "Enterprise plan with customization and broader Google Cloud integrations."},
+            {"id": "gemini_api_oauth", "label": "Gemini API OAuth", "billing": "Google Cloud project", "usage": "Official third-party OAuth path with a user-provided Google Cloud OAuth client."},
+        ],
+        "provider_modes": [
+            {
+                "id": "gemini_api_oauth",
+                "label": "Gemini API OAuth",
+                "allowed": True,
+                "status": "implemented",
+                "note": "Implemented as the separate Google Gemini API OAuth provider. It requires a user-configured Google Cloud OAuth client and does not spend Antigravity or Google AI subscription quota.",
+            },
+            {
+                "id": "antigravity_subscription_oauth",
+                "label": "Antigravity subscription OAuth",
+                "allowed": False,
+                "status": "not_implemented",
+                "note": "Google Antigravity terms prohibit using third-party tools to access the Antigravity service through its OAuth flow.",
+            },
+        ],
+        "notes": [
+            "Official Gemini API OAuth requires a Google Cloud OAuth client and is separate from Google AI Pro, Google AI Ultra, Antigravity, Gemini Code Assist, and Gemini CLI quotas.",
+            "Antigravity and Gemini Code Assist subscription OAuth are metadata-only here because Google does not authorize third-party tools to access the service through those product OAuth flows.",
+            "Gemini CLI quotas are provided by Gemini Code Assist editions and shared with Code Assist agent mode; the CLI can also use a Gemini API key for pay-as-you-go usage.",
+        ],
+        "sources": [
+            {"label": "Google Antigravity terms", "url": "https://antigravity.google/terms"},
+            {"label": "Google Antigravity plans", "url": "https://antigravity.google/docs/plans?id=GoogleAntigravity"},
+            {"label": "Google Antigravity pricing", "url": "https://antigravity.google/pricing?app=antigravity"},
+            {"label": "Gemini Code Assist overview", "url": "https://developers.google.com/gemini-code-assist/docs/overview"},
+            {"label": "Gemini Code Assist quotas", "url": "https://developers.google.com/gemini-code-assist/resources/quotas"},
+            {"label": "Gemini CLI", "url": "https://developers.google.com/gemini-code-assist/docs/gemini-cli"},
+            {"label": "Gemini API OAuth", "url": "https://ai.google.dev/gemini-api/docs/oauth"},
+        ],
+    },
+    XAI_GROK_PROVIDER_ID: {
+        "provider_id": XAI_GROK_PROVIDER_ID,
+        "display_name": "xAI Grok",
+        "implemented": True,
+        "plans": [
+            {"id": "free", "label": "Free", "billing": "$0/month", "usage": "Grok app access with free limits."},
+            {"id": "supergrok_lite", "label": "SuperGrok Lite", "billing": "Subscription", "usage": "Intermediate Grok app limits."},
+            {"id": "supergrok", "label": "SuperGrok", "billing": "$30/month", "usage": "Higher app limits, Grok 4 model, connectors, image and video generation."},
+            {"id": "supergrok_heavy", "label": "SuperGrok Heavy", "billing": "Subscription", "usage": "Highest individual Grok app tier."},
+            {"id": "business", "label": "Business", "billing": "Team plan", "usage": "Team seats, billing, role-based access, and admin controls."},
+            {"id": "enterprise", "label": "Enterprise", "billing": "Contact sales", "usage": "Custom rate limits, SSO, SCIM, data residency, and volume pricing."},
+            {"id": "api_credits", "label": "API credits", "billing": "Prepaid/usage credits", "usage": "xAI API access after account setup and credit loading."},
+        ],
+        "notes": [
+            "xAI API billing is separate from Grok app subscriptions unless xAI explicitly entitles the account.",
+            "The API quickstart uses API keys from the xAI console and requires loading credits.",
+        ],
+        "sources": [
+            {"label": "xAI pricing", "url": "https://x.ai/pricing"},
+            {"label": "xAI API quickstart", "url": "https://docs.x.ai/developers/quickstart"},
+        ],
+    },
+}
+
+
+def usage_plan_catalog() -> dict[str, dict[str, Any]]:
+    return deepcopy(USAGE_PLAN_CATALOG)
+
+
+def usage_plan_entry(provider_id: str) -> dict[str, Any]:
+    return deepcopy(USAGE_PLAN_CATALOG.get(provider_id, {}))
+
+
+def usage_plans_for(provider_id: str) -> list[dict[str, Any]]:
+    entry = usage_plan_entry(provider_id)
+    plans = entry.get("plans", [])
+    return plans if isinstance(plans, list) else []
+
+
+def usage_plan_notes_for(provider_id: str) -> list[str]:
+    entry = usage_plan_entry(provider_id)
+    notes = entry.get("notes", [])
+    return notes if isinstance(notes, list) else []
+
+
+def usage_plan_sources_for(provider_id: str) -> list[dict[str, str]]:
+    entry = usage_plan_entry(provider_id)
+    sources = entry.get("sources", [])
+    return sources if isinstance(sources, list) else []

--- a/plugins/_oauth/helpers/usage_plans.py
+++ b/plugins/_oauth/helpers/usage_plans.py
@@ -102,25 +102,3 @@ USAGE_PLAN_CATALOG: dict[str, dict[str, Any]] = {
 
 def usage_plan_catalog() -> dict[str, dict[str, Any]]:
     return deepcopy(USAGE_PLAN_CATALOG)
-
-
-def usage_plan_entry(provider_id: str) -> dict[str, Any]:
-    return deepcopy(USAGE_PLAN_CATALOG.get(provider_id, {}))
-
-
-def usage_plans_for(provider_id: str) -> list[dict[str, Any]]:
-    entry = usage_plan_entry(provider_id)
-    plans = entry.get("plans", [])
-    return plans if isinstance(plans, list) else []
-
-
-def usage_plan_notes_for(provider_id: str) -> list[str]:
-    entry = usage_plan_entry(provider_id)
-    notes = entry.get("notes", [])
-    return notes if isinstance(notes, list) else []
-
-
-def usage_plan_sources_for(provider_id: str) -> list[dict[str, str]]:
-    entry = usage_plan_entry(provider_id)
-    sources = entry.get("sources", [])
-    return sources if isinstance(sources, list) else []

--- a/plugins/_oauth/helpers/usage_plans.py
+++ b/plugins/_oauth/helpers/usage_plans.py
@@ -5,9 +5,7 @@ from typing import Any
 
 CODEX_PROVIDER_ID = "codex_oauth"
 GITHUB_COPILOT_PROVIDER_ID = "github_copilot_oauth"
-CLAUDE_CODE_PROVIDER_ID = "claude_code_oauth"
 GEMINI_API_PROVIDER_ID = "gemini_api_oauth"
-GEMINI_CODE_ASSIST_PROVIDER_ID = "gemini_code_assist_oauth"
 XAI_GROK_PROVIDER_ID = "xai_grok_oauth"
 
 
@@ -57,27 +55,6 @@ USAGE_PLAN_CATALOG: dict[str, dict[str, Any]] = {
             {"label": "GitHub Copilot plans", "url": "https://docs.github.com/en/copilot/get-started/plans"},
         ],
     },
-    CLAUDE_CODE_PROVIDER_ID: {
-        "provider_id": CLAUDE_CODE_PROVIDER_ID,
-        "display_name": "Claude Code",
-        "implemented": False,
-        "plans": [
-            {"id": "pro", "label": "Pro", "billing": "Subscription", "usage": "Shared Claude and Claude Code usage limits."},
-            {"id": "max_5x", "label": "Max 5x", "billing": "Subscription", "usage": "Higher included usage than Pro."},
-            {"id": "max_20x", "label": "Max 20x", "billing": "Subscription", "usage": "Highest individual Claude Code subscription allocation."},
-            {"id": "team", "label": "Team", "billing": "Seat-based subscription", "usage": "Claude Code included with every Team seat; premium seats add more usage."},
-            {"id": "enterprise_premium", "label": "Enterprise Premium", "billing": "Seat-based subscription", "usage": "Enterprise seat type with Claude Code access."},
-            {"id": "enterprise_usage_based", "label": "Enterprise usage-based", "billing": "API-rate consumption", "usage": "Usage billed by consumption instead of per-seat caps."},
-        ],
-        "notes": [
-            "Claude subscription usage and Anthropic API-key billing are distinct systems.",
-            "An ANTHROPIC_API_KEY can make Claude Code use API billing instead of subscription allocation.",
-        ],
-        "sources": [
-            {"label": "Claude Code with Pro or Max", "url": "https://support.claude.com/en/articles/11145838-use-claude-code-with-your-pro-or-max-plan"},
-            {"label": "Claude Code with Team or Enterprise", "url": "https://support.claude.com/en/articles/11845131-use-claude-code-with-your-team-or-enterprise-plan"},
-        ],
-    },
     GEMINI_API_PROVIDER_ID: {
         "provider_id": GEMINI_API_PROVIDER_ID,
         "display_name": "Google Gemini API",
@@ -96,51 +73,6 @@ USAGE_PLAN_CATALOG: dict[str, dict[str, Any]] = {
             {"label": "Gemini API OAuth", "url": "https://ai.google.dev/gemini-api/docs/oauth"},
             {"label": "Gemini OpenAI compatibility", "url": "https://ai.google.dev/gemini-api/docs/openai"},
             {"label": "Gemini API billing", "url": "https://ai.google.dev/gemini-api/docs/billing"},
-        ],
-    },
-    GEMINI_CODE_ASSIST_PROVIDER_ID: {
-        "provider_id": GEMINI_CODE_ASSIST_PROVIDER_ID,
-        "display_name": "Google Gemini / Antigravity",
-        "implemented": False,
-        "implementation_status": "metadata_only",
-        "plans": [
-            {"id": "individual", "label": "Antigravity Individual", "billing": "$0/month", "usage": "Baseline Antigravity quota, unlimited tab completions, and CLI access."},
-            {"id": "google_ai_pro", "label": "Google AI Pro", "billing": "Subscription", "usage": "More generous Antigravity rate limits and AI credit overages."},
-            {"id": "google_ai_ultra", "label": "Google AI Ultra", "billing": "Subscription", "usage": "Highest Antigravity quota, highest weekly limits, and third-party model access."},
-            {"id": "organization", "label": "Organization plan", "billing": "Google Cloud", "usage": "Gemini Enterprise Agent Platform access, Cloud project integration, and consumption pricing."},
-            {"id": "code_assist_standard", "label": "Gemini Code Assist Standard", "billing": "Google Cloud subscription", "usage": "Organization plan for code assistance, agent mode, and Gemini CLI quotas."},
-            {"id": "code_assist_enterprise", "label": "Gemini Code Assist Enterprise", "billing": "Google Cloud subscription", "usage": "Enterprise plan with customization and broader Google Cloud integrations."},
-            {"id": "gemini_api_oauth", "label": "Gemini API OAuth", "billing": "Google Cloud project", "usage": "Official third-party OAuth path with a user-provided Google Cloud OAuth client."},
-        ],
-        "provider_modes": [
-            {
-                "id": "gemini_api_oauth",
-                "label": "Gemini API OAuth",
-                "allowed": True,
-                "status": "implemented",
-                "note": "Implemented as the separate Google Gemini API OAuth provider. It requires a user-configured Google Cloud OAuth client and does not spend Antigravity or Google AI subscription quota.",
-            },
-            {
-                "id": "antigravity_subscription_oauth",
-                "label": "Antigravity subscription OAuth",
-                "allowed": False,
-                "status": "not_implemented",
-                "note": "Google Antigravity terms prohibit using third-party tools to access the Antigravity service through its OAuth flow.",
-            },
-        ],
-        "notes": [
-            "Official Gemini API OAuth requires a Google Cloud OAuth client and is separate from Google AI Pro, Google AI Ultra, Antigravity, Gemini Code Assist, and Gemini CLI quotas.",
-            "Antigravity and Gemini Code Assist subscription OAuth are metadata-only here because Google does not authorize third-party tools to access the service through those product OAuth flows.",
-            "Gemini CLI quotas are provided by Gemini Code Assist editions and shared with Code Assist agent mode; the CLI can also use a Gemini API key for pay-as-you-go usage.",
-        ],
-        "sources": [
-            {"label": "Google Antigravity terms", "url": "https://antigravity.google/terms"},
-            {"label": "Google Antigravity plans", "url": "https://antigravity.google/docs/plans?id=GoogleAntigravity"},
-            {"label": "Google Antigravity pricing", "url": "https://antigravity.google/pricing?app=antigravity"},
-            {"label": "Gemini Code Assist overview", "url": "https://developers.google.com/gemini-code-assist/docs/overview"},
-            {"label": "Gemini Code Assist quotas", "url": "https://developers.google.com/gemini-code-assist/resources/quotas"},
-            {"label": "Gemini CLI", "url": "https://developers.google.com/gemini-code-assist/docs/gemini-cli"},
-            {"label": "Gemini API OAuth", "url": "https://ai.google.dev/gemini-api/docs/oauth"},
         ],
     },
     XAI_GROK_PROVIDER_ID: {

--- a/plugins/_oauth/webui/config.html
+++ b/plugins/_oauth/webui/config.html
@@ -181,7 +181,7 @@
 
           <div class="oauth-plan-grid">
             <template x-for="entry in $store.oauthConfig.usagePlanEntries()" :key="entry.provider_id">
-              <article class="oauth-plan-card" :class="entry.implemented ? 'is-implemented' : 'is-metadata-only'">
+              <article class="oauth-plan-card">
                 <div class="oauth-plan-head">
                   <strong x-text="entry.display_name"></strong>
                   <span x-text="$store.oauthConfig.usagePlanStatus(entry)"></span>
@@ -693,10 +693,6 @@
       border: 1px solid var(--color-border);
       border-radius: 8px;
       background: color-mix(in srgb, var(--color-panel) 82%, transparent);
-    }
-
-    .oauth-plan-card.is-metadata-only {
-      border-style: dashed;
     }
 
     .oauth-plan-head {

--- a/plugins/_oauth/webui/config.html
+++ b/plugins/_oauth/webui/config.html
@@ -15,59 +15,132 @@
         x-effect="$store.oauthConfig.bindConfig(config)"
         x-destroy="$store.oauthConfig.cleanup()"
       >
-        <section class="oauth-hero" :class="$store.oauthConfig.connected() ? 'is-connected' : ''">
-          <div class="oauth-mark">
-            <span class="material-symbols-outlined" x-text="$store.oauthConfig.connected() ? 'check' : 'key'"></span>
-          </div>
+        <section class="oauth-provider-grid">
+          <template x-for="card in $store.oauthConfig.providerCards()" :key="card.provider_id">
+            <article class="oauth-provider-card" :class="card.connected ? 'is-connected' : ''">
+              <div class="oauth-provider-head">
+                <div class="oauth-mark">
+                  <span class="material-symbols-outlined" x-text="card.connected ? 'check' : card.mark"></span>
+                </div>
+                <div class="oauth-copy">
+                  <h2 x-text="card.display_name"></h2>
+                  <p x-text="$store.oauthConfig.providerStatusLabel(card.provider_id)"></p>
+                </div>
+              </div>
 
-          <div class="oauth-copy">
-            <h2>Codex/ChatGPT</h2>
-            <p x-show="!$store.oauthConfig.connected() && !$store.oauthConfig.connecting">
-              Connect your account to unlock Codex models locally.
-            </p>
-            <p x-show="$store.oauthConfig.connected()">
-              Connected and ready.
-            </p>
-            <p x-show="$store.oauthConfig.connecting">
-              Finish sign-in in the browser tab.
-            </p>
-          </div>
+              <label class="oauth-provider-input" x-show="card.supports_enterprise_domain && !card.connected">
+                <span>Enterprise domain</span>
+                <input
+                  type="text"
+                  x-model="$store.oauthConfig.providerUiFor(card.provider_id).enterprise_domain"
+                  name="enterprise_domain"
+                  placeholder="github.com"
+                />
+              </label>
 
-          <div class="oauth-primary">
-            <button
-              class="oauth-connect"
-              type="button"
-              @click="$store.oauthConfig.connectCodex()"
-              :disabled="$store.oauthConfig.connecting"
-              x-show="!$store.oauthConfig.connected()"
-            >
-              <span class="material-symbols-outlined" x-text="$store.oauthConfig.connecting ? 'progress_activity' : 'login'"></span>
-              <span x-text="$store.oauthConfig.connecting ? 'Waiting' : 'Connect'"></span>
-            </button>
-            <button
-              class="oauth-connect danger"
-              type="button"
-              @click="$store.oauthConfig.disconnectCodex()"
-              :disabled="$store.oauthConfig.disconnecting"
-              x-show="$store.oauthConfig.connected()"
-            >
-              <span class="material-symbols-outlined" x-text="$store.oauthConfig.disconnecting ? 'progress_activity' : 'link_off'"></span>
-              <span x-text="$store.oauthConfig.disconnecting ? 'Disconnecting' : 'Disconnect'"></span>
-            </button>
-          </div>
+              <div class="oauth-provider-fields" x-show="card.supports_oauth_client_config && !card.connected">
+                <label class="oauth-provider-input">
+                  <span>OAuth client ID</span>
+                  <input
+                    type="text"
+                    x-model="$store.oauthConfig.providerUiFor(card.provider_id).client_id"
+                    name="oauth_client_id"
+                    placeholder="Google Cloud OAuth client ID"
+                  />
+                </label>
+                <label class="oauth-provider-input">
+                  <span>OAuth client secret</span>
+                  <input
+                    type="password"
+                    x-model="$store.oauthConfig.providerUiFor(card.provider_id).client_secret"
+                    name="oauth_client_secret"
+                    autocomplete="off"
+                    placeholder="Google Cloud OAuth client secret"
+                  />
+                </label>
+                <label class="oauth-provider-input" x-show="card.supports_quota_project">
+                  <span>Quota project</span>
+                  <input
+                    type="text"
+                    x-model="$store.oauthConfig.providerUiFor(card.provider_id).quota_project_id"
+                    name="quota_project_id"
+                    placeholder="Optional Google Cloud project ID"
+                  />
+                </label>
+              </div>
+
+              <div class="oauth-device" x-show="$store.oauthConfig.devices[card.provider_id]?.user_code">
+                <span>Enter this code</span>
+                <strong x-text="$store.oauthConfig.devices[card.provider_id]?.user_code"></strong>
+                <button class="text-button" type="button" @click="$store.oauthConfig.cancelConnect(card.provider_id)">
+                  <span class="material-symbols-outlined">close</span>
+                  <span>Cancel</span>
+                </button>
+              </div>
+
+              <div class="oauth-manual-callback" x-show="card.supports_manual_callback && $store.oauthConfig.devices[card.provider_id]?.flow === 'browser_pkce' && !card.connected">
+                <input
+                  type="text"
+                  x-model="$store.oauthConfig.providerUiFor(card.provider_id).manualCallback"
+                  placeholder="Paste callback URL, query string, or code"
+                />
+                <button type="button" class="oauth-connect secondary" @click="$store.oauthConfig.submitManualCallback(card.provider_id)">
+                  <span class="material-symbols-outlined">check</span>
+                  <span>Submit</span>
+                </button>
+                <button type="button" class="oauth-connect secondary" @click="$store.oauthConfig.cancelConnect(card.provider_id)">
+                  <span class="material-symbols-outlined">close</span>
+                  <span>Cancel</span>
+                </button>
+              </div>
+
+              <div class="oauth-auth-attempt" x-show="$store.oauthConfig.devices[card.provider_id] && !$store.oauthConfig.devices[card.provider_id]?.user_code && !card.supports_manual_callback">
+                <span>Sign-in started</span>
+                <button class="text-button" type="button" @click="$store.oauthConfig.cancelConnect(card.provider_id)">
+                  <span class="material-symbols-outlined">close</span>
+                  <span>Cancel</span>
+                </button>
+              </div>
+
+              <p class="oauth-provider-note" x-show="card.warning || card.note" x-text="card.warning || card.note"></p>
+
+              <div class="oauth-primary">
+                <button
+                  class="oauth-connect"
+                  type="button"
+                  @click="$store.oauthConfig.connectProvider(card.provider_id)"
+                  :disabled="Boolean($store.oauthConfig.connectingProvider) || Boolean($store.oauthConfig.disconnectingProvider)"
+                  x-show="!card.connected"
+                >
+                  <span class="material-symbols-outlined" x-text="$store.oauthConfig.connectingProvider === card.provider_id ? 'progress_activity' : 'login'"></span>
+                  <span x-text="$store.oauthConfig.connectingProvider === card.provider_id ? 'Waiting' : 'Connect'"></span>
+                </button>
+                <button
+                  class="oauth-connect danger"
+                  type="button"
+                  @click="$store.oauthConfig.disconnectProvider(card.provider_id)"
+                  :disabled="$store.oauthConfig.disconnectingProvider === card.provider_id"
+                  x-show="card.connected"
+                >
+                  <span class="material-symbols-outlined" x-text="$store.oauthConfig.disconnectingProvider === card.provider_id ? 'progress_activity' : 'link_off'"></span>
+                  <span x-text="$store.oauthConfig.disconnectingProvider === card.provider_id ? 'Disconnecting' : 'Disconnect'"></span>
+                </button>
+                <button
+                  class="oauth-connect secondary"
+                  type="button"
+                  @click="$store.oauthConfig.loadModels({ providerId: card.provider_id })"
+                  :disabled="!card.connected || $store.oauthConfig.loadingModelsProvider === card.provider_id"
+                >
+                  <span class="material-symbols-outlined" x-text="$store.oauthConfig.loadingModelsProvider === card.provider_id ? 'progress_activity' : 'search'"></span>
+                  <span>Check models</span>
+                </button>
+              </div>
+            </article>
+          </template>
         </section>
 
-        <section class="oauth-device" x-show="$store.oauthConfig.device">
-          <span>Enter this code</span>
-          <strong x-text="$store.oauthConfig.device?.user_code"></strong>
-          <button class="text-button" type="button" @click="$store.oauthConfig.cancelConnect()">
-            <span class="material-symbols-outlined">close</span>
-            <span>Cancel</span>
-          </button>
-        </section>
-
-        <section class="oauth-usage" x-show="$store.oauthConfig.connected() && $store.oauthConfig.usageWindows().length">
-          <template x-for="window in $store.oauthConfig.usageWindows()" :key="window.key">
+        <section class="oauth-usage" x-show="$store.oauthConfig.providerConnected('codex_oauth') && $store.oauthConfig.usageWindows('codex_oauth').length">
+          <template x-for="window in $store.oauthConfig.usageWindows('codex_oauth')" :key="window.key">
             <div class="oauth-usage-window">
               <div class="oauth-usage-head">
                 <span>
@@ -86,23 +159,53 @@
 
         <section class="oauth-status-row">
           <div>
-            <span>Status</span>
-            <strong x-text="$store.oauthConfig.statusLabel()"></strong>
+            <span>OAuth Connections</span>
+            <strong x-text="$store.oauthConfig.providerCards().filter((card) => card.connected).length + ' connected'"></strong>
           </div>
-          <div x-show="$store.oauthConfig.status?.codex?.email">
-            <span>Account</span>
-            <strong x-text="$store.oauthConfig.status?.codex?.email"></strong>
+          <div>
+            <span>Model provider</span>
+            <strong x-text="$store.oauthConfig.providerLabel($store.oauthConfig.activeModelProvider)"></strong>
           </div>
           <button class="oauth-icon-button" type="button" @click="$store.oauthConfig.loadStatus()" title="Refresh status" aria-label="Refresh status">
             <span class="material-symbols-outlined">refresh</span>
           </button>
         </section>
 
+        <section class="oauth-plan-catalog" x-show="$store.oauthConfig.usagePlanEntries().length">
+          <div class="oauth-section-head">
+            <div>
+              <h3>Usage plans</h3>
+              <p>Subscription and billing metadata for account-backed model providers.</p>
+            </div>
+          </div>
+
+          <div class="oauth-plan-grid">
+            <template x-for="entry in $store.oauthConfig.usagePlanEntries()" :key="entry.provider_id">
+              <article class="oauth-plan-card" :class="entry.implemented ? 'is-implemented' : 'is-metadata-only'">
+                <div class="oauth-plan-head">
+                  <strong x-text="entry.display_name"></strong>
+                  <span x-text="$store.oauthConfig.usagePlanStatus(entry)"></span>
+                </div>
+
+                <div class="oauth-plan-list">
+                  <template x-for="plan in entry.plans" :key="entry.provider_id + plan.id">
+                    <span x-text="plan.label"></span>
+                  </template>
+                </div>
+
+                <template x-for="note in $store.oauthConfig.usagePlanNotes(entry)" :key="entry.provider_id + note">
+                  <p x-text="note"></p>
+                </template>
+              </article>
+            </template>
+          </div>
+        </section>
+
         <section class="oauth-model-config">
           <div class="oauth-section-head">
             <div>
               <h3>Agent Zero models</h3>
-              <p>Select the Codex/ChatGPT models used by the Main and Utility model slots.</p>
+              <p>Select OAuth provider models used by the Main model and Utility model slots.</p>
             </div>
             <span class="oauth-save-chip" x-show="$store.oauthConfig.modelConfigDirty">Pending changes</span>
           </div>
@@ -119,27 +222,26 @@
                     <span class="oauth-model-icon material-symbols-outlined" x-text="slot.icon"></span>
                     <div class="oauth-model-title">
                       <strong x-text="slot.title"></strong>
-                      <span
-                        x-show="!$store.oauthConfig.slotUsesCodex(slot.key)"
-                        x-text="$store.oauthConfig.slotStatusLabel(slot.key)"
-                      ></span>
+                      <span x-text="$store.oauthConfig.slotStatusLabel(slot.key)"></span>
                     </div>
                     <div class="oauth-model-actions">
-                      <button
-                        class="oauth-model-action"
-                        type="button"
-                        x-show="!$store.oauthConfig.slotUsesCodex(slot.key)"
-                        @click="$store.oauthConfig.useCodexForSlot(slot.key)"
-                      >
-                        <span class="material-symbols-outlined">swap_horiz</span>
-                        <span>Use Codex</span>
-                      </button>
+                      <template x-for="provider in $store.oauthConfig.providerCards().filter((card) => card.connected)" :key="slot.key + provider.provider_id">
+                        <button
+                          class="oauth-model-action"
+                          type="button"
+                          x-show="!$store.oauthConfig.slotUsesProvider(slot.key, provider.provider_id)"
+                          @click="$store.oauthConfig.useProviderForSlot(slot.key, provider.provider_id)"
+                        >
+                          <span class="material-symbols-outlined">swap_horiz</span>
+                          <span x-text="$store.oauthConfig.providerUseLabel(provider.provider_id)"></span>
+                        </button>
+                      </template>
                       <button
                         class="oauth-model-action icon"
                         type="button"
                         title="Copy Main model"
                         aria-label="Copy Main model"
-                        x-show="slot.key === 'utility_model' && $store.oauthConfig.slotUsesCodex('chat_model')"
+                        x-show="slot.key === 'utility_model' && $store.oauthConfig.slotUsesOauth('chat_model')"
                         @click="$store.oauthConfig.copyMainToUtility()"
                       >
                         <span class="material-symbols-outlined">content_copy</span>
@@ -156,24 +258,24 @@
                         x-model="$store.oauthConfig.modelSlot(slot.key).name"
                         @input="$store.oauthConfig.markModelDirty(slot.key)"
                         @focus="$store.oauthConfig.openModelDropdown(slot.key)"
-                        :disabled="!$store.oauthConfig.slotUsesCodex(slot.key)"
-                        placeholder="Search or enter a Codex model"
+                        :disabled="!$store.oauthConfig.slotUsesOauth(slot.key)"
+                        placeholder="Search or enter a provider model"
                       />
                       <button
                         class="oauth-model-search"
                         type="button"
-                        title="Search available Codex models"
-                        aria-label="Search available Codex models"
-                        @click="$store.oauthConfig.loadModels({ openDropdown: slot.key })"
-                        :disabled="!$store.oauthConfig.slotUsesCodex(slot.key) || !$store.oauthConfig.connected() || $store.oauthConfig.loadingModels"
+                        title="Check models"
+                        aria-label="Check models"
+                        @click="$store.oauthConfig.loadModels({ providerId: $store.oauthConfig.modelSlot(slot.key).provider, openDropdown: slot.key })"
+                        :disabled="!$store.oauthConfig.slotUsesOauth(slot.key) || !$store.oauthConfig.providerConnected($store.oauthConfig.modelSlot(slot.key).provider) || $store.oauthConfig.loadingModelsProvider === $store.oauthConfig.modelSlot(slot.key).provider"
                       >
-                        <span class="material-symbols-outlined" x-text="$store.oauthConfig.loadingModels ? 'progress_activity' : 'search'"></span>
+                        <span class="material-symbols-outlined" x-text="$store.oauthConfig.loadingModelsProvider === $store.oauthConfig.modelSlot(slot.key).provider ? 'progress_activity' : 'search'"></span>
                       </button>
                     </div>
 
                     <div
                       class="oauth-model-dropdown"
-                      x-show="$store.oauthConfig.modelDropdown[slot.key]?.open && !$store.oauthConfig.loadingModels"
+                      x-show="$store.oauthConfig.modelDropdown[slot.key]?.open && !$store.oauthConfig.loadingModelsProvider"
                       x-transition.opacity
                     >
                       <template x-for="model in $store.oauthConfig.filteredModels(slot.key)" :key="slot.key + model">
@@ -199,7 +301,7 @@
           <div class="oauth-section-head">
             <div>
               <h3>Available models</h3>
-              <p>Available models from Codex account</p>
+              <p>Available models from selected provider</p>
             </div>
           </div>
           <div class="oauth-models">
@@ -214,8 +316,8 @@
 
           <div class="oauth-details">
             <div>
-              <span>Endpoint</span>
-              <code x-text="$store.oauthConfig.endpointUrl()"></code>
+              <span>Codex endpoint</span>
+              <code x-text="$store.oauthConfig.providerEndpointUrl('codex_oauth')"></code>
             </div>
             <div>
               <span>Auth file</span>
@@ -230,19 +332,19 @@
               <small>Use an Agent Zero-owned file. Shared Codex CLI auth files are rejected.</small>
             </label>
             <label>
-              <span>Issuer</span>
+              <span>Codex issuer</span>
               <input type="text" x-model="$store.oauthConfig.codex().issuer" />
             </label>
             <label>
-              <span>Token URL</span>
+              <span>Codex token URL</span>
               <input type="text" x-model="$store.oauthConfig.codex().token_url" />
             </label>
             <label>
-              <span>Base path</span>
+              <span>Codex base path</span>
               <input type="text" x-model="$store.oauthConfig.codex().proxy_base_path" />
             </label>
             <label>
-              <span>Upstream URL</span>
+              <span>Codex upstream URL</span>
               <input type="text" x-model="$store.oauthConfig.codex().upstream_base_url" />
             </label>
             <label>
@@ -250,11 +352,11 @@
               <input type="text" x-model="$store.oauthConfig.codex().codex_version" placeholder="Auto" />
             </label>
             <label class="oauth-switch">
-              <span>Require proxy token</span>
+              <span>Codex proxy token required</span>
               <input type="checkbox" x-model="$store.oauthConfig.codex().require_proxy_token" />
             </label>
             <label>
-              <span>Proxy token</span>
+              <span>Codex proxy token</span>
               <input type="password" x-model="$store.oauthConfig.codex().proxy_token" autocomplete="off" />
             </label>
           </div>
@@ -271,53 +373,69 @@
       color: var(--color-text);
     }
 
-    .oauth-hero {
+    .oauth-provider-grid {
       display: grid;
-      grid-template-columns: 52px minmax(0, 1fr) auto;
-      align-items: center;
-      gap: 16px;
-      min-height: 118px;
-      padding: 18px;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .oauth-provider-card {
+      display: grid;
+      align-content: start;
+      gap: 14px;
+      min-width: 0;
+      min-height: 188px;
+      padding: 16px;
       border: 1px solid var(--color-border);
       border-radius: 8px;
       background: color-mix(in srgb, var(--color-panel) 86%, transparent);
     }
 
+    .oauth-provider-card.is-connected .oauth-mark {
+      color: #08120c;
+      background: #35d07f;
+    }
+
+    .oauth-provider-head {
+      display: grid;
+      grid-template-columns: 48px minmax(0, 1fr);
+      align-items: center;
+      gap: 12px;
+    }
+
     .oauth-mark {
       display: grid;
-      width: 52px;
-      height: 52px;
+      width: 48px;
+      height: 48px;
       place-items: center;
       border-radius: 50%;
       background: color-mix(in srgb, var(--color-border) 52%, transparent);
     }
 
     .oauth-mark .material-symbols-outlined {
-      font-size: 28px;
-    }
-
-    .oauth-hero.is-connected .oauth-mark {
-      color: #08120c;
-      background: #35d07f;
+      font-size: 26px;
     }
 
     .oauth-copy h2 {
       margin: 0 0 4px;
-      font-size: 1.35rem;
+      font-size: 1rem;
       letter-spacing: 0;
     }
 
     .oauth-copy p {
+      overflow: hidden;
       margin: 0;
       color: var(--color-text-secondary);
-      font-size: 0.88rem;
-      line-height: 1.4;
+      font-size: 0.82rem;
+      line-height: 1.35;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .oauth-primary {
       display: flex;
       flex-wrap: wrap;
-      justify-content: flex-end;
+      justify-content: flex-start;
       gap: 8px;
     }
 
@@ -326,21 +444,22 @@
       align-items: center;
       justify-content: center;
       gap: 8px;
-      min-width: 124px;
-      min-height: 40px;
-      padding: 0 16px;
+      min-width: 112px;
+      min-height: 38px;
+      padding: 0 13px;
       border: 0;
       border-radius: 8px;
       background: #f5f7fa;
       color: #111418;
       font: inherit;
-      font-size: 0.88rem;
+      font-size: 0.84rem;
       font-weight: 750;
       cursor: pointer;
     }
 
     .oauth-connect.secondary {
-      background: color-mix(in srgb, var(--color-border) 60%, transparent);
+      border: 1px solid color-mix(in srgb, var(--color-border) 76%, transparent);
+      background: color-mix(in srgb, var(--color-border) 44%, transparent);
       color: var(--color-text);
     }
 
@@ -355,12 +474,68 @@
       opacity: .65;
     }
 
+    .oauth-provider-input,
+    .oauth-provider-fields,
+    .oauth-manual-callback,
+    .oauth-auth-attempt {
+      display: grid;
+      min-width: 0;
+      gap: 6px;
+    }
+
+    .oauth-provider-fields {
+      gap: 8px;
+    }
+
+    .oauth-manual-callback {
+      grid-template-columns: minmax(0, 1fr) auto auto;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .oauth-auth-attempt {
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center;
+      padding: 10px 12px;
+      border: 1px solid color-mix(in srgb, #f5f7fa 18%, var(--color-border));
+      border-radius: 8px;
+      background: color-mix(in srgb, #f5f7fa 7%, var(--color-panel));
+    }
+
+    .oauth-provider-input span,
+    .oauth-auth-attempt span {
+      color: var(--color-text-secondary);
+      font-size: 0.76rem;
+      font-weight: 700;
+    }
+
+    .oauth-provider-input input,
+    .oauth-manual-callback input {
+      width: 100%;
+      min-width: 0;
+      min-height: 36px;
+      padding: 7px 10px;
+      border: 1px solid color-mix(in srgb, var(--color-border) 74%, transparent);
+      border-radius: 8px;
+      background: var(--color-input);
+      color: var(--color-text);
+      font: inherit;
+      font-size: 0.82rem;
+    }
+
+    .oauth-provider-note {
+      margin: 0;
+      color: var(--color-text-secondary);
+      font-size: 0.76rem;
+      line-height: 1.35;
+    }
+
     .oauth-device {
       display: grid;
       grid-template-columns: minmax(0, 1fr) auto auto;
       align-items: center;
-      gap: 14px;
-      padding: 14px 16px;
+      gap: 10px;
+      padding: 10px 12px;
       border: 1px solid color-mix(in srgb, #f5f7fa 18%, var(--color-border));
       border-radius: 8px;
       background: color-mix(in srgb, #f5f7fa 7%, var(--color-panel));
@@ -368,12 +543,12 @@
 
     .oauth-device span {
       color: var(--color-text-secondary);
-      font-size: 0.84rem;
+      font-size: 0.78rem;
       font-weight: 700;
     }
 
     .oauth-device strong {
-      font-size: 1.45rem;
+      font-size: 1.12rem;
       letter-spacing: 0;
     }
 
@@ -496,6 +671,81 @@
       border: 0;
     }
 
+    .oauth-plan-catalog {
+      display: grid;
+      gap: 12px;
+      padding: 0;
+      border: 0;
+    }
+
+    .oauth-plan-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .oauth-plan-card {
+      display: grid;
+      min-width: 0;
+      align-content: start;
+      gap: 10px;
+      padding: 12px;
+      border: 1px solid var(--color-border);
+      border-radius: 8px;
+      background: color-mix(in srgb, var(--color-panel) 82%, transparent);
+    }
+
+    .oauth-plan-card.is-metadata-only {
+      border-style: dashed;
+    }
+
+    .oauth-plan-head {
+      display: flex;
+      min-width: 0;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+    }
+
+    .oauth-plan-head strong {
+      overflow: hidden;
+      font-size: 0.88rem;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .oauth-plan-head span {
+      flex: 0 0 auto;
+      padding: 2px 7px;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--color-border) 48%, transparent);
+      color: var(--color-text-secondary);
+      font-size: 0.68rem;
+      font-weight: 750;
+    }
+
+    .oauth-plan-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .oauth-plan-list span {
+      padding: 4px 7px;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--color-border) 34%, transparent);
+      color: var(--color-text-secondary);
+      font-size: 0.72rem;
+      line-height: 1.2;
+    }
+
+    .oauth-plan-card p {
+      margin: 0;
+      color: var(--color-text-secondary);
+      font-size: 0.74rem;
+      line-height: 1.35;
+    }
+
     .oauth-models-panel {
       display: grid;
       gap: 10px;
@@ -592,7 +842,9 @@
 
     .oauth-model-actions {
       display: flex;
+      flex-wrap: wrap;
       align-items: center;
+      justify-content: flex-end;
       gap: 6px;
     }
 
@@ -724,7 +976,7 @@
 
     .oauth-details div {
       display: grid;
-      grid-template-columns: 84px minmax(0, 1fr);
+      grid-template-columns: 116px minmax(0, 1fr);
       align-items: center;
       gap: 10px;
     }
@@ -793,15 +1045,23 @@
       font-size: 0.76rem;
     }
 
+    @media (max-width: 980px) {
+      .oauth-provider-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+
     @media (max-width: 720px) {
-      .oauth-hero,
       .oauth-device,
       .oauth-usage,
       .oauth-status-row,
+      .oauth-plan-grid,
       .oauth-model-grid,
       .oauth-model-head,
       .oauth-grid,
-      .oauth-details div {
+      .oauth-details div,
+      .oauth-manual-callback,
+      .oauth-auth-attempt {
         grid-template-columns: 1fr;
       }
 

--- a/plugins/_oauth/webui/oauth-config-store.js
+++ b/plugins/_oauth/webui/oauth-config-store.js
@@ -322,8 +322,8 @@ export const store = createStore("oauthConfig", {
       .filter((entry) => entry && Array.isArray(entry.plans) && entry.plans.length);
   },
 
-  usagePlanStatus(entry) {
-    return entry?.implemented ? "Provider available" : "Metadata only";
+  usagePlanStatus() {
+    return "Provider available";
   },
 
   usagePlanNotes(entry) {

--- a/plugins/_oauth/webui/oauth-config-store.js
+++ b/plugins/_oauth/webui/oauth-config-store.js
@@ -284,14 +284,6 @@ export const store = createStore("oauthConfig", {
     return path ? `${window.location.origin}${path}` : "";
   },
 
-  connected() {
-    return this.providerConnected(CODEX_PROVIDER);
-  },
-
-  statusLabel() {
-    return this.providerStatusLabel(CODEX_PROVIDER);
-  },
-
   usage(providerId = CODEX_PROVIDER) {
     return this.providerStatus(providerId)?.usage || null;
   },
@@ -364,14 +356,6 @@ export const store = createStore("oauthConfig", {
     return `${Math.round(hours / 24)}d`;
   },
 
-  endpointUrl() {
-    return this.providerEndpointUrl(CODEX_PROVIDER);
-  },
-
-  callbackUrl() {
-    return this.providerCallbackUrl(CODEX_PROVIDER);
-  },
-
   installSettingsHooks(context) {
     if (!context || context.__oauthConfigHooksInstalled) return;
 
@@ -429,10 +413,6 @@ export const store = createStore("oauthConfig", {
     return this.modelSlot(key).provider === providerId;
   },
 
-  slotUsesCodex(key) {
-    return this.slotUsesProvider(key, CODEX_PROVIDER);
-  },
-
   providerName(provider) {
     if (!provider) return "Not configured";
     const found = (modelConfigStore.chatProviders || []).find((item) => item.value === provider);
@@ -468,10 +448,6 @@ export const store = createStore("oauthConfig", {
     } else if (this.providerConnected(providerId)) {
       void this.loadModels({ providerId, openDropdown: key, silent: true });
     }
-  },
-
-  useCodexForSlot(key) {
-    this.useProviderForSlot(key, CODEX_PROVIDER);
   },
 
   copyMainToUtility() {
@@ -634,10 +610,6 @@ export const store = createStore("oauthConfig", {
       this.connecting = false;
       void toastFrontendError(messageOf(error), "OAuth Connections");
     }
-  },
-
-  connectCodex() {
-    return this.connectProvider(CODEX_PROVIDER);
   },
 
   startPolling(providerId = CODEX_PROVIDER) {
@@ -857,10 +829,6 @@ export const store = createStore("oauthConfig", {
       if (this.disconnectingProvider === providerId) this.disconnectingProvider = "";
       this.disconnecting = Boolean(this.disconnectingProvider);
     }
-  },
-
-  disconnectCodex() {
-    return this.disconnectProvider(CODEX_PROVIDER);
   },
 
   cancelConnect(providerId = "") {

--- a/plugins/_oauth/webui/oauth-config-store.js
+++ b/plugins/_oauth/webui/oauth-config-store.js
@@ -9,12 +9,19 @@ import {
 
 const MODEL_CONFIG_API = "/plugins/_model_config";
 const STATUS_API = "/plugins/_oauth/status";
-const START_DEVICE_LOGIN_API = "/plugins/_oauth/start_device_login";
-const POLL_DEVICE_LOGIN_API = "/plugins/_oauth/poll_device_login";
+const START_LOGIN_API = "/plugins/_oauth/start_login";
+const POLL_LOGIN_API = "/plugins/_oauth/poll_device_login";
+const MANUAL_CALLBACK_API = "/plugins/_oauth/manual_callback";
 const MODELS_API = "/plugins/_oauth/models";
 const DISCONNECT_API = "/plugins/_oauth/disconnect";
 const MAX_POLL_MS = 120000;
 const CODEX_PROVIDER = "codex_oauth";
+const PROVIDER_MARKS = {
+  github: "terminal",
+  google: "cloud",
+  openai: "key",
+  xai: "neurology",
+};
 const MODEL_SLOTS = [
   {
     key: "chat_model",
@@ -46,6 +53,17 @@ function ensureConfig(config) {
   codex.proxy_token = String(codex.proxy_token || "");
   codex.codex_version = String(codex.codex_version || "");
   codex.models = Array.isArray(codex.models) ? codex.models : [];
+
+  config.gemini_api = config.gemini_api && typeof config.gemini_api === "object" ? config.gemini_api : {};
+  const geminiApi = config.gemini_api;
+  geminiApi.enabled = geminiApi.enabled !== false;
+  geminiApi.client_id = String(geminiApi.client_id || "");
+  geminiApi.client_secret = String(geminiApi.client_secret || "");
+  geminiApi.quota_project_id = String(geminiApi.quota_project_id || "");
+  geminiApi.scopes = Array.isArray(geminiApi.scopes) ? geminiApi.scopes : [];
+  geminiApi.api_base_url = String(geminiApi.api_base_url || "https://generativelanguage.googleapis.com/v1beta/openai");
+  geminiApi.proxy_base_path = String(geminiApi.proxy_base_path || "/oauth/gemini-api");
+  geminiApi.callback_path = String(geminiApi.callback_path || "/oauth/gemini-api/callback");
   return config;
 }
 
@@ -77,6 +95,10 @@ function messageOf(error) {
   return error instanceof Error ? error.message : String(error);
 }
 
+function providerUiDefaults() {
+  return {};
+}
+
 export const store = createStore("oauthConfig", {
   config: null,
   status: null,
@@ -84,6 +106,12 @@ export const store = createStore("oauthConfig", {
   connecting: false,
   disconnecting: false,
   loadingModels: false,
+  providerModels: {},
+  providerUi: providerUiDefaults(),
+  connectingProvider: "",
+  disconnectingProvider: "",
+  loadingModelsProvider: "",
+  activeModelProvider: CODEX_PROVIDER,
   models: [],
   modelSlots: MODEL_SLOTS,
   modelConfig: null,
@@ -98,9 +126,13 @@ export const store = createStore("oauthConfig", {
     chat_model: { open: false },
     utility_model: { open: false },
   },
+  devices: {},
+  pollTimers: {},
+  pollStartedAt: {},
+  callbackPollTimers: {},
+  callbackPollStartedAt: {},
   device: null,
   pollTimer: null,
-  pollStartedAt: 0,
 
   async init(config, context = null) {
     this.bindConfig(config);
@@ -110,8 +142,18 @@ export const store = createStore("oauthConfig", {
 
   cleanup() {
     this.stopPolling();
+    this.stopCallbackPolling();
     this.config = null;
     this.status = null;
+    this.connecting = false;
+    this.disconnecting = false;
+    this.loadingModels = false;
+    this.providerModels = {};
+    this.providerUi = providerUiDefaults();
+    this.connectingProvider = "";
+    this.disconnectingProvider = "";
+    this.loadingModelsProvider = "";
+    this.activeModelProvider = CODEX_PROVIDER;
     this.models = [];
     this.modelConfig = null;
     this.modelConfigLoading = false;
@@ -122,6 +164,10 @@ export const store = createStore("oauthConfig", {
       chat_model: { open: false },
       utility_model: { open: false },
     };
+    this.devices = {};
+    this.pollStartedAt = {};
+    this.callbackPollTimers = {};
+    this.callbackPollStartedAt = {};
     this.device = null;
   },
 
@@ -136,26 +182,152 @@ export const store = createStore("oauthConfig", {
     return this.config?.codex || {};
   },
 
+  geminiApi() {
+    return this.config?.gemini_api || {};
+  },
+
+  providerMap() {
+    const mapped = this.status?.provider_map;
+    if (mapped && typeof mapped === "object") return mapped;
+    const providers = Array.isArray(this.status?.providers) ? this.status.providers : [];
+    return providers.reduce((result, provider) => {
+      if (provider?.provider_id) result[provider.provider_id] = provider;
+      return result;
+    }, {});
+  },
+
+  providerStatus(providerId) {
+    return this.providerMap()[providerId] || {};
+  },
+
+  providerUiFor(providerId) {
+    const key = String(providerId || "");
+    if (!key) return {};
+    if (!this.providerUi[key]) {
+      this.providerUi = {
+        ...this.providerUi,
+        [key]: {
+          enterprise_domain: "",
+          manualCallback: "",
+          client_id: "",
+          client_secret: "",
+          quota_project_id: "",
+        },
+      };
+    }
+    return this.providerUi[key];
+  },
+
+  providerCards() {
+    const map = this.providerMap();
+    const providers = Array.isArray(this.status?.providers)
+      ? this.status.providers
+      : Object.values(map);
+    return providers
+      .filter((provider) => provider?.provider_id)
+      .map((status) => {
+        const providerId = status.provider_id;
+        return {
+          ...status,
+          provider_id: providerId,
+          connected: Boolean(status.connected),
+          mark: status.mark || PROVIDER_MARKS[status.icon] || "key",
+          use_label: status.use_label || `Use ${status.short_name || status.display_name || providerId}`,
+          device: this.devices[providerId] || null,
+          connecting: this.connectingProvider === providerId,
+          disconnecting: this.disconnectingProvider === providerId,
+          loadingModels: this.loadingModelsProvider === providerId,
+        };
+      });
+  },
+
+  providerIds() {
+    return this.providerCards().map((card) => card.provider_id);
+  },
+
+  isOauthProvider(providerId) {
+    const key = String(providerId || "");
+    return Boolean(key && this.providerMap()[key]);
+  },
+
+  providerConnected(providerId) {
+    return Boolean(this.providerStatus(providerId)?.connected);
+  },
+
+  providerLabel(providerId) {
+    const status = this.providerStatus(providerId);
+    return status.display_name || providerId;
+  },
+
+  providerUseLabel(providerId) {
+    const status = this.providerStatus(providerId);
+    return status.use_label || `Use ${status.short_name || status.display_name || providerId}`;
+  },
+
+  providerStatusLabel(providerId) {
+    if (this.loadingStatus) return "Checking";
+    const status = this.providerStatus(providerId);
+    if (!status.connected) return "Not connected";
+    return status.account_label || status.email || "Connected";
+  },
+
+  providerEndpointUrl(providerId) {
+    const status = this.providerStatus(providerId);
+    const proxyBase = String(status.proxy_base_path || "").replace(/\/$/, "");
+    const base = status.v1_base_path || (proxyBase ? `${proxyBase}/v1` : "");
+    return base ? `${window.location.origin}${base}` : "";
+  },
+
+  providerCallbackUrl(providerId) {
+    const status = this.providerStatus(providerId);
+    const path = status.callback_path || "";
+    return path ? `${window.location.origin}${path}` : "";
+  },
+
   connected() {
-    return Boolean(this.status?.codex?.connected);
+    return this.providerConnected(CODEX_PROVIDER);
   },
 
   statusLabel() {
-    if (this.loadingStatus) return "Checking";
-    return this.connected() ? "Connected" : "Not connected";
+    return this.providerStatusLabel(CODEX_PROVIDER);
   },
 
-  usage() {
-    return this.status?.codex?.usage || null;
+  usage(providerId = CODEX_PROVIDER) {
+    return this.providerStatus(providerId)?.usage || null;
   },
 
-  usageWindows() {
-    const usage = this.usage();
+  usageWindows(providerId = CODEX_PROVIDER) {
+    const usage = this.usage(providerId);
     if (!usage?.available) return [];
     return [
       { key: "primary", title: "Session", ...(usage.primary || {}) },
       { key: "secondary", title: "Week", ...(usage.secondary || {}) },
     ].filter((window) => Number.isFinite(this.remainingPercent(window)));
+  },
+
+  usagePlanCatalog() {
+    const catalog = this.status?.usage_plan_catalog;
+    return catalog && typeof catalog === "object" ? catalog : {};
+  },
+
+  usagePlanEntries() {
+    const catalog = this.usagePlanCatalog();
+    const providerIds = this.providerIds();
+    const ids = [
+      ...providerIds,
+      ...Object.keys(catalog).filter((providerId) => !providerIds.includes(providerId)),
+    ];
+    return ids
+      .map((providerId) => catalog[providerId])
+      .filter((entry) => entry && Array.isArray(entry.plans) && entry.plans.length);
+  },
+
+  usagePlanStatus(entry) {
+    return entry?.implemented ? "Provider available" : "Metadata only";
+  },
+
+  usagePlanNotes(entry) {
+    return Array.isArray(entry?.notes) ? entry.notes.slice(0, 2) : [];
   },
 
   usageWidth(window) {
@@ -193,13 +365,11 @@ export const store = createStore("oauthConfig", {
   },
 
   endpointUrl() {
-    const base = this.codex().proxy_base_path || "/oauth/codex";
-    return `${window.location.origin}${base}/v1`;
+    return this.providerEndpointUrl(CODEX_PROVIDER);
   },
 
   callbackUrl() {
-    const path = this.codex().callback_path || "/auth/callback";
-    return `${window.location.origin}${path}`;
+    return this.providerCallbackUrl(CODEX_PROVIDER);
   },
 
   installSettingsHooks(context) {
@@ -251,19 +421,27 @@ export const store = createStore("oauthConfig", {
     return this.modelConfig[key];
   },
 
+  slotUsesOauth(key) {
+    return this.isOauthProvider(this.modelSlot(key).provider);
+  },
+
+  slotUsesProvider(key, providerId) {
+    return this.modelSlot(key).provider === providerId;
+  },
+
   slotUsesCodex(key) {
-    return this.modelSlot(key).provider === CODEX_PROVIDER;
+    return this.slotUsesProvider(key, CODEX_PROVIDER);
   },
 
   providerName(provider) {
     if (!provider) return "Not configured";
     const found = (modelConfigStore.chatProviders || []).find((item) => item.value === provider);
-    return found?.label || provider;
+    return found?.label || this.providerLabel(provider);
   },
 
   slotStatusLabel(key) {
     const slot = this.modelSlot(key);
-    if (slot.provider === CODEX_PROVIDER) return "";
+    if (this.slotUsesOauth(key)) return `Using ${this.providerLabel(slot.provider)}`;
     return `Currently ${this.providerName(slot.provider)}`;
   },
 
@@ -272,39 +450,50 @@ export const store = createStore("oauthConfig", {
     this.modelSlotDirty = { ...this.modelSlotDirty, [key]: true };
   },
 
-  useCodexForSlot(key) {
+  useProviderForSlot(key, providerId) {
+    if (!this.isOauthProvider(providerId)) return;
     const slot = this.modelSlot(key);
     const previousProvider = slot.provider;
-    slot.provider = CODEX_PROVIDER;
+    slot.provider = providerId;
     slot.api_base = "";
-    if (previousProvider && previousProvider !== CODEX_PROVIDER) {
+    if (previousProvider && previousProvider !== providerId) {
       slot.name = "";
     }
     if (!slot.kwargs || typeof slot.kwargs !== "object") slot.kwargs = {};
+    this.activeModelProvider = providerId;
+    this.models = this.providerModels[providerId] || [];
     this.markModelDirty(key);
     if (this.models.length) {
       this.openModelDropdown(key);
-    } else {
-      void this.loadModels({ openDropdown: key, silent: true });
+    } else if (this.providerConnected(providerId)) {
+      void this.loadModels({ providerId, openDropdown: key, silent: true });
     }
+  },
+
+  useCodexForSlot(key) {
+    this.useProviderForSlot(key, CODEX_PROVIDER);
   },
 
   copyMainToUtility() {
     if (!this.modelConfig) return;
     const main = this.modelSlot("chat_model");
     const utility = this.modelSlot("utility_model");
-    utility.provider = CODEX_PROVIDER;
+    utility.provider = main.provider || "";
     utility.name = main.name || "";
     utility.api_base = main.api_base || "";
     utility.kwargs = clone(main.kwargs || {});
+    this.activeModelProvider = utility.provider || this.activeModelProvider;
     this.markModelDirty("utility_model");
   },
 
   openModelDropdown(key) {
-    if (!this.slotUsesCodex(key)) return;
+    if (!this.slotUsesOauth(key)) return;
+    const providerId = this.modelSlot(key).provider;
+    this.activeModelProvider = providerId;
+    this.models = this.providerModels[providerId] || [];
     this.modelDropdown[key] = { ...this.modelDropdown[key], open: true };
-    if (!this.models.length && !this.loadingModels) {
-      void this.loadModels({ openDropdown: key, silent: true });
+    if (!this.models.length && !this.loadingModelsProvider && this.providerConnected(providerId)) {
+      void this.loadModels({ providerId, openDropdown: key, silent: true });
     }
   },
 
@@ -313,8 +502,9 @@ export const store = createStore("oauthConfig", {
   },
 
   filteredModels(key) {
-    const query = String(this.modelSlot(key).name || "").trim().toLowerCase();
-    const models = this.models || [];
+    const slot = this.modelSlot(key);
+    const query = String(slot.name || "").trim().toLowerCase();
+    const models = this.providerModels[slot.provider] || this.models || [];
     const filtered = query
       ? models.filter((model) => String(model).toLowerCase().includes(query))
       : models;
@@ -323,7 +513,12 @@ export const store = createStore("oauthConfig", {
 
   selectModel(key, model) {
     const slot = this.modelSlot(key);
-    slot.provider = CODEX_PROVIDER;
+    const providerId = this.isOauthProvider(this.activeModelProvider)
+      ? this.activeModelProvider
+      : slot.provider;
+    if (this.isOauthProvider(providerId)) {
+      slot.provider = providerId;
+    }
     slot.name = model;
     this.markModelDirty(key);
     this.closeModelDropdown(key);
@@ -334,7 +529,7 @@ export const store = createStore("oauthConfig", {
     for (const slot of MODEL_SLOTS) {
       if (!this.modelSlotDirty[slot.key]) continue;
       const model = this.modelSlot(slot.key);
-      if (model.provider === CODEX_PROVIDER && !String(model.name || "").trim()) {
+      if (this.isOauthProvider(model.provider) && !String(model.name || "").trim()) {
         throw new Error(`Choose a ${slot.title} before saving.`);
       }
     }
@@ -370,6 +565,21 @@ export const store = createStore("oauthConfig", {
     try {
       const response = await callJsonApi(STATUS_API, {});
       this.status = response;
+      for (const card of this.providerCards()) {
+        const ui = this.providerUiFor(card.provider_id);
+        if (card.enterprise_domain && !ui.enterprise_domain) {
+          ui.enterprise_domain = card.enterprise_domain;
+        }
+        if (card.client_id && !ui.client_id) {
+          ui.client_id = card.client_id;
+        }
+        if (card.quota_project_id && !ui.quota_project_id) {
+          ui.quota_project_id = card.quota_project_id;
+        }
+      }
+      if (!this.isOauthProvider(this.activeModelProvider)) {
+        this.activeModelProvider = this.providerCards()[0]?.provider_id || CODEX_PROVIDER;
+      }
     } catch (error) {
       void toastFrontendError(messageOf(error), "OAuth Connections");
     } finally {
@@ -377,115 +587,294 @@ export const store = createStore("oauthConfig", {
     }
   },
 
-  async connectCodex() {
-    if (this.connecting) return;
+  async connectProvider(providerId) {
+    if (!this.isOauthProvider(providerId) || this.connectingProvider) return;
+    this.connectingProvider = providerId;
     this.connecting = true;
     try {
-      const response = await callJsonApi(START_DEVICE_LOGIN_API, {});
-      if (!response?.ok || !response.verification_url || !response.attempt_id) {
-        throw new Error(response?.error || "Could not start Codex sign-in.");
+      const payload = { provider_id: providerId };
+      const status = this.providerStatus(providerId);
+      const ui = this.providerUiFor(providerId);
+      if (status.supports_enterprise_domain) {
+        payload.enterprise_domain = ui.enterprise_domain || "";
       }
-      this.device = response;
-      window.open(response.verification_url, "_blank", "noopener,noreferrer");
-      void toastFrontendInfo("Enter the code shown here in the opened browser tab.", "OAuth Connections");
-      this.startPolling();
+      if (status.supports_oauth_client_config) {
+        payload.client_id = ui.client_id || this.geminiApi().client_id || "";
+        payload.client_secret = ui.client_secret || this.geminiApi().client_secret || "";
+      }
+      if (status.supports_quota_project) {
+        payload.quota_project_id = ui.quota_project_id || this.geminiApi().quota_project_id || "";
+      }
+      const response = await callJsonApi(START_LOGIN_API, payload);
+      if (!response?.ok) {
+        throw new Error(response?.error || `Could not start ${this.providerLabel(providerId)} sign-in.`);
+      }
+
+      this.devices = { ...this.devices, [providerId]: response };
+      if (providerId === CODEX_PROVIDER) this.device = response;
+
+      if (response.flow === "device_code" && response.verification_url && response.attempt_id) {
+        window.open(response.verification_url, "_blank", "noopener,noreferrer");
+        void toastFrontendInfo("Enter the code shown here in the opened browser tab.", "OAuth Connections");
+        this.startPolling(providerId);
+        return;
+      }
+
+      if (response.flow === "browser_pkce" && response.auth_url) {
+        window.open(response.auth_url, "_blank", "noopener,noreferrer");
+        void toastFrontendInfo("Finish sign-in in the opened browser tab.", "OAuth Connections");
+        this.startCallbackPolling(providerId);
+        return;
+      }
+
+      throw new Error(response?.error || `Could not start ${this.providerLabel(providerId)} sign-in.`);
     } catch (error) {
+      this.clearProviderDevice(providerId);
+      this.connectingProvider = "";
       this.connecting = false;
       void toastFrontendError(messageOf(error), "OAuth Connections");
     }
   },
 
-  startPolling() {
-    this.stopPolling();
-    this.pollStartedAt = Date.now();
+  connectCodex() {
+    return this.connectProvider(CODEX_PROVIDER);
+  },
+
+  startPolling(providerId = CODEX_PROVIDER) {
+    this.stopPolling(providerId);
+    this.pollStartedAt = { ...this.pollStartedAt, [providerId]: Date.now() };
     const tick = async () => {
-      if (!this.device?.attempt_id) return;
+      const device = this.devices[providerId];
+      if (!device?.attempt_id) return;
       try {
-        const response = await callJsonApi(POLL_DEVICE_LOGIN_API, {
-          attempt_id: this.device.attempt_id,
+        const response = await callJsonApi(POLL_LOGIN_API, {
+          provider_id: providerId,
+          attempt_id: device.attempt_id,
         });
         if (!response?.ok) {
           if (response?.expired) {
-            this.connecting = false;
-            this.device = null;
-            this.stopPolling();
+            this.clearProviderDevice(providerId);
+            this.stopPolling(providerId);
           }
-          throw new Error(response?.error || "Could not finish Codex sign-in.");
+          throw new Error(response?.error || `Could not finish ${this.providerLabel(providerId)} sign-in.`);
         }
         if (response.completed) {
           await this.loadStatus();
-          this.device = null;
-          this.connecting = false;
-          this.stopPolling();
-          void toastFrontendSuccess("Codex account connected.", "OAuth Connections");
+          this.clearProviderDevice(providerId);
+          this.stopPolling(providerId);
+          if (this.connectingProvider === providerId) this.connectingProvider = "";
+          this.connecting = Boolean(this.connectingProvider);
+          void toastFrontendSuccess(`${this.providerLabel(providerId)} connected.`, "OAuth Connections");
           return;
         }
       } catch (error) {
-        this.connecting = false;
-        this.stopPolling();
+        if (this.connectingProvider === providerId) this.connectingProvider = "";
+        this.connecting = Boolean(this.connectingProvider);
+        this.stopPolling(providerId);
         void toastFrontendError(messageOf(error), "OAuth Connections");
         return;
       }
-      if (Date.now() - this.pollStartedAt > MAX_POLL_MS) {
-        this.connecting = false;
-        this.device = null;
-        this.stopPolling();
-        return;
+      if (Date.now() - Number(this.pollStartedAt[providerId] || 0) > MAX_POLL_MS) {
+        if (this.connectingProvider === providerId) this.connectingProvider = "";
+        this.connecting = Boolean(this.connectingProvider);
+        this.clearProviderDevice(providerId);
+        this.stopPolling(providerId);
       }
     };
+    const delay = Math.max(1500, Number(this.devices[providerId]?.interval || 5) * 1000);
+    this.pollTimers = { ...this.pollTimers, [providerId]: window.setInterval(tick, delay) };
+    if (providerId === CODEX_PROVIDER) this.pollTimer = this.pollTimers[providerId];
     void tick();
-    const delay = Math.max(1500, Number(this.device.interval || 5) * 1000);
-    this.pollTimer = window.setInterval(tick, delay);
   },
 
-  stopPolling() {
-    if (this.pollTimer) window.clearInterval(this.pollTimer);
+  pollProvider(providerId = CODEX_PROVIDER) {
+    this.startPolling(providerId);
+  },
+
+  startCallbackPolling(providerId) {
+    this.stopCallbackPolling(providerId);
+    this.callbackPollStartedAt = { ...this.callbackPollStartedAt, [providerId]: Date.now() };
+    const tick = async () => {
+      await this.loadStatus();
+      if (this.providerConnected(providerId)) {
+        this.clearProviderDevice(providerId);
+        this.stopCallbackPolling(providerId);
+        if (this.connectingProvider === providerId) this.connectingProvider = "";
+        this.connecting = Boolean(this.connectingProvider);
+        void toastFrontendSuccess(`${this.providerLabel(providerId)} connected.`, "OAuth Connections");
+        return;
+      }
+      if (Date.now() - Number(this.callbackPollStartedAt[providerId] || 0) > MAX_POLL_MS) {
+        this.stopCallbackPolling(providerId);
+        if (this.connectingProvider === providerId) this.connectingProvider = "";
+        this.connecting = Boolean(this.connectingProvider);
+      }
+    };
+    this.callbackPollTimers = {
+      ...this.callbackPollTimers,
+      [providerId]: window.setInterval(tick, 2500),
+    };
+    void tick();
+  },
+
+  stopPolling(providerId = "") {
+    if (providerId) {
+      if (this.pollTimers[providerId]) window.clearInterval(this.pollTimers[providerId]);
+      const timers = { ...this.pollTimers };
+      delete timers[providerId];
+      this.pollTimers = timers;
+      const startedAt = { ...this.pollStartedAt };
+      delete startedAt[providerId];
+      this.pollStartedAt = startedAt;
+      if (providerId === CODEX_PROVIDER) this.pollTimer = null;
+      return;
+    }
+
+    for (const timer of Object.values(this.pollTimers || {})) {
+      if (timer) window.clearInterval(timer);
+    }
+    this.pollTimers = {};
+    this.pollStartedAt = {};
     this.pollTimer = null;
   },
 
-  async loadModels({ openDropdown = "", silent = false } = {}) {
-    if (this.loadingModels) return;
-    this.loadingModels = true;
+  stopCallbackPolling(providerId = "") {
+    if (providerId) {
+      if (this.callbackPollTimers[providerId]) window.clearInterval(this.callbackPollTimers[providerId]);
+      const timers = { ...this.callbackPollTimers };
+      delete timers[providerId];
+      this.callbackPollTimers = timers;
+      const startedAt = { ...this.callbackPollStartedAt };
+      delete startedAt[providerId];
+      this.callbackPollStartedAt = startedAt;
+      return;
+    }
+
+    for (const timer of Object.values(this.callbackPollTimers || {})) {
+      if (timer) window.clearInterval(timer);
+    }
+    this.callbackPollTimers = {};
+    this.callbackPollStartedAt = {};
+  },
+
+  clearProviderDevice(providerId = "") {
+    if (!providerId) {
+      this.devices = {};
+      this.device = null;
+      return;
+    }
+    const devices = { ...this.devices };
+    delete devices[providerId];
+    this.devices = devices;
+    if (providerId === CODEX_PROVIDER) this.device = null;
+  },
+
+  async submitManualCallback(providerId) {
+    if (!this.isOauthProvider(providerId)) return;
+    const callback = String(this.providerUiFor(providerId).manualCallback || "").trim();
+    if (!callback) {
+      void toastFrontendError("Paste callback URL, query string, or code.", "OAuth Connections");
+      return;
+    }
+    this.connectingProvider = providerId;
+    this.connecting = true;
     try {
-      const response = await callJsonApi(MODELS_API, {});
-      if (!response?.ok) throw new Error(response?.error || "Could not load Codex models.");
-      this.models = Array.isArray(response.models) ? response.models : [];
-      if (openDropdown) this.openModelDropdown(openDropdown);
-      if (!silent) void toastFrontendSuccess("Codex models loaded.", "OAuth Connections");
+      const response = await callJsonApi(MANUAL_CALLBACK_API, {
+        provider_id: providerId,
+        callback,
+      });
+      if (!response?.ok) {
+        throw new Error(response?.error || `Could not finish ${this.providerLabel(providerId)} sign-in.`);
+      }
+      this.providerUiFor(providerId).manualCallback = "";
+      this.clearProviderDevice(providerId);
+      this.stopCallbackPolling(providerId);
+      await this.loadStatus();
+      void toastFrontendSuccess(`${this.providerLabel(providerId)} connected.`, "OAuth Connections");
     } catch (error) {
+      void toastFrontendError(messageOf(error), "OAuth Connections");
+    } finally {
+      if (this.connectingProvider === providerId) this.connectingProvider = "";
+      this.connecting = Boolean(this.connectingProvider);
+    }
+  },
+
+  async loadModels({ providerId = "", openDropdown = "", silent = false } = {}) {
+    const selectedProvider = providerId || this.activeModelProvider || CODEX_PROVIDER;
+    if (!this.isOauthProvider(selectedProvider) || this.loadingModelsProvider) return;
+    this.loadingModelsProvider = selectedProvider;
+    this.loadingModels = true;
+    this.activeModelProvider = selectedProvider;
+    try {
+      const response = await callJsonApi(MODELS_API, { provider_id: selectedProvider });
+      if (!response?.ok) {
+        throw new Error(response?.error || `Could not load ${this.providerLabel(selectedProvider)} models.`);
+      }
+      const models = Array.isArray(response.models) ? response.models : [];
+      this.providerModels = { ...this.providerModels, [selectedProvider]: models };
+      this.models = models;
+      if (openDropdown) this.openModelDropdown(openDropdown);
+      if (!silent) void toastFrontendSuccess(`${this.providerLabel(selectedProvider)} models loaded.`, "OAuth Connections");
+    } catch (error) {
+      this.providerModels = { ...this.providerModels, [selectedProvider]: [] };
       this.models = [];
       if (!silent) void toastFrontendError(messageOf(error), "OAuth Connections");
     } finally {
+      this.loadingModelsProvider = "";
       this.loadingModels = false;
     }
   },
 
-  async disconnectCodex() {
-    if (this.disconnecting || !this.connected()) return;
-    const confirmed = window.confirm("Disconnect this OpenAI account and remove stored OAuth tokens?");
+  async disconnectProvider(providerId) {
+    if (!this.isOauthProvider(providerId) || this.disconnectingProvider || !this.providerConnected(providerId)) return;
+    const confirmed = window.confirm(`Disconnect ${this.providerLabel(providerId)} and remove stored OAuth tokens?`);
     if (!confirmed) return;
 
+    this.disconnectingProvider = providerId;
     this.disconnecting = true;
     try {
-      const response = await callJsonApi(DISCONNECT_API, {});
+      const response = await callJsonApi(DISCONNECT_API, { provider_id: providerId });
       if (!response?.ok) throw new Error(response?.error || "Could not disconnect the account.");
-      this.status = response.codex ? { ok: true, codex: response.codex } : this.status;
-      this.models = [];
-      this.device = null;
-      this.connecting = false;
-      this.stopPolling();
-      void toastFrontendSuccess("OpenAI account disconnected.", "OAuth Connections");
+      if (response.provider) {
+        const providerMap = { ...this.providerMap(), [providerId]: response.provider };
+        this.status = { ...(this.status || {}), provider_map: providerMap, providers: Object.values(providerMap) };
+        if (providerId === CODEX_PROVIDER) this.status.codex = response.provider;
+      }
+      const providerModels = { ...this.providerModels };
+      delete providerModels[providerId];
+      this.providerModels = providerModels;
+      if (this.activeModelProvider === providerId) this.models = [];
+      this.clearProviderDevice(providerId);
+      if (this.connectingProvider === providerId) this.connectingProvider = "";
+      this.connecting = Boolean(this.connectingProvider);
+      this.stopPolling(providerId);
+      this.stopCallbackPolling(providerId);
+      void toastFrontendSuccess(`${this.providerLabel(providerId)} disconnected.`, "OAuth Connections");
       await this.loadStatus();
     } catch (error) {
       void toastFrontendError(messageOf(error), "OAuth Connections");
     } finally {
-      this.disconnecting = false;
+      if (this.disconnectingProvider === providerId) this.disconnectingProvider = "";
+      this.disconnecting = Boolean(this.disconnectingProvider);
     }
   },
 
-  cancelConnect() {
-    this.connecting = false;
-    this.device = null;
-    this.stopPolling();
+  disconnectCodex() {
+    return this.disconnectProvider(CODEX_PROVIDER);
+  },
+
+  cancelConnect(providerId = "") {
+    if (providerId) {
+      this.stopPolling(providerId);
+      this.stopCallbackPolling(providerId);
+      this.clearProviderDevice(providerId);
+      if (this.connectingProvider === providerId) this.connectingProvider = "";
+    } else {
+      this.stopPolling();
+      this.stopCallbackPolling();
+      this.clearProviderDevice();
+      this.connectingProvider = "";
+    }
+    this.connecting = Boolean(this.connectingProvider);
   },
 });

--- a/tests/test_oauth_codex.py
+++ b/tests/test_oauth_codex.py
@@ -15,8 +15,8 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from plugins._oauth.helpers import codex
 from plugins._oauth.helpers import routes
-from plugins._oauth.extensions.python._functions.models.get_api_key.end._20_codex_account_dummy_key import (
-    CodexAccountDummyKey,
+from plugins._oauth.extensions.python._functions.models.get_api_key.end._20_oauth_account_dummy_key import (
+    OAuthAccountDummyKey,
 )
 
 
@@ -689,7 +689,7 @@ def test_provider_config_uses_container_local_agent_zero_origin():
 def test_codex_provider_reports_dummy_api_key_when_missing():
     data = {"args": ("codex_oauth",), "kwargs": {}, "result": "None"}
 
-    CodexAccountDummyKey(agent=None).execute(data=data)
+    OAuthAccountDummyKey(agent=None).execute(data=data)
 
     assert data["result"] == "oauth"
 
@@ -697,6 +697,6 @@ def test_codex_provider_reports_dummy_api_key_when_missing():
 def test_codex_provider_preserves_configured_api_key():
     data = {"args": ("codex_oauth",), "kwargs": {}, "result": "configured"}
 
-    CodexAccountDummyKey(agent=None).execute(data=data)
+    OAuthAccountDummyKey(agent=None).execute(data=data)
 
     assert data["result"] == "configured"

--- a/tests/test_oauth_gemini_api.py
+++ b/tests/test_oauth_gemini_api.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import time
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+@dataclass(frozen=True)
+class PkcePair:
+    verifier: str
+    challenge: str
+
+
+from plugins._oauth.helpers.providers import gemini_api as gemini
+from plugins._oauth.helpers.providers.base import GEMINI_API_PROVIDER_ID, ProviderError
+from plugins._oauth.helpers.state import pop_attempt, put_attempt
+
+
+def _config() -> dict:
+    return {
+        "enabled": True,
+        "client_id": "client-id.apps.googleusercontent.com",
+        "client_secret": "client-secret",
+        "scopes": [
+            "openid",
+            "email",
+            "profile",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/generative-language.retriever",
+        ],
+        "quota_project_id": "quota-project",
+        "api_base_url": gemini.GEMINI_OPENAI_API_BASE,
+        "proxy_base_path": "/oauth/gemini-api",
+        "callback_path": "/oauth/gemini-api/callback",
+    }
+
+
+class FakeRequest:
+    headers = {}
+    url_root = "http://localhost:50001/"
+
+
+def _fake_codex_helper():
+    fake_codex = types.SimpleNamespace()
+    fake_codex.generate_pkce = lambda: PkcePair("verifier", "challenge")
+    fake_codex.generate_state = lambda: "state-1"
+    return fake_codex
+
+
+def _jwt(claims: dict) -> str:
+    header = _b64({"alg": "none", "typ": "JWT"})
+    payload = _b64(claims)
+    return f"{header}.{payload}.signature"
+
+
+def _b64(payload: dict) -> str:
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("utf-8").rstrip("=")
+
+
+def test_start_login_builds_google_pkce_authorize_url_without_network(monkeypatch):
+    provider = gemini.GeminiApiOAuthProvider()
+    monkeypatch.setattr(gemini, "_gemini_api_config", _config)
+    monkeypatch.setattr(gemini, "_codex_helper", _fake_codex_helper)
+
+    result = provider.start_login({}, FakeRequest())
+
+    try:
+        assert result.ok is True
+        assert result.provider_id == GEMINI_API_PROVIDER_ID
+        assert result.flow == "browser_pkce"
+        assert result.redirect_uri == "http://localhost:50001/oauth/gemini-api/callback"
+
+        parsed = urlparse(result.auth_url)
+        query = parse_qs(parsed.query)
+        assert result.auth_url.startswith("https://accounts.google.com/o/oauth2/v2/auth?")
+        assert query["response_type"] == ["code"]
+        assert query["client_id"] == ["client-id.apps.googleusercontent.com"]
+        assert query["scope"] == [" ".join(_config()["scopes"])]
+        assert query["code_challenge"] == ["challenge"]
+        assert query["code_challenge_method"] == ["S256"]
+        assert query["state"] == ["state-1"]
+        assert query["access_type"] == ["offline"]
+        assert query["prompt"] == ["consent"]
+        assert query["redirect_uri"] == ["http://localhost:50001/oauth/gemini-api/callback"]
+    finally:
+        pop_attempt("state-1")
+
+
+def test_start_login_requires_user_supplied_oauth_client(monkeypatch):
+    provider = gemini.GeminiApiOAuthProvider()
+    cfg = _config()
+    cfg["client_id"] = ""
+    cfg["client_secret"] = ""
+    monkeypatch.setattr(gemini, "_gemini_api_config", lambda: cfg)
+    monkeypatch.setattr(gemini, "_codex_helper", _fake_codex_helper)
+
+    result = provider.start_login({}, FakeRequest())
+
+    assert result.ok is False
+    assert result.provider_id == GEMINI_API_PROVIDER_ID
+    assert "OAuth client ID and client secret" in result.error
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            "http://localhost:50001/oauth/gemini-api/callback?code=abc&state=state-1",
+            {"code": "abc", "state": "state-1", "error": None, "error_description": None},
+        ),
+        ("?code=abc&state=state-1", {"code": "abc", "state": "state-1", "error": None, "error_description": None}),
+        ("code=abc&state=state-1", {"code": "abc", "state": "state-1", "error": None, "error_description": None}),
+        ("abc", {"code": "abc", "state": None, "error": None, "error_description": None}),
+    ],
+)
+def test_parse_manual_callback_accepts_url_query_and_bare_code(raw, expected):
+    assert gemini.parse_manual_callback(raw) == expected
+
+
+def test_manual_callback_exchanges_code_and_stores_tokens(tmp_path, monkeypatch):
+    provider = gemini.GeminiApiOAuthProvider()
+    auth_path = tmp_path / "auth.json"
+    put_attempt(
+        "state-1",
+        "verifier-1",
+        "http://localhost:50001/oauth/gemini-api/callback",
+        provider_id=GEMINI_API_PROVIDER_ID,
+        extra={
+            "client_id": "client-id.apps.googleusercontent.com",
+            "client_secret": "client-secret",
+            "quota_project_id": "quota-project",
+            "token_endpoint": gemini.GOOGLE_TOKEN_ENDPOINT,
+            "api_base_url": gemini.GEMINI_OPENAI_API_BASE,
+        },
+    )
+    calls = []
+
+    monkeypatch.setattr(provider, "auth_path", lambda: auth_path)
+
+    def fake_exchange(token_endpoint, code, redirect_uri, code_verifier, client_id, client_secret):
+        calls.append((token_endpoint, code, redirect_uri, code_verifier, client_id, client_secret))
+        return {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "expires_in": 3600,
+            "id_token": _jwt({"email": "user@example.com"}),
+            "token_type": "Bearer",
+        }
+
+    monkeypatch.setattr(provider, "exchange_code", fake_exchange)
+
+    result = provider.manual_callback(
+        {"callback": "http://localhost:50001/oauth/gemini-api/callback?code=code-1&state=state-1"}
+    )
+
+    assert result.ok is True
+    assert result.completed is True
+    assert result.account_label == "user@example.com"
+    assert calls == [
+        (
+            gemini.GOOGLE_TOKEN_ENDPOINT,
+            "code-1",
+            "http://localhost:50001/oauth/gemini-api/callback",
+            "verifier-1",
+            "client-id.apps.googleusercontent.com",
+            "client-secret",
+        )
+    ]
+    saved = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert saved["provider"] == GEMINI_API_PROVIDER_ID
+    assert saved["access"] == "access-token"
+    assert saved["refresh"] == "refresh-token"
+    assert saved["quota_project_id"] == "quota-project"
+    assert saved["client_id"] == "client-id.apps.googleusercontent.com"
+
+
+def test_ensure_fresh_auth_rejects_malicious_stored_token_endpoint(monkeypatch):
+    provider = gemini.GeminiApiOAuthProvider()
+    monkeypatch.setattr(
+        provider,
+        "read_auth",
+        lambda: {
+            "access": "expired-access-token",
+            "refresh": "refresh-token",
+            "expires": 1,
+            "client_id": "client-id.apps.googleusercontent.com",
+            "client_secret": "client-secret",
+            "token_endpoint": "https://evil.example/oauth/token",
+        },
+    )
+
+    with pytest.raises(ProviderError) as exc_info:
+        provider.ensure_fresh_auth()
+
+    assert exc_info.value.code == "invalid_token_endpoint"
+
+
+def test_models_returns_curated_list_without_network(monkeypatch):
+    provider = gemini.GeminiApiOAuthProvider()
+    monkeypatch.setattr(provider, "read_auth", lambda: {})
+
+    models = provider.models()
+
+    assert models[:3] == [
+        "gemini-3.5-flash",
+        "gemini-3.1-pro-preview",
+        "gemini-3-flash-preview",
+    ]
+
+
+def test_models_does_not_send_bearer_token_to_malicious_base_url(monkeypatch):
+    calls = []
+
+    class FakeResponse:
+        ok = True
+
+        def json(self):
+            return {"data": [{"id": "models/gemini-3.5-flash"}]}
+
+    class FakeRequests:
+        @staticmethod
+        def get(url, headers, timeout):
+            calls.append((url, headers, timeout))
+            return FakeResponse()
+
+    monkeypatch.setitem(sys.modules, "requests", FakeRequests)
+
+    provider = gemini.GeminiApiOAuthProvider()
+    monkeypatch.setattr(
+        provider,
+        "read_auth",
+        lambda: {
+            "access": "access-token",
+            "refresh": "refresh-token",
+            "expires": int(time.time() * 1000) + 3_600_000,
+            "base_url": "https://evil.example/v1",
+            "quota_project_id": "quota-project",
+        },
+    )
+
+    assert provider.models() == ["gemini-3.5-flash"]
+    assert calls == [
+        (
+            "https://generativelanguage.googleapis.com/v1beta/openai/models",
+            {
+                "Accept": "application/json",
+                "Authorization": "Bearer access-token",
+                "x-goog-user-project": "quota-project",
+            },
+            30,
+        )
+    ]

--- a/tests/test_oauth_github_copilot.py
+++ b/tests/test_oauth_github_copilot.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from plugins._oauth.helpers.providers import github_copilot as copilot
+from plugins._oauth.helpers.providers.base import GITHUB_COPILOT_PROVIDER_ID
+from plugins._oauth.helpers.state import pop_device_attempt
+
+
+def test_normalize_enterprise_domain_defaults_blank_to_github_dot_com():
+    assert copilot.normalize_enterprise_domain("") == "github.com"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("github.example.com", "github.example.com"),
+        ("https://github.example.com/org", "github.example.com"),
+    ],
+)
+def test_normalize_enterprise_domain_accepts_domain_or_url(value, expected):
+    assert copilot.normalize_enterprise_domain(value) == expected
+
+
+def test_normalize_enterprise_domain_rejects_invalid_url():
+    with pytest.raises(ValueError, match="Invalid GitHub Enterprise"):
+        copilot.normalize_enterprise_domain("http://")
+
+
+def test_copilot_base_url_from_token_uses_proxy_endpoint():
+    token = "tid=1;exp=9999999999;proxy-ep=proxy.individual.githubcopilot.com;sku=monthly"
+
+    assert copilot.copilot_base_url_from_token(token, "") == "https://api.individual.githubcopilot.com"
+
+
+def test_copilot_base_url_from_token_falls_back_for_malicious_proxy_endpoint():
+    token = "tid=1;exp=9999999999;proxy-ep=evil.example.com;sku=monthly"
+
+    assert copilot.copilot_base_url_from_token(token, "") == "https://api.individual.githubcopilot.com"
+
+
+def test_poll_pending_and_slow_down_do_not_complete(monkeypatch):
+    provider = copilot.GitHubCopilotOAuthProvider()
+    pending = provider._store_device_attempt_for_test("github.com", "device-pending", "PENDING", 5)
+    slowed = provider._store_device_attempt_for_test("github.com", "device-slow", "SLOW", 5)
+
+    def fake_poll(domain, device_code):
+        if device_code == "device-slow":
+            return {"error": "slow_down"}
+        return {"error": "authorization_pending"}
+
+    monkeypatch.setattr(copilot, "_post_device_poll", fake_poll)
+
+    try:
+        pending_result = provider.poll_login({"attempt_id": pending.attempt_id})
+        slowed_result = provider.poll_login({"attempt_id": slowed.attempt_id})
+
+        assert pending_result.ok is True
+        assert pending_result.completed is False
+        assert pending_result.interval == 5
+        assert slowed_result.ok is True
+        assert slowed_result.completed is False
+        assert slowed_result.interval == 10
+    finally:
+        pop_device_attempt(pending.attempt_id)
+        pop_device_attempt(slowed.attempt_id)
+
+
+def test_poll_success_stores_copilot_credentials(tmp_path, monkeypatch):
+    provider = copilot.GitHubCopilotOAuthProvider()
+    auth_path = tmp_path / "auth.json"
+    attempt = provider._store_device_attempt_for_test("github.com", "device-ok", "OK", 5)
+
+    monkeypatch.setattr(provider, "auth_path", lambda: auth_path)
+    monkeypatch.setattr(
+        copilot,
+        "_post_device_poll",
+        lambda domain, device_code: {"access_token": "github-access-token"},
+    )
+    monkeypatch.setattr(
+        copilot,
+        "refresh_copilot_token",
+        lambda refresh, domain: {
+            "provider": GITHUB_COPILOT_PROVIDER_ID,
+            "type": "oauth",
+            "refresh": refresh,
+            "access": "copilot-access-token",
+            "expires": 9_999_999_000,
+            "enterprise_domain": "",
+            "base_url": "https://api.individual.githubcopilot.com",
+        },
+    )
+    monkeypatch.setattr(
+        copilot,
+        "enable_known_models",
+        lambda token, domain: {"attempted": 8, "enabled": 8, "failed": []},
+    )
+
+    result = provider.poll_login({"attempt_id": attempt.attempt_id})
+
+    assert result.ok is True
+    assert result.completed is True
+    saved = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert saved["provider"] == GITHUB_COPILOT_PROVIDER_ID
+    assert saved["refresh"] == "github-access-token"
+    assert saved["access"] == "copilot-access-token"
+    assert saved["base_url"] == "https://api.individual.githubcopilot.com"
+
+
+def test_models_returns_curated_list_without_network(monkeypatch):
+    provider = copilot.GitHubCopilotOAuthProvider()
+    monkeypatch.setattr(provider, "read_auth", lambda: {})
+
+    models = provider.models()
+
+    assert models[:3] == ["gpt-5.2-codex", "gpt-5.2", "claude-sonnet-4.5"]
+    assert "grok-code-fast-1" in models
+
+
+def test_ensure_fresh_auth_refreshes_expired_credentials(tmp_path, monkeypatch):
+    provider = copilot.GitHubCopilotOAuthProvider()
+    auth_path = tmp_path / "auth.json"
+    provider.write_auth = lambda data: copilot.write_private_json(auth_path, data)
+    provider.read_auth = lambda: copilot.read_json_file(auth_path)
+    provider.write_auth(
+        {
+            "provider": GITHUB_COPILOT_PROVIDER_ID,
+            "type": "oauth",
+            "refresh": "github-refresh-token",
+            "access": "expired-access-token",
+            "expires": 1,
+            "enterprise_domain": "",
+            "base_url": "https://api.individual.githubcopilot.com",
+            "models_warning": "existing warning",
+        }
+    )
+
+    monkeypatch.setattr(
+        copilot,
+        "refresh_copilot_token",
+        lambda refresh, domain: {
+            "provider": GITHUB_COPILOT_PROVIDER_ID,
+            "type": "oauth",
+            "refresh": refresh,
+            "access": "fresh-access-token",
+            "expires": int(time.time() * 1000) + 3_600_000,
+            "enterprise_domain": "",
+            "base_url": "https://api.individual.githubcopilot.com",
+        },
+    )
+
+    auth = provider.ensure_fresh_auth()
+
+    assert auth["refresh"] == "github-refresh-token"
+    assert auth["access"] == "fresh-access-token"
+    assert auth["models_warning"] == "existing warning"
+    saved = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert saved["access"] == "fresh-access-token"
+
+
+def test_models_uses_refreshed_auth_without_live_network(monkeypatch):
+    provider = copilot.GitHubCopilotOAuthProvider()
+    calls = []
+
+    monkeypatch.setattr(
+        provider,
+        "ensure_fresh_auth",
+        lambda: {
+            "access": "fresh-access-token",
+            "base_url": "https://api.individual.githubcopilot.com",
+        },
+    )
+
+    class FakeResponse:
+        ok = True
+
+        def json(self):
+            return {"data": [{"id": "fresh-model"}]}
+
+    class FakeRequests:
+        @staticmethod
+        def get(url, headers, timeout):
+            calls.append((url, headers, timeout))
+            return FakeResponse()
+
+    monkeypatch.setitem(sys.modules, "requests", FakeRequests)
+
+    assert provider.models() == ["fresh-model"]
+    assert calls[0][1]["Authorization"] == "Bearer fresh-access-token"
+
+
+def test_models_does_not_send_bearer_token_to_malicious_base_url(monkeypatch):
+    provider = copilot.GitHubCopilotOAuthProvider()
+    calls = []
+
+    monkeypatch.setattr(
+        provider,
+        "ensure_fresh_auth",
+        lambda: {
+            "access": "fresh-access-token",
+            "base_url": "https://evil.example.com/v1",
+        },
+    )
+
+    class FakeResponse:
+        ok = True
+
+        def json(self):
+            return {"data": [{"id": "safe-model"}]}
+
+    class FakeRequests:
+        @staticmethod
+        def get(url, headers, timeout):
+            calls.append((url, headers, timeout))
+            return FakeResponse()
+
+    monkeypatch.setitem(sys.modules, "requests", FakeRequests)
+
+    assert provider.models() == ["safe-model"]
+    assert calls[0][0] == "https://api.individual.githubcopilot.com/models"
+    assert not calls[0][0].startswith("https://evil.example.com")
+    assert calls[0][1]["Authorization"] == "Bearer fresh-access-token"
+
+
+def test_refresh_copilot_token_normalizes_malicious_proxy_endpoint(monkeypatch):
+    class FakeResponse:
+        ok = True
+        status_code = 200
+
+        def json(self):
+            return {
+                "token": "tid=1;exp=9999999999;proxy-ep=evil.example.com;sku=monthly",
+                "expires_at": int(time.time()) + 3600,
+            }
+
+    class FakeRequests:
+        @staticmethod
+        def get(url, headers, timeout):
+            return FakeResponse()
+
+    monkeypatch.setitem(sys.modules, "requests", FakeRequests)
+
+    auth = copilot.refresh_copilot_token("github-refresh-token", "")
+
+    assert auth["base_url"] == "https://api.individual.githubcopilot.com"

--- a/tests/test_oauth_providers.py
+++ b/tests/test_oauth_providers.py
@@ -1,0 +1,1200 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import os
+import sys
+import stat
+import types
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+try:
+    import helpers.api  # noqa: F401
+except ModuleNotFoundError as exc:
+    if exc.name != "flask":
+        raise
+    fake_api = types.ModuleType("helpers.api")
+
+    class ApiHandler:
+        def __init__(self, app=None, thread_lock=None):
+            self.app = app
+            self.thread_lock = thread_lock
+
+    class Request:
+        pass
+
+    fake_api.ApiHandler = ApiHandler
+    fake_api.Request = Request
+    sys.modules["helpers.api"] = fake_api
+
+try:
+    import helpers.extension  # noqa: F401
+except ModuleNotFoundError as exc:
+    if exc.name not in {"regex", "simpleeval"}:
+        raise
+    fake_extension = types.ModuleType("helpers.extension")
+
+    class Extension:
+        def __init__(self, agent=None, **kwargs):
+            self.agent = agent
+            self.kwargs = kwargs
+
+    fake_extension.Extension = Extension
+    sys.modules["helpers.extension"] = fake_extension
+
+from plugins._oauth.api import status as status_api
+from plugins._oauth.api import disconnect as disconnect_api
+from plugins._oauth.api import manual_callback as manual_callback_api
+from plugins._oauth.api import poll_device_login as poll_device_login_api
+from plugins._oauth.api import start_device_login as start_device_login_api
+from plugins._oauth.api import start_login as start_login_api
+from plugins._oauth.api.models import Models
+from plugins._oauth.extensions.python._functions.models.get_api_key.end._20_codex_account_dummy_key import (
+    CodexAccountDummyKey,
+)
+from plugins._oauth.helpers import state
+from plugins._oauth.helpers.providers import base as provider_base
+from plugins._oauth.helpers.providers.base import (
+    CODEX_PROVIDER_ID,
+    DUMMY_API_KEY,
+    GEMINI_API_PROVIDER_ID,
+    GITHUB_COPILOT_PROVIDER_ID,
+    XAI_GROK_PROVIDER_ID,
+    CallbackResult,
+    LoginPollResult,
+    LoginStartResult,
+    ProviderError,
+    provider_data_dir,
+    public_error,
+    write_private_json,
+)
+from plugins._oauth.helpers.providers.registry import get_provider, provider_registry
+from plugins._oauth.helpers.usage_plans import (
+    CLAUDE_CODE_PROVIDER_ID,
+    GEMINI_CODE_ASSIST_PROVIDER_ID,
+    usage_plan_catalog,
+)
+
+
+class FakeRequest:
+    headers = {}
+    url_root = "http://localhost:50001/"
+
+
+def test_registry_exposes_initial_oauth_providers():
+    registry = provider_registry()
+
+    assert list(registry) == [
+        CODEX_PROVIDER_ID,
+        GITHUB_COPILOT_PROVIDER_ID,
+        GEMINI_API_PROVIDER_ID,
+        XAI_GROK_PROVIDER_ID,
+    ]
+    assert registry[CODEX_PROVIDER_ID].metadata().display_name == "Codex/ChatGPT"
+    assert registry[GITHUB_COPILOT_PROVIDER_ID].metadata().model_provider_id == GITHUB_COPILOT_PROVIDER_ID
+    assert registry[GEMINI_API_PROVIDER_ID].metadata().supports_oauth_client_config is True
+    assert registry[XAI_GROK_PROVIDER_ID].metadata().auth_flow == "browser_pkce"
+
+
+def test_get_provider_rejects_unknown_provider_id():
+    with pytest.raises(KeyError, match="Unknown OAuth provider"):
+        get_provider("missing")
+
+
+def test_get_provider_coerces_non_string_provider_id():
+    with pytest.raises(KeyError, match="Unknown OAuth provider: 123"):
+        get_provider(123)
+
+
+@pytest.mark.parametrize("provider_id", [0, False])
+def test_get_provider_rejects_falsey_non_string_provider_id(provider_id):
+    with pytest.raises(KeyError, match=f"Unknown OAuth provider: {provider_id}"):
+        get_provider(provider_id)
+
+
+@pytest.mark.parametrize("provider_id", [None, ""])
+def test_get_provider_defaults_empty_provider_id_to_codex(provider_id):
+    assert get_provider(provider_id).provider_id == CODEX_PROVIDER_ID
+
+
+def test_state_keeps_login_attempts_provider_scoped():
+    attempt = state.put_attempt(
+        "state-a",
+        "verifier-a",
+        "http://127.0.0.1:56121/callback",
+        provider_id=XAI_GROK_PROVIDER_ID,
+        extra={"nonce": "nonce-a"},
+    )
+
+    loaded = state.get_attempt("state-a")
+
+    assert loaded == attempt
+    assert loaded.provider_id == XAI_GROK_PROVIDER_ID
+    assert loaded.extra == {"nonce": "nonce-a"}
+    assert state.pop_attempt("state-a") == attempt
+    assert state.get_attempt("state-a") is None
+
+
+def test_state_keeps_device_attempts_provider_scoped():
+    attempt = state.put_device_attempt(
+        "attempt-a",
+        "device-a",
+        "USER-CODE",
+        5,
+        99_999_999_999,
+        provider_id=GITHUB_COPILOT_PROVIDER_ID,
+        extra={"domain": "github.com"},
+    )
+
+    loaded = state.get_device_attempt("attempt-a")
+
+    assert loaded == attempt
+    assert loaded.provider_id == GITHUB_COPILOT_PROVIDER_ID
+    assert loaded.extra == {"domain": "github.com"}
+    assert state.pop_device_attempt("attempt-a") == attempt
+    assert state.get_device_attempt("attempt-a") is None
+
+
+def test_starter_providers_report_login_flow_values():
+    class FakeProvider:
+        def __init__(self, provider_id: str, flow: str):
+            self.provider_id = provider_id
+            self.flow = flow
+
+        def start_login(self, input=None, request=None):
+            return LoginStartResult(
+                ok=False,
+                provider_id=self.provider_id,
+                flow=self.flow,
+                message="not connected",
+            )
+
+    registry = {
+        GITHUB_COPILOT_PROVIDER_ID: FakeProvider(GITHUB_COPILOT_PROVIDER_ID, "device_code"),
+        XAI_GROK_PROVIDER_ID: FakeProvider(XAI_GROK_PROVIDER_ID, "browser_pkce"),
+    }
+
+    github = registry[GITHUB_COPILOT_PROVIDER_ID].start_login({})
+    xai = registry[XAI_GROK_PROVIDER_ID].start_login({})
+
+    assert github.flow == "device_code"
+    assert xai.flow == "browser_pkce"
+
+
+def test_result_contract_preserves_account_id_with_account_label():
+    poll = LoginPollResult(
+        ok=True,
+        provider_id=CODEX_PROVIDER_ID,
+        account_label="user@example.com",
+        account_id="acct-1",
+    )
+    callback = CallbackResult(
+        ok=True,
+        provider_id=CODEX_PROVIDER_ID,
+        account_label="user@example.com",
+        account_id="acct-1",
+    )
+
+    assert poll.account_label == "user@example.com"
+    assert poll.account_id == "acct-1"
+    assert callback.account_label == "user@example.com"
+    assert callback.account_id == "acct-1"
+
+
+def test_provider_data_dir_creates_directory(tmp_path, monkeypatch):
+    fake_files = types.SimpleNamespace(
+        USER_DIR="usr",
+        PLUGINS_DIR="plugins",
+        get_abs_path=lambda *parts: str(tmp_path.joinpath(*parts)),
+    )
+    monkeypatch.setitem(sys.modules, "helpers.files", fake_files)
+
+    path = provider_data_dir("provider-a")
+
+    assert path == tmp_path / "usr" / "plugins" / "_oauth" / "provider-a"
+    assert path.is_dir()
+
+
+@pytest.mark.parametrize("provider_slug", ["../codex", "nested/codex", "nested\\codex", "", "."])
+def test_provider_data_dir_rejects_unsafe_slugs(provider_slug):
+    with pytest.raises(ProviderError, match="Invalid OAuth provider storage slug.") as exc_info:
+        provider_data_dir(provider_slug)
+
+    assert exc_info.value.code == "invalid_provider_slug"
+
+
+def test_write_private_json_does_not_reuse_preexisting_temp_file(tmp_path):
+    path = tmp_path / "auth.json"
+    stale_tmp = tmp_path / "auth.json.tmp"
+    stale_tmp.write_text("stale", encoding="utf-8")
+    stale_tmp.chmod(0o666)
+    stale_inode = stale_tmp.stat().st_ino
+
+    write_private_json(path, {"access_token": "secret"})
+
+    assert stale_tmp.read_text(encoding="utf-8") == "stale"
+    assert stale_tmp.stat().st_ino == stale_inode
+    assert path.read_text(encoding="utf-8").find("secret") > -1
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_write_private_json_cleans_up_generated_temp_file_on_error(tmp_path, monkeypatch):
+    def fail_dump(*args, **kwargs):
+        raise RuntimeError("write failed")
+
+    monkeypatch.setattr(provider_base.json, "dump", fail_dump)
+
+    path = tmp_path / "auth.json"
+    with pytest.raises(RuntimeError, match="write failed"):
+        write_private_json(path, {"token": "secret"})
+
+    assert list(tmp_path.glob(".auth.json.*.tmp")) == []
+    assert not path.exists()
+
+
+def test_write_private_json_does_not_follow_preexisting_temp_symlink(tmp_path):
+    leak_target = tmp_path / "leak-target"
+    leak_target.write_text("safe", encoding="utf-8")
+    stale_tmp = tmp_path / "auth.json.tmp"
+    try:
+        stale_tmp.symlink_to(leak_target)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation is not supported: {exc}")
+
+    path = tmp_path / "auth.json"
+    write_private_json(path, {"token": "secret"})
+
+    assert leak_target.read_text(encoding="utf-8") == "safe"
+    assert stale_tmp.is_symlink()
+    assert '"token": "secret"' in path.read_text(encoding="utf-8")
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_write_private_json_sets_generated_temp_private_before_dump(tmp_path, monkeypatch):
+    observed_modes = []
+    real_dump = provider_base.json.dump
+
+    def inspect_mode_before_dump(data, handle, *args, **kwargs):
+        temp_files = list(tmp_path.glob(".auth.json.*.tmp"))
+        assert len(temp_files) == 1
+        observed_modes.append(stat.S_IMODE(temp_files[0].stat().st_mode))
+        return real_dump(data, handle, *args, **kwargs)
+
+    monkeypatch.setattr(provider_base.json, "dump", inspect_mode_before_dump)
+
+    path = tmp_path / "auth.json"
+    write_private_json(path, {"token": "secret"})
+
+    assert observed_modes == [0o600]
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_public_error_returns_user_facing_string():
+    assert public_error(RuntimeError("visible")) == "visible"
+    assert public_error(Exception()) == "Exception"
+
+
+def test_status_api_returns_provider_registry_shape(monkeypatch):
+    class FakeProvider:
+        def __init__(self, provider_id: str):
+            self.provider_id = provider_id
+
+        def status(self):
+            return {"provider_id": self.provider_id, "connected": False}
+
+    fake_registry = {
+        provider_id: FakeProvider(provider_id)
+        for provider_id in [
+            CODEX_PROVIDER_ID,
+            GITHUB_COPILOT_PROVIDER_ID,
+            GEMINI_API_PROVIDER_ID,
+            XAI_GROK_PROVIDER_ID,
+        ]
+    }
+    monkeypatch.setattr(status_api, "provider_registry", lambda: fake_registry)
+    monkeypatch.setattr(status_api, "is_installed", lambda: True)
+
+    response = asyncio.run(status_api.Status(None, None).process({}, FakeRequest()))
+
+    assert response["ok"] is True
+    assert response["routes_installed"] is True
+    assert [provider["provider_id"] for provider in response["providers"]] == [
+        CODEX_PROVIDER_ID,
+        GITHUB_COPILOT_PROVIDER_ID,
+        GEMINI_API_PROVIDER_ID,
+        XAI_GROK_PROVIDER_ID,
+    ]
+    assert set(response["provider_map"]) == {
+        CODEX_PROVIDER_ID,
+        GITHUB_COPILOT_PROVIDER_ID,
+        GEMINI_API_PROVIDER_ID,
+        XAI_GROK_PROVIDER_ID,
+    }
+    assert set(response["usage_plan_catalog"]) >= {
+        CODEX_PROVIDER_ID,
+        GITHUB_COPILOT_PROVIDER_ID,
+        GEMINI_API_PROVIDER_ID,
+        XAI_GROK_PROVIDER_ID,
+        CLAUDE_CODE_PROVIDER_ID,
+        GEMINI_CODE_ASSIST_PROVIDER_ID,
+    }
+    assert response["codex"] == response["provider_map"][CODEX_PROVIDER_ID]
+
+
+def test_status_api_contains_provider_status_exceptions(monkeypatch):
+    class GoodProvider:
+        provider_id = CODEX_PROVIDER_ID
+
+        def status(self):
+            return {"provider_id": CODEX_PROVIDER_ID, "connected": True}
+
+    class FailingProvider:
+        provider_id = XAI_GROK_PROVIDER_ID
+
+        def status(self):
+            raise RuntimeError("status failed")
+
+    monkeypatch.setattr(
+        status_api,
+        "provider_registry",
+        lambda: {
+            CODEX_PROVIDER_ID: GoodProvider(),
+            XAI_GROK_PROVIDER_ID: FailingProvider(),
+        },
+    )
+    monkeypatch.setattr(status_api, "is_installed", lambda: True)
+
+    response = asyncio.run(status_api.Status(None, None).process({}, FakeRequest()))
+
+    assert response["ok"] is True
+    assert response["provider_map"][CODEX_PROVIDER_ID]["connected"] is True
+    assert response["provider_map"][XAI_GROK_PROVIDER_ID] == {
+        "provider_id": XAI_GROK_PROVIDER_ID,
+        "connected": False,
+        "error": "status failed",
+    }
+
+
+@pytest.mark.parametrize(
+    ("provider_id", "expected_flow"),
+    [
+        (GITHUB_COPILOT_PROVIDER_ID, "device_code"),
+        (GEMINI_API_PROVIDER_ID, "browser_pkce"),
+        (XAI_GROK_PROVIDER_ID, "browser_pkce"),
+    ],
+)
+def test_start_login_dispatches_to_selected_starter_provider(monkeypatch, provider_id, expected_flow):
+    class FakeProvider:
+        def __init__(self, provider_id: str):
+            self.provider_id = provider_id
+
+        def start_login(self, input, request):
+            return LoginStartResult(
+                ok=False,
+                provider_id=self.provider_id,
+                flow=expected_flow,
+                message="not connected",
+            )
+
+    monkeypatch.setattr(start_login_api, "get_provider", lambda selected: FakeProvider(selected))
+
+    response = asyncio.run(
+        start_login_api.StartLogin(None, None).process(
+            {"provider_id": provider_id},
+            FakeRequest(),
+        )
+    )
+
+    assert response["ok"] is False
+    assert response["provider_id"] == provider_id
+    assert response["flow"] == expected_flow
+    assert response["message"]
+
+
+def test_start_login_without_provider_id_uses_legacy_codex_browser_login(monkeypatch):
+    calls = []
+
+    class FakeCodexProvider:
+        def start_browser_login(self, input, request):
+            calls.append(("browser", input, request))
+            return LoginStartResult(
+                ok=True,
+                provider_id=CODEX_PROVIDER_ID,
+                flow="browser_pkce",
+                auth_url="http://auth.example/authorize",
+                redirect_uri="http://localhost/auth/callback",
+            )
+
+        def start_login(self, input, request):
+            calls.append(("device", input, request))
+            return LoginStartResult(ok=True, provider_id=CODEX_PROVIDER_ID, flow="device_code")
+
+    monkeypatch.setattr(start_login_api, "get_provider", lambda provider_id: FakeCodexProvider())
+
+    request = FakeRequest()
+    response = asyncio.run(start_login_api.StartLogin(None, None).process({}, request))
+
+    assert calls == [("browser", {}, request)]
+    assert response["ok"] is True
+    assert response["provider_id"] == CODEX_PROVIDER_ID
+    assert response["flow"] == "browser_pkce"
+    assert response["auth_url"] == "http://auth.example/authorize"
+    assert response["redirect_uri"] == "http://localhost/auth/callback"
+
+
+def test_start_login_with_blank_provider_id_uses_provider_aware_codex_login(monkeypatch):
+    calls = []
+
+    class FakeCodexProvider:
+        def start_browser_login(self, input, request):
+            calls.append(("browser", input, request))
+            return LoginStartResult(ok=True, provider_id=CODEX_PROVIDER_ID, flow="browser_pkce")
+
+        def start_login(self, input, request):
+            calls.append(("device", input, request))
+            return LoginStartResult(ok=True, provider_id=CODEX_PROVIDER_ID, flow="device_code")
+
+    monkeypatch.setattr(start_login_api, "get_provider", lambda provider_id: FakeCodexProvider())
+
+    request = FakeRequest()
+    response = asyncio.run(
+        start_login_api.StartLogin(None, None).process({"provider_id": ""}, request)
+    )
+
+    assert calls == [("device", {"provider_id": ""}, request)]
+    assert response["ok"] is True
+    assert response["provider_id"] == CODEX_PROVIDER_ID
+    assert response["flow"] == "device_code"
+
+
+def test_start_login_provider_exception_returns_structured_error(monkeypatch):
+    class FailingProvider:
+        def start_login(self, input, request):
+            raise RuntimeError("login failed")
+
+    monkeypatch.setattr(start_login_api, "get_provider", lambda provider_id: FailingProvider())
+
+    response = asyncio.run(
+        start_login_api.StartLogin(None, None).process(
+            {"provider_id": GITHUB_COPILOT_PROVIDER_ID},
+            FakeRequest(),
+        )
+    )
+
+    assert response == {
+        "ok": False,
+        "provider_id": GITHUB_COPILOT_PROVIDER_ID,
+        "error": "login failed",
+    }
+
+
+def test_manual_callback_dispatches_to_xai_provider_without_active_attempt():
+    response = asyncio.run(
+        manual_callback_api.ManualCallback(None, None).process(
+            {"provider_id": XAI_GROK_PROVIDER_ID, "callback_url": "http://localhost/callback?code=abc"},
+            FakeRequest(),
+        )
+    )
+
+    assert response["ok"] is False
+    assert response["provider_id"] == XAI_GROK_PROVIDER_ID
+    assert "no active xai grok sign-in attempt" in response["error"].lower()
+
+
+def test_start_device_login_wrapper_calls_codex_provider(monkeypatch):
+    calls = []
+
+    class FakeProvider:
+        def start_login(self, input, request):
+            calls.append((input, request))
+            return LoginStartResult(
+                ok=True,
+                provider_id=CODEX_PROVIDER_ID,
+                flow="device_code",
+                attempt_id="attempt-1",
+            )
+
+    monkeypatch.setattr(
+        start_device_login_api,
+        "get_provider",
+        lambda provider_id: calls.append(("provider_id", provider_id)) or FakeProvider(),
+    )
+
+    request = FakeRequest()
+    response = asyncio.run(
+        start_device_login_api.StartDeviceLogin(None, None).process(
+            {"ignored_provider_id": XAI_GROK_PROVIDER_ID},
+            request,
+        )
+    )
+
+    assert calls[0] == ("provider_id", CODEX_PROVIDER_ID)
+    assert calls[1][0] == {"ignored_provider_id": XAI_GROK_PROVIDER_ID}
+    assert calls[1][1] is request
+    assert response["ok"] is True
+    assert response["provider_id"] == CODEX_PROVIDER_ID
+    assert response["flow"] == "device_code"
+    assert response["attempt_id"] == "attempt-1"
+
+
+def test_poll_device_login_wrapper_calls_codex_provider(monkeypatch):
+    calls = []
+
+    class FakeProvider:
+        def poll_login(self, input, request):
+            calls.append((input, request))
+            return LoginPollResult(
+                ok=True,
+                provider_id=CODEX_PROVIDER_ID,
+                completed=True,
+                account_label="user@example.com",
+                account_id="account-1",
+            )
+
+    monkeypatch.setattr(
+        poll_device_login_api,
+        "get_provider",
+        lambda provider_id: calls.append(("provider_id", provider_id)) or FakeProvider(),
+    )
+
+    request = FakeRequest()
+    response = asyncio.run(
+        poll_device_login_api.PollDeviceLogin(None, None).process(
+            {"attempt_id": "attempt-1"},
+            request,
+        )
+    )
+
+    assert calls[0] == ("provider_id", CODEX_PROVIDER_ID)
+    assert calls[1][0] == {"attempt_id": "attempt-1"}
+    assert calls[1][1] is request
+    assert response["ok"] is True
+    assert response["provider_id"] == CODEX_PROVIDER_ID
+    assert response["completed"] is True
+    assert response["account_label"] == "user@example.com"
+    assert response["account_id"] == "account-1"
+
+
+def test_poll_device_login_with_provider_id_calls_github_provider(monkeypatch):
+    calls = []
+
+    class FakeProvider:
+        def poll_login(self, input, request):
+            calls.append((input, request))
+            return LoginPollResult(
+                ok=True,
+                provider_id=GITHUB_COPILOT_PROVIDER_ID,
+                completed=True,
+                account_label="github.com",
+            )
+
+    monkeypatch.setattr(
+        poll_device_login_api,
+        "get_provider",
+        lambda provider_id: calls.append(("provider_id", provider_id)) or FakeProvider(),
+    )
+
+    request = FakeRequest()
+    payload = {"provider_id": GITHUB_COPILOT_PROVIDER_ID, "attempt_id": "attempt-1"}
+    response = asyncio.run(
+        poll_device_login_api.PollDeviceLogin(None, None).process(payload, request)
+    )
+
+    assert calls[0] == ("provider_id", GITHUB_COPILOT_PROVIDER_ID)
+    assert calls[1] == (payload, request)
+    assert response["ok"] is True
+    assert response["provider_id"] == GITHUB_COPILOT_PROVIDER_ID
+    assert response["completed"] is True
+    assert response["account_label"] == "github.com"
+
+
+def test_poll_device_login_unknown_provider_returns_structured_error():
+    response = asyncio.run(
+        poll_device_login_api.PollDeviceLogin(None, None).process(
+            {"provider_id": "missing", "attempt_id": "attempt-1"},
+            FakeRequest(),
+        )
+    )
+
+    assert response["ok"] is False
+    assert response["provider_id"] == "missing"
+    assert "Unknown OAuth provider" in response["error"]
+
+
+@pytest.mark.parametrize(
+    "provider_id",
+    [CODEX_PROVIDER_ID, GITHUB_COPILOT_PROVIDER_ID, GEMINI_API_PROVIDER_ID, XAI_GROK_PROVIDER_ID],
+)
+@pytest.mark.parametrize("initial", [None, "None"])
+def test_oauth_providers_report_dummy_api_key_when_missing(provider_id, initial):
+    data = {"args": (provider_id,), "kwargs": {}, "result": initial}
+
+    CodexAccountDummyKey(agent=None).execute(data=data)
+
+    assert data["result"] == DUMMY_API_KEY
+
+
+@pytest.mark.parametrize(
+    "provider_id",
+    [CODEX_PROVIDER_ID, GITHUB_COPILOT_PROVIDER_ID, GEMINI_API_PROVIDER_ID, XAI_GROK_PROVIDER_ID],
+)
+def test_oauth_providers_report_dummy_api_key_when_result_missing(provider_id):
+    data = {"args": (provider_id,), "kwargs": {}}
+
+    CodexAccountDummyKey(agent=None).execute(data=data)
+
+    assert data["result"] == DUMMY_API_KEY
+
+
+@pytest.mark.parametrize(
+    "provider_id",
+    [CODEX_PROVIDER_ID, GITHUB_COPILOT_PROVIDER_ID, GEMINI_API_PROVIDER_ID, XAI_GROK_PROVIDER_ID],
+)
+def test_oauth_providers_preserve_configured_api_key(provider_id):
+    data = {"args": (provider_id,), "kwargs": {}, "result": "configured"}
+
+    CodexAccountDummyKey(agent=None).execute(data=data)
+
+    assert data["result"] == "configured"
+
+
+def test_model_provider_config_contains_all_oauth_providers():
+    provider_path = Path(__file__).resolve().parents[1] / "plugins/_oauth/conf/model_providers.yaml"
+    provider_config = yaml.safe_load(provider_path.read_text(encoding="utf-8"))
+    chat = provider_config["chat"]
+
+    assert set(chat) == {
+        CODEX_PROVIDER_ID,
+        GITHUB_COPILOT_PROVIDER_ID,
+        GEMINI_API_PROVIDER_ID,
+        XAI_GROK_PROVIDER_ID,
+    }
+    assert chat[CODEX_PROVIDER_ID]["kwargs"]["api_key"] == DUMMY_API_KEY
+    assert chat[GITHUB_COPILOT_PROVIDER_ID]["kwargs"]["api_key"] == DUMMY_API_KEY
+    assert chat[GEMINI_API_PROVIDER_ID]["kwargs"]["api_key"] == DUMMY_API_KEY
+    assert chat[XAI_GROK_PROVIDER_ID]["kwargs"]["api_key"] == DUMMY_API_KEY
+    assert chat[CODEX_PROVIDER_ID]["kwargs"]["api_base"] == "http://127.0.0.1/oauth/codex/v1"
+    assert (
+        chat[GITHUB_COPILOT_PROVIDER_ID]["kwargs"]["api_base"]
+        == "http://127.0.0.1/oauth/github-copilot/v1"
+    )
+    assert chat[GEMINI_API_PROVIDER_ID]["kwargs"]["api_base"] == "http://127.0.0.1/oauth/gemini-api/v1"
+    assert chat[XAI_GROK_PROVIDER_ID]["kwargs"]["api_base"] == "http://127.0.0.1/oauth/xai-grok/v1"
+    assert "50001" not in json.dumps(provider_config)
+
+
+def test_provider_metadata_marks_new_oauth_providers_as_oauth_api_key_mode():
+    metadata_path = Path(__file__).resolve().parents[1] / "plugins/_model_config/provider_metadata.yaml"
+    metadata = yaml.safe_load(metadata_path.read_text(encoding="utf-8"))
+
+    assert metadata["chat"][GITHUB_COPILOT_PROVIDER_ID]["api_key_mode"] == "oauth"
+    assert metadata["chat"][GEMINI_API_PROVIDER_ID]["api_key_mode"] == "oauth"
+    assert metadata["chat"][XAI_GROK_PROVIDER_ID]["api_key_mode"] == "oauth"
+
+
+def test_usage_plan_catalog_covers_current_and_nearby_subscription_providers():
+    catalog = usage_plan_catalog()
+
+    assert {plan["id"] for plan in catalog[CODEX_PROVIDER_ID]["plans"]} >= {
+        "free",
+        "go",
+        "plus",
+        "pro",
+        "business",
+        "enterprise_edu",
+        "api_key",
+    }
+    assert {plan["id"] for plan in catalog[GITHUB_COPILOT_PROVIDER_ID]["plans"]} >= {
+        "free",
+        "student",
+        "pro",
+        "pro_plus",
+        "max",
+        "business",
+        "enterprise",
+    }
+    assert {plan["id"] for plan in catalog[GEMINI_API_PROVIDER_ID]["plans"]} >= {
+        "oauth_cloud_project",
+        "api_key",
+        "vertex_ai",
+    }
+    assert catalog[GEMINI_API_PROVIDER_ID]["implemented"] is True
+    assert {plan["id"] for plan in catalog[CLAUDE_CODE_PROVIDER_ID]["plans"]} >= {
+        "pro",
+        "max_5x",
+        "max_20x",
+        "team",
+        "enterprise_premium",
+        "enterprise_usage_based",
+    }
+    assert {plan["id"] for plan in catalog[GEMINI_CODE_ASSIST_PROVIDER_ID]["plans"]} >= {
+        "individual",
+        "google_ai_pro",
+        "google_ai_ultra",
+        "organization",
+        "code_assist_standard",
+        "code_assist_enterprise",
+        "gemini_api_oauth",
+    }
+    assert catalog[GEMINI_CODE_ASSIST_PROVIDER_ID]["implementation_status"] == "metadata_only"
+    google_modes = {
+        mode["id"]: mode
+        for mode in catalog[GEMINI_CODE_ASSIST_PROVIDER_ID]["provider_modes"]
+    }
+    assert google_modes["gemini_api_oauth"]["allowed"] is True
+    assert google_modes["antigravity_subscription_oauth"]["allowed"] is False
+    assert {plan["id"] for plan in catalog[XAI_GROK_PROVIDER_ID]["plans"]} >= {
+        "free",
+        "supergrok_lite",
+        "supergrok",
+        "supergrok_heavy",
+        "business",
+        "enterprise",
+        "api_credits",
+    }
+    assert catalog[CLAUDE_CODE_PROVIDER_ID]["implemented"] is False
+    assert catalog[GEMINI_CODE_ASSIST_PROVIDER_ID]["implemented"] is False
+
+
+def test_disconnect_api_returns_provider_result_contract(monkeypatch):
+    class FakeProvider:
+        def __init__(self, provider_id: str):
+            self.provider_id = provider_id
+
+        def disconnect(self):
+            return {"disconnected": True, "removed_auth_files": ["auth.json"]}
+
+        def status(self):
+            return {"provider_id": self.provider_id, "connected": False}
+
+    provider = FakeProvider(GITHUB_COPILOT_PROVIDER_ID)
+    monkeypatch.setattr(disconnect_api, "get_provider", lambda provider_id: provider)
+
+    response = asyncio.run(
+        disconnect_api.Disconnect(None, None).process(
+            {"provider_id": GITHUB_COPILOT_PROVIDER_ID},
+            FakeRequest(),
+        )
+    )
+
+    assert response["ok"] is True
+    assert response["provider_id"] == GITHUB_COPILOT_PROVIDER_ID
+    assert response["result"] == {"disconnected": True, "removed_auth_files": ["auth.json"]}
+    assert response["provider"] == {"provider_id": GITHUB_COPILOT_PROVIDER_ID, "connected": False}
+    assert response["disconnected"] is True
+    assert response["removed_auth_files"] == ["auth.json"]
+
+
+def test_disconnect_api_keeps_codex_legacy_field(monkeypatch):
+    class FakeProvider:
+        provider_id = CODEX_PROVIDER_ID
+
+        def disconnect(self):
+            return {"disconnected": True}
+
+        def status(self):
+            return {"provider_id": CODEX_PROVIDER_ID, "connected": False}
+
+    provider = FakeProvider()
+    monkeypatch.setattr(disconnect_api, "get_provider", lambda provider_id: provider)
+
+    response = asyncio.run(disconnect_api.Disconnect(None, None).process({}, FakeRequest()))
+
+    assert response["result"] == {"disconnected": True}
+    assert response["provider"] == {"provider_id": CODEX_PROVIDER_ID, "connected": False}
+    assert response["codex"] == response["provider"]
+
+
+def test_start_login_unknown_provider_returns_structured_error():
+    response = asyncio.run(
+        start_login_api.StartLogin(None, None).process({"provider_id": "missing"}, FakeRequest())
+    )
+
+    assert response["ok"] is False
+    assert response["provider_id"] == "missing"
+    assert "Unknown OAuth provider" in response["error"]
+
+
+@pytest.mark.parametrize("provider_id", [0, False])
+@pytest.mark.parametrize(
+    "handler",
+    [
+        start_login_api.StartLogin,
+        Models,
+        disconnect_api.Disconnect,
+        manual_callback_api.ManualCallback,
+    ],
+)
+def test_provider_aware_apis_do_not_default_falsey_non_string_provider_ids(handler, provider_id):
+    response = asyncio.run(handler(None, None).process({"provider_id": provider_id}, FakeRequest()))
+
+    assert response["ok"] is False
+    assert response["provider_id"] == str(provider_id)
+    assert f"Unknown OAuth provider: {provider_id}" in response["error"]
+
+
+def test_disconnect_unknown_provider_returns_structured_error():
+    response = asyncio.run(
+        disconnect_api.Disconnect(None, None).process({"provider_id": "missing"}, FakeRequest())
+    )
+
+    assert response["ok"] is False
+    assert response["provider_id"] == "missing"
+    assert "Unknown OAuth provider" in response["error"]
+
+
+def test_manual_callback_unknown_provider_returns_structured_error():
+    response = asyncio.run(
+        manual_callback_api.ManualCallback(None, None).process({"provider_id": "missing"}, FakeRequest())
+    )
+
+    assert response["ok"] is False
+    assert response["provider_id"] == "missing"
+    assert "Unknown OAuth provider" in response["error"]
+
+
+def test_unknown_provider_id_on_provider_aware_api_returns_structured_error():
+    response = asyncio.run(Models(None, None).process({"provider_id": "missing"}, FakeRequest()))
+
+    assert response["ok"] is False
+    assert response["provider_id"] == "missing"
+    assert response["models"] == []
+    assert "Unknown OAuth provider" in response["error"]
+
+
+def test_register_oauth_routes_adds_codex_routes_and_provider_routes(monkeypatch):
+    fake_flask = types.ModuleType("flask")
+
+    class Response:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    fake_flask.Response = Response
+    fake_flask.jsonify = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
+    fake_flask.request = types.SimpleNamespace()
+    fake_flask.stream_with_context = lambda value: value
+
+    fake_codex = types.ModuleType("plugins._oauth.helpers.codex")
+    fake_config = types.ModuleType("plugins._oauth.helpers.config")
+    fake_config.codex_config = lambda: {
+        "proxy_base_path": "/oauth/codex",
+        "callback_path": "/auth/callback",
+    }
+
+    monkeypatch.setitem(sys.modules, "flask", fake_flask)
+    monkeypatch.setitem(sys.modules, "plugins._oauth.helpers.codex", fake_codex)
+    monkeypatch.setitem(sys.modules, "plugins._oauth.helpers.config", fake_config)
+
+    module_name = "plugins._oauth.helpers.routes"
+    previous_routes_module = sys.modules.pop(module_name, None)
+    try:
+        routes_module = importlib.import_module(module_name)
+
+        class FakeApp:
+            def __init__(self):
+                self.view_functions = {}
+                self.rules = []
+
+            def add_url_rule(self, rule, endpoint, view_func, methods):
+                self.view_functions[endpoint] = view_func
+                self.rules.append((rule, endpoint, methods))
+
+        registered_providers = []
+
+        class FakeProvider:
+            provider_id = "fake_provider"
+
+            def register_routes(self, app):
+                registered_providers.append(app)
+
+        fake_provider = FakeProvider()
+        monkeypatch.setattr(routes_module, "provider_registry", lambda: {"fake_provider": fake_provider})
+
+        app = FakeApp()
+        routes_module.register_oauth_routes(app)
+        routes_module.register_oauth_routes(app)
+
+        assert "oauth_codex_health" in app.view_functions
+        assert app.rules.count(("/oauth/codex/health", "oauth_codex_health", ["GET"])) == 1
+        assert registered_providers == [app, app]
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous_routes_module is not None:
+            sys.modules[module_name] = previous_routes_module
+
+
+def test_github_copilot_streaming_proxy_streams_successful_upstream(monkeypatch):
+    fake_flask = types.ModuleType("flask")
+
+    class Response:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    fake_request = types.SimpleNamespace(
+        method="POST",
+        host="localhost",
+        remote_addr="127.0.0.1",
+        headers={},
+        args={},
+        get_json=lambda silent=True: {"stream": True, "model": "gpt-5.2"},
+    )
+    fake_flask.Response = Response
+    fake_flask.jsonify = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
+    fake_flask.request = fake_request
+    fake_flask.stream_with_context = lambda value: value
+
+    fake_codex = types.ModuleType("plugins._oauth.helpers.codex")
+    fake_codex.response_headers = lambda upstream: dict(upstream.headers)
+    fake_config = types.ModuleType("plugins._oauth.helpers.config")
+    fake_config.codex_config = lambda: {
+        "proxy_base_path": "/oauth/codex",
+        "callback_path": "/auth/callback",
+        "proxy_token": "",
+        "require_proxy_token": False,
+    }
+
+    class FakeUpstream:
+        ok = True
+        status_code = 200
+        headers = {}
+        content = b"not-streamed"
+
+        def iter_content(self, chunk_size):
+            yield b"data: {}\n\n"
+
+    fake_requests = types.ModuleType("requests")
+    fake_requests.post = lambda *args, **kwargs: FakeUpstream()
+
+    monkeypatch.setitem(sys.modules, "flask", fake_flask)
+    monkeypatch.setitem(sys.modules, "plugins._oauth.helpers.codex", fake_codex)
+    monkeypatch.setitem(sys.modules, "plugins._oauth.helpers.config", fake_config)
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+    module_name = "plugins._oauth.helpers.routes"
+    previous_routes_module = sys.modules.pop(module_name, None)
+    try:
+        routes_module = importlib.import_module(module_name)
+
+        class FakeProvider:
+            def ensure_fresh_auth(self):
+                return {
+                    "access": "fresh-access-token",
+                    "base_url": "https://api.individual.githubcopilot.com",
+                }
+
+            def read_auth(self):
+                return self.ensure_fresh_auth()
+
+        monkeypatch.setattr(routes_module, "get_provider", lambda provider_id: FakeProvider())
+
+        response = routes_module.github_copilot_responses()
+
+        assert isinstance(response, Response)
+        assert response.kwargs["headers"]["Content-Type"] == "text/event-stream"
+        assert response.kwargs["status"] == 200
+        assert response.args[0] != b"not-streamed"
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous_routes_module is not None:
+            sys.modules[module_name] = previous_routes_module
+
+
+def test_github_copilot_proxy_does_not_send_bearer_token_to_malicious_base_url(monkeypatch):
+    fake_flask = types.ModuleType("flask")
+
+    class Response:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    fake_flask.Response = Response
+    fake_flask.jsonify = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
+    fake_flask.request = types.SimpleNamespace(
+        method="POST",
+        host="localhost",
+        remote_addr="127.0.0.1",
+        headers={},
+        args={},
+        get_json=lambda silent=True: {"stream": False, "model": "gpt-5.2"},
+    )
+    fake_flask.stream_with_context = lambda value: value
+
+    fake_codex = types.ModuleType("plugins._oauth.helpers.codex")
+    fake_codex.response_headers = lambda upstream: dict(upstream.headers)
+    fake_config = types.ModuleType("plugins._oauth.helpers.config")
+    fake_config.codex_config = lambda: {
+        "proxy_base_path": "/oauth/codex",
+        "callback_path": "/auth/callback",
+        "proxy_token": "",
+        "require_proxy_token": False,
+    }
+
+    calls = []
+
+    class FakeUpstream:
+        ok = True
+        status_code = 200
+        headers = {"Content-Type": "application/json"}
+        content = b'{"ok":true}'
+
+    fake_requests = types.ModuleType("requests")
+
+    def fake_post(url, headers, json, stream, timeout):
+        calls.append((url, headers, json, stream, timeout))
+        return FakeUpstream()
+
+    fake_requests.post = fake_post
+
+    monkeypatch.setitem(sys.modules, "flask", fake_flask)
+    monkeypatch.setitem(sys.modules, "plugins._oauth.helpers.codex", fake_codex)
+    monkeypatch.setitem(sys.modules, "plugins._oauth.helpers.config", fake_config)
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+    module_name = "plugins._oauth.helpers.routes"
+    previous_routes_module = sys.modules.pop(module_name, None)
+    try:
+        routes_module = importlib.import_module(module_name)
+
+        class FakeProvider:
+            def ensure_fresh_auth(self):
+                return {
+                    "access": "fresh-access-token",
+                    "base_url": "https://evil.example.com/v1",
+                }
+
+            def read_auth(self):
+                return self.ensure_fresh_auth()
+
+        monkeypatch.setattr(routes_module, "get_provider", lambda provider_id: FakeProvider())
+
+        response = routes_module.github_copilot_responses()
+
+        assert isinstance(response, Response)
+        assert calls[0][0] == "https://api.individual.githubcopilot.com/responses"
+        assert calls[0][1]["Authorization"] == "Bearer fresh-access-token"
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous_routes_module is not None:
+            sys.modules[module_name] = previous_routes_module
+
+
+def test_proxy_authorization_does_not_trust_host_header(monkeypatch):
+    fake_flask = types.ModuleType("flask")
+    fake_flask.Response = object
+    fake_flask.jsonify = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
+    fake_flask.request = types.SimpleNamespace(
+        host="localhost",
+        remote_addr="203.0.113.10",
+        headers={},
+        args={},
+    )
+    fake_flask.stream_with_context = lambda value: value
+
+    fake_codex = types.ModuleType("plugins._oauth.helpers.codex")
+    fake_config = types.ModuleType("plugins._oauth.helpers.config")
+    fake_config.codex_config = lambda: {
+        "proxy_base_path": "/oauth/codex",
+        "callback_path": "/auth/callback",
+        "proxy_token": "",
+        "require_proxy_token": False,
+    }
+
+    monkeypatch.setitem(sys.modules, "flask", fake_flask)
+    monkeypatch.setitem(sys.modules, "plugins._oauth.helpers.codex", fake_codex)
+    monkeypatch.setitem(sys.modules, "plugins._oauth.helpers.config", fake_config)
+
+    module_name = "plugins._oauth.helpers.routes"
+    previous_routes_module = sys.modules.pop(module_name, None)
+    try:
+        routes_module = importlib.import_module(module_name)
+
+        assert routes_module._proxy_authorized() is False
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous_routes_module is not None:
+            sys.modules[module_name] = previous_routes_module
+
+
+def test_xai_proxy_does_not_send_bearer_token_to_malicious_base_url(monkeypatch):
+    fake_flask = types.ModuleType("flask")
+
+    class Response:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    fake_flask.Response = Response
+    fake_flask.jsonify = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
+    fake_flask.request = types.SimpleNamespace(
+        method="POST",
+        host="localhost",
+        remote_addr="127.0.0.1",
+        headers={},
+        args={},
+        get_json=lambda silent=True: {"stream": False, "model": "grok-4.3"},
+    )
+    fake_flask.stream_with_context = lambda value: value
+
+    fake_codex = types.ModuleType("plugins._oauth.helpers.codex")
+    fake_codex.response_headers = lambda upstream: dict(upstream.headers)
+    fake_config = types.ModuleType("plugins._oauth.helpers.config")
+    fake_config.codex_config = lambda: {
+        "proxy_base_path": "/oauth/codex",
+        "callback_path": "/auth/callback",
+        "proxy_token": "",
+        "require_proxy_token": False,
+    }
+
+    calls = []
+
+    class FakeUpstream:
+        ok = True
+        status_code = 200
+        headers = {"Content-Type": "application/json"}
+        content = b'{"ok":true}'
+
+    fake_requests = types.ModuleType("requests")
+
+    def fake_post(url, headers, json, stream, timeout):
+        calls.append((url, headers, json, stream, timeout))
+        return FakeUpstream()
+
+    fake_requests.post = fake_post
+
+    monkeypatch.setitem(sys.modules, "flask", fake_flask)
+    monkeypatch.setitem(sys.modules, "plugins._oauth.helpers.codex", fake_codex)
+    monkeypatch.setitem(sys.modules, "plugins._oauth.helpers.config", fake_config)
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+    module_name = "plugins._oauth.helpers.routes"
+    previous_routes_module = sys.modules.pop(module_name, None)
+    try:
+        routes_module = importlib.import_module(module_name)
+
+        class FakeProvider:
+            def ensure_fresh_auth(self):
+                return {
+                    "access": "access-token",
+                    "refresh": "refresh-token",
+                    "base_url": "https://evil.example/v1",
+                }
+
+        monkeypatch.setattr(routes_module, "get_provider", lambda provider_id: FakeProvider())
+
+        response = routes_module.xai_grok_responses()
+
+        assert isinstance(response, Response)
+        assert calls[0][0] == "https://api.x.ai/v1/responses"
+        assert calls[0][1]["Authorization"] == "Bearer access-token"
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous_routes_module is not None:
+            sys.modules[module_name] = previous_routes_module

--- a/tests/test_oauth_providers.py
+++ b/tests/test_oauth_providers.py
@@ -55,8 +55,8 @@ from plugins._oauth.api import poll_device_login as poll_device_login_api
 from plugins._oauth.api import start_device_login as start_device_login_api
 from plugins._oauth.api import start_login as start_login_api
 from plugins._oauth.api.models import Models
-from plugins._oauth.extensions.python._functions.models.get_api_key.end._20_codex_account_dummy_key import (
-    CodexAccountDummyKey,
+from plugins._oauth.extensions.python._functions.models.get_api_key.end._20_oauth_account_dummy_key import (
+    OAuthAccountDummyKey,
 )
 from plugins._oauth.helpers import state
 from plugins._oauth.helpers.providers import base as provider_base
@@ -635,7 +635,7 @@ def test_poll_device_login_unknown_provider_returns_structured_error():
 def test_oauth_providers_report_dummy_api_key_when_missing(provider_id, initial):
     data = {"args": (provider_id,), "kwargs": {}, "result": initial}
 
-    CodexAccountDummyKey(agent=None).execute(data=data)
+    OAuthAccountDummyKey(agent=None).execute(data=data)
 
     assert data["result"] == DUMMY_API_KEY
 
@@ -647,7 +647,7 @@ def test_oauth_providers_report_dummy_api_key_when_missing(provider_id, initial)
 def test_oauth_providers_report_dummy_api_key_when_result_missing(provider_id):
     data = {"args": (provider_id,), "kwargs": {}}
 
-    CodexAccountDummyKey(agent=None).execute(data=data)
+    OAuthAccountDummyKey(agent=None).execute(data=data)
 
     assert data["result"] == DUMMY_API_KEY
 
@@ -659,7 +659,7 @@ def test_oauth_providers_report_dummy_api_key_when_result_missing(provider_id):
 def test_oauth_providers_preserve_configured_api_key(provider_id):
     data = {"args": (provider_id,), "kwargs": {}, "result": "configured"}
 
-    CodexAccountDummyKey(agent=None).execute(data=data)
+    OAuthAccountDummyKey(agent=None).execute(data=data)
 
     assert data["result"] == "configured"
 
@@ -689,13 +689,25 @@ def test_model_provider_config_contains_all_oauth_providers():
     assert "50001" not in json.dumps(provider_config)
 
 
-def test_provider_metadata_marks_new_oauth_providers_as_oauth_api_key_mode():
+def test_oauth_provider_config_marks_oauth_providers_as_oauth_api_key_mode():
+    provider_path = Path(__file__).resolve().parents[1] / "plugins/_oauth/conf/model_providers.yaml"
+    provider_config = yaml.safe_load(provider_path.read_text(encoding="utf-8"))
+    chat = provider_config["chat"]
+
+    assert chat[CODEX_PROVIDER_ID]["api_key_mode"] == "oauth"
+    assert chat[GITHUB_COPILOT_PROVIDER_ID]["api_key_mode"] == "oauth"
+    assert chat[GEMINI_API_PROVIDER_ID]["api_key_mode"] == "oauth"
+    assert chat[XAI_GROK_PROVIDER_ID]["api_key_mode"] == "oauth"
+
+
+def test_model_config_provider_metadata_stays_oauth_provider_agnostic():
     metadata_path = Path(__file__).resolve().parents[1] / "plugins/_model_config/provider_metadata.yaml"
     metadata = yaml.safe_load(metadata_path.read_text(encoding="utf-8"))
 
-    assert metadata["chat"][GITHUB_COPILOT_PROVIDER_ID]["api_key_mode"] == "oauth"
-    assert metadata["chat"][GEMINI_API_PROVIDER_ID]["api_key_mode"] == "oauth"
-    assert metadata["chat"][XAI_GROK_PROVIDER_ID]["api_key_mode"] == "oauth"
+    assert CODEX_PROVIDER_ID not in metadata["chat"]
+    assert GITHUB_COPILOT_PROVIDER_ID not in metadata["chat"]
+    assert GEMINI_API_PROVIDER_ID not in metadata["chat"]
+    assert XAI_GROK_PROVIDER_ID not in metadata["chat"]
 
 
 def test_usage_plan_catalog_covers_connectable_subscription_providers_only():

--- a/tests/test_oauth_providers.py
+++ b/tests/test_oauth_providers.py
@@ -75,11 +75,7 @@ from plugins._oauth.helpers.providers.base import (
     write_private_json,
 )
 from plugins._oauth.helpers.providers.registry import get_provider, provider_registry
-from plugins._oauth.helpers.usage_plans import (
-    CLAUDE_CODE_PROVIDER_ID,
-    GEMINI_CODE_ASSIST_PROVIDER_ID,
-    usage_plan_catalog,
-)
+from plugins._oauth.helpers.usage_plans import usage_plan_catalog
 
 
 class FakeRequest:
@@ -341,8 +337,12 @@ def test_status_api_returns_provider_registry_shape(monkeypatch):
         GITHUB_COPILOT_PROVIDER_ID,
         GEMINI_API_PROVIDER_ID,
         XAI_GROK_PROVIDER_ID,
-        CLAUDE_CODE_PROVIDER_ID,
-        GEMINI_CODE_ASSIST_PROVIDER_ID,
+    }
+    assert set(response["usage_plan_catalog"]) == {
+        CODEX_PROVIDER_ID,
+        GITHUB_COPILOT_PROVIDER_ID,
+        GEMINI_API_PROVIDER_ID,
+        XAI_GROK_PROVIDER_ID,
     }
     assert response["codex"] == response["provider_map"][CODEX_PROVIDER_ID]
 
@@ -698,8 +698,15 @@ def test_provider_metadata_marks_new_oauth_providers_as_oauth_api_key_mode():
     assert metadata["chat"][XAI_GROK_PROVIDER_ID]["api_key_mode"] == "oauth"
 
 
-def test_usage_plan_catalog_covers_current_and_nearby_subscription_providers():
+def test_usage_plan_catalog_covers_connectable_subscription_providers_only():
     catalog = usage_plan_catalog()
+
+    assert set(catalog) == {
+        CODEX_PROVIDER_ID,
+        GITHUB_COPILOT_PROVIDER_ID,
+        GEMINI_API_PROVIDER_ID,
+        XAI_GROK_PROVIDER_ID,
+    }
 
     assert {plan["id"] for plan in catalog[CODEX_PROVIDER_ID]["plans"]} >= {
         "free",
@@ -725,30 +732,6 @@ def test_usage_plan_catalog_covers_current_and_nearby_subscription_providers():
         "vertex_ai",
     }
     assert catalog[GEMINI_API_PROVIDER_ID]["implemented"] is True
-    assert {plan["id"] for plan in catalog[CLAUDE_CODE_PROVIDER_ID]["plans"]} >= {
-        "pro",
-        "max_5x",
-        "max_20x",
-        "team",
-        "enterprise_premium",
-        "enterprise_usage_based",
-    }
-    assert {plan["id"] for plan in catalog[GEMINI_CODE_ASSIST_PROVIDER_ID]["plans"]} >= {
-        "individual",
-        "google_ai_pro",
-        "google_ai_ultra",
-        "organization",
-        "code_assist_standard",
-        "code_assist_enterprise",
-        "gemini_api_oauth",
-    }
-    assert catalog[GEMINI_CODE_ASSIST_PROVIDER_ID]["implementation_status"] == "metadata_only"
-    google_modes = {
-        mode["id"]: mode
-        for mode in catalog[GEMINI_CODE_ASSIST_PROVIDER_ID]["provider_modes"]
-    }
-    assert google_modes["gemini_api_oauth"]["allowed"] is True
-    assert google_modes["antigravity_subscription_oauth"]["allowed"] is False
     assert {plan["id"] for plan in catalog[XAI_GROK_PROVIDER_ID]["plans"]} >= {
         "free",
         "supergrok_lite",
@@ -758,8 +741,6 @@ def test_usage_plan_catalog_covers_current_and_nearby_subscription_providers():
         "enterprise",
         "api_credits",
     }
-    assert catalog[CLAUDE_CODE_PROVIDER_ID]["implemented"] is False
-    assert catalog[GEMINI_CODE_ASSIST_PROVIDER_ID]["implemented"] is False
 
 
 def test_disconnect_api_returns_provider_result_contract(monkeypatch):

--- a/tests/test_oauth_static.py
+++ b/tests/test_oauth_static.py
@@ -4,30 +4,61 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_oauth_settings_exposes_codex_model_slots():
+def test_oauth_settings_exposes_provider_cards_and_model_slots():
     config_html = (PROJECT_ROOT / "plugins/_oauth/webui/config.html").read_text(encoding="utf-8")
     store_js = (PROJECT_ROOT / "plugins/_oauth/webui/oauth-config-store.js").read_text(encoding="utf-8")
 
+    assert "providerCards" in config_html + store_js
+    assert "OAuth Connections" in config_html + store_js
+    assert "OAUTH_PROVIDERS" not in store_js
+    assert "PROVIDER_FALLBACKS" not in store_js
     assert "Agent Zero models" in config_html
     assert "Main model" in store_js
     assert "Utility model" in store_js
-    assert "Use Codex" in config_html
-    assert "Search available Codex models" in config_html
+    assert "provider_map" in store_js
+    assert "Usage plans" in config_html
+    assert "usagePlanEntries" in store_js
+    assert "usage_plan_catalog" in (PROJECT_ROOT / "plugins/_oauth/api/status.py").read_text(encoding="utf-8")
     assert "copyMainToUtility" in config_html + store_js
 
 
-def test_oauth_settings_remove_redundant_model_action_and_account_label():
+def test_oauth_settings_exposes_provider_specific_controls_and_generic_copy():
     config_html = (PROJECT_ROOT / "plugins/_oauth/webui/config.html").read_text(encoding="utf-8")
     store_js = (PROJECT_ROOT / "plugins/_oauth/webui/oauth-config-store.js").read_text(encoding="utf-8")
 
     assert "Check Models" not in config_html
+    assert "Check models" in config_html
+    assert "enterprise_domain" in config_html + store_js
+    assert "manualCallback" in config_html + store_js
+    assert "Paste callback URL, query string, or code" in config_html + store_js
+    assert "supports_enterprise_domain" in config_html + store_js
+    assert "supports_manual_callback" in config_html + store_js
+    assert "supports_oauth_client_config" in config_html + store_js
+    assert "supports_quota_project" in config_html + store_js
+    assert "OAuth client ID" in config_html
+    assert "quota_project_id" in config_html + store_js
+    assert "submitManualCallback(card.provider_id)" in config_html
+    assert "cancelConnect(card.provider_id)" in config_html
+    assert "oauth-auth-attempt" in config_html
     assert "Codex/ChatGPT Account" not in config_html + store_js
+    assert "Available models from selected provider" in config_html
+    assert "Available models from Codex account" not in config_html
+
+
+def test_oauth_connect_buttons_disable_during_any_provider_connection():
+    config_html = (PROJECT_ROOT / "plugins/_oauth/webui/config.html").read_text(encoding="utf-8")
+    store_js = (PROJECT_ROOT / "plugins/_oauth/webui/oauth-config-store.js").read_text(encoding="utf-8")
+
+    assert ':disabled="Boolean($store.oauthConfig.connectingProvider) || Boolean($store.oauthConfig.disconnectingProvider)"' in config_html
+    assert ':disabled="Boolean($store.oauthConfig.connectingProvider) || $store.oauthConfig.disconnectingProvider"' not in config_html
+    assert "cancelConnect(providerId = \"\")" in store_js
+    assert "if (this.connectingProvider === providerId) this.connectingProvider = \"\";" in store_js
 
 
 def test_oauth_available_models_list_sits_above_advanced_without_borders():
     config_html = (PROJECT_ROOT / "plugins/_oauth/webui/config.html").read_text(encoding="utf-8")
 
-    assert "Available models from Codex account" in config_html
+    assert "Available models from selected provider" in config_html
     assert config_html.index("Available models") < config_html.index("<summary>Advanced</summary>")
     assert ".oauth-models-panel {\n      display: grid;\n      gap: 10px;\n      padding: 0;\n      border: 0;\n    }" in config_html
     model_chip_rule = config_html.split(".oauth-models span {", 1)[1].split("}", 1)[0]
@@ -41,8 +72,31 @@ def test_oauth_model_slots_reuse_model_config_api():
     assert 'const MODEL_CONFIG_API = "/plugins/_model_config";' in store_js
     assert "model_config_get" in store_js
     assert "model_config_set" in store_js
-    assert 'const CODEX_PROVIDER = "codex_oauth";' in store_js
+    assert "isOauthProvider" in store_js
+    assert "providerCards()" in store_js
     assert "saveModelConfigIfDirty" in store_js
+
+
+def test_browser_callback_completion_is_observed_from_modal():
+    store_js = (PROJECT_ROOT / "plugins/_oauth/webui/oauth-config-store.js").read_text(encoding="utf-8")
+
+    assert "startCallbackPolling(providerId)" in store_js
+    assert "stopCallbackPolling(providerId)" in store_js
+    assert "this.providerConnected(providerId)" in store_js
+
+
+def test_usage_plan_catalog_is_visible_without_provider_cards():
+    config_html = (PROJECT_ROOT / "plugins/_oauth/webui/config.html").read_text(encoding="utf-8")
+    store_js = (PROJECT_ROOT / "plugins/_oauth/webui/oauth-config-store.js").read_text(encoding="utf-8")
+    plans_py = (PROJECT_ROOT / "plugins/_oauth/helpers/usage_plans.py").read_text(encoding="utf-8")
+
+    assert "oauth-plan-catalog" in config_html
+    assert "Metadata only" in store_js
+    assert "Google Gemini / Antigravity" in plans_py
+    assert "Google Gemini API" in plans_py
+    assert "GEMINI_API_PROVIDER_ID" in plans_py
+    assert "antigravity_subscription_oauth" in plans_py
+    assert '"allowed": False' in plans_py
 
 
 def test_oauth_model_wrappers_do_not_add_box_borders_or_lateral_padding():

--- a/tests/test_oauth_static.py
+++ b/tests/test_oauth_static.py
@@ -91,12 +91,12 @@ def test_usage_plan_catalog_is_visible_without_provider_cards():
     plans_py = (PROJECT_ROOT / "plugins/_oauth/helpers/usage_plans.py").read_text(encoding="utf-8")
 
     assert "oauth-plan-catalog" in config_html
-    assert "Metadata only" in store_js
-    assert "Google Gemini / Antigravity" in plans_py
     assert "Google Gemini API" in plans_py
     assert "GEMINI_API_PROVIDER_ID" in plans_py
-    assert "antigravity_subscription_oauth" in plans_py
-    assert '"allowed": False' in plans_py
+    assert "Google Gemini / Antigravity" not in plans_py
+    assert "Claude Code" not in plans_py
+    assert "antigravity_subscription_oauth" not in plans_py
+    assert "claude_code_oauth" not in plans_py
 
 
 def test_oauth_model_wrappers_do_not_add_box_borders_or_lateral_padding():

--- a/tests/test_oauth_xai_grok.py
+++ b/tests/test_oauth_xai_grok.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import json
+import sys
+import types
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+@dataclass(frozen=True)
+class PkcePair:
+    verifier: str
+    challenge: str
+
+
+from plugins._oauth.helpers.providers.base import ProviderError, XAI_GROK_PROVIDER_ID
+from plugins._oauth.helpers.providers import xai_grok as xai
+from plugins._oauth.helpers.state import pop_attempt, put_attempt
+
+
+def _discovery() -> dict[str, str]:
+    return {
+        "authorization_endpoint": "https://auth.x.ai/oauth/authorize",
+        "token_endpoint": "https://auth.x.ai/oauth/token",
+    }
+
+
+def test_start_login_builds_xai_pkce_authorize_url_without_network(monkeypatch):
+    provider = xai.XaiGrokOAuthProvider()
+    fake_codex = types.ModuleType("plugins._oauth.helpers.codex")
+    fake_codex.PkcePair = PkcePair
+    fake_codex.generate_pkce = lambda: PkcePair("verifier", "challenge")
+    fake_codex.generate_state = lambda: "state-1"
+    monkeypatch.setitem(sys.modules, "plugins._oauth.helpers.codex", fake_codex)
+    monkeypatch.setattr(provider, "discovery", _discovery)
+
+    result = provider.start_login({})
+
+    try:
+        assert result.ok is True
+        assert result.provider_id == XAI_GROK_PROVIDER_ID
+        assert result.flow == "browser_pkce"
+        assert result.redirect_uri == "http://127.0.0.1:56121/callback"
+
+        parsed = urlparse(result.auth_url)
+        query = parse_qs(parsed.query)
+        assert result.auth_url.startswith("https://auth.x.ai/oauth/authorize?")
+        assert query["response_type"] == ["code"]
+        assert query["client_id"] == [xai.XAI_CLIENT_ID]
+        assert query["scope"] == [xai.XAI_SCOPE]
+        assert query["code_challenge"] == ["challenge"]
+        assert query["code_challenge_method"] == ["S256"]
+        assert query["state"] == ["state-1"]
+        assert query["plan"] == ["generic"]
+        assert query["referrer"] == ["agent-zero"]
+        assert query["redirect_uri"] == ["http://127.0.0.1:56121/callback"]
+        assert query["nonce"]
+    finally:
+        pop_attempt("state-1")
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            "http://127.0.0.1:56121/callback?code=abc&state=state-1",
+            {"code": "abc", "state": "state-1", "error": None, "error_description": None},
+        ),
+        ("?code=abc&state=state-1", {"code": "abc", "state": "state-1", "error": None, "error_description": None}),
+        ("code=abc&state=state-1", {"code": "abc", "state": "state-1", "error": None, "error_description": None}),
+        ("abc", {"code": "abc", "state": None, "error": None, "error_description": None}),
+    ],
+)
+def test_parse_manual_callback_accepts_url_query_and_bare_code(raw, expected):
+    assert xai.parse_manual_callback(raw) == expected
+
+
+def test_manual_callback_rejects_state_mismatch(monkeypatch):
+    provider = xai.XaiGrokOAuthProvider()
+    put_attempt(
+        "state-good",
+        "verifier",
+        xai.XAI_REDIRECT_URI,
+        provider_id=XAI_GROK_PROVIDER_ID,
+        extra={"token_endpoint": "https://auth.x.ai/oauth/token"},
+    )
+    monkeypatch.setattr(provider, "discovery", _discovery)
+
+    try:
+        result = provider.manual_callback({"callback": "code=abc&state=state-bad"})
+
+        assert result.ok is False
+        assert "state mismatch" in result.error.lower()
+    finally:
+        pop_attempt("state-good")
+        pop_attempt("state-bad")
+
+
+def test_manual_callback_exchanges_code_and_stores_tokens(tmp_path, monkeypatch):
+    provider = xai.XaiGrokOAuthProvider()
+    auth_path = tmp_path / "auth.json"
+    put_attempt(
+        "state-1",
+        "verifier-1",
+        xai.XAI_REDIRECT_URI,
+        provider_id=XAI_GROK_PROVIDER_ID,
+        extra={"token_endpoint": "https://auth.x.ai/oauth/token", "code_challenge": "challenge-1"},
+    )
+    calls = []
+
+    monkeypatch.setattr(provider, "auth_path", lambda: auth_path)
+    monkeypatch.setattr(provider, "discovery", _discovery)
+
+    def fake_exchange(token_endpoint, code, redirect_uri, code_verifier, code_challenge):
+        calls.append((token_endpoint, code, redirect_uri, code_verifier, code_challenge))
+        return {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "expires_in": 3600,
+            "id_token": "id-token",
+            "token_type": "Bearer",
+        }
+
+    monkeypatch.setattr(provider, "exchange_code", fake_exchange)
+
+    result = provider.manual_callback(
+        {"callback": "http://127.0.0.1:56121/callback?code=code-1&state=state-1"}
+    )
+
+    assert result.ok is True
+    assert result.completed is True
+    assert result.account_label == "xAI Grok"
+    assert calls == [
+        (
+            "https://auth.x.ai/oauth/token",
+            "code-1",
+            "http://127.0.0.1:56121/callback",
+            "verifier-1",
+            "challenge-1",
+        )
+    ]
+    saved = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert saved["provider"] == XAI_GROK_PROVIDER_ID
+    assert saved["access"] == "access-token"
+    assert saved["refresh"] == "refresh-token"
+
+
+def test_models_returns_curated_list_without_network(monkeypatch):
+    provider = xai.XaiGrokOAuthProvider()
+    monkeypatch.setattr(provider, "read_auth", lambda: {})
+
+    models = provider.models()
+
+    assert models[:4] == [
+        "grok-4.3",
+        "grok-4.20-0309-reasoning",
+        "grok-4.20-0309-non-reasoning",
+        "grok-4.20-multi-agent-0309",
+    ]
+
+
+def test_exchange_code_http_403_explains_oauth_tier_restriction(monkeypatch):
+    class FakeResponse:
+        ok = False
+        status_code = 403
+        text = "forbidden"
+
+        def json(self):
+            return {"error": "forbidden"}
+
+    class FakeRequests:
+        @staticmethod
+        def post(*args, **kwargs):
+            return FakeResponse()
+
+    monkeypatch.setitem(sys.modules, "requests", FakeRequests)
+
+    provider = xai.XaiGrokOAuthProvider()
+    with pytest.raises(ProviderError) as exc_info:
+        provider.exchange_code(
+            "https://auth.x.ai/oauth/token",
+            "code",
+            xai.XAI_REDIRECT_URI,
+            "verifier",
+            "challenge",
+        )
+
+    assert exc_info.value.status == 403
+    assert "restricted by tier" in str(exc_info.value)
+    assert "API-key `xai` provider" in str(exc_info.value)
+
+
+def test_refresh_403_preserves_oauth_tier_guidance(monkeypatch):
+    class FakeResponse:
+        ok = False
+        status_code = 403
+
+        def json(self):
+            return {"error": "forbidden"}
+
+    class FakeRequests:
+        @staticmethod
+        def post(*args, **kwargs):
+            return FakeResponse()
+
+    monkeypatch.setitem(sys.modules, "requests", FakeRequests)
+
+    provider = xai.XaiGrokOAuthProvider()
+    monkeypatch.setattr(
+        provider,
+        "read_auth",
+        lambda: {
+            "access": "expired-access-token",
+            "refresh": "refresh-token",
+            "expires": 1,
+            "token_endpoint": "https://auth.x.ai/oauth/token",
+        },
+    )
+
+    with pytest.raises(ProviderError) as exc_info:
+        provider.ensure_fresh_auth()
+
+    assert exc_info.value.status == 403
+    assert exc_info.value.code == "oauth_tier_restricted"
+    assert "restricted by tier" in str(exc_info.value)
+    assert "API-key `xai` provider" in str(exc_info.value)
+
+
+def test_ensure_fresh_auth_rejects_malicious_stored_token_endpoint(monkeypatch):
+    calls = []
+
+    class FakeRequests:
+        @staticmethod
+        def post(*args, **kwargs):
+            calls.append((args, kwargs))
+            raise AssertionError("malicious token endpoint must not be called")
+
+    monkeypatch.setitem(sys.modules, "requests", FakeRequests)
+
+    provider = xai.XaiGrokOAuthProvider()
+    monkeypatch.setattr(
+        provider,
+        "read_auth",
+        lambda: {
+            "access": "expired-access-token",
+            "refresh": "refresh-token",
+            "expires": 1,
+            "token_endpoint": "https://evil.example/oauth/token",
+        },
+    )
+
+    with pytest.raises(ProviderError) as exc_info:
+        provider.ensure_fresh_auth()
+
+    assert exc_info.value.code == "invalid_token_endpoint"
+    assert calls == []
+
+
+def test_models_does_not_send_bearer_token_to_malicious_base_url(monkeypatch):
+    calls = []
+
+    class FakeResponse:
+        ok = True
+
+        def json(self):
+            return {"data": [{"id": "safe-model"}]}
+
+    class FakeRequests:
+        @staticmethod
+        def get(url, headers, timeout):
+            calls.append((url, headers, timeout))
+            return FakeResponse()
+
+    monkeypatch.setitem(sys.modules, "requests", FakeRequests)
+
+    provider = xai.XaiGrokOAuthProvider()
+    monkeypatch.setattr(
+        provider,
+        "read_auth",
+        lambda: {
+            "access": "access-token",
+            "refresh": "refresh-token",
+            "expires": int(time.time() * 1000) + 3_600_000,
+            "base_url": "https://evil.example/v1",
+        },
+    )
+
+    assert provider.models() == ["safe-model"]
+    assert calls == [
+        (
+            "https://api.x.ai/v1/models",
+            {"Accept": "application/json", "Authorization": "Bearer access-token"},
+            30,
+        )
+    ]


### PR DESCRIPTION
## Summary
- Refactors `_oauth` around a provider registry while keeping the existing Codex/ChatGPT flow available through an adapter.
- Adds GitHub Copilot OAuth with device-code login, model checking, proxy routing, refresh handling, and disconnect support.
- Adds xAI Grok OAuth with browser PKCE/manual callback handling, model checking, proxy routing, refresh handling, and disconnect support.
- Updates the `_oauth` settings UI, model provider metadata, docs, and regression tests for multi-provider operation.

## Test plan
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p no:cacheprovider tests/test_oauth_github_copilot.py tests/test_oauth_providers.py tests/test_oauth_xai_grok.py tests/test_oauth_static.py -q`
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p no:cacheprovider tests/test_plugin_scan_prompt.py -q`
- [x] `pytest -q` attempted locally; blocked during collection in this Homebrew Python 3.14 shell by missing/import-broken repo dependencies such as `flask`, `litellm`, `simpleeval`, `httpx`, `pathspec`, `git`, `regex`, and `pytz`.

Gemini OAuth is intentionally not included in this PR.