### PR TITLE
Fix vision model sending max_tokens and max_completion_tokens together

### DIFF
--- a/plugins/_model_config/helpers/model_config.py
+++ b/plugins/_model_config/helpers/model_config.py
@@ -882,6 +882,10 @@ def build_vision_model(agent=None):
         ("timeout", DEFAULT_VISION_TIMEOUT_SECONDS),
         ("max_tokens", DEFAULT_VISION_MAX_TOKENS),
     ):
+        if key == "max_tokens" and "max_completion_tokens" in kwargs:
+            # OpenAI rejects requests that set both max_tokens and
+            # max_completion_tokens; preset kwargs already set the limit.
+            continue
         value = cfg.get(key)
         if value not in (None, ""):
             kwargs[key] = _normalize_kwargs({key: value})[key]

--- a/plugins/_model_config/tests/test_build_vision_model_max_tokens.py
+++ b/plugins/_model_config/tests/test_build_vision_model_max_tokens.py
@@ -1,0 +1,85 @@
+from plugins._model_config.helpers import model_config
+
+
+class _StubChatModel:
+    def __init__(self, provider, name, model_config=None, **kwargs):
+        self.provider = provider
+        self.name = name
+        self.model_config = model_config
+        self.kwargs = kwargs
+
+
+def _patch_builder(monkeypatch, cfg):
+    """Stub config resolution and model construction; return kwargs capture."""
+    monkeypatch.setattr(
+        model_config, "get_vision_model_config", lambda agent=None: dict(cfg)
+    )
+    captured = {}
+
+    def fake_get_chat_model(provider, name, model_config=None, **kwargs):
+        captured["provider"] = provider
+        captured["name"] = name
+        captured["kwargs"] = kwargs
+        return _StubChatModel(provider, name, model_config=model_config, **kwargs)
+
+    monkeypatch.setattr(model_config.models, "get_chat_model", fake_get_chat_model)
+    return captured
+
+
+def _base_cfg(**extra):
+    cfg = {
+        "provider": "openai",
+        "name": "gpt-4o-mini",
+        "api_key": "",
+        "kwargs": {},
+    }
+    cfg.update(extra)
+    return cfg
+
+
+def test_max_tokens_injected_without_max_completion_tokens(monkeypatch):
+    """No kwargs collision: default max_tokens is still injected."""
+    captured = _patch_builder(monkeypatch, _base_cfg())
+    model_config.build_vision_model()
+    kwargs = captured["kwargs"]
+    assert kwargs["max_tokens"] == model_config.DEFAULT_VISION_MAX_TOKENS
+    assert kwargs["timeout"] == model_config.DEFAULT_VISION_TIMEOUT_SECONDS
+    assert "max_completion_tokens" not in kwargs
+
+
+def test_max_tokens_not_injected_with_max_completion_tokens(monkeypatch):
+    """Regression: preset kwargs with max_completion_tokens must not get
+    max_tokens injected too; OpenAI rejects requests setting both."""
+    captured = _patch_builder(
+        monkeypatch,
+        _base_cfg(kwargs={"max_completion_tokens": 32768}),
+    )
+    model_config.build_vision_model()
+    kwargs = captured["kwargs"]
+    assert "max_tokens" not in kwargs
+    assert kwargs["max_completion_tokens"] == 32768
+    assert kwargs["timeout"] == model_config.DEFAULT_VISION_TIMEOUT_SECONDS
+
+
+def test_explicit_slot_max_tokens_injected_without_collision(monkeypatch):
+    """Explicit slot-level max_tokens with no kwargs collision is injected."""
+    captured = _patch_builder(monkeypatch, _base_cfg(max_tokens=4096))
+    model_config.build_vision_model()
+    kwargs = captured["kwargs"]
+    assert kwargs["max_tokens"] == 4096
+    assert kwargs["timeout"] == model_config.DEFAULT_VISION_TIMEOUT_SECONDS
+    assert "max_completion_tokens" not in kwargs
+
+
+def test_max_completion_tokens_wins_over_slot_max_tokens(monkeypatch):
+    """Both set: max_completion_tokens wins, max_tokens is never injected.
+    Mirrors the Responses-API de-collision precedence in
+    helpers/litellm_transport.py (max_completion_tokens or max_tokens)."""
+    captured = _patch_builder(
+        monkeypatch,
+        _base_cfg(max_tokens=4096, kwargs={"max_completion_tokens": 32768}),
+    )
+    model_config.build_vision_model()
+    kwargs = captured["kwargs"]
+    assert "max_tokens" not in kwargs
+    assert kwargs["max_completion_tokens"] == 32768


### PR DESCRIPTION
## Problem

Setting `max_completion_tokens` in a vision preset's kwargs breaks every `vision_load` call with:

```
litellm.BadRequestError: OpenAIException - Setting 'max_tokens' and 'max_completion_tokens' at the same time is not supported.
```

The cause is in `build_vision_model()` (plugins/_model_config/helpers/model_config.py). It always injects `max_tokens`, either from the preset or the default of 2000, into the model kwargs. When the preset also sets `max_completion_tokens` under kwargs, both parameters end up in the same request and the provider rejects it.

The Responses API path already handles this collision (helpers/litellm_transport.py pops both and maps them to `max_output_tokens`), but the vision side-car builds its call through `unified_call` and never goes through that normalization.

## Fix

Skip the `max_tokens` injection in `build_vision_model()` when `max_completion_tokens` is already present in the merged kwargs. Preset intent wins, which matches the precedence used on the Responses path.

## Testing

Added `plugins/_model_config/tests/test_build_vision_model_max_tokens.py` with four cases:

1. no `max_completion_tokens` anywhere: `max_tokens` still injected (default behavior unchanged)
2. `max_completion_tokens` in kwargs: `max_tokens` not injected (the bug)
3. explicit slot-level `max_tokens=4096` with no collision: injected as 4096
4. slot-level `max_tokens` and kwargs `max_completion_tokens` both set: only `max_completion_tokens` survives

All four pass with `python -m pytest plugins/_model_config/tests/test_build_vision_model_max_tokens.py -v`.

Also confirmed on a live instance: with the patch, `vision_load` succeeds again where it previously returned the BadRequestError above.
