### PR TITLE
fix(webui): show a vertical scrollbar in the chat list

### DIFF
--- a/tests/test_chat_list_scrollbar.py
+++ b/tests/test_chat_list_scrollbar.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_chat_list_shows_vertical_scrollbar_without_horizontal_scroll() -> None:
+    html = (
+        PROJECT_ROOT / "webui/components/sidebar/chats/chats-list.html"
+    ).read_text(encoding="utf-8")
+
+    assert 'class="config-list chats-config-list"' in html
+    assert 'class="config-list chats-config-list no-scrollbar"' not in html
+
+    style_start = html.index(".chats-config-list {")
+    style = html[style_start : html.index("}", style_start)]
+    assert "overflow-y: auto;" in style
+    assert "overflow-x: hidden;" in style
+    assert "overflow: scroll;" not in style

--- a/webui/components/sidebar/chats/chats-list.html
+++ b/webui/components/sidebar/chats/chats-list.html
@@ -22,7 +22,7 @@
 
 
 
-        <ul class="config-list chats-config-list no-scrollbar" x-show="$store.chats.topLevelContexts().length > 0">
+        <ul class="config-list chats-config-list" x-show="$store.chats.topLevelContexts().length > 0">
           <template x-for="(context, contextIndex) in $store.chats.topLevelContexts()" :key="context.id">
             <li class="chat-tree-item"
               :class="{ 'sidebar-list-divider': $store.sidebar.hasRowDividerBefore('chat', context, contextIndex, $store.chats.topLevelContexts()) }">
@@ -117,7 +117,8 @@
     .chats-config-list {
       flex: 1;
       min-height: 0;
-      overflow: scroll;
+      overflow-x: hidden;
+      overflow-y: auto;
       scroll-behavior: smooth;
       max-height: 100%;
     }


### PR DESCRIPTION
## Summary

- remove the utility that explicitly hides the chat-list scrollbar
- allow vertical scrolling while preventing horizontal overflow
- add a focused regression test for the chat-list classes and overflow rules

Fixes #1685.

## Testing

- `python -m pytest tests/test_chat_list_scrollbar.py tests/test_sidebar_row_actions.py -q` — 6 passed
- `git diff --check`

## Manual testing

Not run in a real browser. Operating systems that use overlay scrollbars may still hide them when idle; this change removes the application-level rule that always hid them.