### PR TITLE
Add TrustedRouter model provider

### DIFF
--- a/conf/model_providers.yaml
+++ b/conf/model_providers.yaml
@@ -203,6 +203,13 @@ chat:
         "HTTP-Referer": "https://agent-zero.ai/"
         "X-Title": "Agent Zero"
         "X-OpenRouter-Categories": "personal-agent,cloud-agent"
+  trustedrouter:
+    name: TrustedRouter
+    litellm_provider: openai
+    models_list:
+      endpoint_url: "/models"
+    kwargs:
+      api_base: https://api.trustedrouter.com/v1
   sambanova:
     name: Sambanova
     litellm_provider: sambanova

--- a/plugins/_onboarding/webui/onboarding-providers.js
+++ b/plugins/_onboarding/webui/onboarding-providers.js
@@ -245,7 +245,7 @@ export const ONBOARDING_PROVIDER_OVERRIDES = {
   trustedrouter: {
     logo: "https://trustedrouter.com/favicon.ico",
     setup_url: "https://trustedrouter.com/",
-    api_key_url: "https://trustedrouter.com/console/keys",
+    api_key_url: "https://trustedrouter.com/console/api-keys",
     docs_url: "https://trustedrouter.com/docs",
     default_chat_model: "trustedrouter/auto",
     default_utility_model: "trustedrouter/auto",

--- a/plugins/_onboarding/webui/onboarding-providers.js
+++ b/plugins/_onboarding/webui/onboarding-providers.js
@@ -1,5 +1,6 @@
 export const TOP_CLOUD_PROVIDER_IDS = [
   "openrouter",
+  "trustedrouter",
   "a0_venice",
   "openai",
   "anthropic",
@@ -240,6 +241,17 @@ export const ONBOARDING_PROVIDER_OVERRIDES = {
     api_key_mode: "required",
     model_list_autoload: true,
     short_description: "One key for many model families.",
+  },
+  trustedrouter: {
+    logo: "https://trustedrouter.com/favicon.ico",
+    setup_url: "https://trustedrouter.com/",
+    api_key_url: "https://trustedrouter.com/console/keys",
+    docs_url: "https://trustedrouter.com/docs",
+    default_chat_model: "trustedrouter/auto",
+    default_utility_model: "trustedrouter/auto",
+    api_key_mode: "required",
+    model_list_autoload: true,
+    short_description: "OpenRouter-compatible routing with attested gateways.",
   },
   other: {
     logo: "/public/darkSymbol.svg",


### PR DESCRIPTION
## Summary
- add TrustedRouter to the model provider registry as an OpenAI-compatible provider
- add TrustedRouter to onboarding cloud provider choices
- use https://api.trustedrouter.com/v1 as the base URL and trustedrouter/auto defaults

## Testing
- git diff --check