### PR TITLE
fix: add litellm[proxy] dependency to fix missing fastapi on fresh install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ langchain-core==0.3.49
 langchain-community==0.3.19
 langchain-unstructured==0.1.6
 liteparse==2.0.3
-litellm==1.88.1  # CVE-2026-42271 fix: patched floor is 1.83.7
+litellm[proxy]==1.88.1  # CVE-2026-42271 fix: patched floor is 1.83.7
 openai==2.41.1
 openai-whisper==20250625
 lxml_html_clean>=0.4.0  # CVE-2024-52595 fix: XSS CWE-79 CVSS 8.4


### PR DESCRIPTION
## Issue

Fixes #1728

After installing A0 2.0/2.1 from a fresh environment, users encounter:

```
litellm.exceptions.APIConnectionError: APIConnectionError: DeepseekException - Missing dependency No module named 'fastapi'. Run `pip install 'litellm[proxy]'`
```

## Root Cause

The `litellm` package lists `fastapi` as an optional dependency under the `[proxy]` extra. Without `fastapi` installed, litellm cannot make HTTP connections and raises `APIConnectionError`.

## Fix

Change the `litellm` dependency in `requirements.txt` from:

```diff
-litellm==1.88.1  # CVE-2026-42271 fix: patched floor is 1.83.7
+litellm[proxy]==1.88.1  # CVE-2026-42271 fix: patched floor is 1.83.7
```

Adding the `[proxy]` extra ensures `fastapi` (and other proxy-related dependencies) are installed automatically alongside litellm.

## Verification

- Only `requirements.txt` is modified
- The version pin (`==1.88.1`) and CVE comment are preserved
- No other dependencies or files are affected