### PR TITLE
fix(model_config): do not default max_tokens when vision preset uses max_completion_tokens

### DIFF
--- a/plugins/_model_config/helpers/model_config.py
+++ b/plugins/_model_config/helpers/model_config.py
@@ -878,9 +878,14 @@ def build_vision_model(agent=None):
     mc = build_model_config(cfg, models.ModelType.CHAT)
     mc.vision = True
     kwargs = mc.build_kwargs()
+    # Presets may carry max_completion_tokens (OpenAI-style models);
+    # defaulting max_tokens alongside it makes providers reject the call.
+    token_key = (
+        "max_completion_tokens" if "max_completion_tokens" in kwargs else "max_tokens"
+    )
     for key, default in (
         ("timeout", DEFAULT_VISION_TIMEOUT_SECONDS),
-        ("max_tokens", DEFAULT_VISION_MAX_TOKENS),
+        (token_key, DEFAULT_VISION_MAX_TOKENS),
     ):
         value = cfg.get(key)
         if value not in (None, ""):

--- a/tests/test_model_config_project_presets.py
+++ b/tests/test_model_config_project_presets.py
@@ -1228,6 +1228,33 @@ def test_vision_model_build_applies_only_its_preset_call_limits(monkeypatch):
     assert "max_tokens" not in main
 
 
+def test_vision_model_does_not_duplicate_token_params(monkeypatch):
+    from plugins._model_config.helpers import model_config
+
+    calls = []
+
+    def fake_get_chat_model(provider, name, **kwargs):
+        calls.append((provider, name, kwargs))
+        return kwargs
+
+    monkeypatch.setattr(model_config.models, "get_chat_model", fake_get_chat_model)
+    monkeypatch.setattr(
+        model_config,
+        "get_vision_model_config",
+        lambda _agent=None: {
+            "provider": "openai",
+            "name": "gpt-4o-mini",
+            "kwargs": {"max_completion_tokens": 32768},
+        },
+    )
+
+    built = model_config.build_vision_model()
+    assert built["max_completion_tokens"] == 32768
+    assert "max_tokens" not in built
+    assert built["timeout"] == model_config.DEFAULT_VISION_TIMEOUT_SECONDS
+    assert calls[-1][0] == "openai"
+
+
 def test_legacy_utility_preset_defaults_preserve_tuning_but_clear_kwargs(
     monkeypatch,
     tmp_path,


### PR DESCRIPTION
## Problem

With a Vision Model preset whose kwargs include `max_completion_tokens` (as the v2.11 preset UI saves for OpenAI-style models), every vision-model call fails with:

```
litellm.BadRequestError: Setting 'max_tokens' and 'max_completion_tokens' at the same time is not supported.
```

The native `vision_load` delegation path is broken for these presets.

## Root cause

`build_vision_model()` unconditionally `setdefault`s `max_tokens` on top of preset kwargs that already carry `max_completion_tokens`; both keys reach the provider.

## Fix

Default whichever token key the preset already uses (`max_completion_tokens` when present, else `max_tokens`). No behavior change for presets without `max_completion_tokens`.

## Test

`test_vision_model_does_not_duplicate_token_params` — asserts the built vision model kwargs carry exactly one token key when the preset uses `max_completion_tokens`.
