### PR TITLE
fix: accept complete fenced JSON tool requests

### DIFF
--- a/helpers/extract_tools.py
+++ b/helpers/extract_tools.py
@@ -4,6 +4,12 @@ import regex, re
 from helpers.modules import load_classes_from_file, load_classes_from_folder # keep here for backwards compatibility
 from typing import Any
 
+_JSON_TOOL_REQUEST_FENCE = re.compile(
+    r"```(?:json)?[^\S\r\n]*\r?\n(?P<content>.*?)\r?\n```",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+
+
 def json_parse_dirty(json: str) -> dict[str, Any] | None:
     if not json or not isinstance(json, str):
         return None
@@ -25,6 +31,10 @@ def extract_tool_request(content: str) -> dict[str, Any] | None:
         return None
 
     content = content.strip()
+    fence_match = _JSON_TOOL_REQUEST_FENCE.fullmatch(content)
+    if fence_match is not None:
+        content = fence_match.group("content").strip()
+
     root = extract_json_root_string(content)
     if root != content:
         return None

--- a/helpers/extract_tools.py.dox.md
+++ b/helpers/extract_tools.py.dox.md
@@ -28,7 +28,7 @@
 - Observed side-effect areas: settings/state persistence.
 - Dirty parsing scans complete JSON object roots in prose and prefers the first object that normalizes as a valid tool request for permissive repair and legacy callers.
   Normalization accepts canonical `tool_name`/`tool_args`, legacy `tool`/`args`, native `type="function"` `name`/`parameters`, and a single-item `actions` wrapper; malformed or multi-action wrappers are rejected.
-- `extract_tool_request` is the execution boundary: it accepts a request only when the complete trimmed content is one valid tool object. Plain text, ordinary JSON, and tool-shaped JSON embedded in prose remain final text.
+- `extract_tool_request` is the execution boundary: it accepts a request only when the complete trimmed content is one valid bare tool object or that object is wholly wrapped in one JSON code fence, with or without the `json` language marker. Plain text, ordinary JSON, mixed prose, malformed fences, multiple fences, and tool-shaped JSON embedded in prose are rejected at this execution boundary.
 - `is_misformatted_tool_request` identifies a tool request wrapped in a JSON code fence, concatenated complete roots containing tool intent, or a complete Agent Zero envelope that starts with `thoughts` and whose dirty parser has absorbed `headline`, `tool_name`, and `tool_args` into that list. It routes that output to the existing repair prompt without executing it.
 - Streaming tool snapshots use `extract_tool_request`; the permissive root helpers remain available for repair and legacy callers, not tool execution.
 - Root extraction ignores objects nested inside an open parent object, so streamed wrapper tools such as `parallel` cannot stop early on the first nested `tool_calls` item.

--- a/tests/test_tool_request_normalization.py
+++ b/tests/test_tool_request_normalization.py
@@ -117,16 +117,62 @@ def test_normalize_tool_request_rejects_multiple_wrapped_actions() -> None:
         )
 
 
-def test_extract_tool_request_requires_a_complete_tool_message() -> None:
+def test_extract_tool_request_accepts_bare_json() -> None:
     request = '{"tool_name":"response","tool_args":{"text":"ok"}}'
 
     assert extract_tool_request(request) == {
         "tool_name": "response",
         "tool_args": {"text": "ok"},
     }
+
+
+@pytest.mark.parametrize("language", ["json", ""])
+def test_extract_tool_request_accepts_complete_fenced_json(language: str) -> None:
+    request = '{"tool_name":"response","tool_args":{"text":"ok"}}'
+
+    assert extract_tool_request(f"```{language}\n{request}\n```") == {
+        "tool_name": "response",
+        "tool_args": {"text": "ok"},
+    }
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        'Example: {"tool_name":"response","tool_args":{"text":"ok"}}',
+        '{"tool_name":"response","tool_args":{"text":"ok"}} trailing text',
+        'Example:\n```json\n{"tool_name":"response","tool_args":{"text":"ok"}}\n```',
+        '```json\n{"tool_name":"response","tool_args":{"text":"ok"}}\n```\nDone.',
+        '```json\nRun this:\n{"tool_name":"response","tool_args":{"text":"ok"}}\n```',
+    ],
+)
+def test_extract_tool_request_rejects_mixed_natural_language(content: str) -> None:
+    assert extract_tool_request(content) is None
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        '```json\n{"tool_name":"response","tool_args":{"text":"ok"}}',
+        '```json\n{"tool_name":"response","tool_args":{"text":"ok"}\n```',
+        (
+            '```json\n{"tool_name":"response","tool_args":{"text":"first"}}'
+            '{"tool_name":"response","tool_args":{"text":"second"}}\n```'
+        ),
+        (
+            '```json\n{"tool_name":"response","tool_args":{"text":"first"}}\n```\n'
+            '```json\n{"tool_name":"response","tool_args":{"text":"second"}}\n```'
+        ),
+    ],
+)
+def test_extract_tool_request_rejects_malformed_or_multiple_fences(
+    content: str,
+) -> None:
+    assert extract_tool_request(content) is None
+
+
+def test_extract_tool_request_rejects_non_tool_json() -> None:
     assert extract_tool_request('{"status":"ok"}') is None
-    assert extract_tool_request(f"Example: {request}") is None
-    assert extract_tool_request(f"{request} trailing text") is None
 
 
 def test_is_misformatted_tool_request_requires_agent_tool_envelope() -> None:


### PR DESCRIPTION
## Summary

- unwrap a single code fence when the entire assistant reply is one valid tool-request JSON object
- support both `json`-tagged and untagged fences while keeping the execution boundary fail-closed for prose, malformed fences, multiple fences, and non-tool JSON
- update the helper DOX contract and expand the existing normalization regression suite

Fixes #1811

## Why

`is_misformatted_tool_request()` already recognizes fenced tool JSON, but `extract_tool_request()` only accepted bare JSON. A correct tool call wrapped by a chat model in one Markdown fence therefore entered the misformat circuit breaker instead of executing.

The parser remains intentionally strict: it only unwraps a fence when `fullmatch()` covers the complete trimmed reply, then applies the existing complete-root and tool-envelope checks.

## Verification

- `python -m pytest -q tests/test_tool_request_normalization.py` — 27 passed
- `python -m compileall -q helpers/extract_tools.py`
- `git diff --check origin/main...HEAD`
