### PR TITLE
fix(oauth): send Codex client version header on upstream requests

### DIFF
--- a/plugins/_oauth/helpers/codex.py
+++ b/plugins/_oauth/helpers/codex.py
@@ -599,6 +599,9 @@ def request_codex(
             "thread-id": metadata["thread_id"],
         }
     )
+    client_version = resolve_codex_version()
+    if client_version:
+        request_headers["version"] = client_version
 
     return requests.request(
         method,

--- a/tests/test_oauth_codex.py
+++ b/tests/test_oauth_codex.py
@@ -223,7 +223,10 @@ def test_prepare_responses_body_sends_empty_continuation_input_as_list(monkeypat
     assert body["previous_response_id"] == "resp_1"
 
 
-def test_request_codex_sends_current_codex_headers_from_body(monkeypatch):
+@pytest.mark.parametrize("client_version", ["0.142.5", ""])
+def test_request_codex_sends_current_codex_headers_from_body(
+    monkeypatch, client_version
+):
     calls = []
     body = json.dumps(
         {
@@ -255,6 +258,7 @@ def test_request_codex_sends_current_codex_headers_from_body(monkeypatch):
             account_id="account-1",
         ),
     )
+    monkeypatch.setattr(codex, "resolve_codex_version", lambda: client_version)
 
     def fake_request(method, target, headers, data, params, timeout, stream):
         calls.append(
@@ -291,6 +295,10 @@ def test_request_codex_sends_current_codex_headers_from_body(monkeypatch):
     assert call["headers"]["session-id"] == "session-1"
     assert call["headers"]["thread-id"] == "thread-1"
     assert call["headers"]["x-codex-window-id"] == "agent-zero"
+    if client_version:
+        assert call["headers"]["version"] == "0.142.5"
+    else:
+        assert "version" not in call["headers"]
 
 
 def test_chat_messages_to_response_body_preserves_image_parts_for_responses():


### PR DESCRIPTION
## Summary

The Codex OAuth proxy listed GPT-5.6 family models via `/models` but completion calls failed with HTTP 404 Model not found. Upstream gates newer models on a client `version` request header. `request_codex` never sent that header, while the models catalog already passed `client_version` from `resolve_codex_version()`.

## Changes

- Set the `version` request header in `request_codex` when `resolve_codex_version()` returns a non-empty value
- Leave the header unset when no version is configured or discoverable
- Extend the request header unit test for both non-empty and empty version cases

Fixes #1765

## Verification

- `python3 -m pytest tests/test_oauth_codex.py -q -k "request_codex" -o addopts=` (2 passed)

## Backwards compatibility

No API or config changes. Clients without a resolvable Codex version behave as before (header omitted).
