### PR TITLE
fix(webui): allow hiding mobile canvas rail

### DIFF
--- a/tests/test_ui_control_visibility.py
+++ b/tests/test_ui_control_visibility.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import re
 import subprocess
 import sys
 
@@ -41,6 +42,21 @@ def test_ui_controls_have_independent_mobile_and_desktop_visibility() -> None:
     assert "isUiControlVisible('connectionStatus')" in chat_top
     assert "isUiControlVisible('projectSelector')" in chat_top
     assert "isUiControlVisible('rightCanvasRail')" in canvas
+
+
+def test_mobile_canvas_rail_respects_visibility_preference() -> None:
+    canvas = read("webui/components/canvas/right-canvas.html")
+    canvas_css = read("webui/components/canvas/right-canvas.css")
+    mobile_rail_rule = re.search(
+        r"body\.right-canvas-mobile-mode \.right-canvas-rail \{([^}]*)\}",
+        canvas_css,
+        re.S,
+    )
+
+    assert 'x-show="$store.preferences.isUiControlVisible(\'rightCanvasRail\')"' in canvas
+    assert mobile_rail_rule is not None
+    assert re.search(r"^\s*display:\s*flex;\s*$", mobile_rail_rule.group(1), re.M)
+    assert "!important" not in mobile_rail_rule.group(1)
 
 
 def test_ui_control_visibility_settings_are_normalized() -> None:

--- a/webui/components/canvas/right-canvas.css
+++ b/webui/components/canvas/right-canvas.css
@@ -344,7 +344,7 @@ body.right-canvas-mobile-mode .right-canvas-rail {
   position: fixed;
   top: 50%;
   right: max(0px, env(safe-area-inset-right));
-  display: flex !important;
+  display: flex;
   transform: translateY(-50%);
   pointer-events: auto;
 }


### PR DESCRIPTION
## Summary

- let the mobile canvas rail keep its flex layout without overriding Alpine visibility
- add a regression check tying the mobile CSS rule to the existing rightCanvasRail preference

Closes #1810

## Testing

- pytest -q tests/test_ui_control_visibility.py::test_mobile_canvas_rail_respects_visibility_preference (1 passed)