### PR TITLE
fix: tolerate benign trailing prose after final tool request

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1412,7 +1412,11 @@ class Agent:
     @extension.extensible
     async def process_tools(self, msg: str):
         # search for tool usage requests in agent message
-        tool_request = extract_tools.extract_tool_request(msg)
+        # Final (non-streaming) message: tolerate benign trailing prose after a
+        # complete tool request while still rejecting preamble, concatenated
+        # roots, and brace-bearing suffixes. Streaming snapshots keep the strict
+        # extract_tool_request boundary in models.py callbacks.
+        tool_request = extract_tools.extract_tool_request_final(msg)
 
         raw_tool_name = ""
         tool_args = {}

--- a/helpers/extract_tools.py
+++ b/helpers/extract_tools.py
@@ -33,6 +33,34 @@ def extract_tool_request(content: str) -> dict[str, Any] | None:
     return request if request is not None and _is_tool_request(request) else None
 
 
+def extract_tool_request_final(content: str) -> dict[str, Any] | None:
+    """Extract a tool request from a final, completed message.
+
+    Lenient sibling of :func:`extract_tool_request` for non-streaming use:
+    accepts trailing non-JSON text after a complete tool request. Preamble
+    text before the request, concatenated additional JSON roots, and
+    trailing text containing braces or brackets are still rejected so those
+    cases keep routing to the repair path instead of executing partially.
+    """
+    if not content or not isinstance(content, str):
+        return None
+
+    content = content.strip()
+    if not content.startswith("{"):
+        return None
+
+    root = extract_json_root_string(content)
+    if root is None or not content.startswith(root):
+        return None
+
+    remainder = content[len(root):]
+    if "{" in remainder or "[" in remainder or '"' in remainder:
+        return None
+
+    request = _parse_json_root_object(root)
+    return request if request is not None and _is_tool_request(request) else None
+
+
 def is_misformatted_tool_request(content: str) -> bool:
     if not content or not isinstance(content, str):
         return False

--- a/tests/test_tool_request_normalization.py
+++ b/tests/test_tool_request_normalization.py
@@ -11,6 +11,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from helpers.extract_tools import (
     extract_tool_request,
+    extract_tool_request_final,
     is_misformatted_tool_request,
     json_parse_dirty,
     normalize_tool_request,
@@ -127,6 +128,32 @@ def test_extract_tool_request_requires_a_complete_tool_message() -> None:
     assert extract_tool_request('{"status":"ok"}') is None
     assert extract_tool_request(f"Example: {request}") is None
     assert extract_tool_request(f"{request} trailing text") is None
+
+
+def test_extract_tool_request_final_tolerates_trailing_prose() -> None:
+    request = '{"tool_name":"response","tool_args":{"text":"ok"}}'
+
+    assert extract_tool_request_final(request) == {
+        "tool_name": "response",
+        "tool_args": {"text": "ok"},
+    }
+    assert extract_tool_request_final(f"{request} stray trailing text") == {
+        "tool_name": "response",
+        "tool_args": {"text": "ok"},
+    }
+    # Preamble before the request stays rejected.
+    assert extract_tool_request_final(f"Example: {request}") is None
+    # Concatenated second root still routes to repair, not silent execution.
+    concatenated = f"{request}{{'second':'root'}}"
+    assert extract_tool_request_final(concatenated) is None
+    # Trailing text containing braces or brackets is not benign prose.
+    assert extract_tool_request_final(f"{request} note {{a}}") is None
+    assert extract_tool_request_final(f"{request} note [b]") is None
+    # Truncated payloads stay rejected.
+    assert extract_tool_request_final(request[: int(len(request) * 0.7)]) is None
+    # Non-objects and plain prose stay rejected.
+    assert extract_tool_request_final('{"status":"ok"}') is None
+    assert extract_tool_request_final("plain text only") is None
 
 
 def test_is_misformatted_tool_request_requires_agent_tool_envelope() -> None:


### PR DESCRIPTION
## Problem

When an agent emits a fully valid tool-request JSON followed by stray non-JSON text, the strict equality gate in extract_tool_request (root != content) rejects the whole message as misformat, the tool never executes, and the run degrades into repair loops.

A naive relaxation (accepting any prefix) is unsafe: streaming early-stop and repair routing rely on strict rejection of trailing text, e.g. tests/test_tool_request_normalization.py asserts trailing-text rejection and stream snapshots must not stop early while a second tool call may still be streaming.

## Solution

Boundary-scoped leniency:

- NEW helpers/extract_tools.py extract_tool_request_final() - accepts a complete tool request followed by benign non-JSON trailing prose, while still rejecting preamble text before the request, concatenated additional JSON roots, and trailing text containing braces, brackets, or double quotes so those cases keep routing to repair instead of executing partially.
- agent.py process_tools now calls the final variant for completed messages. Streaming snapshots keep the strict extract_tool_request boundary, so early-stop semantics are untouched.

## Testing

- New regression test test_extract_tool_request_final_tolerates_trailing_prose covering: trailing prose accepted; preamble rejected; concatenated second root rejected; brace/bracket-bearing suffix rejected; truncation rejected; plain JSON and prose rejected.
- All existing assertions in test_tool_request_normalization.py and test_stream_tool_early_stop.py remain green (strict behavior unchanged).
- Verified zero regressions via baseline comparison of failing-test sets before and after the change (identical sets).