### PR TITLE
feat(kokoro-tts): dual-engine ONNX support with HuggingFace model download

### DIFF
--- a/plugins/_kokoro_tts/api/resolve_hf_repo.py
+++ b/plugins/_kokoro_tts/api/resolve_hf_repo.py
@@ -1,0 +1,61 @@
+import json
+import urllib.error
+import urllib.request
+
+from helpers.api import ApiHandler, Request, Response
+
+
+class ResolveHfRepo(ApiHandler):
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        repo = str(input.get("repo", "") or "").strip()
+        if not repo:
+            return {"success": False, "error": "No repo ID provided."}
+
+        try:
+            url = f"https://huggingface.co/api/models/{repo}"
+            with urllib.request.urlopen(url, timeout=15) as resp:
+                data = json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return {"success": False, "error": f"Repo '{repo}' not found."}
+            return {"success": False, "error": f"HuggingFace API error: {e}"}
+        except Exception as e:
+            return {"success": False, "error": f"Network error: {e}"}
+
+        files = [s["rfilename"] for s in data.get("siblings", [])]
+
+        # Find model: prefer full-precision .onnx
+        onnx_files = [f for f in files if f.endswith(".onnx")]
+        if not onnx_files:
+            return {"success": False, "error": f"No .onnx file found in {repo}."}
+        model_file = next(
+            (
+                f
+                for f in onnx_files
+                if not any(q in f.lower() for q in ("int8", "quantized", "fp16", "q8"))
+            ),
+            onnx_files[0],
+        )
+
+        # Find voices: .npz or .bin (not .onnx)
+        voices_files = [
+            f
+            for f in files
+            if f.endswith(".npz") or (f.endswith(".bin") and not f.endswith(".onnx"))
+        ]
+        if not voices_files:
+            return {
+                "success": False,
+                "error": f"No voices file (.npz or .bin) found in {repo}.",
+            }
+        # Prefer .npz over .bin
+        npz_files = [f for f in voices_files if f.endswith(".npz")]
+        voices_file = npz_files[0] if npz_files else voices_files[0]
+
+        return {
+            "success": True,
+            "repo": repo,
+            "model_file": model_file,
+            "voices_file": voices_file,
+            "all_files": files,
+        }

--- a/plugins/_kokoro_tts/api/status.py
+++ b/plugins/_kokoro_tts/api/status.py
@@ -4,28 +4,37 @@ from helpers.api import ApiHandler, Request, Response
 from plugins._kokoro_tts.helpers import migration, runtime
 
 
+def _pkg_version(name: str) -> tuple[str, str]:
+    try:
+        return importlib.metadata.version(name), ""
+    except Exception as e:
+        return "", str(e)
+
+
 class Status(ApiHandler):
     async def process(self, input: dict, request: Request) -> dict | Response:
         migration.ensure_migrated()
 
-        package_version = ""
-        package_error = ""
-        try:
-            package_version = importlib.metadata.version("kokoro")
-        except Exception as e:
-            package_error = str(e)
+        cfg = runtime.get_config()
+        py_version, py_error = _pkg_version("kokoro")
+        onnx_version, onnx_error = _pkg_version("kokoro_onnx")
 
         return {
             "plugin": "_kokoro_tts",
             "enabled": runtime.is_globally_enabled(),
-            "config": runtime.get_config(),
+            "config": cfg,
+            "engine": cfg.get("engine", "kokoro_py"),
             "model": {
                 "ready": await runtime.is_downloaded(),
                 "loading": await runtime.is_downloading(),
             },
             "package": {
-                "version": package_version,
-                "error": package_error,
+                "version": py_version,
+                "error": py_error,
+            },
+            "onnx_package": {
+                "version": onnx_version,
+                "error": onnx_error,
             },
             "fallback": "Browser-native speechSynthesis remains the fallback when Kokoro is disabled.",
         }

--- a/plugins/_kokoro_tts/default_config.yaml
+++ b/plugins/_kokoro_tts/default_config.yaml
@@ -6,3 +6,5 @@ lang: en-us  # espeak-ng language code: en-us, de, fr, es, it, etc.
 onnx_hf_repo: ''  # HuggingFace repo ID, e.g. Godelaune/Kokoro-82M-ONNX-German-Martin
 onnx_model_file: ''  # auto-detected from repo if empty; e.g. kokoro-martin.onnx
 onnx_voices_file: ''  # auto-detected from repo if empty; e.g. voices-martin.npz
+onnx_mixed_lang: en-us  # secondary espeak-ng language for matched terms
+onnx_mixed_lang_terms: ''  # comma/newline-separated terms to phonemize with secondary language

--- a/plugins/_kokoro_tts/default_config.yaml
+++ b/plugins/_kokoro_tts/default_config.yaml
@@ -1,3 +1,8 @@
 voice: am_puck,am_onyx
 voice_weights: {}
 speed: 1.1
+engine: kokoro_py  # kokoro_py | kokoro_onnx
+lang: en-us  # espeak-ng language code: en-us, de, fr, es, it, etc.
+onnx_hf_repo: ''  # HuggingFace repo ID, e.g. Godelaune/Kokoro-82M-ONNX-German-Martin
+onnx_model_file: ''  # filename in repo, e.g. kokoro-martin.onnx
+onnx_voices_file: ''  # filename in repo, e.g. voices-martin.npz

--- a/plugins/_kokoro_tts/default_config.yaml
+++ b/plugins/_kokoro_tts/default_config.yaml
@@ -4,5 +4,5 @@ speed: 1.1
 engine: kokoro_py  # kokoro_py | kokoro_onnx
 lang: en-us  # espeak-ng language code: en-us, de, fr, es, it, etc.
 onnx_hf_repo: ''  # HuggingFace repo ID, e.g. Godelaune/Kokoro-82M-ONNX-German-Martin
-onnx_model_file: ''  # filename in repo, e.g. kokoro-martin.onnx
-onnx_voices_file: ''  # filename in repo, e.g. voices-martin.npz
+onnx_model_file: ''  # auto-detected from repo if empty; e.g. kokoro-martin.onnx
+onnx_voices_file: ''  # auto-detected from repo if empty; e.g. voices-martin.npz

--- a/plugins/_kokoro_tts/helpers/runtime.py
+++ b/plugins/_kokoro_tts/helpers/runtime.py
@@ -36,6 +36,8 @@ DEFAULT_CONFIG = {
     "onnx_hf_repo": "",          # HuggingFace repo ID for ONNX model download
     "onnx_model_file": "",       # filename in repo, e.g. kokoro-martin.onnx
     "onnx_voices_file": "",      # filename in repo, e.g. voices-martin.npz
+    "onnx_mixed_lang": "en-us",  # secondary espeak-ng language for matched terms
+    "onnx_mixed_lang_terms": "", # comma/newline-separated terms to phonemize with secondary language
 }
 VOICE_ID_PATTERN = re.compile(r"^[a-z]{2}_[a-z0-9_]+$")
 
@@ -100,6 +102,13 @@ def normalize_config(config: dict[str, Any] | None) -> dict[str, Any]:
     for key in ("onnx_hf_repo", "onnx_model_file", "onnx_voices_file"):
         val = str(config.get(key, normalized[key]) or "").strip()
         normalized[key] = val
+
+    mixed_lang = str(config.get("onnx_mixed_lang", normalized["onnx_mixed_lang"]) or "").strip().lower()
+    if mixed_lang:
+        normalized["onnx_mixed_lang"] = mixed_lang
+    normalized["onnx_mixed_lang_terms"] = str(
+        config.get("onnx_mixed_lang_terms", normalized["onnx_mixed_lang_terms"]) or ""
+    ).strip()
 
     return normalized
 
@@ -387,6 +396,35 @@ def _encode_wav_base64(samples: list[float]) -> str:
     return base64.b64encode(buffer.getvalue()).decode("utf-8")
 
 
+def _parse_mixed_lang_terms(raw_terms: str) -> list[str]:
+    terms = [term.strip() for term in re.split(r"[,\n]", raw_terms) if term.strip()]
+    return sorted(dict.fromkeys(terms), key=len, reverse=True)
+
+
+def _mixed_lang_phonemes(
+    pipeline: Any, text: str, *, primary_lang: str, mixed_lang: str, terms: list[str]
+) -> str:
+    if not terms:
+        return pipeline.tokenizer.phonemize(text, primary_lang)
+
+    pattern = re.compile(
+        r"(?<![A-Za-z0-9_])(" + "|".join(re.escape(term) for term in terms) + r")(?![A-Za-z0-9_])",
+        re.IGNORECASE,
+    )
+    phoneme_parts: list[str] = []
+    last_end = 0
+    for match in pattern.finditer(text):
+        if match.start() > last_end:
+            phoneme_parts.append(
+                pipeline.tokenizer.phonemize(text[last_end : match.start()], primary_lang)
+            )
+        phoneme_parts.append(pipeline.tokenizer.phonemize(match.group(0), mixed_lang))
+        last_end = match.end()
+    if last_end < len(text):
+        phoneme_parts.append(pipeline.tokenizer.phonemize(text[last_end:], primary_lang))
+    return " ".join(part for part in phoneme_parts if part)
+
+
 async def _synthesize_onnx(
     sentences: list[str], *, cfg: dict[str, Any]
 ) -> str:
@@ -395,17 +433,32 @@ async def _synthesize_onnx(
     voice = str(cfg["voice"])
     speed = float(cfg["speed"])
     lang = str(cfg["lang"])
+    mixed_lang = str(cfg["onnx_mixed_lang"])
+    mixed_terms = _parse_mixed_lang_terms(str(cfg["onnx_mixed_lang_terms"]))
 
     combined_audio: list[float] = []
 
     try:
         for sentence in sentences:
-            if not sentence.strip():
+            text = sentence.strip()
+            if not text:
                 continue
 
-            samples, sample_rate = _onnx_pipeline.create(
-                sentence.strip(), voice=voice, speed=speed, lang=lang
-            )
+            if mixed_terms:
+                text = _mixed_lang_phonemes(
+                    _onnx_pipeline,
+                    text,
+                    primary_lang=lang,
+                    mixed_lang=mixed_lang,
+                    terms=mixed_terms,
+                )
+                samples, sample_rate = _onnx_pipeline.create(
+                    text, voice=voice, speed=speed, lang=lang, is_phonemes=True
+                )
+            else:
+                samples, sample_rate = _onnx_pipeline.create(
+                    text, voice=voice, speed=speed, lang=lang
+                )
             combined_audio.extend(samples.tolist())
 
         if not combined_audio:

--- a/plugins/_kokoro_tts/helpers/runtime.py
+++ b/plugins/_kokoro_tts/helpers/runtime.py
@@ -4,13 +4,15 @@ import asyncio
 import base64
 import io
 import math
+import os
 import re
+import urllib.request
 import warnings
 from typing import Any
 
 import soundfile as sf
 
-from helpers import plugins
+from helpers import files, plugins
 from helpers.notification import (
     NotificationManager,
     NotificationPriority,
@@ -29,10 +31,26 @@ DEFAULT_CONFIG = {
     "voice": "am_puck,am_onyx",
     "voice_weights": {},
     "speed": 1.1,
+    "engine": "kokoro_py",       # kokoro_py | kokoro_onnx
+    "lang": "en-us",             # espeak-ng language code: en-us, de, fr, es, it, etc.
+    "onnx_hf_repo": "",          # HuggingFace repo ID for ONNX model download
+    "onnx_model_file": "",       # filename in repo, e.g. kokoro-martin.onnx
+    "onnx_voices_file": "",      # filename in repo, e.g. voices-martin.npz
 }
 VOICE_ID_PATTERN = re.compile(r"^[a-z]{2}_[a-z0-9_]+$")
 
+# Map espeak-ng language codes to kokoro-py KPipeline lang_code
+_ESPEAK_TO_KOKORO_LANG = {
+    "en-us": "a",
+    "en-gb": "b",
+    "ja": "j",
+    "zh": "z",
+    "ko": "k",
+}
+
 _pipeline = None
+_pipeline_lang_code: str | None = None
+_onnx_pipeline = None
 is_updating_model = False
 
 
@@ -68,6 +86,21 @@ def normalize_config(config: dict[str, Any] | None) -> dict[str, Any]:
     except (TypeError, ValueError):
         pass
 
+    # Engine selection
+    engine = str(config.get("engine", normalized["engine"]) or "").strip().lower()
+    if engine in ("kokoro_py", "kokoro_onnx"):
+        normalized["engine"] = engine
+
+    # Language code (espeak-ng format)
+    lang = str(config.get("lang", normalized["lang"]) or "").strip().lower()
+    if lang:
+        normalized["lang"] = lang
+
+    # ONNX HuggingFace repo and filenames
+    for key in ("onnx_hf_repo", "onnx_model_file", "onnx_voices_file"):
+        val = str(config.get(key, normalized[key]) or "").strip()
+        normalized[key] = val
+
     return normalized
 
 
@@ -84,18 +117,26 @@ def is_globally_enabled() -> bool:
 
 
 async def preload(config: dict[str, Any] | None = None):
-    return await _preload()
+    cfg = normalize_config(config or get_config())
+    if cfg["engine"] == "kokoro_onnx":
+        return await _preload_onnx(cfg)
+    return await _preload(cfg)
 
 
-async def _preload():
-    global _pipeline, is_updating_model
+async def _preload(config: dict[str, Any] | None = None):
+    global _pipeline, _pipeline_lang_code, is_updating_model
+
+    cfg = normalize_config(config or get_config())
+    lang_code = _ESPEAK_TO_KOKORO_LANG.get(
+        cfg["lang"], cfg["lang"][0] if cfg["lang"] else "a"
+    )
 
     while is_updating_model:
         await asyncio.sleep(0.1)
 
     try:
         is_updating_model = True
-        if not _pipeline:
+        if _pipeline is None or _pipeline_lang_code != lang_code:
             NotificationManager.send_notification(
                 NotificationType.INFO,
                 NotificationPriority.NORMAL,
@@ -106,7 +147,8 @@ async def _preload():
             PrintStyle.standard("Loading Kokoro TTS model...")
             from kokoro import KPipeline
 
-            _pipeline = KPipeline(lang_code="a", repo_id="hexgrad/Kokoro-82M")
+            _pipeline = KPipeline(lang_code=lang_code, repo_id="hexgrad/Kokoro-82M")
+            _pipeline_lang_code = lang_code
             NotificationManager.send_notification(
                 NotificationType.INFO,
                 NotificationPriority.NORMAL,
@@ -118,11 +160,110 @@ async def _preload():
         is_updating_model = False
 
 
+async def _ensure_onnx_model(cfg: dict[str, Any]) -> tuple[str, str]:
+    """Ensure ONNX model and voices files are available locally.
+
+    Downloads from HuggingFace if ``onnx_hf_repo`` is set and files are not yet cached.
+    Returns ``(model_path, voices_path)``. Returns empty strings if ``onnx_hf_repo``
+    is empty (files must exist locally in that case).
+    """
+    hf_repo = cfg.get("onnx_hf_repo", "")
+    model_file = cfg.get("onnx_model_file", "")
+    voices_file = cfg.get("onnx_voices_file", "")
+
+    if not hf_repo:
+        return "", ""
+
+    sanitized = hf_repo.replace("/", "_")
+    cache_dir = files.get_abs_path("usr/models", sanitized)
+    model_path = os.path.join(cache_dir, model_file) if model_file else ""
+    voices_path = os.path.join(cache_dir, voices_file) if voices_file else ""
+
+    model_ok = bool(model_path) and os.path.isfile(model_path)
+    voices_ok = bool(voices_path) and os.path.isfile(voices_path)
+
+    if model_ok and voices_ok:
+        return model_path, voices_path
+
+    os.makedirs(cache_dir, exist_ok=True)
+
+    if not model_ok and model_file:
+        url = f"https://huggingface.co/{hf_repo}/resolve/main/{model_file}"
+        PrintStyle.standard(f"Downloading ONNX model: {url}")
+        NotificationManager.send_notification(
+            NotificationType.INFO,
+            NotificationPriority.NORMAL,
+            "Downloading ONNX model from HuggingFace...",
+            display_time=99,
+            group="kokoro-onnx-download",
+        )
+        urllib.request.urlretrieve(url, model_path)
+
+    if not voices_ok and voices_file:
+        url = f"https://huggingface.co/{hf_repo}/resolve/main/{voices_file}"
+        PrintStyle.standard(f"Downloading ONNX voices: {url}")
+        urllib.request.urlretrieve(url, voices_path)
+
+    NotificationManager.send_notification(
+        NotificationType.INFO,
+        NotificationPriority.NORMAL,
+        "ONNX model download complete.",
+        display_time=2,
+        group="kokoro-onnx-download",
+    )
+
+    return model_path, voices_path
+
+
+async def _preload_onnx(config: dict[str, Any]):
+    global _onnx_pipeline, is_updating_model
+
+    while is_updating_model:
+        await asyncio.sleep(0.1)
+
+    try:
+        is_updating_model = True
+        if not _onnx_pipeline:
+            NotificationManager.send_notification(
+                NotificationType.INFO,
+                NotificationPriority.NORMAL,
+                "Loading Kokoro ONNX TTS model...",
+                display_time=99,
+                group="kokoro-onnx-preload",
+            )
+            PrintStyle.standard("Loading Kokoro ONNX TTS model...")
+
+            model_path, voices_path = await _ensure_onnx_model(config)
+
+            if not model_path or not voices_path:
+                raise ValueError(
+                    "ONNX engine requires onnx_hf_repo, onnx_model_file, and "
+                    "onnx_voices_file to be configured, or model files to exist locally."
+                )
+
+            from kokoro_onnx import Kokoro
+
+            _onnx_pipeline = Kokoro(model_path, voices_path)
+
+            NotificationManager.send_notification(
+                NotificationType.INFO,
+                NotificationPriority.NORMAL,
+                "Kokoro ONNX TTS model loaded.",
+                display_time=2,
+                group="kokoro-onnx-preload",
+            )
+    finally:
+        is_updating_model = False
+
+
 async def is_downloading() -> bool:
     return is_updating_model
 
 
 async def is_downloaded() -> bool:
+    cfg = get_config()
+    if cfg.get("engine") == "kokoro_onnx":
+        return _onnx_pipeline is not None
     return _pipeline is not None
 
 
@@ -130,12 +271,7 @@ async def synthesize_sentences(
     sentences: list[str], config: dict[str, Any] | None = None
 ) -> str:
     cfg = normalize_config(config or get_config())
-    return await _synthesize_sentences(
-        sentences,
-        voice=str(cfg["voice"]),
-        voice_weights=dict(cfg["voice_weights"]),
-        speed=float(cfg["speed"]),
-    )
+    return await _synthesize_sentences(sentences, cfg=cfg)
 
 
 def _resolve_voice(
@@ -155,9 +291,21 @@ def _resolve_voice(
 
 
 async def _synthesize_sentences(
-    sentences: list[str], *, voice: str, voice_weights: dict[str, float], speed: float
+    sentences: list[str], *, cfg: dict[str, Any]
 ) -> str:
-    await _preload()
+    if cfg["engine"] == "kokoro_onnx":
+        return await _synthesize_onnx(sentences, cfg=cfg)
+    return await _synthesize_kokoro_py(sentences, cfg=cfg)
+
+
+async def _synthesize_kokoro_py(
+    sentences: list[str], *, cfg: dict[str, Any]
+) -> str:
+    await _preload(cfg)
+
+    voice = str(cfg["voice"])
+    voice_weights = dict(cfg["voice_weights"])
+    speed = float(cfg["speed"])
 
     combined_audio: list[float] = []
     resolved_voice = _resolve_voice(_pipeline, voice, voice_weights)
@@ -178,9 +326,43 @@ async def _synthesize_sentences(
         if not combined_audio:
             return ""
 
-        buffer = io.BytesIO()
-        sf.write(buffer, combined_audio, 24000, format="WAV")
-        return base64.b64encode(buffer.getvalue()).decode("utf-8")
+        return _encode_wav_base64(combined_audio)
     except Exception as e:
         PrintStyle.error(f"Error in Kokoro TTS synthesis: {e}")
+        raise
+
+
+def _encode_wav_base64(samples: list[float]) -> str:
+    buffer = io.BytesIO()
+    sf.write(buffer, samples, 24000, format="WAV")
+    return base64.b64encode(buffer.getvalue()).decode("utf-8")
+
+
+async def _synthesize_onnx(
+    sentences: list[str], *, cfg: dict[str, Any]
+) -> str:
+    await _preload_onnx(cfg)
+
+    voice = str(cfg["voice"])
+    speed = float(cfg["speed"])
+    lang = str(cfg["lang"])
+
+    combined_audio: list[float] = []
+
+    try:
+        for sentence in sentences:
+            if not sentence.strip():
+                continue
+
+            samples, sample_rate = _onnx_pipeline.create(
+                sentence.strip(), voice=voice, speed=speed, lang=lang
+            )
+            combined_audio.extend(samples.tolist())
+
+        if not combined_audio:
+            return ""
+
+        return _encode_wav_base64(combined_audio)
+    except Exception as e:
+        PrintStyle.error(f"Error in Kokoro ONNX TTS synthesis: {e}")
         raise

--- a/plugins/_kokoro_tts/helpers/runtime.py
+++ b/plugins/_kokoro_tts/helpers/runtime.py
@@ -160,6 +160,48 @@ async def _preload(config: dict[str, Any] | None = None):
         is_updating_model = False
 
 
+def _detect_hf_files(hf_repo: str) -> tuple[str, str]:
+    """Auto-detect ONNX model and voices filenames from a HuggingFace repo.
+
+    Returns ``(model_file, voices_file)``.  Raises :class:`ValueError` if
+    either file cannot be found.
+    """
+    import json
+
+    url = f"https://huggingface.co/api/models/{hf_repo}"
+    with urllib.request.urlopen(url, timeout=15) as resp:
+        data = json.loads(resp.read())
+
+    files = [s["rfilename"] for s in data.get("siblings", [])]
+
+    # Find model: prefer full-precision .onnx
+    onnx_files = [f for f in files if f.endswith(".onnx")]
+    if not onnx_files:
+        raise ValueError(f"No .onnx file found in {hf_repo}")
+    model_file = next(
+        (
+            f
+            for f in onnx_files
+            if not any(q in f.lower() for q in ("int8", "quantized", "fp16", "q8"))
+        ),
+        onnx_files[0],
+    )
+
+    # Find voices: .npz or .bin (but not .onnx)
+    voices_files = [
+        f
+        for f in files
+        if f.endswith(".npz") or (f.endswith(".bin") and not f.endswith(".onnx"))
+    ]
+    if not voices_files:
+        raise ValueError(f"No voices file (.npz or .bin) found in {hf_repo}")
+    # Prefer .npz over .bin
+    npz = [f for f in voices_files if f.endswith(".npz")]
+    voices_file = npz[0] if npz else voices_files[0]
+
+    return model_file, voices_file
+
+
 async def _ensure_onnx_model(cfg: dict[str, Any]) -> tuple[str, str]:
     """Ensure ONNX model and voices files are available locally.
 
@@ -173,6 +215,13 @@ async def _ensure_onnx_model(cfg: dict[str, Any]) -> tuple[str, str]:
 
     if not hf_repo:
         return "", ""
+
+    if hf_repo and (not model_file or not voices_file):
+        detected_model, detected_voices = _detect_hf_files(hf_repo)
+        if not model_file:
+            model_file = detected_model
+        if not voices_file:
+            voices_file = detected_voices
 
     sanitized = hf_repo.replace("/", "_")
     cache_dir = files.get_abs_path("usr/models", sanitized)

--- a/plugins/_kokoro_tts/webui/config.html
+++ b/plugins/_kokoro_tts/webui/config.html
@@ -54,6 +54,8 @@
       if (!config.onnx_hf_repo) config.onnx_hf_repo = '';
       if (!config.onnx_model_file) config.onnx_model_file = '';
       if (!config.onnx_voices_file) config.onnx_voices_file = '';
+      if (!config.onnx_mixed_lang) config.onnx_mixed_lang = 'en-us';
+      if (!config.onnx_mixed_lang_terms) config.onnx_mixed_lang_terms = '';
     },
     voiceIds() {
       const weighted = Object.keys(config.voice_weights || {});
@@ -362,6 +364,36 @@
                   type="text"
                   x-model.trim="config.onnx_voices_file"
                   placeholder="auto-detected, e.g. voices-martin.npz"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <div class="field-label">
+                <div class="field-title">Mixed-language terms</div>
+                <div class="field-description">
+                  Optional: comma or newline-separated terms that should be phonemized with a secondary language before ONNX synthesis.
+                </div>
+              </div>
+              <div class="field-control">
+                <textarea
+                  x-model.trim="config.onnx_mixed_lang_terms"
+                  placeholder="Machine Learning, Kubernetes, Docker, React, TypeScript"
+                  rows="4"
+                ></textarea>
+              </div>
+            </div>
+
+            <div class="field">
+              <div class="field-label">
+                <div class="field-title">Mixed-language code</div>
+                <div class="field-description">espeak-ng language code for matched terms, e.g. en-us.</div>
+              </div>
+              <div class="field-control">
+                <input
+                  type="text"
+                  x-model.trim="config.onnx_mixed_lang"
+                  placeholder="en-us"
                 />
               </div>
             </div>

--- a/plugins/_kokoro_tts/webui/config.html
+++ b/plugins/_kokoro_tts/webui/config.html
@@ -43,6 +43,12 @@
       if (Object.keys(sanitized).length) this.syncVoice(Object.keys(sanitized));
       const speed = Number(config.speed);
       config.speed = Number.isFinite(speed) && speed > 0 ? speed : 1.1;
+
+      // Engine selection (kokoro_py | kokoro_onnx)
+      if (!['kokoro_py', 'kokoro_onnx'].includes(config.engine)) config.engine = 'kokoro_py';
+
+      // espeak-ng language code
+      if (!config.lang) config.lang = 'en-us';
     },
     voiceIds() {
       const weighted = Object.keys(config.voice_weights || {});
@@ -234,6 +240,86 @@
             <output x-text="`${Number(config.speed || 1.1).toFixed(1)}×`"></output>
           </div>
         </div>
+
+        <div class="field">
+          <div class="field-label">
+            <div class="field-title">Engine</div>
+            <div class="field-description">
+              Kokoro engine: kokoro_py (PyTorch/KPipeline) or kokoro_onnx (ONNX runtime).
+            </div>
+          </div>
+          <div class="field-control">
+            <select x-model="config.engine" aria-label="TTS engine">
+              <option value="kokoro_py">kokoro_py (KPipeline / PyTorch)</option>
+              <option value="kokoro_onnx">kokoro_onnx (ONNX Runtime)</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="field">
+          <div class="field-label">
+            <div class="field-title">Language</div>
+            <div class="field-description">
+              espeak-ng language code, e.g. en-us, de, fr, es, it.
+            </div>
+          </div>
+          <div class="field-control">
+            <input
+              type="text"
+              x-model.trim="config.lang"
+              placeholder="en-us"
+              aria-label="espeak-ng language code"
+            />
+          </div>
+        </div>
+
+        <template x-if="config.engine === 'kokoro_onnx'">
+          <div class="kokoro-onnx-section">
+            <div class="field">
+              <div class="field-label">
+                <div class="field-title">ONNX HuggingFace repo</div>
+                <div class="field-description">
+                  HuggingFace repo ID for automatic model download, e.g. Godelaune/Kokoro-82M-ONNX-German-Martin.
+                </div>
+              </div>
+              <div class="field-control">
+                <input
+                  type="text"
+                  x-model.trim="config.onnx_hf_repo"
+                  placeholder="Godelaune/Kokoro-82M-ONNX-German-Martin"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <div class="field-label">
+                <div class="field-title">ONNX model file</div>
+                <div class="field-description">Filename inside the repo, e.g. kokoro-martin.onnx.</div>
+              </div>
+              <div class="field-control">
+                <input
+                  type="text"
+                  x-model.trim="config.onnx_model_file"
+                  placeholder="kokoro-martin.onnx"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <div class="field-label">
+                <div class="field-title">ONNX voices file</div>
+                <div class="field-description">Filename inside the repo, e.g. voices-martin.npz.</div>
+              </div>
+              <div class="field-control">
+                <input
+                  type="text"
+                  x-model.trim="config.onnx_voices_file"
+                  placeholder="voices-martin.npz"
+                />
+              </div>
+            </div>
+          </div>
+        </template>
       </div>
     </template>
   </div>

--- a/plugins/_kokoro_tts/webui/config.html
+++ b/plugins/_kokoro_tts/webui/config.html
@@ -49,6 +49,11 @@
 
       // espeak-ng language code
       if (!config.lang) config.lang = 'en-us';
+
+      // ONNX fields
+      if (!config.onnx_hf_repo) config.onnx_hf_repo = '';
+      if (!config.onnx_model_file) config.onnx_model_file = '';
+      if (!config.onnx_voices_file) config.onnx_voices_file = '';
     },
     voiceIds() {
       const weighted = Object.keys(config.voice_weights || {});
@@ -115,6 +120,31 @@
     },
     syncVoice(ids) {
       config.voice = ids.join(',');
+    },
+    resolving: false,
+    resolveError: '',
+    async resolveHfRepo() {
+      if (!config.onnx_hf_repo) return;
+      this.resolving = true;
+      this.resolveError = '';
+      try {
+        const resp = await fetch('/api/plugins/_kokoro_tts/resolve_hf_repo', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ repo: config.onnx_hf_repo }),
+        });
+        const data = await resp.json();
+        if (data.success) {
+          config.onnx_model_file = data.model_file;
+          config.onnx_voices_file = data.voices_file;
+        } else {
+          this.resolveError = data.error || 'Could not resolve repo files';
+        }
+      } catch (e) {
+        this.resolveError = String(e);
+      } finally {
+        this.resolving = false;
+      }
     },
   }">
     <template x-if="config">
@@ -279,28 +309,43 @@
               <div class="field-label">
                 <div class="field-title">ONNX HuggingFace repo</div>
                 <div class="field-description">
-                  HuggingFace repo ID for automatic model download, e.g. Godelaune/Kokoro-82M-ONNX-German-Martin.
+                  Enter a HuggingFace repo ID and click <em>Detect files</em> to auto-fill the
+                  model and voices filenames. E.g. Godelaune/Kokoro-82M-ONNX-German-Martin.
                 </div>
               </div>
-              <div class="field-control">
+              <div class="field-control kokoro-repo-row">
                 <input
                   type="text"
                   x-model.trim="config.onnx_hf_repo"
+                  @keydown.enter.prevent="resolveHfRepo()"
                   placeholder="Godelaune/Kokoro-82M-ONNX-German-Martin"
+                  aria-label="HuggingFace repo ID"
                 />
+                <button
+                  type="button"
+                  class="button"
+                  @click="resolveHfRepo()"
+                  :disabled="!config.onnx_hf_repo || resolving"
+                >
+                  <span x-show="!resolving">Detect files</span>
+                  <span x-show="resolving">Detecting…</span>
+                </button>
               </div>
+              <div class="kokoro-resolve-error" x-show="resolveError" x-text="resolveError"></div>
             </div>
 
             <div class="field">
               <div class="field-label">
                 <div class="field-title">ONNX model file</div>
-                <div class="field-description">Filename inside the repo, e.g. kokoro-martin.onnx.</div>
+                <div class="field-description">
+                  Auto-detected from repo if empty. Leave blank to auto-detect at runtime.
+                </div>
               </div>
               <div class="field-control">
                 <input
                   type="text"
                   x-model.trim="config.onnx_model_file"
-                  placeholder="kokoro-martin.onnx"
+                  placeholder="auto-detected, e.g. kokoro-martin.onnx"
                 />
               </div>
             </div>
@@ -308,13 +353,15 @@
             <div class="field">
               <div class="field-label">
                 <div class="field-title">ONNX voices file</div>
-                <div class="field-description">Filename inside the repo, e.g. voices-martin.npz.</div>
+                <div class="field-description">
+                  Auto-detected from repo if empty. Leave blank to auto-detect at runtime.
+                </div>
               </div>
               <div class="field-control">
                 <input
                   type="text"
                   x-model.trim="config.onnx_voices_file"
-                  placeholder="voices-martin.npz"
+                  placeholder="auto-detected, e.g. voices-martin.npz"
                 />
               </div>
             </div>
@@ -325,6 +372,35 @@
   </div>
 
   <style>
+    .kokoro-onnx-section {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .kokoro-repo-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .kokoro-repo-row input {
+      flex: 1;
+    }
+
+    .kokoro-repo-row button {
+      flex-shrink: 0;
+    }
+
+    .kokoro-resolve-error {
+      margin-top: 0.4rem;
+      padding: 0.4rem 0.65rem;
+      border-radius: 0.4rem;
+      background: var(--color-bg-danger, #fef2f2);
+      color: var(--color-text-danger, #b91c1c);
+      font-size: var(--font-size-small);
+    }
+
     .kokoro-blend-editor {
       display: flex;
       flex-direction: column;

--- a/plugins/_kokoro_tts/webui/kokoro-tts-store.js
+++ b/plugins/_kokoro_tts/webui/kokoro-tts-store.js
@@ -44,6 +44,11 @@ const model = {
         voice: status?.config?.voice || "",
         voice_weights: status?.config?.voice_weights || {},
         speed: Number(status?.config?.speed || 1.1),
+        engine: status?.config?.engine || "kokoro_py",
+        lang: status?.config?.lang || "en-us",
+        onnx_hf_repo: status?.config?.onnx_hf_repo || "",
+        onnx_model_file: status?.config?.onnx_model_file || "",
+        onnx_voices_file: status?.config?.onnx_voices_file || "",
       };
       this.modelReady = !!status?.model?.ready;
       this.modelLoading = !!status?.model?.loading;

--- a/plugins/_kokoro_tts/webui/kokoro-tts-store.js
+++ b/plugins/_kokoro_tts/webui/kokoro-tts-store.js
@@ -15,6 +15,13 @@ const model = {
     voice: "",
     voice_weights: {},
     speed: 1.1,
+    engine: "kokoro_py",
+    lang: "en-us",
+    onnx_hf_repo: "",
+    onnx_model_file: "",
+    onnx_voices_file: "",
+    onnx_mixed_lang: "en-us",
+    onnx_mixed_lang_terms: "",
   },
   modelReady: false,
   modelLoading: false,
@@ -49,6 +56,8 @@ const model = {
         onnx_hf_repo: status?.config?.onnx_hf_repo || "",
         onnx_model_file: status?.config?.onnx_model_file || "",
         onnx_voices_file: status?.config?.onnx_voices_file || "",
+        onnx_mixed_lang: status?.config?.onnx_mixed_lang || "en-us",
+        onnx_mixed_lang_terms: status?.config?.onnx_mixed_lang_terms || "",
       };
       this.modelReady = !!status?.model?.ready;
       this.modelLoading = !!status?.model?.loading;


### PR DESCRIPTION
## Summary

Extends the built-in Kokoro TTS plugin with a second inference engine: `kokoro_onnx` (ONNX Runtime) alongside the existing `kokoro_py` (PyTorch/KPipeline). This enables community ONNX exports from HuggingFace, e.g. the German voice model `Godelaune/Kokoro-82M-ONNX-German-Martin`, without touching the default experience.

## Changes

- **Dual engine**: new `engine` config selects `kokoro_py` (default, backward compatible) or `kokoro_onnx`
- **Language support**: `lang` config (espeak-ng code, e.g. `en-us`, `de`) mapped to KPipeline lang codes for kokoro_py and passed through to ONNX synthesis
- **HuggingFace download**: ONNX model + voices files auto-download into `usr/models/` cache on first use
- **Repo auto-detect**: new API endpoint `POST /api/plugins/_kokoro_tts/resolve_hf_repo` detects the `.onnx` model and voices (`.npz`/`.bin`) filenames from a HF repo ID; runtime auto-detects when filenames are left empty
- **WebUI**: engine dropdown, language input, conditional ONNX section with "Detect files" button in plugin settings; frontend store syncs all new fields
- **Status API**: reports active engine plus kokoro/kokoro-onnx package versions

## Testing

- ONNX German synthesis verified end-to-end on live server (engine=kokoro_onnx, voice=martin, lang=de, ~200k chars base64 WAV)
- Auto-detect verified for `Godelaune/Kokoro-82M-ONNX-German-Martin` (model=kokoro-martin.onnx, voices=voices-martin.npz)
- Backward compatibility: default config normalizes to kokoro_py/en-us; existing voice/speed/weights behavior unchanged
- Status and synthesize endpoints verified against running WebUI with CSRF session

## Notes for reviewers

- `kokoro-onnx` and `onnxruntime` are optional runtime dependencies for the ONNX engine; the plugin degrades gracefully when only kokoro_py is installed
- System dependency `espeak-ng` is already required by the existing kokoro pipeline path
