### PR TITLE
Add OpenPaths as a cloud model provider

### DIFF
--- a/conf/model_providers.yaml
+++ b/conf/model_providers.yaml
@@ -139,6 +139,13 @@ chat:
         "HTTP-Referer": "https://agent-zero.ai/"
         "X-Title": "Agent Zero"
         "X-OpenRouter-Categories": "personal-agent,cloud-agent"
+  openpaths:
+    name: OpenPaths
+    litellm_provider: openai
+    models_list:
+      endpoint_url: "https://openpaths.io/v1/models"
+    kwargs:
+      api_base: https://openpaths.io/v1
   sambanova:
     name: Sambanova
     litellm_provider: sambanova

--- a/plugins/_onboarding/webui/onboarding-providers.js
+++ b/plugins/_onboarding/webui/onboarding-providers.js
@@ -22,6 +22,7 @@ export const MORE_CLOUD_PROVIDER_IDS = [
   "github_copilot",
   "sambanova",
   "cometapi",
+  "openpaths",
   "other",
 ];
 
@@ -191,6 +192,17 @@ export const ONBOARDING_PROVIDER_OVERRIDES = {
     api_key_mode: "required",
     model_list_autoload: true,
     short_description: "One key for many model families.",
+  },
+  openpaths: {
+    logo: "https://openpaths.io/favicon.png",
+    setup_url: "https://openpaths.io/",
+    api_key_url: "https://openpaths.io/account",
+    docs_url: "https://openpaths.io/works-with-openpaths",
+    default_chat_model: "openpaths/auto",
+    default_utility_model: "openpaths/auto-fast",
+    api_key_mode: "required",
+    model_list_autoload: true,
+    short_description: "One key, neural routing across many models.",
   },
   other: {
     logo: "/public/darkSymbol.svg",


### PR DESCRIPTION
## What

Adds [OpenPaths](https://openpaths.io) as a selectable cloud model provider.

OpenPaths is an OpenAI-compatible model gateway that neural-routes a single request to the best backing model across many families (one key, many models — same role as the existing OpenRouter provider).

## Changes
- `conf/model_providers.yaml`: register `openpaths` under `chat` as a LiteLLM `openai`-compatible provider with `api_base: https://openpaths.io/v1` and model list autoloaded from `https://openpaths.io/v1/models`.
- `plugins/_onboarding/webui/onboarding-providers.js`: add OpenPaths to `MORE_CLOUD_PROVIDER_IDS` and an onboarding metadata card (logo, setup/key/docs URLs, default models `openpaths/auto` + `openpaths/auto-fast`).

## Notes
- API key resolves through the existing `get_api_key` convention via `OPENPATHS_API_KEY` (or `API_KEY_OPENPATHS`) — no new key-handling code.
- Mirrors the existing OpenRouter/Venice openai-compatible entries; no behavior change for other providers.

## Testing
- `conf/model_providers.yaml` validated as YAML; `chat.openpaths` parses with the expected keys.
- With `OPENPATHS_API_KEY` set, OpenPaths appears in onboarding and its model list autoloads from the `/v1/models` endpoint.