### PR TITLE
fix: per-job EventLoopThread + timeout kill for parallel tools

### DIFF
--- a/helpers/parallel_tools.py
+++ b/helpers/parallel_tools.py
@@ -216,7 +216,7 @@ async def start_parallel_jobs(
         try:
             job.state = "running"
             job.started_at = time.time()
-            task = DeferredTask(thread_name=THREAD_BACKGROUND)
+            task = DeferredTask(thread_name=f"parallel-{job.id}")
             job.deferred_task = task
             task.start_task(_run_parallel_job, context.id, job.id)
         except Exception as exc:
@@ -252,6 +252,10 @@ async def await_parallel_jobs(
 
         if time.time() >= deadline:
             wait_timed_out_job_ids = {job.id for job in active}
+            for job in active:
+                if job.deferred_task:
+                    job.deferred_task.kill(terminate_thread=True)
+                _finish_job(job, "timeout", error="Job exceeded timeout and was killed.")
             break
 
         await asyncio.sleep(POLL_INTERVAL_SECONDS)
@@ -316,7 +320,7 @@ async def refresh_parallel_jobs(agent: "Agent") -> list[ParallelJob]:
 
 async def cleanup_parallel_job(agent: "Agent", job: ParallelJob) -> None:
     if job.deferred_task and job.deferred_task.is_alive():
-        job.deferred_task.kill()
+        job.deferred_task.kill(terminate_thread=True)
     if job.kind == "tool":
         await _remove_context(job.worker_context_id)
 
@@ -604,7 +608,7 @@ async def _cancel_job(
     message: str = "Parallel job was cancelled.",
 ) -> None:
     if job.deferred_task and job.deferred_task.is_alive():
-        job.deferred_task.kill()
+        job.deferred_task.kill(terminate_thread=True)
     _finish_job(job, state, error=message)
 
 


### PR DESCRIPTION
## Problem

All parallel jobs share a single `EventLoopThread` singleton (`THREAD_BACKGROUND` in `helpers/defer.py`). Any blocking I/O in one worker freezes all concurrent jobs on that shared loop. Timed-out jobs are marked but never killed — they leak as zombie threads and file descriptors.

This is the root cause behind issues #1485, #1011, and #1248.

## Fix

**Single file changed: `helpers/parallel_tools.py` — 7 insertions, 3 deletions.**

### 1. Per-job event loop threads
`start_parallel_jobs`: each job gets its own `DeferredTask` with a unique thread name instead of the shared singleton:
```diff
- task = DeferredTask(thread_name=THREAD_BACKGROUND)
+ task = DeferredTask(thread_name=f"parallel-{job.id}")
```
Each job runs on an isolated event loop, so blocking I/O in one worker no longer freezes the others.

### 2. Kill timed-out jobs
`await_parallel_jobs`: when the deadline is reached, timed-out jobs are now terminated instead of just marked:
```python
for job in active:
    if job.deferred_task:
        job.deferred_task.kill(terminate_thread=True)
    _finish_job(job, "timeout", error="Job exceeded timeout and was killed.")
```

### 3 & 4. Thread cleanup on cleanup/cancel
`cleanup_parallel_job` and `_cancel_job`: use `kill(terminate_thread=True)` to ensure the event loop thread is properly cleaned up.

## What This Does NOT Change

- No changes to `helpers/defer.py` — the `EventLoopThread` singleton pattern remains untouched
- No changes to `agent.py` or `initialize.py`
- No changes to the `DeferredTask` class itself
- No new dependencies

## Verification

Tested in a live Agent Zero v2.5 Docker deployment with a plugin applying identical changes (monkey-patch approach). Results:

| Test | Result |
|---|---|
| 2-job parallel call | Both completed in 2.3s (was hanging for 300s) |
| Timeout enforcement (60s job, 10s timeout) | Killed at 10.3s, correct `timeout` state |
| 4-job concurrent stress test | All completed independently, clean thread cleanup |
| Process thread count | Stable — no thread/FD accumulation after repeated calls |

## Tradeoffs

Per-job threads create more threads during parallel execution (one per job instead of one shared). Each thread is cleaned up after job completion via `terminate_thread=True`. This is a minor resource tradeoff for eliminating the freeze-everything symptom.

Fixes #1485
Fixes #1011
Fixes #1248