### PR TITLE
fix: streaming timeout retry + progress keepalive during long inference

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -894,15 +894,37 @@ class Agent:
         )
 
         # call model
-        response, reasoning = await call_data["model"].unified_call(
-            messages=call_data["messages"],
-            reasoning_callback=call_data["reasoning_callback"],
-            response_callback=call_data["response_callback"],
-            rate_limiter_callback=(
-                self.rate_limiter_callback if not call_data["background"] else None
-            ),
-            explicit_caching=call_data["explicit_caching"],
-        )
+        # Keepalive heartbeat during long inference
+        _ka_stop = asyncio.Event()
+        async def _ka_heartbeat():
+            _ka_count = 0
+            while not _ka_stop.is_set():
+                try:
+                    await asyncio.wait_for(_ka_stop.wait(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    _ka_count += 1
+                    try:
+                        self.context.log.set_progress(f"Generating... ({_ka_count * 10}s)")
+                    except Exception:
+                        pass
+        _ka_task = asyncio.create_task(_ka_heartbeat())
+        try:
+            response, reasoning = await call_data["model"].unified_call(
+                messages=call_data["messages"],
+                reasoning_callback=call_data["reasoning_callback"],
+                response_callback=call_data["response_callback"],
+                rate_limiter_callback=(
+                    self.rate_limiter_callback if not call_data["background"] else None
+                ),
+                explicit_caching=call_data["explicit_caching"],
+            )
+        finally:
+            _ka_stop.set()
+            _ka_task.cancel()
+            try:
+                await _ka_task
+            except asyncio.CancelledError:
+                pass
 
         await extension.call_extensions_async(
             "chat_model_call_after", self, call_data=call_data, response=response, reasoning=reasoning
@@ -970,16 +992,38 @@ class Agent:
             if call_data.get(key) is not None:
                 turn_kwargs[key] = call_data.get(key)
 
-        llm_result = await call_data["model"].unified_turn(
-            messages=call_data["messages"],
-            reasoning_callback=call_data["reasoning_callback"],
-            response_callback=call_data["response_callback"],
-            rate_limiter_callback=(
-                self.rate_limiter_callback if not call_data["background"] else None
-            ),
-            explicit_caching=call_data["explicit_caching"],
-            **turn_kwargs,
-        )
+        # Keepalive heartbeat during long inference
+        _ka_stop_t = asyncio.Event()
+        async def _ka_heartbeat_t():
+            _ka_count = 0
+            while not _ka_stop_t.is_set():
+                try:
+                    await asyncio.wait_for(_ka_stop_t.wait(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    _ka_count += 1
+                    try:
+                        self.context.log.set_progress(f"Generating... ({_ka_count * 10}s)")
+                    except Exception:
+                        pass
+        _ka_task_t = asyncio.create_task(_ka_heartbeat_t())
+        try:
+            llm_result = await call_data["model"].unified_turn(
+                messages=call_data["messages"],
+                reasoning_callback=call_data["reasoning_callback"],
+                response_callback=call_data["response_callback"],
+                rate_limiter_callback=(
+                    self.rate_limiter_callback if not call_data["background"] else None
+                ),
+                explicit_caching=call_data["explicit_caching"],
+                **turn_kwargs,
+            )
+        finally:
+            _ka_stop_t.set()
+            _ka_task_t.cancel()
+            try:
+                await _ka_task_t
+            except asyncio.CancelledError:
+                pass
 
         downgraded = llm_result.capability.get("builtin_tool_downgrades")
         if downgraded:

--- a/models.py
+++ b/models.py
@@ -17,6 +17,7 @@ from typing import (
 from litellm import embedding
 import litellm
 import openai
+import httpx
 
 from helpers import dotenv
 from helpers import settings, images
@@ -319,6 +320,10 @@ def _is_transient_litellm_error(exc: Exception) -> bool:
         getattr(openai, "InternalServerError", Exception),
         # Some providers map overloads to ServiceUnavailable-like errors
         getattr(openai, "APIStatusError", Exception),
+        # Streaming socket timeouts (aiohttp.SocketTimeoutError maps to these via LiteLLM transport)
+        httpx.ReadTimeout,
+        httpx.ConnectTimeout,
+        httpx.PoolTimeout,
     )
     return isinstance(exc, transient_types)
 
@@ -631,8 +636,11 @@ class LiteLLMChatWrapper(SimpleChatModel):
             except Exception as e:
                 import asyncio
 
-                # Retry only if no chunks received and error is transient
-                if got_any_chunk or not _is_transient_litellm_error(e) or attempt >= max_retries:
+                # Retry logic: allow retry for transient errors even with partial chunks
+                is_transient = _is_transient_litellm_error(e)
+                if attempt >= max_retries:
+                    raise
+                if not is_transient and got_any_chunk:
                     raise
                 attempt += 1
                 await asyncio.sleep(retry_delay_s)
@@ -773,11 +781,11 @@ class LiteLLMChatWrapper(SimpleChatModel):
             except Exception as e:
                 import asyncio
 
-                if (
-                    got_any_chunk
-                    or not _is_transient_litellm_error(e)
-                    or attempt >= max_retries
-                ):
+                # Retry logic: allow retry for transient errors even with partial chunks
+                is_transient = _is_transient_litellm_error(e)
+                if attempt >= max_retries:
+                    raise
+                if not is_transient and got_any_chunk:
                     raise
                 attempt += 1
                 await asyncio.sleep(retry_delay_s)


### PR DESCRIPTION
# Fix: Streaming timeout retry + progress keepalive during long inference

## Problem

During long LLM inference (30-90s for 500K+ token contexts), two bugs cause session death:

1. **Transient timeout classification**: `httpx.ReadTimeout` (originating from `aiohttp.SocketTimeoutError` via LiteLLM's transport) is not classified as transient in `_is_transient_litellm_error()`, so streaming timeouts are never retried.

2. **Partial-chunk guard blocks retries**: The `got_any_chunk` guard blocks ALL retries once any streaming data is received, even for transient errors.

## Fix

### Part 1: Transient classification (models.py)

Add httpx timeout exceptions to the `transient_types` tuple:

```python
transient_types = (
    ...existing types...,
    # Streaming socket timeouts — aiohttp.SocketTimeoutError maps to httpx.ReadTimeout
    httpx.ReadTimeout,
    httpx.ConnectTimeout,
    httpx.PoolTimeout,
)
```

### Part 2: Retry condition (models.py)

Allow retries for transient errors even when partial chunks were received:

```python
# Before: if got_any_chunk or not _is_transient_litellm_error(e) or attempt >= max_retries:
is_transient = _is_transient_litellm_error(e)
if attempt >= max_retries:
    raise
if not is_transient and got_any_chunk:
    raise
```

### Part 3: Progress keepalive (agent.py)

Wrap `call_chat_model` with a background heartbeat task that emits progress events every 10s during long inference, keeping the Socket.IO connection warm:

```python
_stop = asyncio.Event()
async def _heartbeat():
    count = 0
    while not _stop.is_set():
        try:
            await asyncio.wait_for(_stop.wait(), timeout=10.0)
        except asyncio.TimeoutError:
            count += 1
            self.context.log.set_progress(f"Generating... ({count * 10}s)")
_task = asyncio.create_task(_heartbeat())
try:
    response = await model.unified_call(...)
finally:
    _stop.set()
    _task.cancel()
```

## Testing

- Verified on v2.2 with 500K+ token contexts
- Both streaming retry locations patched (unified_call + unified_turn)
- Heartbeat fires every 10s, shows elapsed time in UI progress bar
