### PR TITLE
fix: set context.task for scheduler-run tasks so end-of-turn extensions fire

### DIFF
--- a/helpers/task_scheduler.py
+++ b/helpers/task_scheduler.py
@@ -899,6 +899,10 @@ class TaskScheduler:
 
                 context = await self._get_chat_context(current_task)
                 AgentContext.use(context.id)
+                # adopt the run's own DeferredTask so extension dispatch
+                # (message_loop_end / monologue_end) and is_running() see the run
+                if not (context.task and context.task.is_alive()):
+                    context.task = deferred_task
 
                 # Ensure the context is properly registered in the AgentContext._contexts
                 # This is critical for the polling mechanism to find and stream logs


### PR DESCRIPTION
Fixes #1776.

The scheduler runs tasks by calling `agent.monologue()` directly, so `context.task` is never assigned for scheduler-run contexts — and `agent.py` gates both `message_loop_end` and `monologue_end` extension dispatch on `context.task and context.task.is_alive()`. Net effect: no end-of-turn extensions (including the built-in `_memory` memorize extensions) ever fire for a Scheduled/AdHoc/Planned task.

The scheduler already wraps each run in its own `DeferredTask` (registered in `_running_deferred_tasks` before the wrapper starts); this assigns it to `context.task` right after the run's context is resolved — the same contract the normal chat path establishes via `run_task()`. 4-line diff in `_run_task_wrapper`.

Effects:
- `message_loop_end` / `monologue_end` now dispatch for scheduler runs, so memorization and extension-based plugins see scheduled work. A killed run still correctly skips them — killing the task makes `is_alive()` false, so the post-mortem guard's intent is preserved.
- `context.is_running()` is now truthful for scheduler-run contexts.
- A user message sent to a task context mid-run routes as an intervention (like a normal chat) instead of spawning a second concurrent monologue on the same context.

The `if not (context.task and context.task.is_alive())` guard leaves the context untouched in the edge case where a live task already exists on it (e.g. a user actively chatting in the task context when the run starts).

**Verified** on a v2.4 container: stock = a probe extension on `monologue_end` never fires for an ad-hoc scheduler run (while a normal chat turn fires it); patched = the same run fires `message_loop_end` + `monologue_end` with the task's context id within seconds, and a killed run fires neither.