### PR TITLE
fix: persist generated FLASK_SECRET_KEY to prevent session loss on restart

### DIFF
--- a/helpers/ui_server.py
+++ b/helpers/ui_server.py
@@ -74,7 +74,11 @@ class UiServerRuntime:
     @classmethod
     def create(cls) -> "UiServerRuntime":
         webapp = Flask("app", static_folder=get_abs_path("./webui"), static_url_path="/")
-        webapp.secret_key = os.getenv("FLASK_SECRET_KEY") or secrets.token_hex(32)
+        flask_secret_key = os.getenv("FLASK_SECRET_KEY")
+        if not flask_secret_key:
+            flask_secret_key = secrets.token_hex(32)
+            dotenv.save_dotenv_value("FLASK_SECRET_KEY", flask_secret_key)
+        webapp.secret_key = flask_secret_key
 
         WerkzeugRequest.max_form_memory_size = UPLOAD_LIMIT_BYTES
         webapp.config.update(


### PR DESCRIPTION
## Problem

When `FLASK_SECRET_KEY` is not explicitly set in the environment, the server generates a new random secret key on every restart:

```python
webapp.secret_key = os.getenv("FLASK_SECRET_KEY") or secrets.token_hex(32)
```

This invalidates all browser session cookies, causing authenticated API/WebSocket requests to redirect to `/login` (returning HTML) instead of returning JSON. The frontend then fails with:

``"Unexpected token <"``

This is particularly impactful for Docker deployments where containers are restarted regularly.

## Fix

When `FLASK_SECRET_KEY` is not set, auto-generate one AND persist it to `usr/.env` using the existing `dotenv.save_dotenv_value()` helper:

```python
flask_secret_key = os.getenv("FLASK_SECRET_KEY")
if not flask_secret_key:
    flask_secret_key = secrets.token_hex(32)
    dotenv.save_dotenv_value("FLASK_SECRET_KEY", flask_secret_key)
webapp.secret_key = flask_secret_key
```

This way, the generated key survives restarts and sessions remain valid. Users can still override with their own key via the env var.

## Testing

- Verified on local Docker deployment with 3 separate containers
- Sessions persist across container restarts
- No more `Unexpected token <` errors after restart
- Existing manually-set `FLASK_SECRET_KEY` values are respected (backward compatible)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)