### PR TITLE
FIX: Fix per-subagent model configs

### DIFF
--- a/plugins/_model_config/webui/config.html
+++ b/plugins/_model_config/webui/config.html
@@ -7,12 +7,20 @@
 </head>
 
 <body>
-  <div x-data
+  <div x-data="{ lastConfig: null }"
+       x-effect="
+         if (config && config !== lastConfig) {
+           lastConfig = config;
+           $store.modelConfig.initConfigFields(config);
+           if (typeof context !== 'undefined') {
+             context.settingsSnapshotJson = context._toComparableJson(config);
+           }
+         }
+       "
        x-init="
          await $store.modelConfig.ensureLoaded();
          $store.modelConfig.resetApiKeyDrafts();
          await $store.modelConfig.refreshApiKeyStatus();
-         $store.modelConfig.initConfigFields(config);
          $store.modelConfig.installSettingsHooks(context, config);
        ">
     <template x-if="config && $store.modelConfig._loaded">
@@ -21,7 +29,7 @@
         <!-- Model Sections (Main, Utility, Embedding) -->
         <template x-for="section in $store.modelConfig.MODEL_SECTIONS" :key="section.key">
           <div class="model-section"
-               x-data="{ model: config[section.key], modelType: section.key.replace('_model', ''), providers: $store.modelConfig.getProviders(section.key), searchType: $store.modelConfig.getSearchType(section.key), apiKeyMode: 'store' }">
+               x-data="{ get model() { return config[section.key]; }, modelType: section.key.replace('_model', ''), providers: $store.modelConfig.getProviders(section.key), searchType: $store.modelConfig.getSearchType(section.key), apiKeyMode: 'store' }">
             <div class="section-title" x-text="section.title"></div>
             <div class="section-description" x-text="section.desc"></div>
             <x-component path="/plugins/_model_config/webui/model-field.html"></x-component>

--- a/plugins/_model_config/webui/config.html
+++ b/plugins/_model_config/webui/config.html
@@ -11,8 +11,11 @@
        x-effect="
          if (config && config !== lastConfig) {
            lastConfig = config;
+           const snapshotBeforeInit = typeof context !== 'undefined'
+             ? context._toComparableJson(config)
+             : null;
            $store.modelConfig.initConfigFields(config);
-           if (typeof context !== 'undefined') {
+           if (typeof context !== 'undefined' && context.settingsSnapshotJson === snapshotBeforeInit) {
              context.settingsSnapshotJson = context._toComparableJson(config);
            }
          }

--- a/plugins/_model_config/webui/model-config-store.js
+++ b/plugins/_model_config/webui/model-config-store.js
@@ -311,7 +311,7 @@ export const store = createStore("modelConfig", {
     context.save = async () => {
       context.error = null;
       try {
-        await this.persistApiKeysForConfig(config);
+        await this.persistApiKeysForConfig(context.settings);
       } catch (e) {
         context.error = e?.message || 'Failed to save API keys.';
         return;

--- a/tests/test_model_config_api_keys.py
+++ b/tests/test_model_config_api_keys.py
@@ -118,6 +118,14 @@ def test_model_config_frontend_tracks_inline_api_key_edits():
     assert "$store.modelConfig.resetApiKeyDrafts();" in modal_content
 
 
+def test_model_config_snapshot_sync_only_adjusts_clean_loaded_configs():
+    config_path = PROJECT_ROOT / "plugins" / "_model_config" / "webui" / "config.html"
+    config_content = config_path.read_text(encoding="utf-8")
+
+    assert "const snapshotBeforeInit" in config_content
+    assert "context.settingsSnapshotJson === snapshotBeforeInit" in config_content
+
+
 def test_model_switcher_frontend_renders_custom_overrides():
     switcher_path = PROJECT_ROOT / "plugins" / "_model_config" / "webui" / "switcher-mixin.js"
     refresh_extension_path = (


### PR DESCRIPTION
When per-subagent model assignments are made, they are not saved and the UI doesn't reflect them.  This fix was made with AI assistance and human reviewed.

The problems stemmed from how the frontend's reactivity system (Alpine.js) handled the dynamic loading of settings when a user changed the "Project" and "Agent Profile" dropdowns:

The "Unsaved Changes" Popup: When the user switched the Agent Profile to "Developer", the application fetched the correct settings and created a snapshot to monitor for unsaved changes. However, an initialization script ran a moment later to insert empty default properties (like _kwargs_text) if they were missing. Since this modification happened after the snapshot was taken, the UI falsely believed the user had manually changed something.

Changes Reverting to Default Model: The UI elements where the user typed the new model name were tied to a local variable populated only once when the modal first opened (using the Global configuration). When the user switched the scope to "Developer", the main configuration object was updated under the hood, but the UI fields remained permanently tethered to the old "Global" object.

When the user typed his new model name, they were modifying the orphaned object.

When the user clicked "Save", the system submitted the newly loaded (but completely unmodified) "subagent" object. Because it was empty/unmodified, it saved the fallback default model to disk.

This resulted in the engine ignoring user changes (since the default was saved) and the dialogs showing the default model when reopened.


Fixes:
Modified the Alpine components in _model_config:

Reactive Getters (config.html): Changed model: config[section.key] to a reactive getter get model() { return config[section.key]; }. This ensures the UI fields always point to and mutate the currently active configuration scope, regardless of how many times the user switches the dropdowns.

Lifecycle Syncing (config.html): Migrated the initConfigFields logic from a one-time x-init call into an x-effect that watches for scope changes. When a new scope is loaded, it initializes the fields and immediately updates the settingsSnapshotJson to prevent the false "Unsaved Changes" warning.

Dynamic Store Hooks (model-config-store.js): Updated the installSettingsHooks method to read context.settings dynamically upon save, rather than locking into the stale object from initialization.
