### PR TITLE
Fix DirtyJson decoding \u surrogate pairs as unpaired surrogates

### DIFF
--- a/helpers/dirty_json.py
+++ b/helpers/dirty_json.py
@@ -73,6 +73,23 @@ class DirtyJson:
         else:
             self.current_char = None
 
+    def _consume_low_surrogate_escape(self):
+        """If the next characters are a \\uXXXX escape encoding a UTF-16 low
+        surrogate (DC00-DFFF), consume them and return the code unit as an int.
+        Otherwise consume nothing and return None."""
+        s = self.json_string
+        i = self.index
+        if self.current_char != "\\" or i + 5 >= len(s) or s[i + 1] != "u":
+            return None
+        try:
+            low = int(s[i + 2 : i + 6], 16)
+        except ValueError:
+            return None
+        if not (0xDC00 <= low <= 0xDFFF):
+            return None
+        self._advance(6)
+        return low
+
     def _skip_whitespace(self):
         while self.current_char is not None:
             if self.current_char.isspace():
@@ -293,10 +310,26 @@ class DirtyJson:
                         unicode_char += self.current_char
                         self._advance()
                     try:
-                        result += chr(int(unicode_char, 16))
+                        code = int(unicode_char, 16)
                     except ValueError:
                         # If invalid hex value, treat as literal
                         result += "\\u" + unicode_char
+                        continue
+                    if 0xD800 <= code <= 0xDBFF:
+                        # UTF-16 high surrogate: combine with a following \uXXXX low
+                        # surrogate into the real character (matches json.loads), e.g.
+                        # \ud83c\udf78 -> U+1F378. An unpaired surrogate becomes U+FFFD:
+                        # Python strings tolerate lone surrogates, but any later
+                        # .encode("utf-8") raises "surrogates not allowed", crashing
+                        # tool execution and log writes downstream of the parse.
+                        low = self._consume_low_surrogate_escape()
+                        if low is not None:
+                            code = 0x10000 + ((code - 0xD800) << 10) + (low - 0xDC00)
+                        else:
+                            code = 0xFFFD
+                    elif 0xDC00 <= code <= 0xDFFF:
+                        code = 0xFFFD
+                    result += chr(code)
                     continue
             else:
                 result += self.current_char

--- a/tests/test_dirty_json.py
+++ b/tests/test_dirty_json.py
@@ -93,3 +93,38 @@ def test_value_can_still_end_before_quoted_key_when_comma_is_missing() -> None:
     parsed = DirtyJson.parse_string('{"first":"one" "second":"two"}')
 
     assert parsed == {"first": "one", "second": "two"}
+
+
+def test_unicode_escape_surrogate_pair_is_combined() -> None:
+    # \\ud83c\\udf78 is the JSON escape form of U+1F378; json.loads combines
+    # the pair and DirtyJson must match, otherwise the parsed string carries two
+    # lone UTF-16 surrogates and crashes at the first .encode("utf-8") downstream
+    # (tool execution, log writes).
+    payload = '{"text": "START\\ud83c\\udf78END"}'
+
+    parsed = DirtyJson.parse_string(payload)
+
+    assert parsed == {"text": "START\U0001f378END"}
+    parsed["text"].encode("utf-8")  # must not raise
+
+
+def test_unicode_escape_lone_surrogate_becomes_replacement_char() -> None:
+    high = DirtyJson.parse_string('{"text": "x\\ud83cy"}')
+    low = DirtyJson.parse_string('{"text": "x\\udf78y"}')
+
+    assert high == {"text": "x\ufffdy"}
+    assert low == {"text": "x\ufffdy"}
+    high["text"].encode("utf-8")  # must not raise
+    low["text"].encode("utf-8")  # must not raise
+
+
+def test_unicode_escape_bmp_characters_unchanged() -> None:
+    parsed = DirtyJson.parse_string('{"text": "caf\\u00e9 \\u2713"}')
+
+    assert parsed == {"text": "caf\u00e9 \u2713"}
+
+
+def test_unicode_escape_high_surrogate_followed_by_non_escape_text() -> None:
+    parsed = DirtyJson.parse_string('{"text": "a\\ud83cbcd"}')
+
+    assert parsed == {"text": "a\ufffdbcd"}


### PR DESCRIPTION
Fixes #1773.

Fixes the `UnicodeEncodeError: surrogates not allowed` crash class described in #1773 (also the actual root cause of #1384).

## Problem

`DirtyJson._parse_string` decodes each `\uXXXX` escape independently, so a surrogate-pair escape like `\ud83c\udf78` (U+1F378, the legal JSON encoding any conforming serializer produces for non-BMP characters) parses into two lone UTF-16 surrogates. The string then crashes at the first `.encode("utf-8")` downstream — observed live in `code_execution_tool` (`tty_session.send`) as "Critical error occurred, retrying...", and the same poison hits `print_style` log writes (#1384). Every tool envelope goes through this parser via `extract_tools.json_parse_dirty`, so any model that escape-encodes an emoji in a code/text arg trips it.

## Change

- After decoding a `\uXXXX` escape to a high surrogate (D800-DBFF), look ahead for an immediately following `\uXXXX` low-surrogate escape and combine the pair into the real code point — the same behavior as `json.loads`.
- Any remaining unpaired surrogate (lone high, lone low) becomes U+FFFD, so the parser can never emit a string that is not UTF-8-encodable. (`json.loads` passes lone surrogates through; given every consumer here eventually encodes to UTF-8, emitting the replacement character instead of a guaranteed downstream crash seemed the right call for this parser — happy to match `json.loads` exactly instead if preferred.)
- BMP escapes (`\u00e9`, `\u2713`, ...) and the existing invalid-hex literal fallback are unchanged.

## Tests

Four new cases in `tests/test_dirty_json.py`: pair combining (with an encode assertion on the exact crash site), lone high/low replacement, BMP escapes unchanged, and a high surrogate followed by plain text. `python -m pytest tests/test_dirty_json.py` passes 11/11.
