### PR TITLE
feat(editor): add Open file button to canvas tab bar

### DIFF
--- a/plugins/_editor/webui/editor-panel.html
+++ b/plugins/_editor/webui/editor-panel.html
@@ -41,6 +41,16 @@
             <button
               type="button"
               class="editor-new-tab"
+              title="Open file"
+              aria-label="Open file"
+              :disabled="$store.editor.loading || $store.editor.saving"
+              @click="$store.editor.runNewMenuAction('open')"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true">folder_open</span>
+            </button>
+            <button
+              type="button"
+              class="editor-new-tab"
               title="New Markdown"
               aria-label="New Markdown"
               :disabled="$store.editor.loading || $store.editor.saving"


### PR DESCRIPTION
## Problem

When the Editor runs as a canvas surface (panel mode), the `+` button in the tab bar is hardcoded to create a new Markdown file only:

```html
@click="$store.editor.runNewMenuAction('markdown')"
```

The "Open" option (file browser) is only available:
- In the **empty state** screen (no files open)
- In the **modal-mode header dropdown** (`installHeaderNewMenu`), which requires `.modal-inner` / `.modal-header` elements that are **not present** in canvas panel mode

This means once any file is open, there is no accessible UI to open a second existing file without first closing all tabs.

## Fix

Adds a `folder_open` icon button immediately **before** the `+` (New Markdown) button in the tab bar.

It calls the existing `runNewMenuAction('open')` → `openFileBrowser()` pipeline — no logic changes required.

```html
<button type="button" class="editor-new-tab"
  title="Open file" aria-label="Open file"
  @click="$store.editor.runNewMenuAction('open')">
  <span class="material-symbols-outlined">folder_open</span>
</button>
```

## Result

Users can now open an existing file at any time directly from the tab bar, without closing the current file(s).

## Change scope

- **1 file changed**: `plugins/_editor/webui/editor-panel.html`
- **+10 lines** — one new button element
- No logic, store, API, or style changes
