### PR TITLE
fix: honour vision=false by stripping image_url blocks before API call

### DIFF
--- a/helpers/images.py
+++ b/helpers/images.py
@@ -29,6 +29,19 @@ def prepare_content(content: Any) -> Any:
     return {key: prepare_content(value) for key, value in content.items()}
 
 
+def strip_images(content: Any) -> Any:
+    """Remove all image_url blocks from message content when vision is disabled."""
+    if isinstance(content, list):
+        filtered = [strip_images(item) for item in content if not (isinstance(item, dict) and item.get("type") == "image_url")]
+        if not filtered:
+            return ""  # image-only message; return empty string rather than []
+        # Collapse single-text-block list back to a plain string
+        if len(filtered) == 1 and isinstance(filtered[0], dict) and filtered[0].get("type") == "text":
+            return filtered[0].get("text", "")
+        return filtered
+    return content
+
+
 def is_local_ref(url: str) -> bool:
     if not url:
         return False

--- a/models.py
+++ b/models.py
@@ -327,9 +327,13 @@ class LiteLLMChatWrapper(SimpleChatModel):
             "system": "system",
             "tool": "tool",
         }
+        vision_enabled = self.a0_model_conf.vision if self.a0_model_conf else True
         for m in messages:
             role = role_mapping.get(m.type, m.type)
-            message_dict = {"role": role, "content": images.prepare_content(m.content)}
+            content = images.prepare_content(m.content)
+            if not vision_enabled:
+                content = images.strip_images(content)
+            message_dict = {"role": role, "content": content}
 
             # Handle tool calls for AI messages
             tool_calls = getattr(m, "tool_calls", None)

--- a/tests/test_vision_load_image_refs.py
+++ b/tests/test_vision_load_image_refs.py
@@ -52,6 +52,51 @@ def _install_tool_stub(monkeypatch):
     monkeypatch.delitem(sys.modules, "tools.vision_load", raising=False)
 
 
+def test_strip_images_passthrough_string():
+    assert images.strip_images("hello") == "hello"
+    assert images.strip_images("") == ""
+
+
+def test_strip_images_image_only_returns_empty_string():
+    content = [{"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}]
+    assert images.strip_images(content) == ""
+
+
+def test_strip_images_multi_image_only_returns_empty_string():
+    content = [
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,xyz"}},
+    ]
+    assert images.strip_images(content) == ""
+
+
+def test_strip_images_text_and_image_collapses_to_string():
+    content = [
+        {"type": "text", "text": "describe this"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ]
+    assert images.strip_images(content) == "describe this"
+
+
+def test_strip_images_multiple_text_blocks_preserved():
+    content = [
+        {"type": "text", "text": "first"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        {"type": "text", "text": "second"},
+    ]
+    result = images.strip_images(content)
+    assert result == [{"type": "text", "text": "first"}, {"type": "text", "text": "second"}]
+
+
+def test_strip_images_no_images_unchanged():
+    content = [{"type": "text", "text": "plain text"}]
+    assert images.strip_images(content) == "plain text"
+
+
+def test_strip_images_plain_string_content_unchanged():
+    assert images.strip_images("no images here") == "no images here"
+
+
 def test_prepare_content_keeps_missing_local_image_refs_strict():
     missing_path = "/tmp/a0-missing-desktop-screenshot.png"
 


### PR DESCRIPTION
## Problem

When a user sets `vision: false` on their chat model, Agent Zero still forwards `image_url` content blocks to the LLM provider. This causes providers that do not support image input (most text-only models on OpenRouter and others) to return:

```
{"error":{"message":"No endpoints found that support image input","code":404}}
```

The `vision` field on `ModelConfig` was defined but **never consulted** when building the message payload in `LiteLLMChatWrapper._convert_messages`. All message content, including images, was passed through `images.prepare_content()` unconditionally.

## Fix

**`helpers/images.py`** — adds `strip_images(content)` which removes `image_url` blocks from a content list:
- Image-only content (no text) → returns `""` instead of `[]` to avoid empty-content API errors
- Single remaining text block → collapsed from `[{"type":"text","text":"..."}]` back to a plain string
- Multiple remaining text blocks → returned as-is

**`models.py`** — `_convert_messages` now reads `self.a0_model_conf.vision` and calls `strip_images()` when vision is disabled.

## Tests

7 new unit tests added to `tests/test_vision_load_image_refs.py` covering:
- String passthrough (no-op)
- Image-only list → `""`
- Multi-image-only list → `""`
- Mixed text+image → collapsed to plain string
- Multiple text blocks with image → list with images removed
- Text-only list → collapsed to plain string

All 7 tests pass.

## Reproduction

1. Set chat model to any text-only model (e.g. `deepseek/deepseek-r2`) on OpenRouter
2. Disable vision in settings
3. Send a message — if any prior message in context contains an image attachment, the error `No endpoints found that support image input` is returned
