### PR TITLE
fix: preserve tool_calls when content is non-empty in chat completions parser

### DIFF
--- a/helpers/litellm_transport.py
+++ b/helpers/litellm_transport.py
@@ -517,14 +517,13 @@ class ChatCompletionsTransport:
             message, "reasoning_content"
         ) or ""
         parsed = {"reasoning_delta": reasoning_delta, "response_delta": response_delta}
-        if not response_delta:
-            tool_calls = _as_list(_get_value(message, "tool_calls"))
-            response_delta = ChatCompletionsTransport.tool_calls_text(tool_calls)
-            if response_delta:
-                parsed["response_delta"] = response_delta
-                parsed["_output_items"] = ChatCompletionsTransport.output_items(
-                    tool_calls
-                )
+        tool_calls = _as_list(_get_value(message, "tool_calls"))
+        tool_calls_text = ChatCompletionsTransport.tool_calls_text(tool_calls) if tool_calls else ""
+        if tool_calls_text:
+            parsed["response_delta"] = tool_calls_text
+            parsed["_output_items"] = ChatCompletionsTransport.output_items(
+                tool_calls
+            )
         return parsed
 
     @classmethod
@@ -1046,8 +1045,9 @@ class ResponsesTransport:
     def parse_response(cls, response: Any) -> ChatChunk:
         response_delta = cls.output_text(response)
         reasoning_delta = cls.reasoning_text(response)
-        if not response_delta:
-            response_delta = cls.function_calls_text(response)
+        function_calls_text = cls.function_calls_text(response)
+        if function_calls_text:
+            response_delta = function_calls_text
         return {"reasoning_delta": reasoning_delta, "response_delta": response_delta}
 
     @classmethod


### PR DESCRIPTION
## Problem

`ChatCompletionsTransport.parse()` only extracts `tool_calls` when `content` is empty:

```python
if not response_delta:  # skipped when content exists
    tool_calls = ...
```

Some OpenAI-compatible models (e.g., Zhipu GLM-4.7 via Z.AI Coding Plan) return **both** `content` and `tool_calls` simultaneously. When this happens, the parser uses the text content and silently drops the tool calls, breaking the agentic loop.

Same pattern exists in `ResponsesTransport.parse_response()`.

## Fix

Check for tool_calls first, then fall back to content. Two locations:

1. **`ChatCompletionsTransport.parse()`** (line ~520): Extract tool_calls unconditionally; use them as `response_delta` when present.
2. **`ResponsesTransport.parse_response()`** (line ~1049): Same approach for the Responses API path.

## Testing

Verified live against all three Z.AI Coding Plan models:

| Model | Behavior | Before Fix | After Fix |
|---|---|---|---|
| GLM-5.2 | content="" + tool_calls | ✅ | ✅ |
| GLM-5-Turbo | content="" + tool_calls | ✅ | ✅ |
| GLM-4.7 | content="text" + tool_calls | ❌ dropped | ✅ preserved |

Full agentic pipeline tested: tool call → tool result → natural language response, all through A0's `LiteLLMTransport.complete()`.

Closes #1778
