### PR TITLE
Preserve connector attachment metadata in chat replay

### DIFF
--- a/plugins/_a0_connector/AGENTS.md
+++ b/plugins/_a0_connector/AGENTS.md
@@ -55,6 +55,7 @@
 - Host browser status metadata may advertise `available_browsers` entries with browser ids, labels, CDP endpoints, status, and enabled state; keep older CLI payloads without those fields compatible.
 - Model preset definitions exposed through v1 are global; project arguments select scope but never create project-owned definitions. Model switcher state reports the effective main, utility, and embedding models and preserves embedding-change notifications.
 - Computer Use receipts describe transport success unless the connector returns explicit effect evidence. Linux target-bound typing requires a verified active/focused `window_id`; window activation uses focus, never a press action on an application or window node. Do not retry an identical failed Computer Use call.
+- Accepted WebSocket user-message replay metadata may include attachment basenames only; strip paths, query strings, fragments, and bytes before logging them in `kvps`.
 
 ## Work Guidance
 

--- a/plugins/_a0_connector/api/ws_connector.py
+++ b/plugins/_a0_connector/api/ws_connector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import TYPE_CHECKING, Any, ClassVar
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit
 
 from helpers.print_style import PrintStyle
 from helpers.ws import WsHandler
@@ -82,8 +82,12 @@ def _attachment_log_metadata(attachments: list[str]) -> dict[str, list[str]]:
         normalized = str(attachment or "").strip().replace("\\", "/")
         if not normalized:
             continue
-        parsed = urlsplit(normalized)
+        try:
+            parsed = urlsplit(normalized)
+        except ValueError:
+            continue
         path = parsed.path if parsed.scheme else normalized.split("?", 1)[0].split("#", 1)[0]
+        path = unquote(path).replace("\\", "/")
         if path.endswith("/"):
             continue
         name = path.rstrip("/").rsplit("/", 1)[-1]

--- a/plugins/_a0_connector/api/ws_connector.py
+++ b/plugins/_a0_connector/api/ws_connector.py
@@ -74,6 +74,7 @@ WS_FEATURES = [
 _SNAPSHOT_REPLAY_PAGE_SIZE = 50
 _TAIL_HISTORY_PAGE_SIZE = 100
 _LIVE_STREAM_PAGE_SIZE = 100
+_ATTACHMENT_METADATA_DECODE_LIMIT = 3
 
 
 def _attachment_log_metadata(attachments: list[str]) -> dict[str, list[str]]:
@@ -87,7 +88,14 @@ def _attachment_log_metadata(attachments: list[str]) -> dict[str, list[str]]:
         except ValueError:
             continue
         path = parsed.path if parsed.scheme else normalized.split("?", 1)[0].split("#", 1)[0]
-        path = unquote(path).replace("\\", "/")
+        for _ in range(_ATTACHMENT_METADATA_DECODE_LIMIT):
+            decoded_path = unquote(path)
+            if decoded_path == path:
+                break
+            path = decoded_path
+        else:
+            continue
+        path = path.replace("\\", "/")
         path = path.split("?", 1)[0].split("#", 1)[0]
         if path.endswith("/"):
             continue

--- a/plugins/_a0_connector/api/ws_connector.py
+++ b/plugins/_a0_connector/api/ws_connector.py
@@ -88,6 +88,7 @@ def _attachment_log_metadata(attachments: list[str]) -> dict[str, list[str]]:
             continue
         path = parsed.path if parsed.scheme else normalized.split("?", 1)[0].split("#", 1)[0]
         path = unquote(path).replace("\\", "/")
+        path = path.split("?", 1)[0].split("#", 1)[0]
         if path.endswith("/"):
             continue
         name = path.rstrip("/").rsplit("/", 1)[-1]

--- a/plugins/_a0_connector/api/ws_connector.py
+++ b/plugins/_a0_connector/api/ws_connector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import TYPE_CHECKING, Any, ClassVar
+from urllib.parse import urlsplit
 
 from helpers.print_style import PrintStyle
 from helpers.ws import WsHandler
@@ -73,6 +74,22 @@ WS_FEATURES = [
 _SNAPSHOT_REPLAY_PAGE_SIZE = 50
 _TAIL_HISTORY_PAGE_SIZE = 100
 _LIVE_STREAM_PAGE_SIZE = 100
+
+
+def _attachment_log_metadata(attachments: list[str]) -> dict[str, list[str]]:
+    names: list[str] = []
+    for attachment in attachments:
+        normalized = str(attachment or "").strip().replace("\\", "/")
+        if not normalized:
+            continue
+        parsed = urlsplit(normalized)
+        path = parsed.path if parsed.scheme else normalized.split("?", 1)[0].split("#", 1)[0]
+        if path.endswith("/"):
+            continue
+        name = path.rstrip("/").rsplit("/", 1)[-1]
+        if name and name not in {".", ".."}:
+            names.append(name)
+    return {"attachments": names} if names else {}
 
 
 class WsConnector(WsHandler):
@@ -468,7 +485,7 @@ class WsConnector(WsHandler):
             type="user",
             heading="",
             content=message,
-            kvps={},
+            kvps=_attachment_log_metadata(attachments),
             id=message_id,
         )
 

--- a/tests/test_a0_connector_attachment_metadata.py
+++ b/tests/test_a0_connector_attachment_metadata.py
@@ -34,6 +34,15 @@ def test_attachment_log_metadata_omits_empty_metadata() -> None:
     assert _attachment_log_metadata(["", "/"]) == {}
 
 
+def test_attachment_log_metadata_decodes_encoded_separators() -> None:
+    assert _attachment_log_metadata(
+        [
+            "https://host/%2Fhome%2Falice%2Fsecret.png",
+            "https://host/C:%5CUsers%5CAlice%5Csecret.png",
+        ]
+    ) == {"attachments": ["secret.png", "secret.png"]}
+
+
 class RecordingLog:
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []
@@ -136,6 +145,52 @@ async def test_websocket_text_only_message_keeps_empty_kvps(
         {"context_id": "ctx-1", "message": "Text only"},
         "sid-cli",
     )
+    assert log.calls[0]["kvps"] == {}
+
+
+@pytest.mark.asyncio
+async def test_websocket_malformed_attachment_url_keeps_message_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log = RecordingLog()
+    context = SimpleNamespace(log=log)
+    handler = WsConnector(None, None)
+    monkeypatch.setattr(
+        handler,
+        "_resolve_context",
+        AsyncMock(return_value=(context, "ctx-1")),
+    )
+    monkeypatch.setattr(
+        ws_module,
+        "subscribed_contexts_for_sid",
+        lambda sid: {"ctx-1"} if sid == "sid-cli" else set(),
+    )
+
+    scheduled: list[bool] = []
+
+    def close_scheduled(coroutine: object) -> SimpleNamespace:
+        getattr(coroutine, "close")()
+        scheduled.append(True)
+        return SimpleNamespace()
+
+    monkeypatch.setattr(asyncio, "create_task", close_scheduled)
+
+    result = await handler._handle_send_message(
+        {
+            "context_id": "ctx-1",
+            "message": "Review this",
+            "attachments": ["http://["],
+            "client_message_id": "client-malformed",
+        },
+        "sid-cli",
+    )
+
+    assert result == {
+        "context_id": "ctx-1",
+        "status": "accepted",
+        "client_message_id": "client-malformed",
+    }
+    assert scheduled == [True]
     assert log.calls[0]["kvps"] == {}
 
 

--- a/tests/test_a0_connector_attachment_metadata.py
+++ b/tests/test_a0_connector_attachment_metadata.py
@@ -52,6 +52,30 @@ def test_attachment_log_metadata_strips_encoded_query_and_fragment_suffixes() ->
     ) == {"attachments": ["report", "image"]}
 
 
+def test_attachment_log_metadata_decodes_double_encoded_separators() -> None:
+    assert _attachment_log_metadata(
+        [
+            "https://host/%252Fhome%252Fuser%252Fsecret.png",
+            "https://host/C:%255CUsers%255CAlice%255Csecret.png",
+        ]
+    ) == {"attachments": ["secret.png", "secret.png"]}
+
+
+def test_attachment_log_metadata_strips_double_encoded_delimiter_suffixes() -> None:
+    assert _attachment_log_metadata(
+        [
+            "https://host/report%253Ftoken%253Dredacted.png",
+            "https://host/image%2523private-fragment.png",
+        ]
+    ) == {"attachments": ["report", "image"]}
+
+
+def test_attachment_log_metadata_omits_paths_exceeding_decode_limit() -> None:
+    assert _attachment_log_metadata(
+        ["https://host/%25252Fhome%25252Fuser%25252Fsecret.png"]
+    ) == {}
+
+
 class RecordingLog:
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []

--- a/tests/test_a0_connector_attachment_metadata.py
+++ b/tests/test_a0_connector_attachment_metadata.py
@@ -43,6 +43,15 @@ def test_attachment_log_metadata_decodes_encoded_separators() -> None:
     ) == {"attachments": ["secret.png", "secret.png"]}
 
 
+def test_attachment_log_metadata_strips_encoded_query_and_fragment_suffixes() -> None:
+    assert _attachment_log_metadata(
+        [
+            "https://host/report%3Ftoken%3Dsecret.png",
+            "https://host/image%23private-fragment.png",
+        ]
+    ) == {"attachments": ["report", "image"]}
+
+
 class RecordingLog:
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []

--- a/tests/test_a0_connector_attachment_metadata.py
+++ b/tests/test_a0_connector_attachment_metadata.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from helpers.ws_manager import WsResult
+from plugins._a0_connector.api import ws_connector as ws_module
+from plugins._a0_connector.api.ws_connector import (
+    WsConnector,
+    _attachment_log_metadata,
+)
+from plugins._a0_connector.helpers.event_bridge import log_entry_to_connector_event
+
+
+def test_attachment_log_metadata_keeps_only_safe_basenames() -> None:
+    assert _attachment_log_metadata(
+        [
+            "/a0/usr/uploads/scan.png",
+            r"C:\\Users\\person\\result.jpg",
+            "https://agent.test/api/image_get?path=/a0/usr/uploads/chart.webp&token=secret#view",
+            "/a0/usr/uploads/",
+            "",
+        ]
+    ) == {
+        "attachments": ["scan.png", "result.jpg", "image_get"]
+    }
+
+
+def test_attachment_log_metadata_omits_empty_metadata() -> None:
+    assert _attachment_log_metadata([]) == {}
+    assert _attachment_log_metadata(["", "/"]) == {}
+
+
+class RecordingLog:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def log(self, **kwargs: object) -> None:
+        self.calls.append(dict(kwargs))
+
+
+@pytest.mark.asyncio
+async def test_websocket_attachment_names_reach_replayed_user_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log = RecordingLog()
+    context = SimpleNamespace(log=log)
+    handler = WsConnector(None, None)
+    monkeypatch.setattr(
+        handler,
+        "_resolve_context",
+        AsyncMock(return_value=(context, "ctx-1")),
+    )
+    monkeypatch.setattr(
+        ws_module,
+        "subscribed_contexts_for_sid",
+        lambda sid: {"ctx-1"} if sid == "sid-cli" else set(),
+    )
+
+    scheduled: list[bool] = []
+
+    def close_scheduled(coroutine: object) -> SimpleNamespace:
+        close = getattr(coroutine, "close")
+        close()
+        scheduled.append(True)
+        return SimpleNamespace()
+
+    monkeypatch.setattr(asyncio, "create_task", close_scheduled)
+
+    result = await handler._handle_send_message(
+        {
+            "context_id": "ctx-1",
+            "message": "Review these",
+            "attachments": [
+                "/a0/usr/uploads/scan.png",
+                "/a0/usr/uploads/result.jpg",
+            ],
+            "client_message_id": "client-1",
+        },
+        "sid-cli",
+    )
+
+    assert result == {
+        "context_id": "ctx-1",
+        "status": "accepted",
+        "client_message_id": "client-1",
+    }
+    assert scheduled == [True]
+    assert log.calls == [
+        {
+            "type": "user",
+            "heading": "",
+            "content": "Review these",
+            "kvps": {"attachments": ["scan.png", "result.jpg"]},
+            "id": "client-1",
+        }
+    ]
+
+    replayed = log_entry_to_connector_event(
+        {"no": 0, **log.calls[0]},
+        "ctx-1",
+    )
+    assert replayed["event"] == "user_message"
+    assert replayed["data"]["meta"] == {
+        "attachments": ["scan.png", "result.jpg"]
+    }
+
+
+@pytest.mark.asyncio
+async def test_websocket_text_only_message_keeps_empty_kvps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log = RecordingLog()
+    context = SimpleNamespace(log=log)
+    handler = WsConnector(None, None)
+    monkeypatch.setattr(
+        handler,
+        "_resolve_context",
+        AsyncMock(return_value=(context, "ctx-1")),
+    )
+    monkeypatch.setattr(
+        ws_module,
+        "subscribed_contexts_for_sid",
+        lambda sid: {"ctx-1"} if sid == "sid-cli" else set(),
+    )
+
+    def close_scheduled(coroutine: object) -> SimpleNamespace:
+        getattr(coroutine, "close")()
+        return SimpleNamespace()
+
+    monkeypatch.setattr(asyncio, "create_task", close_scheduled)
+    await handler._handle_send_message(
+        {"context_id": "ctx-1", "message": "Text only"},
+        "sid-cli",
+    )
+    assert log.calls[0]["kvps"] == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "code"),
+    [
+        (
+            {
+                "message": "image",
+                "attachments": [{"path": "data:image/png;base64,AAAA"}],
+            },
+            "INVALID_ATTACHMENTS",
+        ),
+        ({"message": "", "attachments": []}, "MISSING_MESSAGE"),
+    ],
+)
+async def test_websocket_rejected_attachments_do_not_reach_context(
+    payload: dict[str, object],
+    code: str,
+) -> None:
+    handler = WsConnector(None, None)
+    result = await handler.process("connector_send_message", payload, "sid-cli")
+    assert isinstance(result, WsResult)
+    rendered = result.as_result(handler_id="test", fallback_correlation_id=None)
+    assert rendered["ok"] is False
+    assert rendered["error"]["code"] == code


### PR DESCRIPTION
## Summary

- preserve image attachment names on accepted `connector_send_message` log entries so connector history replay can reconstruct user image attachments
- sanitize replay metadata to basenames only, stripping paths, query strings, fragments, and encoded variants
- bound percent-decoding and fail closed when a path does not stabilize
- document the connector privacy contract and add focused regression coverage

## Root cause and impact

The connector normalized attachments and passed them into message execution, but logged the accepted user message with empty `kvps`. Replayed history therefore lost the attachment references even though the original live message contained them, preventing clients such as the A0 CLI from restoring historical user images.

This change records only sanitized attachment basenames in `kvps.attachments`. No path components, query values, fragments, or attachment bytes are retained. Text-only messages continue to log empty metadata, malformed metadata is omitted without blocking accepted message delivery, and invalid attachment references still use the existing rejection path.

## Validation

Recorded after rebasing this exact four-commit range onto `upstream/ready` (`1b8a8978`):

- `tests/test_a0_connector_attachment_metadata.py`: **12 passed**
- `tests/test_a0_connector_launcher_gateway.py`, `tests/test_a0_connector_computer_use_metadata.py`, and `tests/test_a0_connector_prompt_gating.py`: **37 passed**
- `git diff --check upstream/ready...HEAD`: clean
- publication-time AST parsing of the changed Python files: clean

A publication-time local pytest refresh could not collect because the bare local interpreter lacks `python-socketio`; the current `ready` Docker framework image also lacks pytest. No dependencies were installed or changed for publication, so CI should provide the fresh authoritative run.

## Related CLI work

Companion A0 CLI draft: https://github.com/agent0ai/a0-connector/pull/21
