### PR TITLE
fix: use persistent runtime ID for session cookie name

### DIFF
--- a/helpers/ui_server.py
+++ b/helpers/ui_server.py
@@ -80,7 +80,7 @@ class UiServerRuntime:
         WerkzeugRequest.max_form_memory_size = UPLOAD_LIMIT_BYTES
         webapp.config.update(
             JSON_SORT_KEYS=False,
-            SESSION_COOKIE_NAME="session_" + runtime.get_runtime_id(),
+            SESSION_COOKIE_NAME="session_" + runtime.get_persistent_id(),
             SESSION_COOKIE_SAMESITE="Lax",
             SESSION_PERMANENT=True,
             PERMANENT_SESSION_LIFETIME=timedelta(days=1),


### PR DESCRIPTION
## Bug: Session cookies invalidated on every process/container restart

### Problem

`SESSION_COOKIE_NAME` in `helpers/ui_server.py` uses `runtime.get_runtime_id()`, which generates a **new random value** (`secrets.token_hex(8)`) on every process start. This means the cookie **name** changes on every restart, orphaning the browser's existing session cookie and forcing re-login.

This is separate from the `FLASK_SECRET_KEY` persistence (which was already addressed) — even with a stable secret key, the cookie name rotation breaks sessions.

### Impact

Affects every Docker deployment. Users are forced to re-login after any container restart, supervisor process restart, or self-update.

### Fix

Use `runtime.get_persistent_id()` instead, which reads `A0_PERSISTENT_RUNTIME_ID` from `.env` (generating and persisting it on first use). This function already exists in `helpers/runtime.py` and is designed exactly for this purpose — it's already used for CSRF token cookie names and other stable identifiers.

### Change

One line in `helpers/ui_server.py`:

```python
# Before:
SESSION_COOKIE_NAME="session_" + runtime.get_runtime_id(),

# After:
SESSION_COOKIE_NAME="session_" + runtime.get_persistent_id(),
```

### Testing

Verified across a 4-container deployment. After applying the fix:
- Session cookies survive process restarts (`supervisorctl restart run_ui`)
- Session cookies survive container recreation
- Each container maintains its own unique stable cookie name via its own `A0_PERSISTENT_RUNTIME_ID`