### PR TITLE
fix: add "cannot determine type" to Responses API fallback markers

### DIFF
--- a/helpers/litellm_transport.py
+++ b/helpers/litellm_transport.py
@@ -1817,6 +1817,7 @@ def _looks_like_responses_request_rejected(text: str) -> bool:
             "failed to deserialize input",
             "failed to deserialize response",
             "failed to deserialize responses",
+            "cannot determine type",
         )
     )
 

--- a/helpers/litellm_transport.py.dox.md
+++ b/helpers/litellm_transport.py.dox.md
@@ -29,6 +29,7 @@
 - Normalize function tool parameter schemas with an explicit object `properties` field before Responses requests so OpenAI-compatible chat backends reached through LiteLLM can validate them.
 - Prefer Responses API when configured, but fallback to Chat Completions when the provider does not support Responses.
 - Fall back to Chat Completions when a Responses request is rejected before any output by an endpoint-specific or shape-specific Bad Request indicating the provider cannot parse Responses payloads.
+- Treat opaque type-discrimination errors such as `cannot determine type` from OpenAI-compatible Responses endpoints as shape-specific rejections.
 - Fall back to Chat Completions when a Responses endpoint fails before output with an endpoint-specific server error, proxy path-unavailable error, or LiteLLM proxy-extra import error.
 - Fall back to Chat Completions when LiteLLM's Responses mock streaming path tries to JSON-decode a real SSE stream before any output.
 - Preserve Chat Completions tool calls from both non-streaming responses and streaming deltas as canonical `LLMResult` function-call items.

--- a/tests/test_stream_tool_early_stop.py
+++ b/tests/test_stream_tool_early_stop.py
@@ -1366,6 +1366,20 @@ def test_responses_fallback_does_not_mask_rate_limits():
     )
 
 
+def test_responses_fallback_on_untyped_input_item_rejection():
+    class BadRequestError(RuntimeError):
+        status_code = 400
+
+    policy = litellm_transport.TransportPolicy(
+        mode=litellm_transport.TransportMode.RESPONSES
+    )
+
+    assert policy.recover(
+        BadRequestError("Cannot determine type of item"), got_any_chunk=False
+    ) is litellm_transport.TransportRecovery.FALLBACK_TO_CHAT
+    assert policy.mode is litellm_transport.TransportMode.CHAT_COMPLETIONS
+
+
 def test_responses_response_parser_extracts_text_reasoning_and_function_calls():
     text_response = {
         "output": [


### PR DESCRIPTION
## Problem

Some OpenAI-compatible Responses endpoints reject complex input items with `400 Cannot determine type of item`. That is a shape-specific request rejection: retrying through Chat Completions is appropriate before any output has been received.

## Fix

Recognize `cannot determine type` as a Responses request-rejection marker, so the existing transport fallback selects Chat Completions.

## Verification

- `PYTHONPATH=/home/eclypso/a0/.worktrees/pr-1763-repair conda run -n a0 pytest tests/test_stream_tool_early_stop.py tests/test_responses_architecture.py -q` — 60 passed
- `py_compile` for `helpers/litellm_transport.py`

## Scope

Maintainer-rebased cleanly onto `ready`; unrelated local history and ignored runtime state were excluded.