### PR TITLE
fix(_desktop): allow shrinking the Desktop canvas surface

### DIFF
--- a/plugins/_desktop/webui/desktop-panel.html
+++ b/plugins/_desktop/webui/desktop-panel.html
@@ -723,6 +723,12 @@
       }
 
     }
+
+    /* While the canvas is being resized, the left-edge drag sweeps the cursor across this
+       iframe, which captures the pointermove and freezes shrinking (widening drags away, so
+       it works). Disable hit-testing on the frame during the drag — right-canvas-store.js
+       toggles `right-canvas-resizing` on <body> for the duration of the drag. */
+    body.right-canvas-resizing .office-desktop-frame { pointer-events: none; }
   </style>
 </body>
 </html>


### PR DESCRIPTION
Fixes #1693.

The **Desktop** Canvas surface can be dragged wider but not narrower — shrinking with the resize handle freezes.

**Cause:** the live desktop renders in `<iframe class="office-desktop-frame">`. Canvas resize is driven by a global `pointermove` from the left-edge handle; shrinking sweeps the cursor across the iframe, which captures the event and freezes the drag. Widening moves the cursor away from the iframe, so it works. (Browser uses an `<img>` screencast and Editor is DOM, so only the iframe-based Desktop surface is affected.)

**Fix:** one CSS rule in `plugins/_desktop/webui/desktop-panel.html` that disables hit-testing on the frame only while a resize is in progress — `right-canvas-store.js` already sets `right-canvas-resizing` on `<body>` for the duration of the drag:

```css
body.right-canvas-resizing .office-desktop-frame { pointer-events: none; }
```

Verified locally: shrink then works in both directions, no other interaction affected, and it persists across restart.