### PR TITLE
fix(defer): drain pending tasks on EventLoopThread teardown (closes #1723, #1722)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,10 @@ agent_history.gif
 .agent/**
 .claude/**
 .playwright-cli/
+
+# Local-only artifacts (testing Docker image, user-data backups, test venv)
+/agent-zero-backup-*.zip
+/DockerfileFix
+/docker-compose.fix.yml
+/.venv-test/
+/docker/run/agent-zero/

--- a/helpers/defer.py
+++ b/helpers/defer.py
@@ -17,11 +17,23 @@ async def _drain_pending_tasks(loop: asyncio.AbstractEventLoop) -> None:
     "Task was destroyed but it is pending!" when ``loop.close()`` runs while
     background tasks (e.g. ``asyncio.wait_for(...)`` coroutines) are still
     scheduled.
+
+    The drain task itself MUST be excluded from the cancellation set:
+    ``asyncio.run_coroutine_threadsafe`` schedules this coroutine as a Task
+    on ``loop`` and ``asyncio.all_tasks(loop=loop)`` includes it. Cancelling
+    it would abort ``asyncio.gather`` before it could await the other
+    cancellations, leaving the originally-pending tasks still pending.
     """
-    pending = [t for t in asyncio.all_tasks(loop=loop) if not t.done()]
+    current = asyncio.current_task(loop=loop)
+    pending = [
+        t for t in asyncio.all_tasks(loop=loop)
+        if not t.done() and t is not current
+    ]
     for t in pending:
         t.cancel()
     if pending:
+        # Wait for cancellations to settle, ignoring any errors raised by
+        # cancelled children (CancelledError, TimeoutError, ...).
         await asyncio.gather(*pending, return_exceptions=True)
 
 

--- a/helpers/defer.py
+++ b/helpers/defer.py
@@ -9,6 +9,22 @@ T = TypeVar("T")
 THREAD_BACKGROUND = "Background"
 
 
+async def _drain_pending_tasks(loop: asyncio.AbstractEventLoop) -> None:
+    """Cancel and await all still-pending tasks on ``loop``.
+
+    Called from the owning thread via ``run_coroutine_threadsafe`` before the
+    loop is stopped/closed. Without this, asyncio emits warnings like
+    "Task was destroyed but it is pending!" when ``loop.close()`` runs while
+    background tasks (e.g. ``asyncio.wait_for(...)`` coroutines) are still
+    scheduled.
+    """
+    pending = [t for t in asyncio.all_tasks(loop=loop) if not t.done()]
+    for t in pending:
+        t.cancel()
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
 class EventLoopThread:
     _instances: dict[str, "EventLoopThread"] = {}
     _lock = threading.Lock()
@@ -51,6 +67,18 @@ class EventLoopThread:
             if thread and thread is threading.current_thread():
                 loop.stop()
             else:
+                # Drain pending tasks on the background loop BEFORE stopping it.
+                # Without this, closing the loop while tasks are still pending
+                # triggers asyncio warnings of the form:
+                #   "Task was destroyed but it is pending! task: wait_for=>"
+                try:
+                    drain_future = asyncio.run_coroutine_threadsafe(
+                        _drain_pending_tasks(loop), loop
+                    )
+                    drain_future.result(timeout=5)
+                except Exception:
+                    # Best effort: if draining fails we still want to shut down.
+                    pass
                 loop.call_soon_threadsafe(loop.stop)
                 if thread:
                     thread.join()

--- a/helpers/litellm_transport.py
+++ b/helpers/litellm_transport.py
@@ -1537,6 +1537,19 @@ def _is_responses_not_supported_error(exc: Exception) -> bool:
         return True
     if "invalid_request_error" in text and ("item" in text or "/v1/responses" in text):
         return True
+    # MiniMax / Anthropic-style Responses implementations reject the tool
+    # result payload when tool_call_id references cannot be reconciled,
+    # e.g. `code=invalid_prompt`, message like
+    # "invalid params, tool result's tool id(call_function_xxx) not found
+    # (2013)". Fall back to chat completions so tool calling still works.
+    if "invalid_prompt" in text and (
+        "tool result" in text or "tool id" in text or "tool_call_id" in text
+    ):
+        return True
+    if "tool result" in text and "not found" in text:
+        return True
+    if "tool id" in text and "not found" in text:
+        return True
     return any(
         marker in text
         for marker in (

--- a/helpers/litellm_transport.py
+++ b/helpers/litellm_transport.py
@@ -1530,6 +1530,13 @@ def _is_responses_not_supported_error(exc: Exception) -> bool:
         marker in text for marker in ("404", "not found")
     ):
         return True
+    # llama.cpp / partial Responses-API implementations reject the
+    # `items[]` payload with messages like "Cannot determine type of 'item'".
+    # Treat those as "endpoint not supported" so we fall back to chat completions.
+    if "cannot determine type" in text and "item" in text:
+        return True
+    if "invalid_request_error" in text and ("item" in text or "/v1/responses" in text):
+        return True
     return any(
         marker in text
         for marker in (

--- a/plugins/_memory/extensions/python/message_loop_prompts_after/_50_recall_memories.py
+++ b/plugins/_memory/extensions/python/message_loop_prompts_after/_50_recall_memories.py
@@ -35,6 +35,21 @@ class RecallMemories(Extension):
         if not set["memory_recall_enabled"]:
             return None
 
+        # Cancel any previous recall task that is still pending.
+        # Without this, when memory_recall_delayed=True or when a new
+        # recall interval fires before the previous one finished, the old
+        # task is orphaned and asyncio emits
+        # "Task was destroyed but it is pending! task: wait_for=>" when
+        # the DeferredTask/EventLoopThread is torn down.
+        previous_task = self.agent.get_data(DATA_NAME_TASK)
+        if previous_task is not None and not previous_task.done():
+            previous_task.cancel()
+            try:
+                # Eat the CancelledError so it doesn't surface elsewhere
+                await previous_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
         # every X iterations (or the first one) recall memories
         if loop_data.iteration % set["memory_recall_interval"] == 0:
 
@@ -44,11 +59,25 @@ class RecallMemories(Extension):
                 heading="Searching memories...",
             )
 
+            async def _safe_recall():
+                try:
+                    await self.search_memories(
+                        loop_data=loop_data, log_item=log_item, **kwargs
+                    )
+                except asyncio.CancelledError:
+                    # Re-raise so the task wrapper sees it and the
+                    # EventLoopThread's tear-down doesn't leave a pending task.
+                    raise
+                except Exception as e:
+                    err = errors.format_error(e)
+                    self.agent.context.log.log(
+                        type="warning",
+                        heading="Recall memories extension error:",
+                        content=err,
+                    )
+
             task = asyncio.create_task(
-                asyncio.wait_for(
-                    self.search_memories(loop_data=loop_data, log_item=log_item, **kwargs),
-                    timeout=SEARCH_TIMEOUT,
-                )
+                asyncio.wait_for(_safe_recall(), timeout=SEARCH_TIMEOUT)
             )
         else:
             task = None

--- a/tests/test_defer_drain_pending.py
+++ b/tests/test_defer_drain_pending.py
@@ -1,0 +1,152 @@
+"""Regression tests for ``helpers/defer.py`` task-drain on shutdown.
+
+The container logs used to emit lines like::
+
+    Task was destroyed but it is pending!
+    task:  wait_for=>
+
+whenever a coroutine scheduled with ``asyncio.create_task`` (e.g. the memory
+recall task in ``_50_recall_memories.py``) was still pending while the
+``EventLoopThread`` was being torn down. The drain helper used to schedule
+itself with ``asyncio.run_coroutine_threadsafe`` and then list itself in the
+pending set, which cancelled the drain before it could await the actual
+target tasks.
+
+These tests exercise the public ``EventLoopThread.terminate`` flow with a
+pending ``asyncio.wait_for`` task and assert the loop shuts down cleanly.
+
+Note: asyncio surfaces the "Task was destroyed but it is pending!" warning
+through its own ``logger.warning`` call, NOT through the standard
+``warnings`` module. We therefore capture stderr (where the asyncio logger
+writes by default) instead of relying on ``pytest.warns``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+import logging
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from helpers.defer import EventLoopThread  # noqa: E402
+
+
+DESTROYED_PENDING_MARKER = "Task was destroyed but it is pending"
+
+
+@contextlib.contextmanager
+def _capture_asyncio_warnings():
+    """Capture stderr writes that originate from the asyncio logger."""
+
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setLevel(logging.WARNING)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    asyncio_logger = logging.getLogger("asyncio")
+    original_level = asyncio_logger.level
+    asyncio_logger.setLevel(logging.WARNING)
+    asyncio_logger.addHandler(handler)
+    try:
+        yield buf
+    finally:
+        asyncio_logger.removeHandler(handler)
+        asyncio_logger.setLevel(original_level)
+
+
+def _has_destroyed_pending_warning(buf: io.StringIO) -> bool:
+    return DESTROYED_PENDING_MARKER in buf.getvalue()
+
+
+@pytest.fixture
+def fresh_event_loop_thread():
+    """Yield a fresh ``EventLoopThread`` and tear it down afterwards.
+
+    ``EventLoopThread`` is a process-wide singleton keyed by ``thread_name``,
+    so each test uses a unique name to avoid cross-test pollution.
+    """
+
+    name = f"DeferDrainTest-{time.time_ns()}"
+    elt = EventLoopThread(thread_name=name)
+    yield elt
+    try:
+        if elt.loop is not None and not elt.loop.is_closed():
+            elt.terminate()
+    except Exception:
+        pass
+
+
+def test_terminate_cancels_pending_wait_for_task(fresh_event_loop_thread):
+    """``asyncio.wait_for`` task left pending after the parent returns.
+
+    This mirrors the recall-memories task: ``asyncio.create_task`` is
+    scheduled from inside the agent's monologue, then the monologue returns
+    without awaiting it. When the agent is killed the drain must cancel it
+    instead of letting asyncio emit "Task was destroyed but it is pending!".
+    """
+
+    async def slow():
+        await asyncio.sleep(60)
+
+    async def main_coro():
+        # Create but DO NOT await. Same pattern as the recall extension.
+        asyncio.create_task(asyncio.wait_for(slow(), timeout=30))
+        await asyncio.sleep(0.05)  # let the inner task actually start
+
+    elt = fresh_event_loop_thread
+    elt.run_coroutine(main_coro()).result()
+
+    with _capture_asyncio_warnings() as buf:
+        elt.terminate()
+
+    assert not _has_destroyed_pending_warning(buf), (
+        "Pending wait_for task should be drained on terminate, "
+        f"but asyncio emitted:\n{buf.getvalue()}"
+    )
+
+
+def test_terminate_handles_many_pending_tasks(fresh_event_loop_thread):
+    """Multiple ``create_task`` calls should all be drained in one pass."""
+
+    async def slow():
+        await asyncio.sleep(60)
+
+    async def main_coro():
+        for _ in range(5):
+            asyncio.create_task(asyncio.wait_for(slow(), timeout=30))
+        await asyncio.sleep(0.05)
+
+    elt = fresh_event_loop_thread
+    elt.run_coroutine(main_coro()).result()
+
+    with _capture_asyncio_warnings() as buf:
+        elt.terminate()
+
+    assert not _has_destroyed_pending_warning(buf), (
+        "All pending tasks should be cancelled, "
+        f"but asyncio emitted:\n{buf.getvalue()}"
+    )
+
+
+def test_terminate_with_no_pending_tasks_is_clean(fresh_event_loop_thread):
+    """No pending tasks -> no warnings, drain is a no-op."""
+
+    async def main_coro():
+        await asyncio.sleep(0.05)
+
+    elt = fresh_event_loop_thread
+    elt.run_coroutine(main_coro()).result()
+
+    with _capture_asyncio_warnings() as buf:
+        elt.terminate()
+
+    assert not _has_destroyed_pending_warning(buf)


### PR DESCRIPTION
## ⚠️ Read this first

The **4th commit (`9b39533`)** is the actual fix that closes #1723. The first three commits on their own are **not sufficient** — `helpers/defer.py` still emits `Task was destroyed but it is pending! task: wait_for=>` because the drain coroutine was scheduling itself with `asyncio.run_coroutine_threadsafe` and then including itself in the pending set, which aborted `asyncio.gather` before it could await the actual target tasks. The diff for `9b39533` is small (10 lines, including comments) but it is the change that actually resolves the issue. Please review it carefully.

---

## Summary

Two independent fixes bundled together because they share a root cause analysis:

1. **Memory recall leaks asyncio tasks on shutdown** (fixes #1723)
2. **`/v1/responses` fallback does not trigger for llama.cpp / MiniMax** (fixes #1722)

---

## Bug 1 — `Task was destroyed but it is pending! task: wait_for=>` (#1723)

### Root cause

`plugins/_memory/extensions/python/message_loop_prompts_after/_50_recall_memories.py` schedules a memory-recall task with:

```python
task = asyncio.create_task(
    asyncio.wait_for(
        self.search_memories(loop_data=loop_data, log_item=log_item, **kwargs),
        timeout=SEARCH_TIMEOUT,
    )
)
```

The task is stashed in `agent.set_data(...)` and the actual await is delegated to `_91_recall_wait.py`, which only awaits it when `memory_recall_delayed=False` (default) and only on the iteration it was created.

Two leak paths result in `task: wait_for=>` surviving on the `EventLoopThread` until `terminate()` calls `loop.close()`:

1. `memory_recall_delayed=True`: the task is never awaited at all.
2. Next recall interval fires before the previous finishes: the old task is silently overwritten by a new one.

When the `EventLoopThread` is torn down, `loop.close()` destroys still-pending tasks, which is exactly what asyncio reports with the warning seen in the issue.

### Fix (4 commits)

1. **`2ad1b27` — `helpers/defer.py`**: add `_drain_pending_tasks()` and call it from `EventLoopThread.terminate()` before `loop.stop()` and `loop.close()`. ⚠️ **Incomplete on its own** — see `9b39533`.
2. **`252544c` — `helpers/litellm_transport.py`**: detect `"cannot determine type"` + `"item"` (llama.cpp) as Responses-not-supported and fall back to `/v1/chat/completions`.
3. **`7f12542` — `plugins/_memory/.../_50_recall_memories.py`**: cancel any previous recall task before scheduling a new one, and wrap `search_memories` in `_safe_recall()` that swallows non-cancel exceptions. `CancelledError` still propagates so the drain works.
4. **`9b39533` — `helpers/defer.py`**: **the actual fix**. Exclude the drain task itself from its own cancellation set, mirroring the pattern already used by `DeferredTask._drain_event_loop_tasks`. Without this, the drain coroutine — scheduled via `asyncio.run_coroutine_threadsafe` and therefore present in `asyncio.all_tasks(loop=loop)` — was cancelling itself, aborting `asyncio.gather` before it could await the target cancellations, leaving the recall task still pending and producing the warning.

### Test plan

- Pull this branch into a fresh Docker install.
- Send a short message ("hi") to the agent. Verify:
  - No `Task was destroyed but it is pending!` warning in `docker logs agent-zero`.
  - The recall flow still works (memory items appear in the context when expected).
- Configure an OpenAI-compatible provider pointing at llama.cpp. Send any message. Verify:
  - First request may still 400 (expected), but the second one should succeed via `/v1/chat/completions`.
- Optional: enable `memory_recall_delayed=True` in the `_memory` plugin config and re-test. Previously this configuration always produced the warning; with these patches it should not.

Regression test coverage is included in `tests/test_defer_drain_pending.py`. Without `9b39533` the test `test_terminate_handles_many_pending_tasks` reproduces the warning captured from the asyncio logger.

---

## Bug 2 — `Cannot determine type of 'item'` for llama.cpp / MiniMax users (#1722)

### Root cause

Agent Zero sends requests to `/v1/responses` by default. llama.cpp (`llama-server` in OpenAI-compat mode) returns 400 for the `items[]` payload:

```json
{"error":{"code":400,"message":"Cannot determine type of 'item'","type":"invalid_request_error"}}
```

MiniMax official API (`https://api.minimax.io/v1`) does the same with code `invalid_prompt`:

```json
{"error":{"message":"invalid params, tool result tool id(call_function_xxx) not found (2013)","code":"invalid_prompt"}}
```

Agent Zero has fallback logic to `/v1/chat/completions` in `helpers/litellm_transport.py:_is_responses_not_supported_error()`, but its marker list does not include those error messages, so the fallback never fires. Users get stuck in a retry loop until they manually switch provider mode.

### Fix

Add conservative markers to `_is_responses_not_supported_error()`:

- `"cannot determine type"` in text and `"item"` in text (llama.cpp)
- `"invalid_request_error"` in text and (`"item"` in text or `"/v1/responses"` in text) (general Responses-API rejection)
- `"invalid_prompt"` in text and (`"tool result"` or `"tool id"` or `"tool_call_id"` in text) (MiniMax)
- `"tool result"` + `"not found"` (MiniMax variant)
- `"tool id"` + `"not found"` (MiniMax variant)

All markers are scoped to clearly Responses-API-related errors, matching the conservative style of the function.

---

## Files changed

```
 .gitignore                                       |  7 +++
 helpers/defer.py                                 | 40 +++++++++++++++++++-
 helpers/litellm_transport.py                     | 25 ++++++++++-
 tests/test_defer_drain_pending.py                | 152 +++++++++++++++++++++++
 plugins/_memory/.../_50_recall_memories.py       | 37 +++++++++++++---
 5 files changed, 256 insertions(+), 5 deletions(-)
```

Closes #1723
Closes #1722
