### PR TITLE
fix: project agents not discoverable in get_available_agents_dict

### DIFF
--- a/helpers/projects.py
+++ b/helpers/projects.py
@@ -648,7 +648,7 @@ def load_project_subagents(name: str) -> dict[str, SubAgentSettings]:
         abs_path = files.get_abs_path(get_project_meta(name), "agents.json")
         data = dirty_json.parse(files.read_file(abs_path))
         if isinstance(data, dict):
-            return _normalize_subagents(data)  # type: ignore[arg-type,return-value]
+            return _normalize_subagents(data, name)  # type: ignore[arg-type,return-value]
         return {}
     except Exception:
         return {}
@@ -656,17 +656,18 @@ def load_project_subagents(name: str) -> dict[str, SubAgentSettings]:
 
 def save_project_subagents(name: str, subagents_data: dict[str, SubAgentSettings]):
     abs_path = files.get_abs_path(get_project_meta(name), "agents.json")
-    normalized = _normalize_subagents(subagents_data)
+    normalized = _normalize_subagents(subagents_data, name)
     content = dirty_json.stringify(normalized)
     files.write_file(abs_path, content)
 
 
 def _normalize_subagents(
-    subagents_data: dict[str, SubAgentSettings]
+    subagents_data: dict[str, SubAgentSettings],
+    project_name: str,
 ) -> dict[str, SubAgentSettings]:
     from helpers import subagents
 
-    agents_dict = subagents.get_agents_dict()
+    agents_dict = subagents.get_agents_dict(project_name)
 
     normalized: dict[str, SubAgentSettings] = {}
     for key, value in subagents_data.items():

--- a/helpers/subagents.py
+++ b/helpers/subagents.py
@@ -319,7 +319,7 @@ def get_available_agents_dict(
     project_name: str | None,
 ) -> dict[str, SubAgentListItem]:
     # all available agents
-    all_agents = get_agents_dict()
+    all_agents = get_agents_dict(project_name)
     # filter by project settings
     from helpers import projects
 


### PR DESCRIPTION
## Bug

`get_available_agents_dict(project_name)` receives the project name but drops it before calling `get_agents_dict()`, so the project agent scan block (`if project_name:` at line 79) never executes. All project-level agent profiles under `.a0proj/agents/` are invisible to `call_subordinate` at runtime.

The same bug exists in `_normalize_subagents()` in `helpers/projects.py` — `project_name` is not forwarded to `get_agents_dict()`, and the function signature does not accept it.

## Impact

- `call_subordinate` profile validation cannot find project-scoped agents at runtime
- The system prompt `available profiles` list omits all project agents
- The WebUI project settings page cannot see project-level agents
- Project-level agent overrides in `agents.json` have no effect because `_normalize_subagents` cannot resolve project agent names

## Root cause

Both functions already accept `project_name` as a parameter (or have it available in their calling scope). `get_agents_dict()` already has the project scan logic. The argument is simply never forwarded.

```python
# helpers/subagents.py:322
def get_available_agents_dict(project_name: str | None) -> dict[...]:
    all_agents = get_agents_dict()  # ← project_name not forwarded
```

```python
# helpers/projects.py:664-669
def _normalize_subagents(subagents_data) -> dict[...]:
    # project_name not in signature, not forwarded
    agents_dict = subagents.get_agents_dict()
```

## Fix

Two changes, 6 insertions / 5 deletions:

**`helpers/subagents.py`** — forward `project_name`:
```diff
-    all_agents = get_agents_dict()
+    all_agents = get_agents_dict(project_name)
```

**`helpers/projects.py`** — thread `project_name` through `_normalize_subagents`:
```diff
 def _normalize_subagents(
-    subagents_data: dict[str, SubAgentSettings]
+    subagents_data: dict[str, SubAgentSettings],
+    project_name: str,
 ) -> dict[str, SubAgentSettings]:
     from helpers import subagents
-    agents_dict = subagents.get_agents_dict()
+    agents_dict = subagents.get_agents_dict(project_name)
```

Both callers (`load_project_subagents(name)` and `save_project_subagents(name, ...)`) updated to pass `name`:
```diff
-    return _normalize_subagents(data)
+    return _normalize_subagents(data, name)
-    normalized = _normalize_subagents(subagents_data)
+    normalized = _normalize_subagents(subagents_data, name)
```

## Safety

- No new logic — the project scan block already exists and is tested
- When `project_name=None` (no project context), behavior is identical to current (project scan skipped, same as now)
- Default, plugin, and user agents follow the same discovery path, unaffected