### PR TITLE
Add ACP stdio JSON-RPC foundation

### DIFF
--- a/helpers/acp/__init__.py
+++ b/helpers/acp/__init__.py
@@ -1,0 +1,26 @@
+"""ACP protocol foundation helpers."""
+
+from helpers.acp.debug_log import DebugLog, DebugRecord
+from helpers.acp.errors import (
+    AcpError,
+    AcpJsonRpcError,
+    AcpProcessExitedError,
+    AcpProtocolError,
+    AcpTimeoutError,
+    AcpTransportError,
+)
+from helpers.acp.jsonrpc import JsonRpcPeer
+from helpers.acp.transport import StdioTransport
+
+__all__ = [
+    "AcpError",
+    "AcpJsonRpcError",
+    "AcpProcessExitedError",
+    "AcpProtocolError",
+    "AcpTimeoutError",
+    "AcpTransportError",
+    "DebugLog",
+    "DebugRecord",
+    "JsonRpcPeer",
+    "StdioTransport",
+]

--- a/helpers/acp/debug_log.py
+++ b/helpers/acp/debug_log.py
@@ -1,0 +1,107 @@
+"""Bounded masked debug logging for ACP transports and peers."""
+
+from __future__ import annotations
+
+import json
+from collections import deque
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DebugRecord:
+    timestamp: str
+    direction: str
+    kind: str
+    method: str | None
+    id: str | int | None
+    preview: str
+
+
+class DebugLog:
+    def __init__(
+        self,
+        max_records: int = 2000,
+        max_preview_chars: int = 4000,
+        masker: Callable[[str], str] | None = None,
+    ):
+        self.max_preview_chars = max(0, int(max_preview_chars))
+        self.masker = masker
+        self._records: deque[DebugRecord] = deque(maxlen=max(1, int(max_records)))
+
+    def record(
+        self,
+        *,
+        direction: str,
+        kind: str,
+        payload: Any = None,
+        method: str | None = None,
+        id: str | int | None = None,
+    ) -> None:
+        try:
+            preview = self._preview(payload)
+        except Exception:
+            preview = "<preview unavailable>"
+        self._records.append(
+            DebugRecord(
+                timestamp=datetime.now(UTC).isoformat(),
+                direction=direction,
+                kind=kind,
+                method=method,
+                id=id,
+                preview=preview,
+            )
+        )
+
+    def inbound(self, payload: Any) -> None:
+        self.record(direction="inbound", kind=self._kind(payload), payload=payload, method=self._method(payload), id=self._id(payload))
+
+    def outbound(self, payload: Any) -> None:
+        self.record(direction="outbound", kind=self._kind(payload), payload=payload, method=self._method(payload), id=self._id(payload))
+
+    def stderr(self, text: str) -> None:
+        self.record(direction="stderr", kind="stderr", payload=text)
+
+    def system(self, message: str, *, kind: str = "system") -> None:
+        self.record(direction="system", kind=kind, payload=message)
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        return [asdict(record) for record in self._records]
+
+    def clear(self) -> None:
+        self._records.clear()
+
+    def _preview(self, payload: Any) -> str:
+        if isinstance(payload, str):
+            text = payload
+        else:
+            text = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+        if self.masker is not None:
+            text = self.masker(text)
+        return text[: self.max_preview_chars]
+
+    @staticmethod
+    def _method(payload: Any) -> str | None:
+        return payload.get("method") if isinstance(payload, dict) and isinstance(payload.get("method"), str) else None
+
+    @staticmethod
+    def _id(payload: Any) -> str | int | None:
+        if not isinstance(payload, dict):
+            return None
+        value = payload.get("id")
+        return value if isinstance(value, str | int) else None
+
+    @staticmethod
+    def _kind(payload: Any) -> str:
+        if isinstance(payload, dict):
+            if "method" in payload and "id" in payload:
+                return "request"
+            if "method" in payload:
+                return "notification"
+            if "error" in payload:
+                return "error"
+            if "result" in payload:
+                return "response"
+        return "system"

--- a/helpers/acp/errors.py
+++ b/helpers/acp/errors.py
@@ -1,0 +1,30 @@
+"""ACP foundation exception types."""
+
+
+class AcpError(Exception):
+    """Base class for ACP foundation failures."""
+
+
+class AcpTransportError(AcpError):
+    """Raised when the stdio transport cannot operate correctly."""
+
+
+class AcpProcessExitedError(AcpTransportError):
+    """Raised when the child process exits unexpectedly."""
+
+
+class AcpJsonRpcError(AcpError):
+    """Raised when a JSON-RPC peer returns a structured error."""
+
+    def __init__(self, code: int | None, message: str, data=None):
+        self.code = code
+        self.data = data
+        super().__init__(message)
+
+
+class AcpTimeoutError(AcpError):
+    """Raised when an ACP operation times out."""
+
+
+class AcpProtocolError(AcpError):
+    """Raised when protocol data is malformed or invalid."""

--- a/helpers/acp/jsonrpc.py
+++ b/helpers/acp/jsonrpc.py
@@ -1,0 +1,218 @@
+"""Protocol-agnostic JSON-RPC 2.0 peer for ACP foundation work."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from helpers.acp.debug_log import DebugLog
+from helpers.acp.errors import AcpJsonRpcError, AcpProtocolError, AcpTimeoutError, AcpTransportError
+from helpers.acp.transport import StdioTransport
+
+Handler = Callable[[Any], Awaitable[Any] | Any]
+
+
+class JsonRpcPeer:
+    def __init__(self, transport: StdioTransport, *, debug_log: DebugLog | None = None, request_timeout: float = 30.0):
+        self.transport = transport
+        self.debug_log = debug_log or transport.debug_log
+        self.request_timeout = request_timeout
+        self._next_id = 1
+        self._pending: dict[int | str, asyncio.Future] = {}
+        self._request_handlers: dict[str, Handler] = {}
+        self._notification_handlers: dict[str, Handler] = {}
+        self._notification_tasks: set[asyncio.Task] = set()
+        self._reader_task: asyncio.Task | None = None
+        self._closed = False
+
+    async def start(self) -> None:
+        await self.transport.start()
+        if self._reader_task is None:
+            self._reader_task = asyncio.create_task(self._reader_loop())
+
+    async def request(self, method: str, params: Any = None, *, timeout: float | None = None) -> Any:
+        if self._closed:
+            raise AcpTransportError("JSON-RPC peer is closed")
+        request_id = self._next_id
+        self._next_id += 1
+        message = {"jsonrpc": "2.0", "id": request_id, "method": method}
+        if params is not None:
+            message["params"] = params
+        future = asyncio.get_running_loop().create_future()
+        self._pending[request_id] = future
+        try:
+            await self.transport.send_json(message)
+            return await asyncio.wait_for(future, timeout=timeout or self.request_timeout)
+        except TimeoutError as exc:
+            self._pending.pop(request_id, None)
+            if not future.done():
+                future.cancel()
+            raise AcpTimeoutError(f"JSON-RPC request timed out: {method}") from exc
+        except Exception:
+            self._pending.pop(request_id, None)
+            raise
+
+    async def notify(self, method: str, params: Any = None) -> None:
+        message = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            message["params"] = params
+        await self.transport.send_json(message)
+
+    def on_request(self, method: str, handler: Handler) -> None:
+        self._request_handlers[method] = handler
+
+    def on_notification(self, method: str, handler: Handler) -> None:
+        self._notification_handlers[method] = handler
+
+    async def close(self) -> None:
+        self._closed = True
+        await self.cancel_pending(AcpTransportError("JSON-RPC peer closed"))
+        task = self._reader_task
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            self._reader_task = None
+        await self._cancel_notification_tasks()
+        await self.transport.close()
+
+    async def cancel_pending(self, exc: BaseException | None = None) -> None:
+        exc = exc or AcpTransportError("pending JSON-RPC requests cancelled")
+        pending = list(self._pending.values())
+        self._pending.clear()
+        for future in pending:
+            if not future.done():
+                future.set_exception(exc)
+
+    def pending_count(self) -> int:
+        return len(self._pending)
+
+    async def _reader_loop(self) -> None:
+        try:
+            while not self._closed:
+                try:
+                    message = await self.transport.read_json()
+                except AcpTimeoutError:
+                    continue
+                await self._route(message)
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:
+            await self.cancel_pending(exc)
+
+    async def _route(self, message: dict[str, Any]) -> None:
+        request_id = message.get("id")
+        has_id = "id" in message
+        has_method = isinstance(message.get("method"), str)
+        has_result = "result" in message
+        has_error = "error" in message
+        is_pending_response = has_id and request_id in self._pending
+        if is_pending_response:
+            if message.get("jsonrpc") != "2.0":
+                self._reject_invalid_response(request_id, "invalid JSON-RPC version")
+            elif has_method:
+                self._reject_invalid_response(request_id, "response must not include method")
+            elif has_result and has_error:
+                self._reject_invalid_response(request_id, "conflicting result and error fields")
+            elif has_result or has_error:
+                self._handle_response(message)
+            else:
+                self._reject_invalid_response(request_id, "missing result or error field")
+            return
+        if message.get("jsonrpc") != "2.0":
+            if has_id and has_method:
+                await self._send_invalid_request(request_id)
+                return
+            self.debug_log.system("invalid JSON-RPC version", kind="error")
+            return
+        if has_method and has_id:
+            if has_result or has_error:
+                await self._send_invalid_request(request_id)
+                return
+            await self._handle_inbound_request(message)
+        elif has_method:
+            if has_result or has_error:
+                self.debug_log.system("invalid JSON-RPC notification shape", kind="error")
+                return
+            self._handle_notification(message)
+        elif has_id and (has_result or has_error):
+            if has_result and has_error:
+                self._reject_invalid_response(request_id, "conflicting result and error fields")
+                return
+            self._handle_response(message)
+        else:
+            if has_id:
+                self.debug_log.system(f"invalid JSON-RPC response id {request_id}: missing result or error field", kind="error")
+            else:
+                self.debug_log.system("invalid JSON-RPC message shape", kind="error")
+
+    def _reject_invalid_response(self, request_id: Any, message: str) -> None:
+        future = self._pending.pop(request_id, None)
+        self.debug_log.system(f"invalid JSON-RPC response id {request_id}: {message}", kind="error")
+        if future is not None and not future.done():
+            future.set_exception(AcpProtocolError(message))
+
+    def _handle_response(self, message: dict[str, Any]) -> None:
+        request_id = message.get("id")
+        future = self._pending.pop(request_id, None)
+        if future is None:
+            self.debug_log.system(f"unknown JSON-RPC response id: {request_id}", kind="error")
+            return
+        if future.done():
+            return
+        if "error" in message:
+            error = message.get("error") or {}
+            if isinstance(error, dict):
+                future.set_exception(AcpJsonRpcError(error.get("code"), str(error.get("message", "JSON-RPC error")), error.get("data")))
+            else:
+                future.set_exception(AcpJsonRpcError(None, "JSON-RPC error"))
+        else:
+            future.set_result(message.get("result"))
+
+    def _handle_notification(self, message: dict[str, Any]) -> None:
+        handler = self._notification_handlers.get(message["method"])
+        if handler is None:
+            return
+        task = asyncio.create_task(self._call_notification(handler, message.get("params")))
+        self._notification_tasks.add(task)
+        task.add_done_callback(self._notification_tasks.discard)
+
+    async def _call_notification(self, handler: Handler, params: Any) -> None:
+        try:
+            result = handler(params)
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.debug_log.system(f"notification handler failed: {exc}", kind="error")
+
+    async def _handle_inbound_request(self, message: dict[str, Any]) -> None:
+        request_id = message.get("id")
+        method = message["method"]
+        handler = self._request_handlers.get(method)
+        if handler is None:
+            await self.transport.send_json({"jsonrpc": "2.0", "id": request_id, "error": {"code": -32601, "message": "Method not found"}})
+            return
+        try:
+            result = handler(message.get("params"))
+            if inspect.isawaitable(result):
+                result = await result
+            await self.transport.send_json({"jsonrpc": "2.0", "id": request_id, "result": result})
+        except Exception as exc:
+            await self.transport.send_json({"jsonrpc": "2.0", "id": request_id, "error": {"code": -32603, "message": str(exc) or "Internal error"}})
+
+    async def _send_invalid_request(self, request_id: Any) -> None:
+        await self.transport.send_json({"jsonrpc": "2.0", "id": request_id, "error": {"code": -32600, "message": "Invalid Request"}})
+
+    async def _cancel_notification_tasks(self) -> None:
+        tasks = list(self._notification_tasks)
+        self._notification_tasks.clear()
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)

--- a/helpers/acp/transport.py
+++ b/helpers/acp/transport.py
@@ -1,0 +1,223 @@
+"""Async stdio JSON transport for ACP foundation work."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from helpers.acp.debug_log import DebugLog
+from helpers.acp.errors import AcpProcessExitedError, AcpProtocolError, AcpTimeoutError, AcpTransportError
+
+
+class StdioTransport:
+    def __init__(
+        self,
+        argv: list[str],
+        *,
+        cwd: str | Path | None = None,
+        env: dict[str, str] | None = None,
+        debug_log: DebugLog | None = None,
+        startup_timeout: float = 10.0,
+        operation_timeout: float = 30.0,
+        close_timeout: float = 5.0,
+        max_line_bytes: int = 1_048_576,
+        stderr_max_line_bytes: int = 64_000,
+    ):
+        if isinstance(argv, str) or not isinstance(argv, list) or not argv or not all(isinstance(item, str) for item in argv):
+            raise AcpTransportError("argv must be a non-empty list of strings")
+        if cwd is not None:
+            cwd_path = Path(cwd).expanduser().resolve()
+            if not cwd_path.is_dir():
+                raise AcpTransportError("cwd does not exist or is not a directory")
+            self.cwd: str | None = str(cwd_path)
+        else:
+            self.cwd = None
+        self.argv = argv
+        self.env = self._controlled_env(env)
+        self.debug_log = debug_log or DebugLog()
+        self.startup_timeout = startup_timeout
+        self.operation_timeout = operation_timeout
+        self.close_timeout = close_timeout
+        self.max_line_bytes = max_line_bytes
+        self.stderr_max_line_bytes = stderr_max_line_bytes
+        self._process: asyncio.subprocess.Process | None = None
+        self._stderr_task: asyncio.Task | None = None
+        self._closed = False
+        self._unhealthy: BaseException | None = None
+
+    async def start(self) -> None:
+        if self._process is not None:
+            return
+        try:
+            self._process = await asyncio.wait_for(
+                asyncio.create_subprocess_exec(
+                    *self.argv,
+                    cwd=self.cwd,
+                    env=self.env,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                ),
+                timeout=self.startup_timeout,
+            )
+        except TimeoutError as exc:
+            raise AcpTimeoutError("timed out starting ACP child process") from exc
+        except Exception as exc:
+            raise AcpTransportError("failed to start ACP child process") from exc
+        self._stderr_task = asyncio.create_task(self._stderr_loop())
+
+    async def send_json(self, obj: dict[str, Any]) -> None:
+        self._ensure_healthy()
+        process = self._require_process()
+        self.debug_log.outbound(obj)
+        if process.stdin is None or process.returncode is not None:
+            self._mark_unhealthy(AcpProcessExitedError("ACP child process is not running"))
+            raise self._unhealthy
+        try:
+            payload = json.dumps(obj, ensure_ascii=False, separators=(",", ":")).encode() + b"\n"
+            process.stdin.write(payload)
+            await asyncio.wait_for(process.stdin.drain(), timeout=self.operation_timeout)
+        except TimeoutError as exc:
+            self._mark_unhealthy(AcpTimeoutError("timed out writing to ACP child process"))
+            raise self._unhealthy from exc
+        except (TypeError, ValueError) as exc:
+            raise AcpProtocolError("object is not JSON serializable") from exc
+        except Exception as exc:
+            self._mark_unhealthy(AcpProcessExitedError("ACP child process write failed"))
+            raise self._unhealthy from exc
+
+    async def read_json(self) -> dict[str, Any]:
+        self._ensure_healthy()
+        process = self._require_process()
+        if process.stdout is None:
+            raise AcpTransportError("stdout pipe is unavailable")
+        if process.returncode is not None:
+            self._mark_unhealthy(AcpProcessExitedError("ACP child process exited"))
+            raise self._unhealthy
+        try:
+            line = await asyncio.wait_for(self._read_bounded_line(process.stdout), timeout=self.operation_timeout)
+        except TimeoutError as exc:
+            raise AcpTimeoutError("timed out reading from ACP child process") from exc
+        if line == b"":
+            await self._poll_returncode()
+            self._mark_unhealthy(AcpProcessExitedError("ACP child process exited"))
+            raise self._unhealthy
+        try:
+            obj = json.loads(line.decode("utf-8"))
+        except Exception as exc:
+            self._mark_unhealthy(AcpProtocolError("malformed JSON on ACP stdout"))
+            raise self._unhealthy from exc
+        if not isinstance(obj, dict):
+            self._mark_unhealthy(AcpProtocolError("ACP stdout JSON must be an object"))
+            raise self._unhealthy
+        self.debug_log.inbound(obj)
+        return obj
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        process = self._process
+        if process is not None and process.returncode is None:
+            if process.stdin is not None:
+                process.stdin.close()
+                try:
+                    await process.stdin.wait_closed()
+                except Exception:
+                    pass
+            try:
+                await asyncio.wait_for(process.wait(), timeout=self.close_timeout)
+            except TimeoutError:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=min(1.0, self.close_timeout))
+                except TimeoutError:
+                    process.kill()
+                    await process.wait()
+        await self._cancel_stderr_task()
+
+    async def kill(self) -> None:
+        process = self._process
+        if process is not None and process.returncode is None:
+            process.kill()
+            await process.wait()
+        self._closed = True
+        await self._cancel_stderr_task()
+
+    def is_running(self) -> bool:
+        return self._process is not None and self._process.returncode is None and not self._closed
+
+    def returncode(self) -> int | None:
+        return None if self._process is None else self._process.returncode
+
+    def diagnostics(self) -> list[dict[str, Any]]:
+        return self.debug_log.snapshot()
+
+    async def _read_bounded_line(self, stream: asyncio.StreamReader) -> bytes:
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            chunk = await stream.read(1)
+            if chunk == b"":
+                return b"" if total == 0 else b"".join(chunks)
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > self.max_line_bytes:
+                self._mark_unhealthy(AcpProtocolError("ACP stdout line exceeded maximum size"))
+                raise self._unhealthy
+            if chunk == b"\n":
+                return b"".join(chunks)
+
+    async def _stderr_loop(self) -> None:
+        process = self._process
+        if process is None or process.stderr is None:
+            return
+        while True:
+            line = await process.stderr.readline()
+            if not line:
+                return
+            text = line[: self.stderr_max_line_bytes].decode("utf-8", errors="replace").rstrip("\n")
+            self.debug_log.stderr(text)
+
+    async def _cancel_stderr_task(self) -> None:
+        task = self._stderr_task
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        self._stderr_task = None
+
+    async def _poll_returncode(self) -> None:
+        process = self._process
+        if process is not None and process.returncode is None:
+            try:
+                await asyncio.wait_for(process.wait(), timeout=0.1)
+            except TimeoutError:
+                pass
+
+    def _require_process(self) -> asyncio.subprocess.Process:
+        if self._process is None:
+            raise AcpTransportError("ACP child process has not been started")
+        return self._process
+
+    def _ensure_healthy(self) -> None:
+        if self._closed:
+            raise AcpTransportError("ACP transport is closed")
+        if self._unhealthy is not None:
+            raise AcpTransportError(str(self._unhealthy)) from self._unhealthy
+
+    def _mark_unhealthy(self, exc: BaseException) -> None:
+        self._unhealthy = exc
+
+    @staticmethod
+    def _controlled_env(env: dict[str, str] | None) -> dict[str, str]:
+        base = {key: value for key, value in os.environ.items() if key in {"PATH", "PYTHONPATH", "HOME", "LANG", "LC_ALL"}}
+        if env:
+            base.update({str(key): str(value) for key, value in env.items()})
+        return base

--- a/tests/test_acp_debug_log.py
+++ b/tests/test_acp_debug_log.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from helpers.acp.debug_log import DebugLog
+
+
+def test_debug_log_bounded_oldest_to_newest_snapshot():
+    log = DebugLog(max_records=2)
+
+    log.system("one")
+    log.system("two")
+    log.system("three")
+
+    snapshot = log.snapshot()
+    assert [record["preview"] for record in snapshot] == ["two", "three"]
+    assert all(set(record) == {"timestamp", "direction", "kind", "method", "id", "preview"} for record in snapshot)
+
+
+def test_debug_log_masks_and_bounds_payload_preview():
+    log = DebugLog(max_preview_chars=80, masker=lambda text: text.replace("secret-token", "***"))
+
+    log.outbound({"jsonrpc": "2.0", "id": 7, "method": "example", "params": {"aaa_token": "secret-token", "padding": "x" * 100}})
+
+    [record] = log.snapshot()
+    assert record["direction"] == "outbound"
+    assert record["kind"] == "request"
+    assert record["method"] == "example"
+    assert record["id"] == 7
+    assert "secret-token" not in record["preview"]
+    assert "***" in record["preview"]
+    assert len(record["preview"]) <= 80
+
+
+def test_debug_log_clear_removes_records():
+    log = DebugLog()
+    log.stderr("diagnostic")
+
+    log.clear()
+
+    assert log.snapshot() == []

--- a/tests/test_acp_jsonrpc.py
+++ b/tests/test_acp_jsonrpc.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import textwrap
+
+import pytest
+
+from helpers.acp.debug_log import DebugLog
+from helpers.acp.errors import AcpJsonRpcError, AcpProtocolError, AcpTimeoutError, AcpTransportError
+from helpers.acp.jsonrpc import JsonRpcPeer
+from helpers.acp.transport import StdioTransport
+
+
+async def _peer_for_script(tmp_path, source: str, **peer_kwargs):
+    script = tmp_path / "server.py"
+    script.write_text(textwrap.dedent(source))
+    debug_log = peer_kwargs.pop("debug_log", None)
+    request_timeout = peer_kwargs.pop("request_timeout", 2)
+    transport_operation_timeout = peer_kwargs.pop("transport_operation_timeout", 2)
+    transport = StdioTransport([sys.executable, str(script)], operation_timeout=transport_operation_timeout, debug_log=debug_log)
+    peer = JsonRpcPeer(transport, request_timeout=request_timeout, **peer_kwargs)
+    await peer.start()
+    return peer
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_request_response_matching_with_out_of_order_replies(tmp_path):
+    peer = await _peer_for_script(tmp_path, """
+        import json, sys, threading, time
+        def respond(msg):
+            if msg["params"]["value"] == "slow": time.sleep(0.2)
+            print(json.dumps({"jsonrpc":"2.0","id":msg["id"],"result":msg["params"]}), flush=True)
+        for line in sys.stdin:
+            threading.Thread(target=respond, args=(json.loads(line),), daemon=False).start()
+    """)
+    try:
+        slow = asyncio.create_task(peer.request("echo", {"value": "slow"}))
+        fast = asyncio.create_task(peer.request("echo", {"value": "fast"}))
+        assert await fast == {"value": "fast"}
+        assert await slow == {"value": "slow"}
+    finally:
+        await peer.close()
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_notifications_dispatch_without_blocking_response(tmp_path):
+    seen: list[dict] = []
+    peer = await _peer_for_script(tmp_path, """
+        import json, sys
+        for line in sys.stdin:
+            msg=json.loads(line)
+            print(json.dumps({"jsonrpc":"2.0","method":"notice","params":{"from":"server"}}), flush=True)
+            print(json.dumps({"jsonrpc":"2.0","id":msg["id"],"result":"ok"}), flush=True)
+    """)
+    peer.on_notification("notice", lambda params: seen.append(params))
+    try:
+        assert await peer.request("work") == "ok"
+        await asyncio.sleep(0.1)
+        assert seen == [{"from": "server"}]
+    finally:
+        await peer.close()
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_remote_error_and_timeout_clean_pending(tmp_path):
+    peer = await _peer_for_script(tmp_path, """
+        import json, sys, time
+        for line in sys.stdin:
+            msg=json.loads(line)
+            if msg["method"] == "error":
+                print(json.dumps({"jsonrpc":"2.0","id":msg["id"],"error":{"code":-32601,"message":"Method not found"}}), flush=True)
+            else:
+                time.sleep(5)
+    """, request_timeout=0.2)
+    try:
+        with pytest.raises(AcpJsonRpcError):
+            await peer.request("error")
+        with pytest.raises(AcpTimeoutError):
+            await peer.request("slow")
+        assert peer.pending_count() == 0
+    finally:
+        await peer.close()
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_inbound_request_handler_sends_result(tmp_path):
+    peer = await _peer_for_script(tmp_path, """
+        import json, sys
+        print(json.dumps({"jsonrpc":"2.0","id":99,"method":"local/echo","params":{"n":4}}), flush=True)
+        for line in sys.stdin:
+            msg=json.loads(line)
+            if msg.get("id") == 99:
+                print(json.dumps({"jsonrpc":"2.0","id":1,"result":msg["result"]}), flush=True)
+    """)
+    peer.on_request("local/echo", lambda params: {"seen": params["n"]})
+    try:
+        assert await peer.request("trigger") == {"seen": 4}
+    finally:
+        await peer.close()
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_process_exit_rejects_pending_requests(tmp_path):
+    peer = await _peer_for_script(tmp_path, """
+        import json, sys, os
+        for line in sys.stdin:
+            os._exit(2)
+    """)
+    try:
+        with pytest.raises(AcpTransportError):
+            await peer.request("die")
+        assert peer.pending_count() == 0
+    finally:
+        await peer.close()
+
+
+def test_jsonrpc_debug_log_classifies_messages():
+    log = DebugLog()
+    log.inbound({"jsonrpc":"2.0","method":"notice","params":{}})
+    log.outbound({"jsonrpc":"2.0","id":1,"result":"ok"})
+    assert [record["kind"] for record in log.snapshot()] == ["notification", "response"]
+
+@pytest.mark.asyncio
+async def test_jsonrpc_idle_transport_timeout_does_not_kill_peer(tmp_path):
+    peer = await _peer_for_script(tmp_path, """
+        import json, sys
+        for line in sys.stdin:
+            msg=json.loads(line)
+            print(json.dumps({"jsonrpc":"2.0","id":msg["id"],"result":"after-idle"}), flush=True)
+    """, request_timeout=1, transport_operation_timeout=0.2)
+    try:
+        await asyncio.sleep(0.35)
+        assert await peer.request("after/idle") == "after-idle"
+    finally:
+        await peer.close()
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_unknown_request_and_invalid_request_get_structured_errors(tmp_path):
+    peer = await _peer_for_script(tmp_path, """
+        import json, sys
+        trigger=json.loads(sys.stdin.readline())
+        print(json.dumps({"jsonrpc":"2.0","id":10,"method":"missing"}), flush=True)
+        print(json.dumps({"jsonrpc":"2.0","id":11,"method":"bad","result":"conflict"}), flush=True)
+        responses=[]
+        while len(responses) < 2:
+            line=sys.stdin.readline()
+            if not line: break
+            responses.append(json.loads(line))
+        print(json.dumps({"jsonrpc":"2.0","id":trigger["id"],"result":responses}), flush=True)
+    """)
+    try:
+        responses = await peer.request("collect")
+        errors = {response["id"]: response["error"]["code"] for response in responses}
+        assert errors == {10: -32601, 11: -32600}
+    finally:
+        await peer.close()
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_close_cancels_notification_tasks(tmp_path):
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    peer = await _peer_for_script(tmp_path, """
+        import json, sys
+        for line in sys.stdin:
+            msg=json.loads(line)
+            print(json.dumps({"jsonrpc":"2.0","method":"slow/notice","params":{}}), flush=True)
+            print(json.dumps({"jsonrpc":"2.0","id":msg["id"],"result":"ok"}), flush=True)
+    """)
+
+    async def slow_handler(params):
+        started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    peer.on_notification("slow/notice", slow_handler)
+    assert await peer.request("start") == "ok"
+    await asyncio.wait_for(started.wait(), timeout=1)
+    await peer.close()
+    await asyncio.wait_for(cancelled.wait(), timeout=1)
+
+
+def test_jsonrpc_unknown_response_is_logged_not_crashing():
+    log = DebugLog()
+    log.system("unknown JSON-RPC response id: 42", kind="error")
+    assert log.snapshot()[0]["kind"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_invalid_response_rejects_matching_pending_request(tmp_path):
+    peer = await _peer_for_script(tmp_path, """
+        import json, sys
+        for line in sys.stdin:
+            msg=json.loads(line)
+            print(json.dumps({"jsonrpc":"2.0","id":msg["id"],"result":"ok","error":{"code":-32603,"message":"bad"}}), flush=True)
+    """)
+    try:
+        with pytest.raises(AcpProtocolError):
+            await peer.request("bad/response")
+        assert peer.pending_count() == 0
+    finally:
+        await peer.close()
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_invalid_version_response_rejects_pending_request(tmp_path):
+    peer = await _peer_for_script(tmp_path, """
+        import json, sys
+        for line in sys.stdin:
+            msg=json.loads(line)
+            print(json.dumps({"jsonrpc":"1.0","id":msg["id"],"result":"wrong-version"}), flush=True)
+    """)
+    try:
+        with pytest.raises(AcpProtocolError):
+            await peer.request("bad/version")
+        assert peer.pending_count() == 0
+    finally:
+        await peer.close()
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_id_only_response_rejects_pending_request(tmp_path):
+    peer = await _peer_for_script(tmp_path, """
+        import json, sys
+        for line in sys.stdin:
+            msg=json.loads(line)
+            print(json.dumps({"jsonrpc":"2.0","id":msg["id"]}), flush=True)
+    """)
+    try:
+        with pytest.raises(AcpProtocolError):
+            await peer.request("bad/id-only")
+        assert peer.pending_count() == 0
+    finally:
+        await peer.close()
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_pending_id_with_method_and_result_rejects_pending_request(tmp_path):
+    peer = await _peer_for_script(tmp_path, """
+        import json, sys
+        for line in sys.stdin:
+            msg=json.loads(line)
+            print(json.dumps({"jsonrpc":"2.0","id":msg["id"],"method":"not/a/request","result":"bad"}), flush=True)
+    """)
+    try:
+        with pytest.raises(AcpProtocolError):
+            await peer.request("bad/method-result")
+        assert peer.pending_count() == 0
+    finally:
+        await peer.close()

--- a/tests/test_acp_stdio_transport.py
+++ b/tests/test_acp_stdio_transport.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import textwrap
+
+import pytest
+
+from helpers.acp.debug_log import DebugLog
+from helpers.acp.errors import AcpProcessExitedError, AcpProtocolError, AcpTransportError
+from helpers.acp.transport import StdioTransport
+
+
+@pytest.mark.asyncio
+async def test_transport_launches_fake_process_and_round_trips_json(tmp_path):
+    script = tmp_path / "echo_server.py"
+    script.write_text(textwrap.dedent("""
+        import json, sys
+        for line in sys.stdin:
+            obj = json.loads(line)
+            print(json.dumps({"ok": obj}), flush=True)
+    """))
+    transport = StdioTransport([sys.executable, str(script)], operation_timeout=2)
+    await transport.start()
+    try:
+        await transport.send_json({"hello": "world"})
+        assert await transport.read_json() == {"ok": {"hello": "world"}}
+        assert transport.is_running() is True
+    finally:
+        await transport.close()
+
+
+@pytest.mark.asyncio
+async def test_transport_captures_stderr_as_diagnostics_only(tmp_path):
+    script = tmp_path / "stderr_server.py"
+    script.write_text(textwrap.dedent("""
+        import json, sys
+        print("warning secret", file=sys.stderr, flush=True)
+        for line in sys.stdin:
+            print(json.dumps({"jsonrpc":"2.0","id":1,"result":"ok"}), flush=True)
+    """))
+    log = DebugLog(masker=lambda text: text.replace("secret", "***"))
+    transport = StdioTransport([sys.executable, str(script)], debug_log=log, operation_timeout=2)
+    await transport.start()
+    try:
+        await asyncio.sleep(0.1)
+        await transport.send_json({"jsonrpc":"2.0","id":1,"method":"x"})
+        assert await transport.read_json() == {"jsonrpc": "2.0", "id": 1, "result": "ok"}
+        assert any(record["direction"] == "stderr" and "***" in record["preview"] for record in transport.diagnostics())
+    finally:
+        await transport.close()
+
+
+@pytest.mark.asyncio
+async def test_transport_malformed_stdout_marks_unhealthy(tmp_path):
+    script = tmp_path / "bad_server.py"
+    script.write_text('print("not json", flush=True)\nimport time; time.sleep(5)\n')
+    transport = StdioTransport([sys.executable, str(script)], operation_timeout=2)
+    await transport.start()
+    try:
+        with pytest.raises(AcpProtocolError):
+            await transport.read_json()
+        with pytest.raises(AcpTransportError):
+            await transport.send_json({"still": "there"})
+    finally:
+        await transport.kill()
+
+
+@pytest.mark.asyncio
+async def test_transport_rejects_string_command_and_missing_cwd(tmp_path):
+    with pytest.raises(AcpTransportError):
+        StdioTransport("python -V")  # type: ignore[arg-type]
+    with pytest.raises(AcpTransportError):
+        StdioTransport([sys.executable, "-V"], cwd=tmp_path / "missing")
+
+
+@pytest.mark.asyncio
+async def test_transport_process_exit_is_reported(tmp_path):
+    script = tmp_path / "exit_server.py"
+    script.write_text('import sys; sys.exit(3)\n')
+    transport = StdioTransport([sys.executable, str(script)], operation_timeout=0.5)
+    await transport.start()
+    try:
+        with pytest.raises(AcpProcessExitedError):
+            await transport.read_json()
+    finally:
+        await transport.kill()
+
+@pytest.mark.asyncio
+async def test_transport_oversized_stdout_marks_unhealthy(tmp_path):
+    script = tmp_path / "large_server.py"
+    script.write_text('print("{\\\"payload\\\":\\\"" + "x" * 64 + "\\\"}", flush=True)\nimport time; time.sleep(5)\n')
+    transport = StdioTransport([sys.executable, str(script)], operation_timeout=2, max_line_bytes=20)
+    await transport.start()
+    try:
+        with pytest.raises(AcpProtocolError):
+            await transport.read_json()
+        with pytest.raises(AcpTransportError):
+            await transport.read_json()
+    finally:
+        await transport.kill()
+
+
+@pytest.mark.asyncio
+async def test_transport_close_and_kill_are_idempotent(tmp_path):
+    script = tmp_path / "sleep_server.py"
+    script.write_text('import time; time.sleep(30)\n')
+    transport = StdioTransport([sys.executable, str(script)], operation_timeout=1, close_timeout=0.1)
+    await transport.start()
+    await transport.close()
+    await transport.close()
+    await transport.kill()
+    await transport.kill()
+    assert transport.is_running() is False
+
+
+@pytest.mark.asyncio
+async def test_transport_logs_outbound_before_failed_write(tmp_path):
+    script = tmp_path / "exit_server.py"
+    script.write_text('import sys; sys.exit(0)\n')
+    log = DebugLog()
+    transport = StdioTransport([sys.executable, str(script)], debug_log=log, operation_timeout=0.2)
+    await transport.start()
+    await asyncio.sleep(0.1)
+    with pytest.raises(AcpTransportError):
+        await transport.send_json({"jsonrpc": "2.0", "id": 1, "method": "will/fail"})
+    assert any(record["direction"] == "outbound" and record["method"] == "will/fail" for record in log.snapshot())
+    with pytest.raises(AcpTransportError):
+        await transport.send_json({"jsonrpc": "2.0", "id": 2, "method": "fast/fail"})
+
+
+@pytest.mark.asyncio
+async def test_transport_returncode_read_path_marks_unhealthy(tmp_path):
+    script = tmp_path / "exit_before_read.py"
+    script.write_text('import sys; sys.exit(0)\n')
+    transport = StdioTransport([sys.executable, str(script)], operation_timeout=1)
+    await transport.start()
+    await asyncio.sleep(0.1)
+    try:
+        with pytest.raises(AcpProcessExitedError):
+            await transport.read_json()
+        with pytest.raises(AcpTransportError):
+            await transport.read_json()
+    finally:
+        await transport.kill()


### PR DESCRIPTION
## Summary
- Add `helpers.acp` foundation package with ACP errors, bounded masked debug logging, stdio JSON transport, and protocol-agnostic JSON-RPC peer.
- Implement subprocess stdio safety: argv-only launch, controlled env, bounded stdout/stderr handling, diagnostics, timeouts, unhealthy-state tracking, and idempotent cleanup.
- Implement JSON-RPC request/response/notification routing with pending request cleanup, deterministic malformed response rejection, inbound request handling, notifications, and close cleanup.
- Add deterministic fake-subprocess tests for debug log, transport, JSON-RPC routing, timeouts, cleanup, process exit, malformed messages, and oversized output.

## Verification
- `python -m py_compile helpers/acp/*.py tests/test_acp_*.py`
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/test_acp_debug_log.py tests/test_acp_stdio_transport.py tests/test_acp_jsonrpc.py` — 26 passed

## Notes
- Scope is PR 02 foundation only: no ACP initialize/session/tool/WebUI behavior.
- Final focused review approved the pending-response malformed JSON-RPC handling and transport unhealthy-state fixes.
