### PR TITLE
Fix scheduler task detail modal close flow

### DIFF
--- a/webui/components/modals/scheduler/scheduler-store.js
+++ b/webui/components/modals/scheduler/scheduler-store.js
@@ -20,6 +20,8 @@ const NOTIFICATION_DURATION = {
 };
 const DEFAULT_TASK_STATE = "idle";
 const TASK_TYPES = ["scheduled", "adhoc", "planned"];
+const SCHEDULER_MODAL_PATH = "modals/scheduler/scheduler-modal.html";
+const TASK_DETAIL_MODAL_PATH = "modals/scheduler/scheduler-task-detail.html";
 
 /**
  * @typedef {Object} SchedulerPlan
@@ -470,6 +472,7 @@ const schedulerStoreModel = {
   sortDirection: "asc",
   viewMode: readPersistedViewMode(),
   selectedTaskForDetail: null,
+  closeSchedulerAfterTaskDetail: false,
 
   // Pagination ---------------------------------------------------------------
   currentPage: 1,
@@ -987,28 +990,38 @@ const schedulerStoreModel = {
     }
 
     this.selectedTaskForDetail = snapshot;
-    const closePromise = window.openModal("modals/scheduler/scheduler-task-detail.html");
+    this.closeSchedulerAfterTaskDetail = Boolean(window.isModalOpen?.(SCHEDULER_MODAL_PATH));
+    const closePromise = window.openModal(TASK_DETAIL_MODAL_PATH);
     if (closePromise && typeof closePromise.then === "function") {
-      closePromise.then(() => {
+      closePromise.then(async () => {
         if (this.selectedTaskForDetail?.uuid === snapshot.uuid) {
           this.selectedTaskForDetail = null;
+        }
+        if (this.closeSchedulerAfterTaskDetail) {
+          this.closeSchedulerAfterTaskDetail = false;
+          await window.closeModal?.(SCHEDULER_MODAL_PATH);
         }
       });
     }
   },
 
-  closeTaskDetail() {
+  async closeTaskDetail({ closeScheduler = this.closeSchedulerAfterTaskDetail } = {}) {
     this.selectedTaskForDetail = null;
-    window.closeModal();
+    this.closeSchedulerAfterTaskDetail = false;
+    await window.closeModal?.(TASK_DETAIL_MODAL_PATH);
+    if (closeScheduler) {
+      await window.closeModal?.(SCHEDULER_MODAL_PATH);
+    }
   },
 
   async editFromDetail() {
     const taskId = this.selectedTaskForDetail?.uuid;
     if (!taskId) return;
-    this.closeTaskDetail();
+    await this.closeTaskDetail({ closeScheduler: false });
     await this.startEditTask(taskId);
     // Open main scheduler modal to show the editor
-    window.openModal("modals/scheduler/scheduler-modal.html");
+    const openSchedulerModal = window.ensureModalOpen || window.openModal;
+    openSchedulerModal?.(SCHEDULER_MODAL_PATH);
   },
 
   async deleteFromDetail() {


### PR DESCRIPTION
## Summary
- Track when the scheduler parent modal is open before showing task detail.
- Close the task detail modal explicitly and close the scheduler modal when required.
- Preserve the edit flow by reopening/focusing the scheduler modal after closing detail.

## Checks
- `node --check webui/components/modals/scheduler/scheduler-store.js`
- `git diff --check --cached` before commit

Only `webui/components/modals/scheduler/scheduler-store.js` is included in this commit.