### PR TITLE
fix(webui+memory): close post-turn utility process groups (memory memorization renders as in-flight "Processing...")

### DIFF
--- a/plugins/_memory/extensions/python/monologue_end/_50_memorize_fragments.py
+++ b/plugins/_memory/extensions/python/monologue_end/_50_memorize_fragments.py
@@ -27,9 +27,13 @@ class MemorizeMemories(Extension):
             return
 
         # show full util message
+        # update_progress="none": this is a post-turn background bookkeeping
+        # item logged after the final response; it must not take over the
+        # status bar (monologue_end resets progress to "Waiting for input").
         log_item = self.agent.context.log.log(
             type="util",
             heading="Memorizing new information...",
+            update_progress="none",
         )
 
         # memorize in background
@@ -73,25 +77,28 @@ class MemorizeMemories(Extension):
 
             # Add validation and error handling for memories_json
             if not memories_json or not isinstance(memories_json, str):
-                log_item.update(heading="No response from utility model.")
+                log_item.update(heading="No response from utility model.", finished=True)
                 return
 
             # Strip any whitespace that might cause issues
             memories_json = memories_json.strip()
 
             if not memories_json:
-                log_item.update(heading="Empty response from utility model.")
+                log_item.update(heading="Empty response from utility model.", finished=True)
                 return
 
             try:
                 memories = DirtyJson.parse_string(memories_json)
             except Exception as e:
-                log_item.update(heading=f"Failed to parse memories response: {str(e)}")
+                log_item.update(
+                        heading=f"Failed to parse memories response: {str(e)}",
+                        finished=True,
+                    )
                 return
 
             # Validate that memories is a list or convertible to one
             if memories is None:
-                log_item.update(heading="No valid memories found in response.")
+                log_item.update(heading="No valid memories found in response.", finished=True)
                 return
 
             # If memories is not a list, try to make it one
@@ -99,11 +106,11 @@ class MemorizeMemories(Extension):
                 if isinstance(memories, (str, dict)):
                     memories = [memories]
                 else:
-                    log_item.update(heading="Invalid memories format received.")
+                    log_item.update(heading="Invalid memories format received.", finished=True)
                     return
 
             if not isinstance(memories, list) or len(memories) == 0:
-                log_item.update(heading="No useful information to memorize.")
+                log_item.update(heading="No useful information to memorize.", finished=True)
                 return
 
             raw_memories_count = len(memories)
@@ -114,6 +121,7 @@ class MemorizeMemories(Extension):
                 log_item.update(
                     heading="No durable information to memorize.",
                     filtered_memories_count=filtered_memories_count,
+                    finished=True,
                 )
                 return
 
@@ -216,11 +224,23 @@ class MemorizeMemories(Extension):
                     )
                     if rem:
                         log_item.stream(result=f"\nReplaced {len(rem)} previous memories.")
-                
+
+            # Terminal marker: the background job is done. The Web UI uses the
+            # finished kvp to close the process group holding this utility
+            # item; without it the post-turn group never completes and keeps
+            # rendering as an in-flight "Processing..." phase.
+            log_item.update(finished=True, update_progress="none")
 
 
         except Exception as e:
+            # Mark the utility item finished even on failure so its process
+            # group does not stay open, and keep the warning off the status
+            # bar (progress was already reset to "Waiting for input").
+            log_item.update(finished=True, update_progress="none")
             err = errors.format_error(e)
             self.agent.context.log.log(
-                type="warning", heading="Memorize memories extension error", content=err
+                type="warning",
+                heading="Memorize memories extension error",
+                content=err,
+                update_progress="none",
             )

--- a/plugins/_memory/extensions/python/monologue_end/_51_memorize_solutions.py
+++ b/plugins/_memory/extensions/python/monologue_end/_51_memorize_solutions.py
@@ -25,9 +25,13 @@ class MemorizeSolutions(Extension):
             return
  
         # show full util message
+        # update_progress="none": this is a post-turn background bookkeeping
+        # item logged after the final response; it must not take over the
+        # status bar (monologue_end resets progress to "Waiting for input").
         log_item = self.agent.context.log.log(
             type="util",
             heading="Memorizing succesful solutions...",
+            update_progress="none",
         )
 
         # memorize in background
@@ -75,25 +79,28 @@ class MemorizeSolutions(Extension):
 
             # Add validation and error handling for solutions_json
             if not solutions_json or not isinstance(solutions_json, str):
-                log_item.update(heading="No response from utility model.")
+                log_item.update(heading="No response from utility model.", finished=True)
                 return
 
             # Strip any whitespace that might cause issues
             solutions_json = solutions_json.strip()
 
             if not solutions_json:
-                log_item.update(heading="Empty response from utility model.")
+                log_item.update(heading="Empty response from utility model.", finished=True)
                 return
 
             try:
                 solutions = DirtyJson.parse_string(solutions_json)
             except Exception as e:
-                log_item.update(heading=f"Failed to parse solutions response: {str(e)}")
+                log_item.update(
+                        heading=f"Failed to parse solutions response: {str(e)}",
+                        finished=True,
+                    )
                 return
 
             # Validate that solutions is a list or convertible to one
             if solutions is None:
-                log_item.update(heading="No valid solutions found in response.")
+                log_item.update(heading="No valid solutions found in response.", finished=True)
                 return
 
             # If solutions is not a list, try to make it one
@@ -101,11 +108,11 @@ class MemorizeSolutions(Extension):
                 if isinstance(solutions, (str, dict)):
                     solutions = [solutions]
                 else:
-                    log_item.update(heading="Invalid solutions format received.")
+                    log_item.update(heading="Invalid solutions format received.", finished=True)
                     return
 
             if not isinstance(solutions, list) or len(solutions) == 0:
-                log_item.update(heading="No successful solutions to memorize.")
+                log_item.update(heading="No successful solutions to memorize.", finished=True)
                 return
             else:
                 solutions_txt = "\n\n".join([str(solution) for solution in solutions]).strip()
@@ -209,9 +216,22 @@ class MemorizeSolutions(Extension):
                     if rem:
                         log_item.stream(result=f"\nReplaced {len(rem)} previous solutions.")
 
+            # Terminal marker: the background job is done. The Web UI uses the
+            # finished kvp to close the process group holding this utility
+            # item; without it the post-turn group never completes and keeps
+            # rendering as an in-flight "Processing..." phase.
+            log_item.update(finished=True, update_progress="none")
+
 
         except Exception as e:
+            # Mark the utility item finished even on failure so its process
+            # group does not stay open, and keep the warning off the status
+            # bar (progress was already reset to "Waiting for input").
+            log_item.update(finished=True, update_progress="none")
             err = errors.format_error(e)
             self.agent.context.log.log(
-                type="warning", heading="Memorize solutions extension error", content=err
+                type="warning",
+                heading="Memorize solutions extension error",
+                content=err,
+                update_progress="none",
             )

--- a/tests/test_post_turn_utility_group.py
+++ b/tests/test_post_turn_utility_group.py
@@ -1,0 +1,459 @@
+"""Regression tests for post-turn utility process-group completion.
+
+Root cause (2026-08-02): the memory plugin's monologue_end extensions
+(_50_memorize_fragments, _51_memorize_solutions) log a utility item when the
+agent loop ends and then fill it in from a background task. By that point the
+turn's process group was already completed by the final response, so the Web
+UI opened a new process group for these items. That group (a) contains no
+agent steps, so its title stayed on the "Processing..." placeholder, and (b)
+was never marked complete by any later event, so its steps kept the in-flight
+"shiny" animation and the phase never received an END badge — a finished turn
+looked like it was still running.
+
+Fix: the backend marks the utility item with a ``finished`` kvp on every
+terminal update path (and keeps these post-turn items off the status bar with
+``update_progress="none"``), and the Web UI closes the process group when a
+utility step arrives with ``kvps.finished`` and falls back to the last step's
+title for groups without agent steps.
+
+These tests run the real ``memorize()`` coroutines against stubbed
+agents/log items and assert the terminal marker is emitted, and extract the
+real ``updateProcessGroupHeader``/``isProcessGroupComplete``/
+``completeLastProcessGroup`` functions from ``webui/js/messages.js`` into a
+Node harness with a minimal fake DOM to assert group completion and title
+fallback. Both halves fail on the pre-fix implementation, making them
+discriminating.
+"""
+
+import asyncio
+import importlib
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+MESSAGES_JS = PROJECT_ROOT / "webui" / "js" / "messages.js"
+
+NODE_AVAILABLE = shutil.which("node") is not None
+requires_node = pytest.mark.skipif(not NODE_AVAILABLE, reason="node not available")
+
+
+def _load_extension_module(name: str):
+    return importlib.import_module(
+        f"plugins._memory.extensions.python.monologue_end.{name}"
+    )
+
+
+class FakeLogItem:
+    """Records every update() call so tests can inspect terminal markers."""
+
+    def __init__(self):
+        self.updates: list[dict] = []
+        self.streams: list[dict] = []
+
+    def update(self, **kwargs):
+        self.updates.append(kwargs)
+
+    def stream(self, **kwargs):
+        self.streams.append(kwargs)
+
+
+class FakeLog:
+    def __init__(self):
+        self.warnings: list[dict] = []
+
+    def log(self, **kwargs):
+        self.warnings.append(kwargs)
+        return FakeLogItem()
+
+
+def _make_agent(utility_response=None, utility_error: Exception | None = None):
+    """Agent stub exposing only what memorize() touches."""
+
+    async def call_utility_model(**kwargs):
+        if utility_error is not None:
+            raise utility_error
+        return utility_response
+
+    return SimpleNamespace(
+        history=[],
+        context=SimpleNamespace(log=FakeLog()),
+        read_prompt=lambda *a, **k: "system prompt",
+        concat_messages=lambda history: "chat text",
+        call_utility_model=call_utility_model,
+    )
+
+
+def _patch_plugin_config(monkeypatch, mod, consolidation: bool):
+    import helpers.plugins as plugins_mod
+
+    monkeypatch.setattr(
+        plugins_mod,
+        "get_plugin_config",
+        lambda plugin, agent=None, **kwargs: {
+            "memory_memorize_enabled": True,
+            "memory_memorize_consolidation": consolidation,
+            "memory_memorize_replace_threshold": 0,
+        },
+    )
+
+
+def _patch_memory_db(monkeypatch, mod):
+    """Replace Memory.get with an async stub DB (non-consolidation path)."""
+    inserted: list[str] = []
+
+    class FakeDB:
+        async def delete_documents_by_query(self, **kwargs):
+            return []
+
+        async def insert_text(self, text, metadata=None):
+            inserted.append(text)
+            return "id"
+
+    async def fake_get(agent):
+        return FakeDB()
+
+    monkeypatch.setattr(mod.Memory, "get", staticmethod(fake_get))
+    return inserted
+
+
+@pytest.mark.parametrize(
+    "module_name,empty_heading",
+    [
+        ("_50_memorize_fragments", "No useful information to memorize."),
+        ("_51_memorize_solutions", "No successful solutions to memorize."),
+    ],
+)
+def test_empty_utility_result_marks_log_item_finished(
+    monkeypatch, module_name, empty_heading
+):
+    """An empty utility-model result is a terminal path: it must emit the
+    finished kvp so the Web UI can close the post-turn process group."""
+    mod = _load_extension_module(module_name)
+    _patch_plugin_config(monkeypatch, mod, consolidation=False)
+    _patch_memory_db(monkeypatch, mod)
+
+    ext = mod.MemorizeMemories(agent=None) if module_name.startswith("_50") else mod.MemorizeSolutions(agent=None)
+    ext.agent = _make_agent(utility_response="[]")
+    log_item = FakeLogItem()
+
+    asyncio.run(ext.memorize(loop_data=None, log_item=log_item))
+
+    assert log_item.updates, "memorize() never updated the log item"
+    final = log_item.updates[-1]
+    assert final.get("heading") == empty_heading
+    assert final.get("finished") is True, (
+        "terminal update lacks finished=True; the Web UI process group "
+        "would stay open forever"
+    )
+
+
+@pytest.mark.parametrize(
+    "module_name,response",
+    [
+        ("_50_memorize_fragments", '["The user prefers concise final reports.", "The project requires full test runs before release."]'),
+        ("_51_memorize_solutions", '[{"problem": "p", "solution": "s"}]'),
+    ],
+)
+def test_successful_memorization_marks_finished_after_inserts(
+    monkeypatch, module_name, response
+):
+    """Successful memorization (non-consolidation path) must insert all
+    entries first and only then emit the terminal finished marker."""
+    mod = _load_extension_module(module_name)
+    _patch_plugin_config(monkeypatch, mod, consolidation=False)
+    inserted = _patch_memory_db(monkeypatch, mod)
+
+    cls = mod.MemorizeMemories if module_name.startswith("_50") else mod.MemorizeSolutions
+    ext = cls(agent=None)
+    ext.agent = _make_agent(utility_response=response)
+    log_item = FakeLogItem()
+
+    asyncio.run(ext.memorize(loop_data=None, log_item=log_item))
+
+    assert inserted, "nothing was inserted into the memory DB"
+    finished_updates = [u for u in log_item.updates if u.get("finished") is True]
+    assert len(finished_updates) == 1, (
+        f"expected exactly one terminal finished update, got {len(finished_updates)}"
+    )
+    assert log_item.updates[-1].get("finished") is True
+    # the finished marker must not hijack the status bar
+    assert log_item.updates[-1].get("update_progress") == "none"
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    ["_50_memorize_fragments", "_51_memorize_solutions"],
+)
+def test_utility_model_error_still_closes_group_without_status_bar_hijack(
+    monkeypatch, module_name
+):
+    """On failure the item must still be marked finished (no orphaned group)
+    and the warning must not take over the status bar after the turn ended."""
+    mod = _load_extension_module(module_name)
+    _patch_plugin_config(monkeypatch, mod, consolidation=False)
+    _patch_memory_db(monkeypatch, mod)
+
+    cls = mod.MemorizeMemories if module_name.startswith("_50") else mod.MemorizeSolutions
+    ext = cls(agent=None)
+    ext.agent = _make_agent(utility_error=RuntimeError("provider exploded"))
+    log_item = FakeLogItem()
+
+    asyncio.run(ext.memorize(loop_data=None, log_item=log_item))
+
+    assert log_item.updates[-1].get("finished") is True
+    assert log_item.updates[-1].get("update_progress") == "none"
+    warnings = ext.agent.context.log.warnings
+    assert len(warnings) == 1
+    assert warnings[0]["type"] == "warning"
+    assert warnings[0].get("update_progress") == "none"
+
+
+@pytest.mark.parametrize(
+    "module_name,create_heading",
+    [
+        ("_50_memorize_fragments", "Memorizing new information..."),
+        ("_51_memorize_solutions", "Memorizing succesful solutions..."),
+    ],
+)
+def test_execute_creates_log_item_off_status_bar(module_name, create_heading):
+    """The synchronous log item creation at monologue end must pass
+    update_progress="none" so post-turn bookkeeping never hijacks progress."""
+    import inspect
+
+    mod = _load_extension_module(module_name)
+    cls = mod.MemorizeMemories if module_name.startswith("_50") else mod.MemorizeSolutions
+    source = inspect.getsource(cls.execute)
+    log_call_pos = source.find("context.log.log(")
+    assert log_call_pos != -1
+    call_src = source[log_call_pos : source.find(")", log_call_pos)]
+    assert 'update_progress="none"' in call_src
+    assert create_heading in call_src
+
+
+# ---------------------------------------------------------------------------
+# Frontend: updateProcessGroupHeader / completeLastProcessGroup behavior
+# ---------------------------------------------------------------------------
+
+
+def _extract_function(js: str, signature: str) -> str:
+    start = js.find(signature)
+    assert start != -1, f"{signature} not found in webui/js/messages.js"
+    body_start = js.find("{", start)
+    depth = 0
+    for pos in range(body_start, len(js)):
+        char = js[pos]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return js[start : pos + 1]
+    raise AssertionError(f"{signature} body is unbalanced")
+
+
+def _build_node_harness(tmp_path: Path) -> Path:
+    js = MESSAGES_JS.read_text(encoding="utf-8")
+    blocks = [
+        _extract_function(js, "function truncateText("),
+        _extract_function(js, "export function cleanStepTitle("),
+        _extract_function(js, "function updateProcessGroupHeader("),
+        _extract_function(js, "function isProcessGroupComplete("),
+        _extract_function(js, "export function completeLastProcessGroup("),
+    ]
+    shipped = "\n\n".join(blocks)
+    harness = """
+// --- minimal fake DOM ------------------------------------------------------
+class FakeClassList {
+  constructor(owner) { this.owner = owner; this.set = new Set(); }
+  add(...cs) { cs.forEach((c) => this.set.add(c)); }
+  remove(...cs) { cs.forEach((c) => this.set.delete(c)); }
+  contains(c) { return this.set.has(c); }
+  toggle(c, force) {
+    const on = force === undefined ? !this.set.has(c) : Boolean(force);
+    on ? this.set.add(c) : this.set.delete(c);
+  }
+}
+
+class FakeElement {
+  constructor(tag = "div") {
+    this.tag = tag;
+    this.children = [];
+    this.attrs = {};
+    this.classList = new FakeClassList(this);
+    this.dataset = {};
+    this.textContent = "";
+    this.title = "";
+    this.outerHTML = "";
+  }
+  get className() { return [...this.classList.set].join(" "); }
+  setAttribute(k, v) { this.attrs[k] = String(v); }
+  getAttribute(k) { return k in this.attrs ? this.attrs[k] : null; }
+  hasAttribute(k) { return k in this.attrs; }
+  _matches(sel) {
+    if (sel.startsWith(".")) return this.classList.contains(sel.slice(1));
+    if (sel.startsWith("[")) {
+      const m = sel.match(/^\\[([^=\\]]+)(?:="([^"]*)")?\\]$/);
+      if (!m) return false;
+      const val = this.getAttribute(m[1]);
+      return m[2] === undefined ? val !== null : val === m[2];
+    }
+    return false;
+  }
+  _all() {
+    const out = [];
+    const walk = (el) => { out.push(el); el.children.forEach(walk); };
+    this.children.forEach(walk);
+    return out;
+  }
+  querySelector(sel) {
+    // support compound ".a .b" and ".a.b" selectors used by shipped code
+    if (sel.startsWith(":scope ")) sel = sel.slice(7);
+    const parts = sel.split(/\\s+/);
+    let candidates = [this];
+    for (const part of parts) {
+      const next = [];
+      const classes = part.split(".").filter(Boolean);
+      const attrMatch = part.match(/\\.[^\\[]*(\\[.*)$/);
+      for (const el of candidates) {
+        for (const d of el._all()) {
+          let ok = classes.length
+            ? classes.every((c) => d.classList.contains(c))
+            : d._matches(part);
+          if (ok && attrMatch) ok = d._matches(attrMatch[1]);
+          if (ok) next.push(d);
+        }
+      }
+      candidates = next;
+    }
+    return candidates[0] || null;
+  }
+  querySelectorAll(sel) {
+    // support ".a.b" and ".sel[attr="v"]" compound selectors
+    const attrMatch = sel.match(/^(\\.[^\\[]*)?(\\[.*)$/);
+    let base = sel;
+    let attr = null;
+    if (attrMatch && attrMatch[2]) { base = attrMatch[1] || ""; attr = attrMatch[2]; }
+    const classes = base.split(".").filter(Boolean);
+    return this._all().filter((d) => {
+      let ok = classes.length ? classes.every((c) => d.classList.contains(c)) : true;
+      if (ok && attr) ok = d._matches(attr);
+      return ok;
+    });
+  }
+  appendChild(c) { this.children.push(c); return c; }
+}
+
+function makeStep({ type, title, shiny = false }) {
+  const step = new FakeElement();
+  step.classList.add("process-step");
+  step.setAttribute("data-log-type", type);
+  step.setAttribute("data-step-code", type === "agent" ? "GEN" : "UTL");
+  const titleEl = new FakeElement();
+  titleEl.classList.add("step-title");
+  if (shiny) titleEl.classList.add("shiny-text");
+  titleEl.textContent = title;
+  step.appendChild(titleEl);
+  return step;
+}
+
+function makeGroup(steps) {
+  const group = new FakeElement();
+  group.classList.add("process-group");
+  const header = new FakeElement();
+  header.classList.add("process-group-header");
+  const title = new FakeElement();
+  title.classList.add("group-title");
+  title.textContent = "Processing...";
+  const badge = new FakeElement();
+  badge.classList.add("step-badge");
+  const metrics = new FakeElement();
+  metrics.classList.add("group-metrics");
+  header.appendChild(title); header.appendChild(badge); header.appendChild(metrics);
+  group.appendChild(header);
+  steps.forEach((s) => group.appendChild(s));
+  return { group, title, badge };
+}
+
+// --- module-scope stubs the shipped functions rely on ----------------------
+var _lastGroup = null;
+function getLastProcessGroup() { return _lastGroup; }
+function getUserHour12() { return false; }
+function getUserTimezone() { return "UTC"; }
+function formatDateTime(iso) { return iso; }
+
+// --- shipped implementation under test -------------------------------------
+__SHIPPED__
+
+// --- driver ----------------------------------------------------------------
+const results = {};
+
+// Case 1: utility-only group (post-turn memory memorization) — title must
+// fall back to the last step's heading instead of staying "Processing...".
+{
+  const steps = [
+    makeStep({ type: "util", title: "Memorizing new information...", shiny: true }),
+    makeStep({ type: "util", title: "No useful information to memorize.", shiny: true }),
+  ];
+  const { group, title, badge } = makeGroup(steps);
+  _lastGroup = group;
+  updateProcessGroupHeader(group);
+  results.utilTitle = title.textContent;
+  results.utilBadgeBeforeComplete = badge.outerHTML;
+
+  // backend terminal update arrives with kvps.finished → drawMessageUtil
+  // calls completeLastProcessGroup()
+  completeLastProcessGroup();
+  results.utilCompleted = isProcessGroupComplete(group);
+  results.utilBadgeAfterComplete = badge.outerHTML;
+  results.utilShinyRemaining = group.querySelectorAll(".step-title.shiny-text").length;
+}
+
+// Case 2: regression guard — a group with agent steps still takes its title
+// from the last agent step, not from a later utility step.
+{
+  const steps = [
+    makeStep({ type: "agent", title: "A0: Reading storage code" }),
+    makeStep({ type: "util", title: "3 memories found" }),
+  ];
+  const { group, title } = makeGroup(steps);
+  _lastGroup = group;
+  updateProcessGroupHeader(group);
+  results.mixedTitle = title.textContent;
+}
+
+console.log(JSON.stringify(results));
+"""
+    harness = harness.replace("__SHIPPED__", shipped)
+    path = tmp_path / "group_header_harness.mjs"
+    path.write_text(harness, encoding="utf-8")
+    return path
+
+
+@requires_node
+def test_utility_only_group_completes_and_titles_from_last_step(tmp_path):
+    harness = _build_node_harness(tmp_path)
+    proc = subprocess.run(
+        ["node", str(harness)], capture_output=True, text=True, timeout=60
+    )
+    assert proc.returncode == 0, f"node harness failed:\n{proc.stderr}"
+    results = json.loads(proc.stdout.strip().splitlines()[-1])
+
+    # title fallback: last utility step heading, not the placeholder
+    assert results["utilTitle"] == "No useful information to memorize.", (
+        "utility-only group title did not fall back to the last step heading"
+    )
+    # completion: group closed, END badge set, shiny animation removed
+    assert results["utilCompleted"] is True
+    assert "END" in results["utilBadgeAfterComplete"]
+    assert results["utilShinyRemaining"] == 0
+    # mixed groups still prefer the last agent step heading
+    assert results["mixedTitle"] == "A0: Reading storage code"

--- a/webui/js/messages.js
+++ b/webui/js/messages.js
@@ -707,9 +707,9 @@ function updateProcessGroupPagingControls(history) {
     group.dataset.fullInfoSteps = String(
       allSteps.filter((message) => message?.type === "info").length,
     );
-    const lastAgentMessage = allSteps.findLast(
-      (message) => message?.type === "agent",
-    );
+    const lastAgentMessage =
+      allSteps.findLast((message) => message?.type === "agent") ||
+      allSteps[allSteps.length - 1];
     const fullTitle = cleanStepTitle(lastAgentMessage?.heading, 50);
     if (fullTitle) {
       const title = group.querySelector(".process-group-header .group-title");
@@ -2427,17 +2427,26 @@ export function drawMessageUtil({
       ].filter(Boolean)
     : [];
 
+  // Post-turn bookkeeping utilities (e.g. memory memorization) carry a
+  // finished kvp set by the backend when the background job ends. Do not
+  // display it as data; use it to close the process group so a completed
+  // turn does not keep rendering an in-flight "Processing..." phase.
+  const displayKvps = { ...kvps };
+  delete displayKvps.finished;
+
   const result = drawProcessStep({
     id,
     title,
     code: "UTL",
     classes: ["message-util"],
-    kvps,
+    kvps: displayKvps,
     content,
     actionButtons,
     log: arguments[0],
     allowCompletedGroup: false,
   });
+
+  if (kvps?.finished) completeLastProcessGroup();
 
   result.dontScroll = !preferencesStore.showUtils;
   return result;
@@ -3180,15 +3189,18 @@ function updateProcessGroupHeader(group) {
     const agentSteps = Array.from(steps).filter(
       (step) => step.getAttribute("data-log-type") === "agent",
     );
-    if (agentSteps.length > 0) {
-      const lastAgentStep = agentSteps[agentSteps.length - 1];
-      const lastHeading =
-        lastAgentStep.querySelector(".step-title")?.textContent;
-      if (lastHeading) {
-        const cleanTitle = cleanStepTitle(lastHeading, 50);
-        if (cleanTitle) {
-          titleEl.textContent = cleanTitle;
-        }
+    // Groups made only of utility steps (post-turn memory memorization)
+    // never get an agent step; fall back to the last step's title so the
+    // header does not stay on the "Processing..." placeholder forever.
+    const titleStep =
+      agentSteps.length > 0
+        ? agentSteps[agentSteps.length - 1]
+        : steps[steps.length - 1];
+    const lastHeading = titleStep?.querySelector(".step-title")?.textContent;
+    if (lastHeading) {
+      const cleanTitle = cleanStepTitle(lastHeading, 50);
+      if (cleanTitle) {
+        titleEl.textContent = cleanTitle;
       }
     }
   }


### PR DESCRIPTION
## Problem

After a turn fully completes (final response delivered, status bar on "Waiting for input"), the memory plugin's post-turn memorization jobs render as an **in-flight phase**: a process group titled **"Processing..."** with a UTL badge appears, its utility items ("No useful information to memorize." / "No successful solutions to memorize.") keep the shiny in-flight animation, and the group never gets an END badge. The turn is over, but the UI says it isn't.

## Root cause

The monologue_end extensions `_50_memorize_fragments` and `_51_memorize_solutions` log a utility item synchronously at loop end and fill it in seconds later from a background task (`DeferredTask`). By then the turn's process group was already completed by the final response, so `drawProcessStep` opens a **new** process group for these items. That group:

1. contains no `agent`-type steps, so `updateProcessGroupHeader` never replaces the "Processing..." placeholder title (it only reads headings from agent steps), and
2. is **never marked complete** — completion only happens when a response attaches to the group, a user message arrives, or a step with `kvps.finished` is drawn (`drawMessageInfo`). Utility items carry no terminal marker, so nothing ever closes the group.

An uncompleted group keeps `shiny-text` on its newest step (removed only on completion), which is the perpetual flashing, and never receives the END badge.

A secondary status-bar issue: the utility item creation and its error-path warning log use the default `update_progress="persistent"`. The error path in particular logs a *new* warning item after monologue_end reset progress to "Waiting for input", pinning the progress line to the warning with `progress_active=true` until the next turn.

## Fix

**Backend** (`plugins/_memory/extensions/python/monologue_end/_50/_51`):
- every terminal update path now emits `finished=True` (early returns for empty/invalid/unparseable results, a single post-loop marker after successful inserts, and the exception path);
- the log item is created with `update_progress="none"`, the terminal marker uses `update_progress="none"`, and the error-path warning no longer hijacks the status bar.

**Frontend** (`webui/js/messages.js`):
- `drawMessageUtil` calls `completeLastProcessGroup()` when a utility step arrives with `kvps.finished` (mirroring `drawMessageInfo`); the `finished` kvp is hidden from the displayed data;
- `updateProcessGroupHeader` and the full-log classifier fall back to the **last step's** title when a group has no agent steps, so utility-only groups show e.g. "Memorization completed: …" instead of "Processing...".

Turn-start preload utilities are unaffected: they still join the next turn's group via the existing `utility-only` promotion path, and mixed groups still title from the last agent step.

## Tests

`tests/test_post_turn_utility_group.py` (9 tests):
- runs the real `memorize()` coroutines of both extensions against stubbed agents: empty result, successful insert (non-consolidation), and provider-error paths each emit **exactly one** terminal `finished` marker, entries are inserted before the marker, and warnings stay off the status bar;
- asserts `execute()` creates the log item with `update_progress="none"`;
- extracts the real `updateProcessGroupHeader`/`isProcessGroupComplete`/`completeLastProcessGroup` from `messages.js` into a Node fake-DOM harness: a utility-only group titles from its last step, completes with an END badge, and sheds all shiny classes; a mixed group still titles from the last agent step.

**Discriminating:** all 9 fail on pre-fix sources (the frontend assertion reproduces the exact reported symptom: title stays `'Processing...'`), all 9 pass with the fix.

Full suite: pre-existing collection breakage on current `main` is unrelated to this change (8 files — `email_parser_test`, `rate_limiter_test` (real network call), `test_run_ui_config`, `test_state_sync_handler`, `test_state_sync_welcome_screen`, `test_ws_csrf`, `test_ws_manager`, `test_ws_security` — fail identically on pristine `main`). The remainder of the suite passes; see PR checks/comment.

## Evidence of the bug (live, before fix)

Finished chat log: the final response item carries `kvps.finished: true`; the memorize utility items appended after it have `id: null` and no terminal marker, and their updates arrive after monologue_end reset progress — matching the orphaned group the UI renders.