### PR TITLE
Surface custom plugin updates in the WebUI

### DIFF
--- a/api/plugins_list.py.dox.md
+++ b/api/plugins_list.py.dox.md
@@ -18,7 +18,8 @@
 
 - HTTP handlers must derive from `helpers.api.ApiHandler`; WebSocket handlers must derive from `helpers.ws.WsHandler`.
 - Update this file whenever request payloads, authentication or CSRF requirements, response shapes, route side effects, or WebSocket event contracts change.
-- `PluginsList` is an `ApiHandler`.
+- `PluginsList` is an `ApiHandler`; custom plugin records include persisted daily
+  update availability and commit count without fetching remotes on list requests.
 - `PluginsList` defines `process(...)`.
 - Observed side-effect areas: plugin state, settings/state persistence.
 - Imported dependency areas include: `helpers`, `helpers.api`.

--- a/extensions/python/user_message_ui/AGENTS.md
+++ b/extensions/python/user_message_ui/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## Ownership
 
-- Ordered Python files own update-check messaging and future user-message UI hooks.
+- Ordered Python files own Agent Zero and daily custom-plugin update messaging, plus future user-message UI hooks.
 
 ## Local Contracts
 
@@ -17,6 +17,8 @@
 ## Work Guidance
 
 - Gate recurring messages so they do not repeat unnecessarily across chats or tabs.
+- Run remote plugin checks outside the user-message request path, preserve the
+  last good status on remote errors, and retry only failed plugins.
 
 ## Verification
 

--- a/extensions/python/user_message_ui/_10_update_check.py
+++ b/extensions/python/user_message_ui/_10_update_check.py
@@ -1,8 +1,10 @@
 from helpers import notification
+from helpers.defer import DeferredTask
 from helpers.extension import Extension
 from agent import LoopData
-from helpers import files, settings, update_check
+from helpers import files, plugins, settings, update_check
 from helpers.localization import Localization
+import asyncio
 import datetime
 import json
 
@@ -18,6 +20,9 @@ last_notification_id = None
 last_notification_time = datetime.datetime.fromtimestamp(0, tz=Localization.get().get_tzinfo())
 notification_cooldown_seconds = 60 * 60 * 24
 notification_state_file = "usr/update-check-state.json"
+last_plugin_check = datetime.datetime.fromtimestamp(0, tz=Localization.get().get_tzinfo())
+plugin_check_cooldown_seconds = 60 * 60 * 24
+plugin_check_retry_cooldown_seconds = 60 * 60
 
 
 def _now() -> datetime.datetime:
@@ -72,26 +77,97 @@ class UpdateCheck(Extension):
                 return
             last_check = now
             
-            # check for updates
-            version = await update_check.check_version()
+            try:
+                version = await update_check.check_version()
 
-            # if the user should update, send notification
-            if notif := version.get("notification"):
-                now = _now()
-                stored_state = _load_notification_state()
-                stored_notification_time = _parse_timestamp(stored_state.get("last_notification_at"))
-                effective_notification_time = stored_notification_time or last_notification_time
+                # if the user should update, send notification
+                if notif := version.get("notification"):
+                    now = _now()
+                    stored_state = _load_notification_state()
+                    stored_notification_time = _parse_timestamp(stored_state.get("last_notification_at"))
+                    effective_notification_time = stored_notification_time or last_notification_time
 
-                if (now - effective_notification_time).total_seconds() > notification_cooldown_seconds:
-                    last_notification_id = notif.get("id")
-                    last_notification_time = now
-                    try:
-                        _remember_notification(notif, now)
-                    except Exception:
-                        pass
-                    self.send_notification(notif)
+                    if (now - effective_notification_time).total_seconds() > notification_cooldown_seconds:
+                        last_notification_id = notif.get("id")
+                        last_notification_time = now
+                        try:
+                            _remember_notification(notif, now)
+                        except Exception:
+                            pass
+                        self.send_notification(notif)
+            except Exception:
+                pass # no need to log if the update server is inaccessible
+
+            DeferredTask().start_task(self.check_plugin_updates, now)
         except Exception as e:
-            pass # no need to log if the update server is inaccessible
+            pass # no need to log if an update check is inaccessible
+
+    async def check_plugin_updates(self, now: datetime.datetime):
+        global last_plugin_check
+
+        checked_at, previous_updates = plugins.get_custom_plugin_update_state()
+        failed_plugin_names = [
+            name for name, update in previous_updates.items() if update.error
+        ]
+        stored_check_time = _parse_timestamp(checked_at)
+        if failed_plugin_names:
+            effective_check_time = last_plugin_check
+            cooldown_seconds = plugin_check_retry_cooldown_seconds
+        else:
+            effective_check_time = max(
+                stored_check_time or last_plugin_check,
+                last_plugin_check,
+            )
+            cooldown_seconds = plugin_check_cooldown_seconds
+        if (now - effective_check_time).total_seconds() < cooldown_seconds:
+            return
+        previous_check_time = last_plugin_check
+        last_plugin_check = now
+
+        try:
+            updates = await asyncio.to_thread(
+                plugins.get_custom_plugins_updates,
+                failed_plugin_names or None,
+            )
+        except Exception:
+            last_plugin_check = previous_check_time
+            return
+
+        merged_updates = previous_updates.copy() if failed_plugin_names else {}
+        returned_plugin_names = {update.name for update in updates}
+        for plugin_name in failed_plugin_names:
+            if plugin_name not in returned_plugin_names:
+                merged_updates.pop(plugin_name, None)
+        for update in updates:
+            previous_update = previous_updates.get(update.name)
+            if update.error and previous_update:
+                update = previous_update.model_copy(update={"error": update.error})
+            merged_updates[update.name] = update
+
+        has_errors = any(update.error for update in merged_updates.values())
+        try:
+            plugins.save_custom_plugin_updates(
+                list(merged_updates.values()),
+                checked_at if has_errors else now.isoformat(),
+            )
+        except Exception:
+            last_plugin_check = previous_check_time
+            return
+
+        previous_available = {
+            name
+            for name, update in previous_updates.items()
+            if update.commits_since_local > 0
+        }
+        available = {
+            name
+            for name, update in merged_updates.items()
+            if update.commits_since_local > 0
+        }
+        if available and (
+            not failed_plugin_names or available - previous_available
+        ):
+            self.send_plugin_update_notification(len(available))
 
 
     def send_notification(self, notif):
@@ -120,4 +196,28 @@ class UpdateCheck(Extension):
             group=notif.get("group", "update_check"),
             priority=notif.get("priority", notification.NotificationPriority.NORMAL),
             id=notif.get("id", "update_check_available"),
+        )
+
+    def send_plugin_update_notification(self, update_count: int):
+        if not self.agent:
+            return
+
+        count_label = "plugin has" if update_count == 1 else "plugins have"
+        message = (
+            f"{update_count} custom {count_label} updates available."
+            '<div class="toast-action-row">'
+            '<button type="button" class="button confirm" '
+            '@click="$store.pluginListStore.open(\'custom\'); '
+            '$store.notificationStore.dismissToast(toast.toastId)">'
+            "Open plugins</button></div>"
+        )
+        self.agent.context.get_notification_manager().send_notification(
+            title="Plugin updates available",
+            message=message,
+            type=notification.NotificationType.INFO,
+            detail="",
+            display_time=0,
+            group="plugin_updates",
+            priority=notification.NotificationPriority.NORMAL,
+            id="custom_plugin_updates_available",
         )

--- a/helpers/plugins.py
+++ b/helpers/plugins.py
@@ -66,6 +66,7 @@ HOOKS_CACHE_AREA = "plugin_hooks(plugins)"
 PLUGINS_LIST_CACHE_AREA = "plugins_list(plugins)"
 ENABLED_PLUGINS_LIST_CACHE_AREA = "enabled_plugins(plugins)"
 ENABLED_PLUGINS_PATHS_CACHE_AREA = "enabled_plugins_paths(plugins)"
+CUSTOM_PLUGIN_UPDATE_STATE_FILE = "usr/plugin-update-check-state.json"
 
 
 _last_frontend_reload_notification_at = 0.0
@@ -103,6 +104,8 @@ class PluginListItem(BaseModel):
     toggle_state: ToggleState = "disabled"
     current_commit: str = ""
     current_commit_timestamp: str = ""
+    update_available: bool = False
+    update_commits: int = 0
     thumbnail_url: str = ""
 
 
@@ -268,6 +271,7 @@ def get_enhanced_plugins_list(
     """Discover plugins by directory convention. First root wins on ID conflict."""
     results = []
     allowed_names = set(plugin_names) if plugin_names else None
+    _checked_at, custom_plugin_updates = get_custom_plugin_update_state() if custom else ("", {})
 
     def load_plugins(root_path: str, is_custom: bool):
         for d in sorted(Path(root_path).iterdir(), key=lambda p: p.name):
@@ -305,6 +309,7 @@ def get_enhanced_plugins_list(
                         if repo_info.head:
                             current_commit = repo_info.head.hash
                             current_commit_timestamp = repo_info.head.committed_at
+                update = custom_plugin_updates.get(d.name)
                 results.append(
                     PluginListItem(
                         name=d.name,
@@ -327,6 +332,8 @@ def get_enhanced_plugins_list(
                         toggle_state=toggle_state,
                         current_commit=current_commit,
                         current_commit_timestamp=current_commit_timestamp,
+                        update_available=bool(update and update.commits_since_local),
+                        update_commits=update.commits_since_local if update else 0,
                         thumbnail_url=thumbnail_url,
                     )
                 )
@@ -367,6 +374,50 @@ def get_custom_plugins_updates(
         )
 
     return results
+
+
+def get_custom_plugin_update_state() -> tuple[str, dict[str, PluginUpdateInfo]]:
+    try:
+        state = json.loads(files.read_file(CUSTOM_PLUGIN_UPDATE_STATE_FILE))
+        updates = state.get("updates", [])
+        if not isinstance(updates, list):
+            return "", {}
+
+        result: dict[str, PluginUpdateInfo] = {}
+        for update in updates:
+            try:
+                item = PluginUpdateInfo.model_validate(update)
+            except Exception:
+                continue
+            result[item.name] = item
+        return str(state.get("checked_at", "")), result
+    except Exception:
+        return "", {}
+
+
+def save_custom_plugin_updates(
+    updates: list[PluginUpdateInfo], checked_at: str
+) -> None:
+    files.write_file(
+        CUSTOM_PLUGIN_UPDATE_STATE_FILE,
+        json.dumps(
+            {
+                "checked_at": checked_at,
+                "updates": [update.model_dump(mode="json") for update in updates],
+            },
+            indent=2,
+        ),
+    )
+
+
+def clear_custom_plugin_update(plugin_name: str) -> None:
+    checked_at, updates = get_custom_plugin_update_state()
+    if plugin_name in updates:
+        del updates[plugin_name]
+        try:
+            save_custom_plugin_updates(list(updates.values()), checked_at)
+        except Exception:
+            pass
 
 
 def get_plugin_meta(plugin_name: str):

--- a/helpers/plugins.py.dox.md
+++ b/helpers/plugins.py.dox.md
@@ -25,6 +25,7 @@
 - `get_plugins_list()`
 - `get_enhanced_plugins_list(custom: bool=..., builtin: bool=..., plugin_names: list[str] | None=...) -> List[PluginListItem]`: Discover plugins by directory convention. First root wins on ID conflict.
 - `get_custom_plugins_updates(plugin_names: list[str] | None=...) -> List[PluginUpdateInfo]`
+- `get_custom_plugin_update_state() -> tuple[str, dict[str, PluginUpdateInfo]]`, `save_custom_plugin_updates(...)`, and `clear_custom_plugin_update(...)`: persist the daily remote-commit status used by the Custom plugin list; clearing advisory status is best-effort after a successful update.
 - `get_plugin_meta(plugin_name: str)`
 - `find_plugin_dir(plugin_name: str)`
 - `uninstall_plugin(plugin_name)`
@@ -55,6 +56,8 @@
   `agent`, or `api`; this is behavioral context, not an authorization boundary.
 - Project- and agent-scoped plugin changes invalidate runtime caches without a
   frontend reload prompt because the loaded WebUI extension bundle is global.
+- Custom plugin list items expose the last daily remote-commit result as
+  `update_available` and `update_commits`; list rendering never fetches remotes.
 - Update this file whenever public functions, classes, persistence behavior, path/security assumptions, side effects, or cross-module contracts change.
 - Observed side-effect areas: filesystem reads, filesystem writes, filesystem deletion, WebSocket state, plugin state, settings/state persistence, secret handling.
 - Imported dependency areas include: `__future__`, `asyncio`, `glob`, `helpers`, `helpers.defer`, `helpers.watchdog`, `json`, `pathlib`, `pydantic`, `re`, `regex`, `time`, `typing`.

--- a/plugins/_plugin_installer/README.md
+++ b/plugins/_plugin_installer/README.md
@@ -13,7 +13,7 @@ This plugin provides the built-in installation workflow for third-party plugins.
 - **Git install**
   - Clones a repository to a temporary directory, validates the plugin, then installs it into `usr/plugins/`.
 - **Plugin update**
-  - Updates already installed Git-backed custom plugins and re-runs installation hooks.
+  - Checks Git-backed custom plugins daily during the normal update check, shows available updates in the Custom list, and re-runs installation hooks after an update.
 - **Safety checks**
   - Rejects archives with unsafe paths.
   - Rejects missing or invalid `plugin.yaml` files.

--- a/plugins/_plugin_installer/helpers/install.py
+++ b/plugins/_plugin_installer/helpers/install.py
@@ -273,6 +273,7 @@ def update_from_git(plugin_name: str) -> dict:
         raise
 
     after_plugin_change([plugin_name])
+    plugins.clear_custom_plugin_update(plugin_name)
     head = repo.head.commit
 
     return {

--- a/plugins/_plugin_installer/webui/pluginInstallStore.js
+++ b/plugins/_plugin_installer/webui/pluginInstallStore.js
@@ -816,13 +816,12 @@ const model = {
     return this.selectedPlugin?.["updated"] || "";
   },
 
-  async handleUpdatePlugin() {
-    const selectedPlugin = this["selectedPlugin"];
-    const pluginRecord = selectedPlugin && typeof selectedPlugin === "object" ? selectedPlugin : {};
-    const pluginKey = pluginRecord["key"] || pluginRecord["name"] || this.installedPluginInfo?.name || "";
+  async updatePlugin(plugin) {
+    const pluginRecord = plugin && typeof plugin === "object" ? plugin : {};
+    const pluginKey = pluginRecord["key"] || pluginRecord["name"] || "";
     if (!pluginKey) {
       void toastFrontendError("Plugin name is missing", "Plugin Installer");
-      return;
+      return null;
     }
 
     const confirmed = await showConfirmDialog({
@@ -835,9 +834,7 @@ const model = {
         gitUrl: pluginRecord["github"] || "",
       },
     });
-    if (!confirmed) return;
-
-    this.detailError = null;
+    if (!confirmed) return null;
 
     try {
       this.loading = true;
@@ -850,38 +847,53 @@ const model = {
 
       if (!(data?.ok && data?.success)) {
         const message = data?.error || "Update failed";
-        this.detailError = {
-          kind: data?.error_kind || "update_failed",
-          message,
-          conflicting_files: Array.isArray(data?.conflicting_files) ? data.conflicting_files : [],
-        };
         void toastFrontendError(message, "Plugin Installer");
-        return;
+        return data;
       }
-
-      await this.fetchIndex();
-
-      const installedPluginsSource = this["installedPlugins"];
-      const installedPlugins = Array.isArray(installedPluginsSource) ? Array.from(installedPluginsSource) : [];
-      if (!installedPlugins.some((installedKey) => installedKey === pluginKey)) {
-        installedPlugins.push(String(pluginKey));
-        Reflect.set(this, "installedPlugins", installedPlugins);
-      }
-
-      await this._refreshSelectedPluginState(pluginKey);
-      this.refreshPluginList();
 
       toastFrontendSuccess(
         `Plugin "${data.title || data.plugin_name}" updated`,
         "Plugin Installer"
       );
+      return data;
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       void toastFrontendError(`Update error: ${message}`, "Plugin Installer");
+      return null;
     } finally {
       this.loading = false;
       this.loadingMessage = "";
     }
+  },
+
+  async handleUpdatePlugin() {
+    const selectedPlugin = this["selectedPlugin"];
+    const pluginRecord = selectedPlugin && typeof selectedPlugin === "object" ? selectedPlugin : {};
+    const pluginKey = pluginRecord["key"] || pluginRecord["name"] || this.installedPluginInfo?.name || "";
+    this.detailError = null;
+    const data = await this.updatePlugin({ ...pluginRecord, name: pluginKey });
+    if (!data) return;
+
+    if (!(data?.ok && data?.success)) {
+      this.detailError = {
+        kind: data?.error_kind || "update_failed",
+        message: data?.error || "Update failed",
+        conflicting_files: Array.isArray(data?.conflicting_files) ? data.conflicting_files : [],
+      };
+      return;
+    }
+
+    await this.fetchIndex();
+
+    const installedPluginsSource = this["installedPlugins"];
+    const installedPlugins = Array.isArray(installedPluginsSource) ? Array.from(installedPluginsSource) : [];
+    if (!installedPlugins.some((installedKey) => installedKey === pluginKey)) {
+      installedPlugins.push(String(pluginKey));
+      Reflect.set(this, "installedPlugins", installedPlugins);
+    }
+
+    await this._refreshSelectedPluginState(pluginKey);
+    this.refreshPluginList();
   },
 
   getThumbnailUrl(plugin) {

--- a/tests/test_plugin_update_check.py
+++ b/tests/test_plugin_update_check.py
@@ -1,0 +1,233 @@
+import asyncio
+import datetime
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from helpers import files, plugins
+
+
+def test_custom_plugin_list_uses_persisted_update_status(tmp_path, monkeypatch):
+    monkeypatch.setattr(files, "_base_dir", str(tmp_path))
+    plugin_dir = tmp_path / "usr/plugins/demo"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text("name: demo\ntitle: Demo\n", encoding="utf-8")
+
+    plugins.save_custom_plugin_updates(
+        [
+            plugins.PluginUpdateInfo(
+                name="demo",
+                path=str(plugin_dir),
+                commits_since_local=2,
+            )
+        ],
+        "2026-08-29T12:00:00+00:00",
+    )
+
+    item = plugins.get_enhanced_plugins_list(
+        custom=True, builtin=False, plugin_names=["demo"]
+    )[0]
+    assert item.update_available is True
+    assert item.update_commits == 2
+
+    plugins.clear_custom_plugin_update("demo")
+    item = plugins.get_enhanced_plugins_list(
+        custom=True, builtin=False, plugin_names=["demo"]
+    )[0]
+    assert item.update_available is False
+    assert item.update_commits == 0
+
+
+def test_update_status_cleanup_cannot_fail_a_completed_plugin_update(monkeypatch):
+    update = plugins.PluginUpdateInfo(name="demo", path="/a0/usr/plugins/demo")
+
+    def fail_save(*_args):
+        raise OSError("read-only state")
+
+    monkeypatch.setattr(
+        plugins,
+        "get_custom_plugin_update_state",
+        lambda: ("2026-08-29T12:00:00+00:00", {"demo": update}),
+    )
+    monkeypatch.setattr(plugins, "save_custom_plugin_updates", fail_save)
+
+    plugins.clear_custom_plugin_update("demo")
+
+
+def test_custom_plugin_update_controls_use_the_shared_updater():
+    list_html = (PROJECT_ROOT / "webui/components/plugins/list/plugin-list.html").read_text(
+        encoding="utf-8"
+    )
+    list_store = (
+        PROJECT_ROOT / "webui/components/plugins/list/pluginListStore.js"
+    ).read_text(encoding="utf-8")
+    installer_store = (
+        PROJECT_ROOT / "plugins/_plugin_installer/webui/pluginInstallStore.js"
+    ).read_text(encoding="utf-8")
+    update_check = (
+        PROJECT_ROOT / "extensions/python/user_message_ui/_10_update_check.py"
+    ).read_text(encoding="utf-8")
+
+    assert "plugin.update_available" in list_html
+    assert "pluginListStore.updatePlugin(plugin)" in list_html
+    assert "pluginInstallStore.updatePlugin(plugin)" in list_store
+    assert "window.ensureModalOpen || window.openModal" in list_store
+    assert 'action: "update_plugin"' in installer_store
+    assert "custom_plugin_updates_available" in update_check
+    assert "pluginListStore.open" in update_check
+
+
+def test_daily_plugin_check_persists_updates_and_notifies(monkeypatch):
+    update_check = importlib.import_module(
+        "extensions.python.user_message_ui._10_update_check"
+    )
+    updates = [
+        plugins.PluginUpdateInfo(
+            name="demo",
+            path="/a0/usr/plugins/demo",
+            commits_since_local=1,
+        )
+    ]
+    saved = []
+    sent = []
+
+    async def fake_to_thread(callback, plugin_names):
+        assert callback is plugins.get_custom_plugins_updates
+        assert plugin_names is None
+        return updates
+
+    monkeypatch.setattr(update_check, "last_plugin_check", datetime.datetime.min.replace(tzinfo=datetime.UTC))
+    monkeypatch.setattr(
+        update_check.plugins,
+        "get_custom_plugin_update_state",
+        lambda: ("2026-08-28T00:00:00+00:00", {"demo": updates[0]}),
+    )
+    monkeypatch.setattr(update_check.plugins, "save_custom_plugin_updates", lambda *args: saved.append(args))
+    monkeypatch.setattr(update_check.asyncio, "to_thread", fake_to_thread)
+    checker = update_check.UpdateCheck(
+        SimpleNamespace(
+            context=SimpleNamespace(
+                get_notification_manager=lambda: SimpleNamespace(
+                    send_notification=lambda **kwargs: sent.append(kwargs)
+                )
+            )
+        )
+    )
+
+    asyncio.run(
+        checker.check_plugin_updates(
+            datetime.datetime(2026, 8, 29, tzinfo=datetime.UTC)
+        )
+    )
+
+    assert saved == [(updates, "2026-08-29T00:00:00+00:00")]
+    assert sent[0]["id"] == "custom_plugin_updates_available"
+    assert "pluginListStore.open" in sent[0]["message"]
+
+
+def test_plugin_check_preserves_good_state_and_retries_only_failures(monkeypatch):
+    update_check = importlib.import_module(
+        "extensions.python.user_message_ui._10_update_check"
+    )
+    checked_at = "2026-08-28T00:00:00+00:00"
+    previous = plugins.PluginUpdateInfo(
+        name="demo",
+        path="/a0/usr/plugins/demo",
+        commits_since_local=2,
+    )
+    failed = previous.model_copy(
+        update={"commits_since_local": 0, "error": "remote unavailable"}
+    )
+    recovered = previous.model_copy(update={"commits_since_local": 3})
+    state = {"checked_at": checked_at, "updates": {"demo": previous}}
+    requested = []
+    saved = []
+
+    async def fake_to_thread(callback, plugin_names):
+        assert callback is plugins.get_custom_plugins_updates
+        requested.append(plugin_names)
+        return [failed] if len(requested) == 1 else [recovered]
+
+    def save(updates, saved_checked_at):
+        saved.append((updates, saved_checked_at))
+        state["checked_at"] = saved_checked_at
+        state["updates"] = {update.name: update for update in updates}
+
+    monkeypatch.setattr(
+        update_check,
+        "last_plugin_check",
+        datetime.datetime.min.replace(tzinfo=datetime.UTC),
+    )
+    monkeypatch.setattr(
+        update_check.plugins,
+        "get_custom_plugin_update_state",
+        lambda: (state["checked_at"], state["updates"]),
+    )
+    monkeypatch.setattr(update_check.plugins, "save_custom_plugin_updates", save)
+    monkeypatch.setattr(update_check.asyncio, "to_thread", fake_to_thread)
+    checker = update_check.UpdateCheck(None)
+
+    asyncio.run(
+        checker.check_plugin_updates(
+            datetime.datetime(2026, 8, 29, 1, tzinfo=datetime.UTC)
+        )
+    )
+    assert requested == [None]
+    assert saved[-1][0][0].commits_since_local == 2
+    assert saved[-1][0][0].error == "remote unavailable"
+    assert saved[-1][1] == checked_at
+
+    asyncio.run(
+        checker.check_plugin_updates(
+            datetime.datetime(2026, 8, 29, 1, 30, tzinfo=datetime.UTC)
+        )
+    )
+    assert requested == [None]
+
+    asyncio.run(
+        checker.check_plugin_updates(
+            datetime.datetime(2026, 8, 29, 2, tzinfo=datetime.UTC)
+        )
+    )
+    assert requested == [None, ["demo"]]
+    assert saved[-1][0][0].commits_since_local == 3
+    assert saved[-1][0][0].error == ""
+    assert saved[-1][1] == "2026-08-29T02:00:00+00:00"
+
+
+def test_plugin_check_is_scheduled_outside_the_user_message_request(monkeypatch):
+    update_check = importlib.import_module(
+        "extensions.python.user_message_ui._10_update_check"
+    )
+    scheduled = []
+
+    class FakeDeferredTask:
+        def start_task(self, callback, *args):
+            scheduled.append((callback, args))
+
+    async def fake_check_version():
+        return {}
+
+    monkeypatch.setattr(
+        update_check,
+        "last_check",
+        datetime.datetime.min.replace(tzinfo=datetime.UTC),
+    )
+    monkeypatch.setattr(update_check, "DeferredTask", FakeDeferredTask)
+    monkeypatch.setattr(update_check.update_check, "check_version", fake_check_version)
+    monkeypatch.setattr(
+        update_check.settings,
+        "get_settings",
+        lambda: {"update_check_enabled": True},
+    )
+    checker = update_check.UpdateCheck(SimpleNamespace())
+
+    asyncio.run(checker.execute())
+
+    assert scheduled == [(checker.check_plugin_updates, (update_check.last_check,))]

--- a/webui/components/plugins/list/plugin-list.html
+++ b/webui/components/plugins/list/plugin-list.html
@@ -97,6 +97,15 @@
                                             <code class="plugin-path" x-text="plugin.path"></code>
                                         </div>
                                         <div class="plugin-actions" x-data="{ actionsOpen: false }">
+                                            <template x-if="$store.pluginListStore.activeTab === 'custom' && plugin.update_available">
+                                                <button type="button"
+                                                    class="button confirm"
+                                                    :title="`Update (${plugin.update_commits} commit${plugin.update_commits === 1 ? '' : 's'})`"
+                                                    :disabled="$store.pluginListStore.loading"
+                                                    @click="$store.pluginListStore.updatePlugin(plugin)">
+                                                    <x-icon class="icon" name="system_update"></x-icon> Update
+                                                </button>
+                                            </template>
                                             <template x-if="plugin.has_main_screen">
                                                 <button type="button"
                                                     class="button"

--- a/webui/components/plugins/list/pluginListStore.js
+++ b/webui/components/plugins/list/pluginListStore.js
@@ -25,7 +25,8 @@ const model = {
 
   async open(tab = "custom") {
     await this.setTab(tab);
-    window.openModal?.(MODAL_PATH);
+    const openModal = window.ensureModalOpen || window.openModal;
+    await openModal?.(MODAL_PATH);
   },
 
   async init() {
@@ -218,6 +219,21 @@ const model = {
       "/plugins/_plugin_installer/webui/pluginInstallStore.js"
     );
     await pluginInstallStore.openPluginHubDetailByKey(pluginKey);
+  },
+
+  async updatePlugin(plugin) {
+    if (!plugin?.name || !plugin.update_available) return;
+
+    this.loading = true;
+    try {
+      const { store: pluginInstallStore } = await import(
+        "/plugins/_plugin_installer/webui/pluginInstallStore.js"
+      );
+      const data = await pluginInstallStore.updatePlugin(plugin);
+      if (data?.ok && data?.success) await this.refresh();
+    } finally {
+      this.loading = false;
+    }
   },
 
   async deletePlugin(plugin) {

--- a/webui/index.js
+++ b/webui/index.js
@@ -15,6 +15,7 @@ import { store as _tooltipsStore } from "/components/tooltips/tooltip-store.js";
 import { store as messageQueueStore } from "/components/chat/message-queue/message-queue-store.js";
 import { store as syncStore } from "/components/sync/sync-store.js"
 import { store as welcomeStore } from "/components/welcome/welcome-store.js";
+import { store as pluginListStore } from "/components/plugins/list/pluginListStore.js";
 import { store as modelGateStore } from "/components/chat/model-gate-store.js";
 import { getUserHour12, getUserTimezone } from "/js/time-utils.js";
 import { createThreeBubbleLoader } from "/js/loading-indicators.js";


### PR DESCRIPTION
## Summary

- run daily custom-plugin update checks in the background without delaying user messages
- preserve the last good status across remote failures and retry only failed plugins hourly
- show a persistent toast that opens the Plugins modal in the Custom tab
- show Update actions for custom plugins and reuse the existing installer confirmation and update flow
- clear advisory update state after a successful plugin update without turning cleanup failures into update failures

## Verification

- `conda run -n a0 python -m pytest tests/test_plugin_update_check.py tests/test_plugin_git_update.py tests/test_plugin_activation_ui.py tests/test_download_toast_regressions.py tests/test_defer_lifecycle.py -q` (`29 passed`)
- JavaScript syntax checks for both changed stores
- Python compilation and `git diff --check`
- live Docker runtime at `http://localhost:32081`: source/runtime hashes matched, HTTP 200, background update hook returned in 1.1 ms, toast opened the existing Custom plugins modal without duplication, and the browser console stayed clean