### PR TITLE
FEATURE: Allow umask to be changed via docker environment UMASK setting

### DIFF
--- a/docker/run/fs/exe/initialize.sh
+++ b/docker/run/fs/exe/initialize.sh
@@ -19,5 +19,10 @@ chmod 444 /root/.profile
 # update package list to save time later
 apt-get update > /dev/null 2>&1 &
 
+# Honor a docker environment supplied UMASK
+if [ -n "$UMASK" ]; then
+    umask "$UMASK"
+fi
+
 # let supervisord handle the services
 exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
This change allows a user to specify a umask setting using a docker UMASK environment var.

The reason for this is because agent zero runs as root.  When it writes files to the workspace, it writes them as root:root and the user outside the container cannot modify them.

One solution to this is to add the user to an "agentzero" group and use the setgid bit so whatever is written under /a0/usr belongs to a group the user has access to.  However, since agent-zero uses a default umask of 022 the user still cannot write to these files.

By allowing the user to specify a umask of 002, the agent now writes files to /a0/usr that belong to the group via setgid and are writeable by the group via the umask.