### PR TITLE
test(browser): regression tests for issue #723 error clarity

### DIFF
--- a/tests/test_browser_agent_regressions.py
+++ b/tests/test_browser_agent_regressions.py
@@ -2940,3 +2940,112 @@ def test_legacy_browser_dependency_is_removed():
     assert ("browser" + "-use") not in (PROJECT_ROOT / "requirements.txt").read_text(
         encoding="utf-8"
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression: issue #723 — browser failures must return clear error messages
+#
+# The removed browser-use agent produced "Task reached step limit without
+# completion. Last page: about:blank" when the underlying LLM provider
+# rejected structured-output headers.  The current Playwright-based tool
+# must return actionable errors instead.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_browser_tool_returns_clear_error_when_runtime_unavailable(monkeypatch):
+    """Browser tool surfaces a clear message when the runtime cannot start.
+
+    Covers the provider-rejection scenario from issue #723 where API errors
+    (e.g. unsupported ``anthropic-beta`` headers, grammar-too-large replies)
+    caused the old browser-use agent to silently exhaust its step budget and
+    return a confusing "about:blank / step limit" message.  The current tool
+    must propagate a human-readable error immediately instead.
+    """
+
+    async def _failing_get_runtime(context_id, create=True, agent=None):
+        raise RuntimeError(
+            "litellm.BadRequestError: structured-outputs-2025-11-13 not supported"
+        )
+
+    monkeypatch.setattr(browser_tool_module, "get_runtime", _failing_get_runtime)
+    tool = browser_tool_module.Browser(
+        agent=SimpleNamespace(context=SimpleNamespace(id="ctx")),
+        name="browser",
+        method=None,
+        args={},
+        message="",
+        loop_data=None,
+    )
+
+    response = await tool.execute(action="open", url="https://example.com")
+
+    assert response.break_loop is False
+    assert "runtime unavailable" in response.message.lower()
+    # Must not reproduce the old vague "step limit / about:blank" wording
+    assert "step limit" not in response.message.lower()
+    assert "about:blank" not in response.message
+
+
+@pytest.mark.anyio
+async def test_browser_action_failure_names_the_failed_action(monkeypatch):
+    """Browser tool identifies the failing action when runtime.call raises.
+
+    Complements test_browser_tool_returns_clear_error_when_runtime_unavailable
+    for the case where the runtime starts successfully but a subsequent call
+    fails (e.g. CDP disconnection, page crash).  The error must name the
+    action so operators can triage without reading raw tracebacks.
+    """
+
+    class _FailingRuntime:
+        async def call(self, method, *args, **kwargs):
+            raise RuntimeError("CDP connection lost")
+
+    async def _ok_get_runtime(context_id, create=True, agent=None):
+        return _FailingRuntime()
+
+    monkeypatch.setattr(browser_tool_module, "get_runtime", _ok_get_runtime)
+    tool = browser_tool_module.Browser(
+        agent=SimpleNamespace(context=SimpleNamespace(id="ctx")),
+        name="browser",
+        method=None,
+        args={},
+        message="",
+        loop_data=None,
+    )
+
+    response = await tool.execute(action="navigate", browser_id=1, url="https://example.com")
+
+    assert response.break_loop is False
+    assert "navigate" in response.message
+    assert "failed" in response.message.lower()
+    assert "step limit" not in response.message.lower()
+    assert "about:blank" not in response.message
+
+
+@pytest.mark.anyio
+async def test_browser_unknown_action_returns_informative_message(monkeypatch):
+    """Unknown action keyword returns an informative error, not a blank failure."""
+
+    class _NeverCalledRuntime:
+        async def call(self, method, *args, **kwargs):
+            raise AssertionError("runtime.call should not be reached for unknown action")
+
+    async def _ok_get_runtime(context_id, create=True, agent=None):
+        return _NeverCalledRuntime()
+
+    monkeypatch.setattr(browser_tool_module, "get_runtime", _ok_get_runtime)
+    tool = browser_tool_module.Browser(
+        agent=SimpleNamespace(context=SimpleNamespace(id="ctx")),
+        name="browser",
+        method=None,
+        args={},
+        message="",
+        loop_data=None,
+    )
+
+    response = await tool.execute(action="nonexistent_action_xyz")
+
+    assert response.break_loop is False
+    assert "nonexistent_action_xyz" in response.message
+    assert "step limit" not in response.message.lower()


### PR DESCRIPTION
## Summary

- Add three regression tests to `tests/test_browser_agent_regressions.py` that guard against reintroducing the confusing `"Task reached step limit without completion. Last page: about:blank"` error reported in #723.
- Each test patches `get_runtime` to simulate a different failure mode of the Playwright-based browser tool and asserts that the returned message is specific, actionable, and does **not** contain the old `"step limit"` / `"about:blank"` wording.

## Background

Issue #723 reported that every browser task since v0.9.4 silently failed with:

```
Task reached step limit without completion. Last page: about:blank.
The browser agent may need clearer instructions on when to finish.
```

Root cause: the removed `browser-use` library sent an `anthropic-beta: structured-outputs-2025-11-13` header to OpenRouter, which proxied requests to providers (Amazon Bedrock, Google Vertex) that reject it. After three consecutive API errors, `browser-use` exhausted its step budget and returned the generic fallback message above — giving users no indication that the real problem was an API rejection.

The fix (commit `983d431a`) replaced the browser-use agent with the native Playwright `_browser` plugin, which propagates concrete error messages:

| Failure mode | Current message |
|---|---|
| Runtime cannot start | `Browser runtime unavailable: <reason>` |
| Action call fails | `Browser <action> failed: <reason>` |
| Unknown action keyword | `Unknown browser action: <name>` |

The existing `test_legacy_browser_dependency_is_removed` test already verifies that `browser-use` and `_browser_agent` are gone. This PR adds complementary tests that verify the *new* tool's error-handling contracts, so the old vague wording cannot be reintroduced undetected.

## Tests added

| Test name | What it verifies |
|---|---|
| `test_browser_tool_returns_clear_error_when_runtime_unavailable` | `get_runtime` raises → message contains `"runtime unavailable"`, not `"step limit"` |
| `test_browser_action_failure_names_the_failed_action` | `runtime.call` raises → message names the failing action and contains `"failed"` |
| `test_browser_unknown_action_returns_informative_message` | Unknown action keyword → message names the keyword, not a blank failure |

## Test plan

```
pytest tests/test_browser_agent_regressions.py \
  -k "test_browser_tool_returns_clear_error_when_runtime_unavailable \
      or test_browser_action_failure_names_the_failed_action \
      or test_browser_unknown_action_returns_informative_message \
      or test_legacy_browser_dependency_is_removed" \
  -v
```

All four tests pass. No other tests are modified.

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)
