### PR TITLE
Fix Codex OAuth Responses proxy input normalization

### DIFF
--- a/plugins/_oauth/helpers/codex.py
+++ b/plugins/_oauth/helpers/codex.py
@@ -616,12 +616,31 @@ def fetch_models() -> list[str]:
 
 def prepare_responses_body(body: dict[str, Any], *, force_stream: bool) -> dict[str, Any]:
     normalized = dict(body)
+    normalized["input"] = normalize_responses_input(normalized.get("input"))
     normalized.setdefault("instructions", "")
     normalized.setdefault("store", False)
     if force_stream:
         normalized["stream"] = True
     normalized.pop("max_output_tokens", None)
     return normalized
+
+
+
+def normalize_responses_input(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if value is None:
+        return []
+    if isinstance(value, dict):
+        return [value]
+    if isinstance(value, str):
+        if not value:
+            return []
+        return [{"role": "user", "content": value}]
+    text = str(value)
+    if not text:
+        return []
+    return [{"role": "user", "content": text}]
 
 
 def collect_completed_response(response: requests.Response) -> dict[str, Any]:

--- a/tests/test_oauth_codex.py
+++ b/tests/test_oauth_codex.py
@@ -7,12 +7,19 @@ import stat
 import sys
 import threading
 import time
+import types
 from pathlib import Path
 
 import pytest
 import yaml
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+plugins_pkg = types.ModuleType("plugins")
+plugins_pkg.__path__ = [str(PROJECT_ROOT / "plugins")]
+sys.modules["plugins"] = plugins_pkg
+
 from plugins._oauth.helpers import codex
 from plugins._oauth.helpers import routes
 from plugins._oauth.extensions.python._functions.models.get_api_key.end import (
@@ -68,6 +75,27 @@ def test_build_authorize_url_uses_existing_a0_origin_callback(monkeypatch):
     assert "redirect_uri=http%3A%2F%2Flocalhost%3A50001%2Fauth%2Fcallback" in auth_url
     assert "code_challenge=challenge" in auth_url
     assert "originator=codex_cli_rs" in auth_url
+
+
+def test_prepare_responses_body_wraps_string_input_for_codex_upstream():
+    body = codex.prepare_responses_body(
+        {
+            "model": "gpt-5.2",
+            "input": "Hello",
+            "max_output_tokens": 100,
+        },
+        force_stream=True,
+    )
+
+    assert body["input"] == [{"role": "user", "content": "Hello"}]
+    assert body["stream"] is True
+    assert "max_output_tokens" not in body
+
+
+def test_prepare_responses_body_normalizes_empty_string_input_to_list():
+    body = codex.prepare_responses_body({"input": ""}, force_stream=True)
+
+    assert body["input"] == []
 
 
 def test_chat_messages_to_response_body_extracts_instructions():


### PR DESCRIPTION
This PR fixes a Codex OAuth proxy compatibility issue when Agent Zero uses LiteLLM Responses API.

LiteLLM can send `input` as a string or empty string in some Responses API paths. The local Codex OAuth proxy forwarded that payload unchanged to the Codex upstream `/responses` endpoint, which expects `input` to be a list and returns `{"detail":"Input must be a list"}`.

The fix normalizes `input` inside `prepare_responses_body()` before forwarding:
- list: preserved;
- dict: wrapped in a one-item list;
- non-empty string: wrapped as a user message;
- empty string or None: converted to an empty list.

Regression tests cover string input and empty string input.

Checks run:
- `/a0/venv/bin/python -m py_compile plugins/_oauth/helpers/codex.py plugins/_oauth/helpers/routes.py tests/test_oauth_codex.py`
- `/a0/venv/bin/python -m pytest tests/test_oauth_codex.py -q` — 37 passed
