### PR TITLE
docs: clarify colon-syntax action dispatch

### DIFF
--- a/skills/a0-development/references/tools.md
+++ b/skills/a0-development/references/tools.md
@@ -29,7 +29,7 @@ class MyTool(Tool):
 | `break_loop` | `True` stops the current message loop. |
 | `additional` | Optional metadata added with the tool result. |
 
-`Tool` instances receive `agent`, `name`, `method`, `args`, `message`, and `loop_data`. Use `self.method` for method-style tools such as `skills_tool:load`.
+`Tool` instances receive `agent`, `name`, `method`, `args`, `message`, and `loop_data`. Multi-action tools should dispatch on `kwargs.get("action")` or `self.args.get("action")`. Request normalization converts colon syntax such as `skills_tool:load` and legacy `tool_args.method` input into `tool_args["action"]` when no explicit action is present; `self.method` is not an action fallback.
 
 ## Locations
 


### PR DESCRIPTION
## Summary

- document that multi-action tools dispatch from the normalized `action` argument
- explain that colon syntax and legacy `tool_args.method` input are normalized to `tool_args["action"]`
- stop recommending `self.method` as an action fallback

Fixes #1669.
Also resolves the duplicate report #1670.

## Testing

- `python -m pytest tests/test_tool_request_normalization.py tests/test_tool_action_contracts.py -q` — 52 passed
- `git diff --check`

This is a documentation-only change; runtime behavior is unchanged.