### PR TITLE
Fix DirtyJson dropping array elements after an unquoted value

### DIFF
--- a/helpers/dirty_json.py
+++ b/helpers/dirty_json.py
@@ -401,7 +401,6 @@ class DirtyJson:
         ]:
             result += self.current_char
             self._advance()
-        self._advance()
         return result.strip()
 
     def _peek(self, n):

--- a/tests/test_dirty_json.py
+++ b/tests/test_dirty_json.py
@@ -93,3 +93,18 @@ def test_value_can_still_end_before_quoted_key_when_comma_is_missing() -> None:
     parsed = DirtyJson.parse_string('{"first":"one" "second":"two"}')
 
     assert parsed == {"first": "one", "second": "two"}
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ("[foo, bar, baz]", ["foo", "bar", "baz"]),
+        ('[foo, "bar"]', ["foo", "bar"]),
+        ('["foo", bar]', ["foo", "bar"]),
+        ("[foo]", ["foo"]),
+    ],
+)
+def test_unquoted_array_elements_are_all_kept(payload, expected) -> None:
+    # A bareword element must not consume its own trailing delimiter, which
+    # previously truncated the array after the first unquoted value.
+    assert DirtyJson.parse_string(payload) == expected


### PR DESCRIPTION
## Problem

`DirtyJson` silently drops every array element after the first **unquoted** (bareword) value:

```python
DirtyJson.parse_string("[foo, bar, baz]")  # -> ['foo']   (expected ['foo', 'bar', 'baz'])
DirtyJson.parse_string('[foo, "bar"]')     # -> ['foo']   (expected ['foo', 'bar'])
```

Arrays whose first element is quoted work by luck (`'["foo", bar]'` -> `['foo', 'bar']`), which hides the bug in most tests.

## Root cause

`_parse_unquoted_string` stops its scan **on** the delimiter that ends the bareword (`,`, `]`, `}`, `:`), then runs an unconditional `self._advance()` that consumes that delimiter:

```python
while self.current_char is not None and self.current_char not in [":", ",", "}", "]"]:
    result += self.current_char
    self._advance()
self._advance()        # <-- eats the delimiter
return result.strip()
```

Back in `_parse_array_content`, the `if self.current_char == ","` check then never sees the comma (it was already consumed), so control falls into `elif self.current_char != "]"`, which pops the stack and ends the array after the first bareword. Objects only survive because `_parse_object_content` has a fallthrough that re-enters.

## Fix

Drop the extra advance so the cursor is left **on** the delimiter, letting the array/object loops consume it as they already do for quoted values:

```python
    result += self.current_char
    self._advance()
-self._advance()
 return result.strip()
```

## Impact

`DirtyJson` is the repair layer for malformed model tool-call / response JSON (`helpers/extract_tools.py`, `agent.py`, `mcp_handler.py`, memory plugins). Models that emit bareword array elements — common outside strict OpenAI-style output — silently lost their remaining tool arguments. This is data loss, not a crash, so it went unnoticed.

## Tests

Added a parametrized `test_unquoted_array_elements_are_all_kept` covering leading/trailing/mixed bareword elements and the single-element case.

```
$ pytest tests/test_dirty_json.py -q
11 passed
```

All 7 pre-existing `dirty_json` tests still pass; object, number, and quoted-array parsing are unchanged.
