### PR TITLE
feat(models): add Atlas Cloud chat provider

### DIFF
--- a/conf/model_providers.yaml
+++ b/conf/model_providers.yaml
@@ -45,6 +45,14 @@ chat:
         limit: "1000"
     kwargs:
       a0_api_mode: chat
+  atlascloud:
+    name: Atlas Cloud
+    litellm_provider: openai
+    models_list:
+      endpoint_url: "/models"
+    kwargs:
+      a0_api_mode: chat
+      api_base: https://api.atlascloud.ai/v1
   cerebras:
     name: Cerebras
     litellm_provider: cerebras


### PR DESCRIPTION
## Summary

Adds **Atlas Cloud** as a chat provider — **one entry in `conf/model_providers.yaml`**, no code
change. It is OpenAI-compatible, so it follows the nebius/venice shape:

```yaml
  atlascloud:
    name: Atlas Cloud
    litellm_provider: openai
    models_list:
      endpoint_url: "/models"
    kwargs:
      a0_api_mode: chat
      api_base: https://api.atlascloud.ai/v1
```

The provider id is `atlascloud`, so the key resolves from `ATLASCLOUD_API_KEY` (or
`API_KEY_ATLASCLOUD`) through the existing `get_api_key()` derivation in `models.py` — nothing else
needed. The relative `models_list.endpoint_url` lets the Model Configuration plugin populate the
dropdown instead of making users type model ids.

**Only the `chat` section is touched.** `/v1/embeddings` returns `404` on this endpoint, so listing
an embedding provider would be wrong.

## Validation

Per CONTRIBUTING's *"Include exact tests run, or clearly explain why validation was blocked"*:

- `python -m pytest tests/test_model_config_ui.py -q` → **7 passed**
- `tests/test_model_search.py` and `tests/test_model_config_api_keys.py` **could not run here**:
  collection imports `sentence_transformers`, which pulls in torch, and installing that was out of
  scope for a one-line YAML change. Both only read this YAML, and the file still parses
  (`yaml.safe_load`) with the new entry — 30 chat providers resolved.
- The **resolved model-listing URL** (`api_base` + `endpoint_url` =
  `https://api.atlascloud.ai/v1/models`) returns **117 models over httpx**, which is the client
  `plugins/_model_config/api/model_search.py` actually uses. (Worth noting: this endpoint's edge
  rejects Python's *stdlib urllib* default `User-Agent` with `403`, but httpx and requests are
  fine — so the plugin's path works as-is.)
- The configured call path was exercised **end to end with litellm using this exact YAML entry**:
  `litellm.completion(model="openai/deepseek-ai/deepseek-v4-pro", api_base=<kwargs.api_base>)` →
  `finish_reason=stop` with content, 32 tokens.

<!-- atlas-partnership-start -->
---

### 🤝 Partnership & contact

This PR comes from the **Atlas Cloud** team. Beyond the provider entry above, we'd love to explore a closer collaboration with **Agent Zero** — for example **co-marketing** or a featured integration.

If that sounds interesting, reach out anytime:
- 📧 **marketing@atlascloud.ai**
- 🌐 https://www.atlascloud.ai
- 📚 Docs: https://www.atlascloud.ai/docs

And of course, happy to revise this PR to match your project's conventions — just leave a comment. 🙌
<!-- atlas-partnership-end -->
