### PR TITLE
fix(browser): harden agentic browsing harness against live-observed failures

### DIFF
--- a/plugins/_browser/assets/browser-dom-helper.js
+++ b/plugins/_browser/assets/browser-dom-helper.js
@@ -1174,6 +1174,84 @@
     };
   }
 
+  function checkedStateForElement(element) {
+    const tagName = getTagName(element);
+    const role = String(element.getAttribute?.("role") || "").trim().toLowerCase();
+    if (tagName === "INPUT") {
+      const inputType = String(element.getAttribute?.("type") || element.type || "").toLowerCase();
+      if (["checkbox", "radio"].includes(inputType)) {
+        return Boolean(element.checked);
+      }
+    }
+    if (["checkbox", "radio", "switch", "menuitemcheckbox", "menuitemradio"].includes(role)) {
+      return String(element.getAttribute?.("aria-checked") || "").trim().toLowerCase() === "true";
+    }
+    if (role === "button" && element.hasAttribute?.("aria-pressed")) {
+      return String(element.getAttribute?.("aria-pressed") || "").trim().toLowerCase() === "true";
+    }
+    return null;
+  }
+
+  async function setCheckedLocalNode(payload = {}) {
+    const element = getElementByNodeId(payload?.nodeId, "set_checked");
+    const desiredChecked = Boolean(payload?.checked);
+    const currentChecked = checkedStateForElement(element);
+    if (currentChecked === null) {
+      throw createNamedError(
+        "BrowserDomHelperActionError",
+        `Browser DOM helper cannot set checked state on <${getTagName(element).toLowerCase()}>.`,
+        { code: "browser_dom_helper_checked_unsupported" }
+      );
+    }
+    const beforeSnapshot = captureActionEffectSnapshot(element);
+    const tagName = getTagName(element);
+    const role = String(element.getAttribute?.("role") || "").trim().toLowerCase();
+    const { observedMutations } = await withObservedActionWindow(beforeSnapshot.observationRoot, async () => {
+      scrollElementIntoView(element);
+      focusElement(element);
+      if (tagName === "INPUT") {
+        element.checked = desiredChecked;
+        dispatchDomEvent(element, "input", "InputEvent", {
+          inputType: "insertReplacementText"
+        });
+        dispatchDomEvent(element, "change");
+      } else if (["checkbox", "radio", "switch", "menuitemcheckbox", "menuitemradio"].includes(role)) {
+        if (currentChecked !== desiredChecked) {
+          if (typeof element.click === "function") {
+            element.click();
+          } else {
+            dispatchDomEvent(element, "click", "MouseEvent", { button: 0 });
+          }
+          await new Promise((resolve) => globalThis.setTimeout(resolve, 40));
+        }
+        if (checkedStateForElement(element) !== desiredChecked) {
+          element.setAttribute("aria-checked", desiredChecked ? "true" : "false");
+          dispatchDomEvent(element, "input", "InputEvent", {
+            inputType: "insertReplacementText"
+          });
+          dispatchDomEvent(element, "change");
+        }
+      } else if (role === "button" && element.hasAttribute?.("aria-pressed")) {
+        if (currentChecked !== desiredChecked) {
+          if (typeof element.click === "function") {
+            element.click();
+          } else {
+            dispatchDomEvent(element, "click", "MouseEvent", { button: 0 });
+          }
+          await new Promise((resolve) => globalThis.setTimeout(resolve, 40));
+        }
+        if (checkedStateForElement(element) !== desiredChecked) {
+          element.setAttribute("aria-pressed", desiredChecked ? "true" : "false");
+        }
+      }
+    });
+    return {
+      ...collectActionResult(element),
+      ...buildActionEffectResult(beforeSnapshot, captureActionEffectSnapshot(element), observedMutations),
+      checked: checkedStateForElement(element)
+    };
+  }
+
   function scrollLocalNode(payload = {}) {
     const element = getElementByNodeId(payload?.nodeId, "scroll");
     const beforeSnapshot = captureActionEffectSnapshot(element);
@@ -1215,6 +1293,9 @@
     }
     if (type === "scroll_node") {
       return scrollLocalNode(payload);
+    }
+    if (type === "set_checked_node") {
+      return setCheckedLocalNode(payload);
     }
     throw createNamedError(
       "BrowserDomHelperActionError",
@@ -1321,6 +1402,9 @@
     },
     clickNode(frameChain, nodeId) {
       return routeOperation("click_node", { frameChain, nodeId });
+    },
+    setCheckedNode(frameChain, nodeId, checked) {
+      return routeOperation("set_checked_node", { frameChain, nodeId, checked });
     },
     detailNode(frameChain, nodeId) {
       return routeOperation("detail_node", { frameChain, nodeId });

--- a/plugins/_browser/assets/browser-page-content.js
+++ b/plugins/_browser/assets/browser-page-content.js
@@ -535,7 +535,19 @@
     }
 
     if (typeof value === "string") {
-      return value.trim();
+      const trimmed = value.trim();
+      if (/^\[[^\]]+\]$/.test(trimmed)) {
+        const parts = trimmed.slice(1, -1).trim().split(/\s+/u);
+        const last = parts[parts.length - 1];
+        if (last && /^\d+$/u.test(last)) {
+          return last;
+        }
+      }
+      const trailing = trimmed.match(/(?:^|\s)(\d+)$/u);
+      if (trailing) {
+        return trailing[1];
+      }
+      return trimmed;
     }
 
     if (value && typeof value === "object") {
@@ -2607,13 +2619,17 @@
       actionLabel: "setChecked"
     });
     if (entry.helperBacked) {
-      throw createNamedError(
-        "BrowserPageContentActionError",
-        `Browser page content cannot set helper-backed reference "${entry.referenceId}".`,
-        {
-          code: "browser_page_content_checked_helper_backed"
-        }
+      const helper = requireDomHelper("set checked reference");
+      const checkedResult = await helper.setCheckedNode(
+        entry.frameChain,
+        entry.nodeId,
+        Boolean(checked)
       );
+      return buildHelperBackedActionResult(entry, checkedResult, {
+        checked: Boolean(checked),
+        effect: checkedResult?.effect || {},
+        status: checkedResult?.status || {}
+      });
     }
 
     const element = entry.element;

--- a/plugins/_browser/helpers/runtime.py
+++ b/plugins/_browser/helpers/runtime.py
@@ -36,6 +36,20 @@ DOM_HELPER_PATH = PLUGIN_DIR / "assets" / "browser-dom-helper.js"
 CONTENT_HELPER_PATH = PLUGIN_DIR / "assets" / "browser-page-content.js"
 RUNTIME_DATA_KEY = "_browser_runtime"
 DEFAULT_VIEWPORT = {"width": 1024, "height": 768}
+
+
+def _is_navigation_context_error(message: str) -> bool:
+    # Match Playwright's specific navigation-race phrases only. A bare
+    # "navigation" substring would also swallow genuine script/tool errors
+    # (e.g. "navigation is not allowed here") and misreport them as navigations.
+    lower = str(message or "").lower()
+    return any(
+        token in lower
+        for token in (
+            "execution context was destroyed",
+            "most likely because of a navigation",
+        )
+    )
 CHROME_SINGLETON_FILES = ("SingletonLock", "SingletonCookie", "SingletonSocket")
 SCREENCAST_MAX_WIDTH = 4096
 SCREENCAST_MAX_HEIGHT = 4096
@@ -2194,16 +2208,31 @@ class _BrowserRuntimeCore:
         resolved_id = self._resolve_browser_id(browser_id)
         page = self._page(resolved_id)
         await self._ensure_content_helper(page)
-        if text is None:
-            action = await page.evaluate(
-                "(args) => globalThis.__spaceBrowserPageContent__[args.method](args.ref)",
-                {"method": helper_method, "ref": reference_id},
-            )
-        else:
-            action = await page.evaluate(
-                "(args) => globalThis.__spaceBrowserPageContent__[args.method](args.ref, args.text)",
-                {"method": helper_method, "ref": reference_id, "text": text},
-            )
+        try:
+            if text is None:
+                action = await page.evaluate(
+                    "(args) => globalThis.__spaceBrowserPageContent__[args.method](args.ref)",
+                    {"method": helper_method, "ref": reference_id},
+                )
+            else:
+                action = await page.evaluate(
+                    "(args) => globalThis.__spaceBrowserPageContent__[args.method](args.ref, args.text)",
+                    {"method": helper_method, "ref": reference_id, "text": text},
+                )
+        except Exception as exc:
+            if _is_navigation_context_error(str(exc)):
+                await self._settle(page, short=True)
+                self._maybe_promote(resolved_id)
+                return {
+                    "action": {
+                        "navigation": True,
+                        "message": "Navigation occurred during action",
+                        "helper_method": helper_method,
+                        "reference_id": reference_id,
+                    },
+                    "state": await self._state(resolved_id),
+                }
+            raise
         await self._settle(page, short=False)
         self._maybe_promote(resolved_id)
         return {"action": action or {}, "state": await self._state(resolved_id)}
@@ -2244,10 +2273,19 @@ class _BrowserRuntimeCore:
         if not browser_page:
             raise KeyError(f"Browser {browser_id} is not open.")
         page = browser_page.page
+        current_url = page.url
+        error_page = bool(
+            current_url.startswith("chrome-error://")
+            or current_url.startswith("edge-error://")
+            or "chromewebdata" in current_url
+        )
         try:
             title = await page.title()
         except Exception:
             title = ""
+        original_title = title
+        if error_page:
+            title = "Browser error page"
         try:
             history_length = await page.evaluate("() => globalThis.history?.length || 0")
         except Exception:
@@ -2255,8 +2293,11 @@ class _BrowserRuntimeCore:
         return {
             "id": browser_page.id,
             "context_id": self.context_id,
-            "currentUrl": page.url,
+            "currentUrl": current_url,
             "title": title,
+            "original_title": original_title if error_page else "",
+            "error_page": error_page,
+            "error": "browser_error_page" if error_page else None,
             "canGoBack": bool(history_length and int(history_length) > 1),
             "canGoForward": False,
             "loading": False,

--- a/plugins/_browser/tools/browser.py
+++ b/plugins/_browser/tools/browser.py
@@ -37,6 +37,7 @@ class Browser(Tool):
         selector: str = "",
         selectors: list[str] | None = None,
         script: str = "",
+        expression: str = "",
         modifiers: list[str] | str | None = None,
         keys: list[str] | None = None,
         key: str = "",
@@ -173,7 +174,7 @@ class Browser(Tool):
                     await self._resolve_ref(runtime, browser_id, ref, selector, action),
                 )
             elif action == "evaluate":
-                result = await runtime.call("evaluate", browser_id, script)
+                result = await runtime.call("evaluate", browser_id, script or expression)
             elif action in {"key_chord", "keychord"}:
                 if not keys:
                     raise ValueError("key_chord requires non-empty 'keys' list")

--- a/tests/test_browser_agent_regressions.py
+++ b/tests/test_browser_agent_regressions.py
@@ -3801,6 +3801,7 @@ async def test_browser_tool_evaluate_accepts_expression_alias(monkeypatch):
     tool = browser_tool_module.Browser(
         agent=SimpleNamespace(context=SimpleNamespace(id="ctx")),
         name="browser",
+        method=None,
         args={},
         message="",
         loop_data=None,

--- a/tests/test_browser_agent_regressions.py
+++ b/tests/test_browser_agent_regressions.py
@@ -3667,8 +3667,8 @@ class TestBrowserHarnessFixSourceMarkers:
 
     def test_reference_normalization_accepts_descriptive_labels(self):
         helper = self._read("browser-page-content.js")
-        assert "if (/^\[[^\]]+\]$/.test(trimmed)) {" in helper
-        assert "const trailing = trimmed.match(/(?:^|\s)(\d+)$/u);" in helper
+        assert r"if (/^\[[^\]]+\]$/.test(trimmed)) {" in helper
+        assert r"const trailing = trimmed.match(/(?:^|\s)(\d+)$/u);" in helper
         assert "return trailing[1];" in helper
 
     def test_set_checked_delegates_to_dom_helper_for_helper_backed(self):

--- a/tests/test_browser_agent_regressions.py
+++ b/tests/test_browser_agent_regressions.py
@@ -3654,6 +3654,163 @@ def test_browser_cleanup_extensions_follow_extensible_path_layout():
     assert any(cls.__name__ == "CleanupBrowserRuntimeOnReset" for cls in reset_classes)
 
 
+
+
+# --- Harness fixes 1-6: browser interaction reliability ---------------------
+
+
+class TestBrowserHarnessFixSourceMarkers:
+    """Source-level regressions for the browser harness hardening."""
+
+    def _read(self, name):
+        return (PROJECT_ROOT / "plugins" / "_browser" / "assets" / name).read_text(encoding="utf-8")
+
+    def test_reference_normalization_accepts_descriptive_labels(self):
+        helper = self._read("browser-page-content.js")
+        assert "if (/^\[[^\]]+\]$/.test(trimmed)) {" in helper
+        assert "const trailing = trimmed.match(/(?:^|\s)(\d+)$/u);" in helper
+        assert "return trailing[1];" in helper
+
+    def test_set_checked_delegates_to_dom_helper_for_helper_backed(self):
+        content = self._read("browser-page-content.js")
+        dom = self._read("browser-dom-helper.js")
+        assert "await helper.setCheckedNode(" in content
+        assert "setCheckedNode(frameChain, nodeId, checked) {" in dom
+        assert "set_checked_node" in dom
+        assert "async function setCheckedLocalNode(payload = {}) {" in dom
+
+    def test_runtime_handles_navigation_context_error_and_error_pages(self):
+        runtime = (PROJECT_ROOT / "plugins" / "_browser" / "helpers" / "runtime.py").read_text(encoding="utf-8")
+        assert "def _is_navigation_context_error(message: str) -> bool:" in runtime
+        assert '"navigation": True' in runtime
+        assert "defaults and should not be attributed to the browser harness" not in runtime
+        assert "error_page" in runtime
+        assert '"error": "browser_error_page" if error_page else None' in runtime
+        assert "original_title" in runtime
+
+    def test_browser_tool_accepts_expression_alias(self):
+        tool = (PROJECT_ROOT / "plugins" / "_browser" / "tools" / "browser.py").read_text(encoding="utf-8")
+        assert "expression: str = """ in tool
+        assert "script or expression" in tool
+
+
+@pytest.mark.anyio
+async def test_browser_runtime_navigation_context_click_returns_navigation_marker(monkeypatch):
+    calls = []
+
+    class FakePage:
+        url = "https://example.com/"
+
+        async def evaluate(self, script, payload=None):
+            calls.append((script, payload))
+            raise Exception("Execution context was destroyed, most likely because of a navigation")
+
+    class FakeBrowserPage:
+        def __init__(self, page):
+            self.id = 9
+            self.page = page
+
+    core = _BrowserRuntimeCore("ctx")
+    core.context = object()
+    core.pages[9] = FakeBrowserPage(FakePage())
+    core._ensure_content_helper = lambda _page: asyncio.sleep(0)
+
+    settled = []
+    async def fake_settle(page, short=False):
+        settled.append(short)
+
+    async def fake_state(browser_id):
+        return {"id": browser_id, "currentUrl": "https://example.com/"}
+
+    core._settle = fake_settle
+    core._state = fake_state
+
+    result = await core._reference_action("click", 9, 1)
+
+    assert calls
+    assert result["action"]["navigation"] is True
+    assert result["state"] == {"id": 9, "currentUrl": "https://example.com/"}
+    assert settled == [True]
+
+
+@pytest.mark.anyio
+async def test_browser_runtime_reraises_generic_error_mentioning_navigation():
+    class FakePage:
+        url = "https://example.com/"
+
+        async def evaluate(self, script, payload=None):
+            raise ValueError("navigation is not allowed for this element")
+
+    class FakeBrowserPage:
+        def __init__(self, page):
+            self.id = 9
+            self.page = page
+
+    core = _BrowserRuntimeCore("ctx")
+    core.context = object()
+    core.pages[9] = FakeBrowserPage(FakePage())
+    core._ensure_content_helper = lambda _page: asyncio.sleep(0)
+
+    with pytest.raises(ValueError, match="navigation is not allowed"):
+        await core._reference_action("click", 9, 1)
+
+
+@pytest.mark.anyio
+async def test_browser_runtime_state_reports_error_page_on_chrome_error():
+    class FakePage:
+        url = "chrome-error://chromewebdata/"
+
+        async def title(self):
+            return "example.com"
+
+        async def evaluate(self, script, payload=None):
+            if "history?" in script:
+                return 1
+            return None
+
+    browser_page = BrowserPage(id=3, page=FakePage())
+    core = _BrowserRuntimeCore("ctx")
+    core.context = object()
+    core.pages[3] = browser_page
+
+    state = await core._state(3)
+
+    assert state["currentUrl"] == "chrome-error://chromewebdata/"
+    assert state["title"] == "Browser error page"
+    assert state["original_title"] == "example.com"
+    assert state["error_page"] is True
+    assert state["error"] == "browser_error_page"
+
+
+@pytest.mark.anyio
+async def test_browser_tool_evaluate_accepts_expression_alias(monkeypatch):
+    calls = []
+
+    class FakeRuntime:
+        async def call(self, method, *args, **kwargs):
+            calls.append((method, args, kwargs))
+            return {"result": 3, "state": {}}
+
+    async def fake_get_runtime(context_id, create=True, agent=None):
+        del create, agent
+        assert context_id == "ctx"
+        return FakeRuntime()
+
+    monkeypatch.setattr(browser_tool_module, "get_runtime", fake_get_runtime)
+
+    tool = browser_tool_module.Browser(
+        agent=SimpleNamespace(context=SimpleNamespace(id="ctx")),
+        name="browser",
+        args={},
+        message="",
+        loop_data=None,
+    )
+    response = await tool.execute(action="evaluate", browser_id=1, expression="1+2")
+
+    assert calls == [("evaluate", (1, "1+2"), {})]
+    assert "3" in response.message
+
+
 def test_legacy_browser_dependency_is_removed():
     assert not (PROJECT_ROOT / "plugins" / ("_browser" + "_agent")).exists()
     assert ("browser" + "-use") not in (PROJECT_ROOT / "requirements.txt").read_text(


### PR DESCRIPTION
## What this PR does

Hardens the `_browser` plugin's agentic-browsing harness against six failure modes observed in live agent sessions (evidence from saved chat logs of a real browsing task). Developed by the agent itself while debugging its own tooling, then reviewed, corrected and validated before submission.

### Fixes

1. **Reference labels accepted as refs** (`browser-page-content.js`): `normalizeReferenceId` now parses rendered reference descriptors like `[input text 1]` and `link 3` back to their numeric id — previously the model copying the label it saw on screen produced an unresolvable ref.
2. **`set_checked` works on helper-backed references** (`browser-page-content.js`, `browser-dom-helper.js`): helper-backed refs previously threw `browser_page_content_checked_helper_backed`; they now route through the DOM helper via a new `set_checked_node` operation (`setCheckedLocalNode` / `setCheckedNode`), supporting native checkbox/radio inputs, ARIA `checkbox`/`radio`/`switch`/`menuitemcheckbox`/`menuitemradio` roles, and `aria-pressed` toggle buttons, with proper `input`/`change` event dispatch.
3. **Navigation races no longer error out the action** (`runtime.py`): `_reference_action` catches Playwright's navigation-context errors (`Execution context was destroyed, most likely because of a navigation`) and returns a `{"navigation": True}` action result with fresh page state, instead of failing the tool call. Matching is restricted to Playwright's specific phrases so genuine script errors mentioning "navigation" still raise (regression-tested).
4. **Error pages are surfaced, not hidden** (`runtime.py`): `_state` detects `chrome-error://`, `edge-error://` and `chromewebdata` URLs and reports `error_page`/`error: "browser_error_page"` fields plus `original_title`, so automation can distinguish DNS/load failures from a loaded page.
5. **`evaluate` accepts `expression` as an alias for `script`** (`browser.py`): the documented/natural argument name now works — previously `action=evaluate` with `expression` silently evaluated an empty script and returned `null`.

### Review corrections applied before opening

- Removed an overly broad bare `"navigation"` substring from the navigation-error matcher (would have swallowed genuine errors like "navigation is not allowed here"); added a regression test proving such errors re-raise.
- Fixed the expression-alias test's incorrect call-args assertion (`(1,)` → `(1, "1+2")`) — the test failed as originally written.

### Verification

- `tests/test_browser_agent_regressions.py`: **109 passed, 1 skipped** in the `agent0ai/agent-zero:v2.6` image with `agent_zero_usr` mounted read-only — including new behavioral tests for the navigation race (fake page raising Playwright's error), chrome-error state reporting, the expression alias end-to-end through `Browser.execute`, and source markers for the JS helpers.
- Full suite (`--continue-on-collection-errors`): failure set **byte-identical** to pristine `5ff106a2` (93 pre-existing failures/errors from the `sys.modules` stub poisoning that #1799 fixes; zero new failures). JS assets pass `node --check`; Python files compile.
- Fixes 3-5 sit behind additive keys/parameters; existing state consumers and tool callers are unaffected (no existing assertions needed changes).
