### PR TITLE
fix: surface tool load errors in get_tool fallback

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1572,7 +1572,10 @@ class Agent:
             try:
                 classes = extract_tools.load_classes_from_file(path, Tool)  # type: ignore[arg-type]
                 break
-            except Exception:
+            except Exception as error:
+                PrintStyle(font_color="red", padding=True).print(
+                    f"Failed to load tool '{name}' from {path}: {error}"
+                )
                 continue
 
         tool_class = classes[0] if classes else Unknown


### PR DESCRIPTION
## Problem

`Agent.get_tool` silently swallows any exception raised while loading a tool module and falls back to the `Unknown` tool. When a plugin tool fails
to import (e.g. a stale module cache or a missing symbol), the only visible symptom is
the generic **"tool not found"** message, which sends users debugging the tool name
instead of the actual import error.

I hit exactly this while developing a plugin: a helper module cached in `sys.modules` 