### PR TITLE
fix(history): emit ToolMessage for tool results instead of HumanMessage

### DIFF
--- a/helpers/history.py
+++ b/helpers/history.py
@@ -8,7 +8,7 @@ import uuid
 from typing import Coroutine, Literal, TypedDict, cast, Union, Dict, List, Any
 from helpers import messages, tokens, settings, call_llm
 from enum import Enum
-from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage, AIMessage
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage, AIMessage, ToolMessage
 from plugins._model_config.helpers.model_config import get_chat_model_config
 
 
@@ -713,7 +713,20 @@ def output_langchain(messages: list[OutputMessage]):
         if m["ai"]:
             result.append(AIMessage(content))  # type: ignore
         else:
-            result.append(HumanMessage(content))  # type: ignore
+            # Tool results are stored with ai=False. hist_add_tool_result packs
+            # {tool_name, tool_result, ...} into the content dict. Emit as
+            # ToolMessage so the model can distinguish tool output from user input.
+            raw_content = m.get("content")
+            tool_name = None
+            tool_result_text = None
+            tool_call_id = (m.get("metadata") or {}).get("id") or ""
+            if isinstance(raw_content, dict):
+                tool_name = raw_content.get("tool_name")
+                tool_result_text = raw_content.get("tool_result")
+            if tool_name and isinstance(tool_result_text, str):
+                result.append(ToolMessage(content=tool_result_text, tool_call_id=tool_call_id))  # type: ignore
+            else:
+                result.append(HumanMessage(content))  # type: ignore
     # ensure message type alternation
     result = group_messages_abab(result)
     return result


### PR DESCRIPTION
## Summary

Fix `output_langchain()` (`helpers/history.py`) to emit `ToolMessage` for tool results instead of collapsing them into `HumanMessage`. This makes tool results structurally distinguishable from user-typed messages in the LLM's context.

## Problem

`helpers/history.py:707-718` converts internal `OutputMessage` records to LangChain messages using only a boolean `ai` flag. Tool results are stored via `hist_add_tool_result` with `ai=False` — the same flag used for user messages — so both collapse to `HumanMessage`. From the model's perspective, **a `memory_load` tool return and a user typing in the chat are indistinguishable**.

This breaks multi-step slash-command protocols (`/start`, `/start-all`, and any agent workflow with sequential tool calls). Smaller models (e.g., MiniMax-M3) interpret the tool result as fresh user input and break out of the protocol with a clarification response. Frontier models handle this via conversational context, but smaller ones don't.

A reproduction is captured at `incidents/2026-07-12-tool-results-as-human/` in the wgnr.ai fork. The companion chat log excerpt (chat `5w0Bthh7`, 2026-07-12) shows the model repeatedly executing the same mailbox scan because it interpreted each successful scan result as user input asking for clarification.

## Fix

Detect tool-result messages via metadata (`tool_name` key) and emit them as LangChain's native `ToolMessage` instead of `HumanMessage`:

```python
# Before (helpers/history.py:707-718)
def output_langchain(messages: list[OutputMessage]):
    result = []
    for m in messages:
        content = _output_content_langchain(content=m["content"])
        if not content or (isinstance(content, str) and not content.strip()):
            continue
        if m["ai"]:
            result.append(AIMessage(content))
        else:
            result.append(HumanMessage(content))
    result = group_messages_abab(result)
    return result

# After
from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage  # added ToolMessage

def output_langchain(messages: list[OutputMessage]):
    result = []
    for m in messages:
        content = _output_content_langchain(content=m["content"])
        if not content or (isinstance(content, str) and not content.strip()):
            continue
        if m["ai"]:
            result.append(AIMessage(content))
        else:
            # Tool results are stored with ai=False. hist_add_tool_result packs
            # {tool_name, tool_result, ...} into the content dict. Emit as
            # ToolMessage so the model can distinguish tool output from user input.
            raw_content = m.get("content")
            tool_name = None
            tool_result_text = None
            tool_call_id = (m.get("metadata") or {}).get("id") or ""
            if isinstance(raw_content, dict):
                tool_name = raw_content.get("tool_name")
                tool_result_text = raw_content.get("tool_result")
            if tool_name and isinstance(tool_result_text, str):
                result.append(ToolMessage(content=tool_result_text, tool_call_id=tool_call_id))
            else:
                result.append(HumanMessage(content))
    result = group_messages_abab(result)
    return result
```

## Behavior matrix

| Message type | Before | After |
|---|---|---|
| AI response (`ai=True`) | `AIMessage` | `AIMessage` |
| User message (`ai=False`, no tool metadata) | `HumanMessage` | `HumanMessage` |
| Tool result (`ai=False`, `tool_name` in content dict) | `HumanMessage` ← **bug** | `ToolMessage` ← **fixed** |

## Compatibility

- `langchain_core.messages.ToolMessage` is supported in langchain-core ≥0.1. The framework already imports `HumanMessage, SystemMessage, AIMessage` from `langchain_core.messages` (`history.py:11`); adding `ToolMessage` is a trivial extension.
- LiteLLM transport: providers that support OpenAI-style `tool` role (OpenAI, Anthropic, Google, Mistral, Groq) handle `ToolMessage` natively. Providers without native tool support may need a fallback in `_model_config` — not addressed in this PR.
- `group_messages_abab()` (called at line 718) enforces alternation: never two same-role messages in a row. After this change, consecutive tool results become consecutive `ToolMessage` entries; the alternation rule still applies (consecutive `ToolMessage` entries are merged via `_merge_outputs`). Verified by code inspection; a runtime test would be ideal.

## Testing

Unit test additions (proposed in `tests/helpers/test_history.py`):

```python
def test_output_langchain_emits_tool_message_for_tool_results():
    result = history.output_langchain([
        OutputMessage(ai=True, content="AI says hello"),
        OutputMessage(ai=False, content="User typed this"),
        OutputMessage(ai=False, content={"tool_name": "memory_load", "tool_result": "memory data"}, metadata={"id": "call_abc"}),
    ])
    assert isinstance(result[0], AIMessage)
    assert isinstance(result[1], HumanMessage)
    assert isinstance(result[2], ToolMessage)
    assert result[2].content == "memory data"
    assert result[2].tool_call_id == "call_abc"
```

End-to-end verification performed by wgnr.ai on 2026-07-12 (chat `5w0Bthh7`): `/start` slash command executed all 5 steps cleanly, the model produced a TL;DR-formatted greeting with real tool data, and the options menu was delivered. Before this fix, the same chat failed at Step 1 (`memory_load` returned memory records that the model interpreted as a fresh user message asking for clarification).

## Affected versions

- v2.3 (`3bb40576`) — buggy (verified by wgnr.ai local fork)
- v2.4 (`fddcc3d`) — buggy (verified by raw GitHub fetch of `tools/response.py` line 7; same pattern applies here)
- `main` — buggy (verified by raw GitHub fetch)

## Related

- Sibling fix: `/start` template workaround in `wgnr_ai_data` commit `62908be` (companion PR or follow-up)
- Companion finding: chat model `temperature: 0` (set during the 2026-07-11 config canonicalization) was a contributing cause of rigid pattern-matching; raised to 0.1 in wgnr.ai's fork. This is a wgnr.ai-internal config change, not an Agent Zero framework change.
- Reproduction: `incidents/2026-07-12-tool-results-as-human/` in the wgnr.ai fork (chat log excerpts preserved).