### PR TITLE
Fix plain text response logs

### DIFF
--- a/extensions/python/monologue_end/_85_ensure_response_log.py
+++ b/extensions/python/monologue_end/_85_ensure_response_log.py
@@ -1,0 +1,75 @@
+import json
+from typing import Any
+
+from helpers.extension import Extension
+
+
+class EnsureResponseLog(Extension):
+    async def execute(self, loop_data: Any = None, **kwargs):
+        if not self.agent:
+            return
+
+        if not loop_data:
+            return
+
+        if "log_item_response" in loop_data.params_temporary:
+            return
+
+        gen_item = loop_data.params_temporary.get("log_item_generating")
+        if not gen_item:
+            return
+
+        response_text = self._get_latest_ai_response_text()
+        if not response_text:
+            return
+
+        loop_data.params_temporary["log_item_response"] = self.agent.context.log.log(
+            type="response",
+            heading=f"icon://chat {self.agent.agent_name}: Responding",
+            content=response_text,
+            id=getattr(gen_item, "id", "") or "",
+        )
+
+    def _get_latest_ai_response_text(self) -> str:
+        try:
+            topic = self.agent.history.current if self.agent else None
+            messages = topic.messages if topic else []
+            last_msg = messages[-1] if messages else None
+            if not last_msg or not last_msg.ai or not last_msg.content:
+                return ""
+            return self._normalize_response_content(last_msg.content)
+        except Exception:
+            return ""
+
+    @staticmethod
+    def _normalize_response_content(content) -> str:
+        if isinstance(content, dict):
+            tool_name = content.get("tool_name")
+            if tool_name and tool_name != "response":
+                return ""
+
+            if isinstance(content.get("tool_args"), dict):
+                text = content["tool_args"].get("text")
+                if text:
+                    return str(text)
+
+            if content.get("text"):
+                return str(content["text"])
+
+            if tool_name == "response":
+                return ""
+
+            return str(content)
+
+        if not isinstance(content, str):
+            return str(content)
+
+        stripped = content.strip()
+        try:
+            parsed = json.loads(stripped)
+        except Exception:
+            return stripped
+
+        if isinstance(parsed, dict):
+            return EnsureResponseLog._normalize_response_content(parsed)
+        return stripped

--- a/extensions/python/monologue_end/_85_ensure_response_log.py
+++ b/extensions/python/monologue_end/_85_ensure_response_log.py
@@ -34,10 +34,10 @@ class EnsureResponseLog(Extension):
         try:
             topic = self.agent.history.current if self.agent else None
             messages = topic.messages if topic else []
-            last_msg = messages[-1] if messages else None
-            if not last_msg or not last_msg.ai or not last_msg.content:
-                return ""
-            return self._normalize_response_content(last_msg.content)
+            for message in reversed(messages):
+                if message.ai and message.content:
+                    return self._normalize_response_content(message.content)
+            return ""
         except Exception:
             return ""
 

--- a/tests/test_response_log_fallback.py
+++ b/tests/test_response_log_fallback.py
@@ -20,13 +20,16 @@ class FakeLog:
 
 
 def _agent_with_last_message(content, *, ai=True):
+    return _agent_with_messages([SimpleNamespace(ai=ai, content=content)])
+
+
+def _agent_with_messages(messages):
     log = FakeLog()
-    message = SimpleNamespace(ai=ai, content=content)
     agent = SimpleNamespace(
         agent_name="A0",
         context=SimpleNamespace(log=log),
         history=SimpleNamespace(
-            current=SimpleNamespace(messages=[message]),
+            current=SimpleNamespace(messages=messages),
         ),
     )
     return agent, log
@@ -35,6 +38,35 @@ def _agent_with_last_message(content, *, ai=True):
 @pytest.mark.asyncio
 async def test_monologue_end_logs_plain_text_ai_response_from_history():
     agent, log = _agent_with_last_message("Plain text final answer.")
+    loop_data = _LoopData(
+        params_temporary={
+            "log_item_generating": SimpleNamespace(id="stream-log-id"),
+        }
+    )
+
+    await EnsureResponseLog(agent=agent).execute(loop_data=loop_data)
+
+    assert log.entries == [
+        {
+            "type": "response",
+            "heading": "icon://chat A0: Responding",
+            "content": "Plain text final answer.",
+            "id": "stream-log-id",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_monologue_end_logs_latest_ai_response_when_warning_follows_it():
+    agent, log = _agent_with_messages(
+        [
+            SimpleNamespace(ai=True, content="Plain text final answer."),
+            SimpleNamespace(
+                ai=False,
+                content="You have misformatted your message. Follow system prompt instructions.",
+            ),
+        ]
+    )
     loop_data = _LoopData(
         params_temporary={
             "log_item_generating": SimpleNamespace(id="stream-log-id"),

--- a/tests/test_response_log_fallback.py
+++ b/tests/test_response_log_fallback.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+
+import pytest
+
+from extensions.python.monologue_end._85_ensure_response_log import EnsureResponseLog
+
+
+class _LoopData:
+    def __init__(self, **kwargs):
+        self.params_temporary = kwargs.get("params_temporary", {})
+
+
+class FakeLog:
+    def __init__(self):
+        self.entries = []
+
+    def log(self, **kwargs):
+        self.entries.append(kwargs)
+        return SimpleNamespace(id=kwargs.get("id"))
+
+
+def _agent_with_last_message(content, *, ai=True):
+    log = FakeLog()
+    message = SimpleNamespace(ai=ai, content=content)
+    agent = SimpleNamespace(
+        agent_name="A0",
+        context=SimpleNamespace(log=log),
+        history=SimpleNamespace(
+            current=SimpleNamespace(messages=[message]),
+        ),
+    )
+    return agent, log
+
+
+@pytest.mark.asyncio
+async def test_monologue_end_logs_plain_text_ai_response_from_history():
+    agent, log = _agent_with_last_message("Plain text final answer.")
+    loop_data = _LoopData(
+        params_temporary={
+            "log_item_generating": SimpleNamespace(id="stream-log-id"),
+        }
+    )
+
+    await EnsureResponseLog(agent=agent).execute(loop_data=loop_data)
+
+    assert log.entries == [
+        {
+            "type": "response",
+            "heading": "icon://chat A0: Responding",
+            "content": "Plain text final answer.",
+            "id": "stream-log-id",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_monologue_end_skips_when_live_response_already_logged():
+    agent, log = _agent_with_last_message("Already logged.")
+    loop_data = _LoopData(
+        params_temporary={
+            "log_item_generating": SimpleNamespace(id="stream-log-id"),
+            "log_item_response": SimpleNamespace(id="response-log-id"),
+        }
+    )
+
+    await EnsureResponseLog(agent=agent).execute(loop_data=loop_data)
+
+    assert log.entries == []
+
+
+@pytest.mark.asyncio
+async def test_monologue_end_does_not_log_non_response_tool_request():
+    agent, log = _agent_with_last_message(
+        '{"tool_name":"search_engine","tool_args":{"query":"Agent Zero"}}'
+    )
+    loop_data = _LoopData(
+        params_temporary={
+            "log_item_generating": SimpleNamespace(id="stream-log-id"),
+        }
+    )
+
+    await EnsureResponseLog(agent=agent).execute(loop_data=loop_data)
+
+    assert log.entries == []


### PR DESCRIPTION
## Summary

Fixes #1708.

- Add a `monologue_end` fallback extension that creates a `type=response` log entry when the final AI response was saved to history but no live response log was produced.
- Preserve existing live-response behavior by skipping the fallback when `log_item_response` already exists.
- Avoid logging ordinary non-response tool-call JSON as user-visible response text.

## Context

Some models return final answers as plain text instead of the expected `{"tool_name":"response","tool_args":{"text":"..."}}` response-tool JSON. In that path, the answer is saved to history, but the WebUI never receives a `type=response` log entry, so users can be left seeing only the last “Calling LLM...” entry.

This change keeps the streaming parser path unchanged and adds a narrow fallback after streaming has ended, using the latest AI history message as the source of truth.

## Testing

- `python3 -m py_compile extensions/python/monologue_end/_85_ensure_response_log.py tests/test_response_log_fallback.py`
- Ran the new async regression cases through a lightweight local import harness:
  - plain-text AI response creates a response log
  - existing live response log is not duplicated
  - non-response tool-call JSON is not logged as response text

Blocked locally:

- `python3 -m pytest tests/test_response_log_fallback.py`
- Result: local Python environment does not have `pytest` installed (`No module named pytest`)