### PR TITLE
Add message queue sync regression test

### DIFF
--- a/helpers/message_queue.py
+++ b/helpers/message_queue.py
@@ -36,7 +36,7 @@ def _sync_output(context: "AgentContext"):
             "id": item["id"],
             "seq": item.get("seq", 0),
             "text": item["text"][:100] + "..." if len(item["text"]) > 100 else item["text"],
-            "attachments": [a.split("/")[-1] for a in item.get("attachments", [])],
+            "attachments": [os.path.basename(a) for a in item.get("attachments", [])],
             "attachment_count": len(item.get("attachments", [])),
         })
     context.set_output_data(QUEUE_KEY, truncated)

--- a/tests/test_message_queue_sync.py
+++ b/tests/test_message_queue_sync.py
@@ -1,0 +1,38 @@
+from helpers import message_queue as mq
+
+
+class DummyOutput:
+    pass
+
+
+class DummyContext:
+    def __init__(self):
+        self.data = {}
+        self.output = DummyOutput()
+
+    def get_data(self, key):
+        return self.data.get(key)
+
+    def set_data(self, key, value):
+        self.data[key] = value
+
+    def set_output_data(self, key, value):
+        setattr(self.output, key, value)
+
+
+def test_add_syncs_queue_output_without_context_message_queue_attribute():
+    context = DummyContext()
+
+    item = mq.add(context, "hello", ["queued.png"])
+
+    assert item["id"]
+    assert mq.get_queue(context)[0]["text"] == "hello"
+    assert context.output.message_queue == [
+        {
+            "id": item["id"],
+            "seq": 1,
+            "text": "hello",
+            "attachments": ["queued.png"],
+            "attachment_count": 1,
+        }
+    ]


### PR DESCRIPTION
## Summary
- Add regression coverage for message queue output synchronization without relying on a `context.message_queue` attribute.
- Use `os.path.basename` when serializing queued attachment names for frontend polling.

## Why
Queued messages can remain visually pending/spinning if `_sync_output()` raises before the frontend receives updated `message_queue` output data. This test locks the expected contract: queue state is read from context data and published through `set_output_data()`.

## Tests
- `python3 -m pytest tests/test_message_queue_sync.py -q`
- `python3 -m py_compile helpers/message_queue.py`
