### PR TITLE
fix: reliably verify rollback stash creation

### DIFF
--- a/docker/run/fs/exe/self_update_manager.py
+++ b/docker/run/fs/exe/self_update_manager.py
@@ -667,12 +667,17 @@ def get_top_stash_ref(repo_dir: Path) -> str:
     return git_optional_output(repo_dir, "stash", "list", "--format=%gd", "-n", "1")
 
 
+def get_top_stash_commit(repo_dir: Path) -> str:
+    """Return the commit hash for the current top stash."""
+    return git_optional_output(repo_dir, "stash", "list", "--format=%H", "-n", "1")
+
+
 def create_rollback_stash(repo_dir: Path, logger: AttemptLogger) -> str | None:
     if not has_local_rollback_changes(repo_dir):
         logger.log("No tracked or non-ignored untracked changes need rollback protection.")
         return None
 
-    previous_top = get_top_stash_ref(repo_dir)
+    previous_top = get_top_stash_commit(repo_dir)
     message = f"a0-self-update rollback snapshot {now_iso()}"
     run_command(
         [
@@ -690,7 +695,8 @@ def create_rollback_stash(repo_dir: Path, logger: AttemptLogger) -> str | None:
         error_message="Failed to save local tracked/untracked changes before updating.",
     )
     stash_ref = get_top_stash_ref(repo_dir)
-    if not stash_ref or stash_ref == previous_top:
+    current_top = get_top_stash_commit(repo_dir)
+    if not stash_ref or not current_top or current_top == previous_top:
         raise RuntimeError("Failed to create the pre-update rollback stash.")
     logger.log(
         f"Saved local tracked/untracked changes into {stash_ref}. "

--- a/tests/test_self_update_stash.py
+++ b/tests/test_self_update_stash.py
@@ -1,0 +1,53 @@
+import importlib.util
+import subprocess
+from pathlib import Path
+
+
+_MODULE_PATH = Path(__file__).parents[1] / "docker/run/fs/exe/self_update_manager.py"
+_SPEC = importlib.util.spec_from_file_location("self_update_manager", _MODULE_PATH)
+assert _SPEC and _SPEC.loader
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+get_top_stash_commit = _MODULE.get_top_stash_commit
+get_top_stash_ref = _MODULE.get_top_stash_ref
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()
+
+
+def test_new_stash_is_detected_when_stash_list_is_nonempty(tmp_path: Path) -> None:
+    git(tmp_path, "init", "-q")
+    git(tmp_path, "config", "user.email", "test@example.invalid")
+    git(tmp_path, "config", "user.name", "Test")
+    (tmp_path / "tracked.txt").write_text("base\n")
+    git(tmp_path, "add", "tracked.txt")
+    git(tmp_path, "commit", "-qm", "initial")
+
+    (tmp_path / "tracked.txt").write_text("existing\n")
+    git(tmp_path, "stash", "push", "-qm", "existing")
+    previous_commit = get_top_stash_commit(tmp_path)
+
+    (tmp_path / "tracked.txt").write_text("rollback\n")
+    git(tmp_path, "stash", "push", "-qm", "rollback")
+
+    assert get_top_stash_commit(tmp_path) != previous_commit
+    assert get_top_stash_ref(tmp_path) == "stash@{0}"
+
+
+def test_stash_ref_remains_usable_for_lifecycle_operations(tmp_path: Path) -> None:
+    git(tmp_path, "init", "-q")
+    git(tmp_path, "config", "user.email", "test@example.invalid")
+    git(tmp_path, "config", "user.name", "Test")
+    (tmp_path / "tracked.txt").write_text("base\n")
+    git(tmp_path, "add", "tracked.txt")
+    git(tmp_path, "commit", "-qm", "initial")
+
+    (tmp_path / "tracked.txt").write_text("rollback\n")
+    git(tmp_path, "stash", "push", "-qm", "rollback")
+    ref = get_top_stash_ref(tmp_path)
+
+    git(tmp_path, "stash", "apply", ref)
+    assert (tmp_path / "tracked.txt").read_text() == "rollback\n"
+    git(tmp_path, "reset", "--hard", "-q")
+    git(tmp_path, "stash", "drop", ref)


### PR DESCRIPTION
## Summary

Fixes the rollback-stash verification bug reported in #1753.

When the repository already has a stash, `git stash list --format=%gd -n 1` returns `stash@{0}` both before and after a successful `git stash push`. The updater therefore falsely raises `Failed to create the pre-update rollback stash.` and never reaches the requested checkout.

## Root cause

The positional stash ref is stable while the stash commit changes.

## Fix

- Keep `stash@{0}` as the lifecycle ref used by `stash apply`/`stash drop`.
- Add a commit-hash lookup using `%H` for before/after creation verification.
- Compare commit hashes instead of positional refs.

## Tests

Added regression coverage for detecting a new stash when an existing stash is present and retaining a positional ref that works with `stash apply` and `stash drop`. Both tests pass when run directly in temporary Git repositories.

This PR addresses the stash-verification bug only. The separate health-check timeout issue in #1753 remains outside this PR.

Related to #1753
