### PR TITLE
fix(model_config): improve mobile responsiveness and dropdown boundary constraints

### DIFF
--- a/plugins/_model_config/extensions/webui/chat-input-progress-start/model-switcher.html
+++ b/plugins/_model_config/extensions/webui/chat-input-progress-start/model-switcher.html
@@ -467,16 +467,16 @@
       max-width: min(95px, 26vw);
     }
     .model-switcher-dropdown {
-      left: 0 !important;
-      right: auto !important;
-      min-width: min(260px, calc(100vw - 24px)) !important;
-      max-width: calc(100vw - 24px) !important;
+      left: 0;
+      right: auto;
+      min-width: min(260px, calc(100vw - 24px));
+      max-width: calc(100vw - 24px);
     }
     .agent-profile-dropdown {
-      right: 0 !important;
-      left: auto !important;
-      min-width: min(240px, calc(100vw - 24px)) !important;
-      max-width: calc(100vw - 24px) !important;
+      right: 0;
+      left: auto;
+      min-width: min(240px, calc(100vw - 24px));
+      max-width: calc(100vw - 24px);
     }
   }
 

--- a/plugins/_model_config/extensions/webui/chat-input-progress-start/model-switcher.html
+++ b/plugins/_model_config/extensions/webui/chat-input-progress-start/model-switcher.html
@@ -206,7 +206,12 @@
     align-items: center;
     gap: 8px;
     min-width: 0;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+  }
+  .model-switcher-anchor,
+  .agent-profile-anchor {
+    min-width: 0;
+    flex-shrink: 1;
   }
   .model-context-strip > x-extension,
   .model-context-strip > x-extension > x-component,
@@ -285,7 +290,9 @@
     position: absolute;
     bottom: calc(100% + 6px);
     left: 0;
+    right: auto;
     min-width: 280px;
+    max-width: min(320px, calc(100vw - 24px));
     max-height: 550px;
     overflow-y: auto;
     background-color: var(--color-panel);
@@ -298,9 +305,10 @@
   .agent-profile-dropdown {
     position: absolute;
     bottom: calc(100% + 6px);
-    left: 0;
+    right: 0;
+    left: auto;
     min-width: 260px;
-    max-width: min(320px, 90vw);
+    max-width: min(320px, calc(100vw - 24px));
     max-height: 550px;
     overflow-y: auto;
     background-color: var(--color-panel);
@@ -443,11 +451,41 @@
   }
 
   @media (max-width: 600px) {
+    .model-context-strip {
+      gap: 4px;
+      flex-wrap: nowrap;
+    }
+    .model-switcher-btn,
+    .agent-profile-btn {
+      padding: 3px 6px;
+      font-size: 0.7rem;
+    }
     .model-switcher-label {
-      max-width: 160px;
+      max-width: min(130px, 34vw);
     }
     .agent-profile-label {
-      max-width: 92px;
+      max-width: min(95px, 26vw);
+    }
+    .model-switcher-dropdown {
+      left: 0 !important;
+      right: auto !important;
+      min-width: min(260px, calc(100vw - 24px)) !important;
+      max-width: calc(100vw - 24px) !important;
+    }
+    .agent-profile-dropdown {
+      right: 0 !important;
+      left: auto !important;
+      min-width: min(240px, calc(100vw - 24px)) !important;
+      max-width: calc(100vw - 24px) !important;
+    }
+  }
+
+  @media (max-width: 420px) {
+    .model-switcher-label {
+      max-width: min(100px, 30vw);
+    }
+    .agent-profile-label {
+      max-width: min(75px, 22vw);
     }
   }
 </style>


### PR DESCRIPTION
## Summary

This PR improves mobile usability and dropdown layout constraints for the `_model_config` plugin's model and agent profile switchers.

### Changes
- **Dropdown Boundaries:** Added max-width constraints (`max-width: min(320px, calc(100vw - 24px))`) and aligned `.agent-profile-dropdown` to `right: 0` to prevent dropdown menus from overflowing viewport edges on mobile devices.
- **Flex Layout Stabilization:** Set `.model-context-strip` to `flex-wrap: nowrap` and anchors to `min-width: 0; flex-shrink: 1;` to avoid layout breaks on long model/preset names.
- **Mobile Styling:** Added `@media (max-width: 600px)` and `@media (max-width: 420px)` queries with scaled padding, compact font sizing, and dynamic label truncation (`max-width: min(130px, 34vw)`).

### Verification
- Tested dropdown rendering on desktop and responsive mobile viewports (360px–420px widths).
- Verified that long profile and model names truncate gracefully without pushing UI elements off-screen.