### PR TITLE
fix(ui_bundler): revalidate asset-bundle cache signature so patched webui assets invalidate without restart

### DIFF
--- a/helpers/ui_bundler.py
+++ b/helpers/ui_bundler.py
@@ -97,9 +97,6 @@ def get_ui_asset_bundle(
     """Build a versioned recursive text-asset bundle from the supplied entries."""
     entries = list(dict.fromkeys(entry_urls))
     cache_key = _cache_key(entries)
-    cached = cache.get(_CACHE_AREA, cache_key)
-    if cached is not None:
-        return cached["bundle"]
 
     roots, extension_roots = _get_asset_roots(agent)
 
@@ -118,7 +115,15 @@ def get_ui_asset_bundle(
             if url:
                 entries.append(url)
 
+    # Recompute the signature on every call: patched core or plugin webui
+    # assets must invalidate the cached bundle without a process restart.
+    # The filesystem stat cost is acceptable for a once-per-page-load
+    # endpoint; the cached bundle is reused only while it still matches.
     signature = _bundle_signature(roots, entries)
+    cached = cache.get(_CACHE_AREA, cache_key)
+    if cached is not None and cached["signature"] == signature:
+        return cached["bundle"]
+
     result = _build_asset_bundle(entries, roots, signature)
     cache.add(
         _CACHE_AREA,

--- a/helpers/ui_bundler.py.dox.md
+++ b/helpers/ui_bundler.py.dox.md
@@ -21,7 +21,7 @@
 - Valid UTF-8 HTML, CSS, and JavaScript files no larger than 512 KiB each are embedded. Oversized eligible text is still scanned for dependencies but its body is omitted so the browser can request it normally. Images, audio, video, fonts, manifests, and other file types remain under normal browser HTTP caching.
 - Every entry carries the response content type required by browsers and native ES modules.
 - Bundle versions cover the caller entries, cache policy, and HTML/CSS/JavaScript path/mtime/size inventory. Policy or eligible-file changes therefore advance the service-worker cache version; the helper cache also participates in normal extension/plugin invalidation.
-- Caller entry sets have distinct helper-cache keys. A built bundle is returned without rescanning the filesystem until extension/plugin invalidation or process restart; deployed core WebUI changes take effect with the new server process.
+- Caller entry sets have distinct helper-cache keys. Every call recomputes the asset signature and reuses the cached bundle only while the signature still matches, so patched core or plugin WebUI assets invalidate the cached bundle on the next request without a process restart; the signature stat cost runs once per page-load endpoint request.
 - Serialized JSON is returned by the authenticated `/ui/asset-bundle` endpoint rather than inserted into the application document. HTTP gzip compresses the shared transfer.
 
 ## Work Guidance

--- a/tests/test_ui_bundler.py
+++ b/tests/test_ui_bundler.py
@@ -228,3 +228,48 @@ def test_bundle_recursively_scans_a_caller_supplied_entry(
     index_bundle = ui_bundler.get_ui_asset_bundle(["/index.html"], agent=None)
     assert set(index_bundle["files"]) == {"/index.html"}
     assert index_bundle["version"] != bundle["version"]
+
+
+def test_bundle_cache_invalidates_when_plugin_asset_changes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    webui = tmp_path / "webui"
+    extension_root = tmp_path / "extensions" / "webui"
+    plugin_root = tmp_path / "plugins" / "example" / "webui"
+    assets = {
+        webui / "index.html": (
+            '<script type="module" src="/plugins/example/webui/store.js"></script>'
+        ).encode(),
+        plugin_root / "store.js": b"export const slot = 'none';",
+    }
+    for path, content in assets.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+
+    configure_roots(tmp_path, monkeypatch, extension_root, plugin_root)
+    bundle = ui_bundler.get_ui_asset_bundle(["/index.html"], agent=None)
+    assert (
+        bundle["files"]["/plugins/example/webui/store.js"][2]
+        == "export const slot = 'none';"
+    )
+
+    # Unchanged assets keep serving the cached bundle without a rebuild.
+    cached_bundle = ui_bundler.get_ui_asset_bundle(["/index.html"], agent=None)
+    assert cached_bundle is bundle
+
+    # Patching a plugin webui asset must invalidate the in-memory bundle on
+    # the next call without cache.clear() or a process restart, so the served
+    # version advances and clients re-register the service worker
+    # (dev-ticket-2026-08-24). Different content length guarantees the
+    # signature changes even when mtime granularity is coarse.
+    (plugin_root / "store.js").write_bytes(b"export const slot = 'vision';")
+    rebuilt = ui_bundler.get_ui_asset_bundle(["/index.html"], agent=None)
+    assert rebuilt is not bundle
+    assert rebuilt["version"] != bundle["version"]
+    assert (
+        rebuilt["files"]["/plugins/example/webui/store.js"][2]
+        == "export const slot = 'vision';"
+    )
+
+    # The rebuilt bundle is cached again under the new signature.
+    assert ui_bundler.get_ui_asset_bundle(["/index.html"], agent=None) is rebuilt


### PR DESCRIPTION
## Problem

`get_ui_asset_bundle()` cached the UI asset bundle in an in-memory cache keyed by entry-URL hash only, and returned the cached bundle WITHOUT recomputing `_bundle_signature()` (which already covers plugin webui file mtimes). Any change to core or plugin webui assets after process start (e.g. a plugin patching `_model_config/webui/model-config-store.js`) left the server serving a stale bundle version via `/ui/asset-bundle` until restart. The stale version kept splash.html's service-worker registration unchanged, so browsers kept executing pre-patch JS — in our case a preset-save loop that silently dropped a model slot on every save. We hit this on a live deployment with a plugin-patched preset UI.

## Root cause

The cache hit path never revalidated against the signature. The signature function already existed and already covered all asset roots; the bug was purely that it was not checked on cache hits.

## Fix

Recompute the signature on every call (stat-pass over bundle roots, ~300 files, once per page load — negligible); reuse the cached bundle only on signature match; rebuild + re-cache on mismatch. Clients self-heal automatically: new bundle version → splash registers the service worker under the new URL → activate handler purges old caches.

## Verification

- Regression test `test_bundle_cache_invalidates_when_plugin_asset_changes` (touch plugin asset → next `get_ui_asset_bundle` returns new version + new content)
- 4/4 ui_bundler tests + 18/18 related webui asset suites pass
- End-to-end confirmed on a live deployment (patched preset-save UI now persists after the fix; it failed 5× before)
