### PR TITLE
feat(browser): integrate Chrome companion runtime and production setup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ docs focus on practical setup, screenshots, and user workflows.
 - **[Plugins](developer/plugins.md):** Compact plugin starting points and sharing checklist.
 - **[Extensions](developer/extensions.md):** Short guide for when an extension is the right tool.
 - **[Connectivity](developer/connectivity.md):** Choose between A0 CLI, MCP, A2A, and external APIs.
+- **[Chrome Browser Bridge](developer/browser-companion-release-metadata.md):** Pre-store setup, one-time pairing, signed release policy, and platform availability.
 - **[WebSockets](developer/websockets.md):** Short local handoff to DeepWiki and source files.
 - **[MCP Configuration](developer/mcp-configuration.md):** Compact reference for MCP JSON.
 - **[Notifications](developer/notifications.md):** Notification system architecture and setup.
@@ -137,6 +138,7 @@ docs focus on practical setup, screenshots, and user workflows.
   - [Plugins](developer/plugins.md)
   - [Extensions](developer/extensions.md)
   - [Connectivity](developer/connectivity.md)
+  - [Chrome Browser Bridge](developer/browser-companion-release-metadata.md)
   - [WebSockets](developer/websockets.md)
   - [MCP Configuration](developer/mcp-configuration.md)
   - [Notifications](developer/notifications.md)

--- a/docs/developer/browser-companion-release-metadata.md
+++ b/docs/developer/browser-companion-release-metadata.md
@@ -1,0 +1,93 @@
+# Chrome Browser Bridge setup and releases
+
+## Install and pair once
+
+The Chrome Web Store item is still a draft. The extension's supplied unpacked
+ZIP contains an offline `START-HERE.html` guide and ready-to-load `extension`
+folder. No source build is required. Keep that folder at a permanent location,
+then use Chrome → Extensions → Developer mode → Load unpacked. The production
+identity is `nhliclifilepdkoolioacpjpijomfplj`; Chrome's Developer mode switch
+does not select a development trust channel. The old development endpoints and
+limited runtime are retired; old credentials and saved site grants are not
+converted or deleted. Existing development selections stop without fallback and
+require explicit production pairing and selection.
+
+Install the native companion on the computer running Chrome, not in Docker or
+WSL. macOS 13+ has a signed/notarized 2.12.3 installer for Intel and Apple Silicon.
+Windows and Linux can load the extension, but their production native installers
+remain incomplete. [Current user setup guide](https://github.com/TerminallyLazy/agent-zero-browser-support/blob/main/SETUP.md).
+
+After installation, create a five-minute code in Browser settings, enter the
+WebUI address and code in extension Options, and select this browser as Agent
+Zero's default. The default applies across chats without replacing explicit
+project choices. Pairing survives ordinary updates and panel closure. Runtime
+readiness additionally requires signed release admission and reconciliation.
+Remembered-site or explicitly enabled All websites access avoids repeated site
+prompts; consequential actions still require separate approval.
+
+## Operator activation policy
+
+Pairing requires `A0_BROWSER_BRIDGE_ROLLOUT=preview|available` and
+`A0_BROWSER_BRIDGE_EXTENSION_ID` set to the exact production ID. An optional
+`A0_BROWSER_BRIDGE_SERVER_BASE_URL` pins the canonical external URL; only HTTPS
+or loopback HTTP is supported. Preserve normal WebUI authentication and CSRF.
+
+`A0_BROWSER_BRIDGE_RELEASE_POLICY_FILE` must identify an operator-provisioned
+publisher-signed policy. Core rechecks its signature, expiry, and exact extension
+ID/version plus companion version/platform/architecture on admission. Extension
+0.1.1 needs new exact entries for companion 2.12.3 on Darwin aarch64 and x86_64;
+the old 0.1.0 entries do not admit it. Preserve reviewed existing entries when
+issuing an update. Never edit signed JSON by hand, auto-accept a higher version,
+use a fixture key, or add unreleased Windows/Linux tuples. This policy is distinct
+from the installer catalog and the presentation metadata below. Its maximum
+lifetime is 90 days and it requires publisher renewal before expiry.
+
+The source-adjacent `_a0_connector` and `_browser` DOX contracts own endpoint
+schemas and runtime authority. Old foundation-only/hello-only descriptions no
+longer describe the composed production runtime.
+
+## Installer metadata API
+
+Agent Zero exposes a read-only installer metadata endpoint:
+
+```text
+POST /api/plugins/_a0_connector/v1/browser_companion_release
+```
+
+The endpoint requires the normal authenticated WebUI session and CSRF token. It accepts only an empty JSON object. It does not download, execute, or install anything.
+
+Connector capability discovery advertises `browser_companion_release_metadata` when the endpoint and its helper are present. That flag reports API-contract availability only; it does not mean that a release, installer, companion, pairing flow, or browser runtime is ready.
+
+## Docker boundary
+
+The native companion belongs on the computer running Chrome or another supported Chromium-family browser. It is never installed in the Agent Zero Docker container: a container cannot register a native-messaging host in the user's desktop browser merely by writing its own filesystem.
+
+Browser settings can use this endpoint to present pinned OS-specific downloads. The user downloads and runs the wrapper on the browser host. Pairing begins only after that host installation verifies locally.
+
+## Server-pinned metadata
+
+This foundation remains unavailable unless the Agent Zero server operator configures all three values:
+
+- `A0_BROWSER_COMPANION_CATALOG_URL`: an immutable HTTPS catalog URL without credentials, query, or fragment;
+- `A0_BROWSER_COMPANION_CATALOG_KEY_FINGERPRINT`: `sha256:` followed by the pinned release-root fingerprint;
+- `A0_BROWSER_COMPANION_RELEASE_METADATA`: a bounded JSON object containing the stable release, detached catalog-signature URL, protocol/trust ranges, minimum secure companion version, release key ID, and complete artifact matrix.
+
+Schema v1 requires the complete macOS/Windows/Linux matrix. Schema v2 adds a
+nonempty, sorted, unique `platforms` list and requires complete delivery groups
+only for those platforms. A Mac-only v2 release must not imply Windows/Linux
+availability. Each artifact has an immutable HTTPS URL, exact filename,
+SHA-256 digest, and byte size.
+
+`A0_BROWSER_COMPANION_RELEASE_METADATA` is a strict WebUI presentation envelope,
+not the signed catalog. Top-level v1 keys are `schema_version`, `release`,
+`channel`, `published_at`, `protocol`, `trust`, `minimum_secure_companion`,
+`catalog_signature_url`, `release_key_id`, and `artifacts`; v2 additionally
+requires `platforms`. Every artifact has exactly `name`, `platform`, `arch`,
+`kind`, `download_url`, `sha256`, and `size`. Unknown or duplicate fields fail
+closed. Catalog-only origins and native registration data are not projected.
+
+The release pipeline—not browser page content—owns these values. The endpoint rejects request-supplied URLs, paths, extension IDs, or metadata overrides. Responses never contain signing/private keys, Agent Zero credentials, native paths, raw environment data, or exception text.
+
+Missing, invalid, incomplete, below-floor, or protocol-incompatible configuration returns `state: unavailable` with empty artifact data. A usable presentation returns the distinct `a0.browser-bridge.release-metadata.v1` contract with `state: available`, references the install contract separately, and always includes `install_ready: false`. Available means only that the pinned public presentation metadata is syntactically complete and compatible with this server. Core's compiled minimum secure companion is `2.12.0`; supplied metadata may raise the effective floor but cannot lower it. Agent Zero Core does not fetch or cryptographically verify the catalog or artifact bytes at this endpoint. The browser-host installer or CLI treats this projection as unverified, fetches the catalog and detached signature, verifies them against its independently pinned public root, and requires the signed catalog to match the selected artifact's name, platform, architecture, kind, download URL, digest, and size. It then verifies the artifact digest, platform signature, and self-test before execution. The host companion, browser registration, extension, and pairing remain unchecked.
+
+Catalog, signature, and artifact URLs are bounded canonical HTTPS URLs. Raw or percent-decoded controls, backslashes, credentials, query/fragment delimiters, ambiguous hostnames, double-leading path separators, dot segments, and artifact filename mismatches fail closed.

--- a/extensions/python/_functions/AGENTS.md
+++ b/extensions/python/_functions/AGENTS.md
@@ -19,6 +19,10 @@
 - The `AgentContext.run_task/end` hook attaches integration callbacks to the returned `DeferredTask`; keep terminal side effects out of `agent.py`.
 - Recovery-loop circuit breakers must stop at the General Settings limit and render their user-visible cost warning from a core framework prompt.
 - Prompt settings snapshots must be task-local, accessed through `get_settings_for_prompt()`, and end with the matching `Agent.prepare_prompt` call, including exceptional exits.
+- The `UiServerRuntime.create/end` legacy browser guard is a Core hook so
+  disabling the connector cannot revive retired HTTP routes. It delegates
+  exact-journal checks to the plugin helper; it never starts retirement or
+  installs the production browser runtime.
 
 ## Work Guidance
 

--- a/extensions/python/_functions/helpers/ui_server/UiServerRuntime/create/end/_05_legacy_browser_guard.py
+++ b/extensions/python/_functions/helpers/ui_server/UiServerRuntime/create/end/_05_legacy_browser_guard.py
@@ -1,0 +1,10 @@
+from helpers.extension import Extension
+
+
+class LegacyBrowserGuard(Extension):
+    def execute(self, data: dict, **kwargs):
+        if data.get("exception") is not None:
+            return
+        from plugins._a0_connector.helpers.browser_bridge_legacy_retirement import install_legacy_retirement_guard
+
+        install_legacy_retirement_guard(data["result"].webapp)

--- a/helpers/persist_chat.py
+++ b/helpers/persist_chat.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Any
 
 from agent import Agent, AgentConfig, AgentContext, AgentContextType
-from helpers import files, history
+from helpers import files, history, extension
 from helpers.litellm_transport import delete_stored_response_ids
 from helpers.localization import Localization
 from initialize import initialize_agent
@@ -176,6 +176,7 @@ def remove_msg_files(ctxid):
     files.delete_dir(path)
 
 
+@extension.extensible
 def _serialize_context(context: AgentContext):
     profile = str(
         getattr(context.agent0.config, "profile", None)
@@ -247,6 +248,7 @@ def _serialize_log(log: Log):
     }
 
 
+@extension.extensible
 def _deserialize_context(data):
     profile = data.get("agent_profile")
     override_settings = {"agent_profile": profile} if profile else None

--- a/helpers/persist_chat.py.dox.md
+++ b/helpers/persist_chat.py.dox.md
@@ -47,6 +47,11 @@
 - Chat loading skips directories that do not contain `chat.json`; malformed existing chat files still report load errors.
 - Chat saves write and fsync a same-directory temporary file, atomically replace `chat.json`, and fsync the directory so an interrupted save cannot truncate the previous chat.
 - Contexts are marked with private `SAVED_CHAT_CONTEXT_DATA_KEY` only after a successful save or load from disk so snapshot code can detect deleted chat files without hiding fresh unsaved chats.
+- `_serialize_context` and `_deserialize_context` use generic synchronous
+  `extension.extensible` hooks. Plugin-owned migration may quarantine exact
+  owned fields before save/export or load/import; Core persistence contains no
+  plugin-specific imports, selectors, or redaction rules. A start-hook failure
+  prevents serialization/deserialization rather than persisting partial data.
 - Chat and message-file removal reject empty or whitespace-only context IDs before provider or filesystem deletion begins.
 
 ## Key Concepts

--- a/helpers/tool.py
+++ b/helpers/tool.py
@@ -42,14 +42,19 @@ class Tool:
     async def before_execution(self, **kwargs):
         PrintStyle(font_color="#1B4F72", padding=True, background_color="white", bold=True).print(f"{self.agent.agent_name}: Using tool '{self.name}'")
         self.log = self.get_log_object()
-        if self.args and isinstance(self.args, dict):
-            for key, value in self.args.items():
+        display_args = self.get_display_args()
+        if display_args and isinstance(display_args, dict):
+            for key, value in display_args.items():
                 ctx = {"content": str(value) if not isinstance(value, str) else value}
                 await call_extensions_async("tool_output_update", self.agent, ctx=ctx)
                 display_value = ctx["content"]
                 PrintStyle(font_color="#85C1E9", bold=True).stream(self.nice_key(key)+": ")
                 PrintStyle(font_color="#85C1E9", padding=isinstance(value,str) and "\n" in value).stream(display_value)
                 PrintStyle().print()
+
+    def get_display_args(self):
+        """Presentation only; overrides must not mutate execution arguments."""
+        return self.args
 
     async def after_execution(self, response: Response, **kwargs):
         text = sanitize_string(response.message.strip())

--- a/helpers/tool.py.dox.md
+++ b/helpers/tool.py.dox.md
@@ -19,6 +19,7 @@
   - `async before_execution(self, **kwargs)`
   - `async after_execution(self, response: Response, **kwargs)`
   - `get_log_object(self)`
+  - `get_display_args(self)`
   - `nice_key(self, key: str)`
 
 ## Runtime Contracts
@@ -26,6 +27,11 @@
 - Helper modules own reusable framework APIs and must preserve public callers unless all callers, tests, and docs are updated together.
 - Update this file whenever public functions, classes, persistence behavior, path/security assumptions, side effects, or cross-module contracts change.
 - `Tool` defines `execute(...)`.
+- `get_display_args()` defaults to the original args, preserving existing tool
+  output. `before_execution` uses this projection for console output and
+  `tool_output_update` callbacks. Sensitive tools may return a redacted copy;
+  they must not mutate execution arguments and must separately project their
+  structured log. This is not a rewrite of the model's conversation history.
 - Observed side-effect areas: settings/state persistence.
 - Imported dependency areas include: `abc`, `agent`, `dataclasses`, `helpers.extension`, `helpers.print_style`, `helpers.strings`, `typing`.
 
@@ -46,6 +52,7 @@
 - Related tests observed by source search:
   - `tests/test_a0_connector_prompt_gating.py`
   - `tests/test_browser_agent_regressions.py`
+  - `tests/test_browser_extension_viewer_boundary.py`
   - `tests/test_default_prompt_budget.py`
   - `tests/test_dirty_json.py`
   - `tests/test_document_query_plugin.py`

--- a/helpers/ui_server.py
+++ b/helpers/ui_server.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from datetime import timedelta
 import asyncio
+from contextlib import AsyncExitStack, asynccontextmanager
 import gzip
 import json
 import logging
@@ -30,7 +31,7 @@ import socketio  # type: ignore[import-untyped]
 
 from helpers import dotenv, fasta2a_server, files, git, login, mcp_server, runtime
 from helpers.api import get_safe_next_url, register_api_route, requires_auth
-from helpers.extension import extensible, get_webui_extension_manifest
+from helpers.extension import call_extensions_async, extensible, get_webui_extension_manifest
 from helpers.files import get_abs_path
 from helpers.print_style import PrintStyle
 from helpers.server_startup import StartupMonitor
@@ -82,6 +83,7 @@ class UiServerRuntime:
     _route_handlers: "UiRouteHandlers | None" = field(default=None, init=False)
 
     @classmethod
+    @extensible
     def create(cls) -> "UiServerRuntime":
         webapp = Flask("app", static_folder=get_abs_path("./webui"), static_url_path="/")
         webapp.secret_key = os.getenv("FLASK_SECRET_KEY") or secrets.token_hex(32)
@@ -226,6 +228,15 @@ class UiServerRuntime:
         self._transport_registered = True
 
     def build_asgi_app(self, startup_monitor: StartupMonitor):
+        monitor_lifespan = startup_monitor.lifespan()
+
+        @asynccontextmanager
+        async def server_lifespan(app):
+            async with AsyncExitStack() as shutdown:
+                await call_extensions_async("webui_server_start", runtime=self, shutdown=shutdown)
+                async with monitor_lifespan(app):
+                    yield
+
         with startup_monitor.stage("wsgi.middleware.create"):
             wsgi_app = WSGIMiddleware(self.webapp)
 
@@ -242,7 +253,7 @@ class UiServerRuntime:
                     Mount("/a2a", app=a2a_app),
                     Mount("/", app=wsgi_app),
                 ],
-                lifespan=startup_monitor.lifespan(),
+                lifespan=server_lifespan,
             )
             compressed_http_app = GZipMiddleware(
                 starlette_app,

--- a/helpers/ui_server.py.dox.md
+++ b/helpers/ui_server.py.dox.md
@@ -49,6 +49,13 @@
 - Authenticated extension asset routes serve root-contained files from both `extensions/webui/` and `usr/extensions/webui/`, matching the URLs emitted by the WebUI extension manifest.
 - The authenticated `/` route uses `serve_splash()` to return the no-store, self-contained bootstrap document. The authenticated extensionless `/ui/index` route renders the existing index and runtime/user placeholders for the splash to install into the current document without navigation; `/index.html` remains a direct fallback for the same rendering path. The authenticated `/safe` route first returns a no-store, self-contained document that unregisters all origin service workers, then renders the existing index through `serve_index()` when its internal `__direct=1` marker is present; it never initializes the asset bundle or a worker. The authenticated `serve_ui_asset_bundle()` endpoint passes the application entry URL to the generic recursive bundler and supports gzip transfer and payload-specific ETag revalidation while component, extension, and Alpine lifecycles remain unchanged.
 - The Starlette HTTP branch applies negotiated gzip to responses of at least 1 KiB at compression level 6 while preserving already encoded responses; Socket.IO remains outside that middleware branch.
+- `create` end hooks receive the constructed runtime before route registration.
+  Service installation belongs to `webui_server_start`, called inside each ASGI
+  lifespan with `runtime` and a fresh `shutdown` AsyncExitStack. Hooks register
+  cleanup on that stack; startup failure, serving failure and normal shutdown
+  all await it, even if plugins are subsequently disabled. Uvicorn retries can
+  reuse the server object without reusing retired services or a spent stack.
+  The shared server imports no plugin services.
 - Keep request/response, tool, or helper semantics documented here at the same time as source changes.
 
 ## Work Guidance

--- a/helpers/ws.py
+++ b/helpers/ws.py
@@ -14,6 +14,7 @@ from helpers import files, cache
 from helpers.print_style import PrintStyle
 from helpers.errors import format_error
 from helpers.tunnel_origins import get_active_tunnel_origins, origin_key
+from helpers.ws_principal import WsPrincipal, WsScopeDeniedError, restricted_correlation_id
 
 if TYPE_CHECKING:
     from helpers.ws_manager import WsManager
@@ -176,6 +177,7 @@ class _SecurityContext:
     csrf_cookie: str | None
     remote_addr: str | None
     api_key: str | None
+    principal: WsPrincipal | None = None
 
 
 _ws_contexts: dict[str, _SecurityContext] = {}
@@ -204,6 +206,8 @@ class WsHandler:
         self.lock = lock
         self._manager = manager
         self._namespace = namespace
+        self._principal: WsPrincipal | None = None
+        self._principal_sid: str | None = None
 
     # Properties
 
@@ -247,6 +251,28 @@ class WsHandler:
     def requires_csrf(cls) -> bool:
         return cls.requires_auth()
 
+    @classmethod
+    def accepted_principal_types(cls) -> frozenset[str]:
+        return frozenset()
+
+    @classmethod
+    def authenticate_principal(cls, auth: dict) -> WsPrincipal | None:
+        """Plugin-owned proof verification, called only after origin validation."""
+        return None
+
+    @classmethod
+    def principal_is_active(cls, principal: WsPrincipal) -> bool:
+        return False
+
+    def principal_for_sid(self, sid: str) -> WsPrincipal | None:
+        if self._principal is not None:
+            if sid != self._principal_sid:
+                raise WsScopeDeniedError("Restricted WebSocket identity mismatch")
+            return self._principal
+        with _contexts_lock:
+            ctx = _ws_contexts.get(sid)
+            return ctx.principal if ctx else None
+
     # Lifecycle hooks
 
     async def on_connect(self, sid: str) -> None:
@@ -275,10 +301,13 @@ class WsHandler:
         *,
         correlation_id: str | None = None,
     ) -> None:
+        if self._principal is not None and self._principal_sid != sid:
+            raise WsScopeDeniedError("Restricted WebSocket identity mismatch")
         await self.manager.emit_to(
             self._namespace, sid, event, data,
             handler_id=self.identifier,
             correlation_id=correlation_id,
+            **({"expected_principal": self._principal} if self._principal else {}),
         )
 
     async def broadcast(
@@ -289,6 +318,8 @@ class WsHandler:
         exclude_sids: str | Iterable[str] | None = None,
         correlation_id: str | None = None,
     ) -> None:
+        if self._principal is not None:
+            raise WsScopeDeniedError("Restricted WebSocket broadcast denied")
         await self.manager.broadcast(
             self._namespace, event, data,
             exclude_sids=exclude_sids,
@@ -313,6 +344,8 @@ class WsHandler:
         ``WsManager.route_event_all`` so that existing frontend
         assertions remain valid.
         """
+        if self._principal is not None:
+            raise WsScopeDeniedError("Restricted WebSocket fan-out denied")
         cid = correlation_id or uuid.uuid4().hex
 
         with _contexts_lock:
@@ -328,6 +361,9 @@ class WsHandler:
             ctx = contexts_snapshot.get(sid)
             # Skip sids whose security context was removed (concurrent disconnect).
             if ctx is None:
+                continue
+            # Global fan-out must not invoke a restricted connection's handlers.
+            if ctx.principal is not None:
                 continue
             security_errors: list[dict[str, Any]] = []
             passing: list[WsHandler] = []
@@ -396,6 +432,18 @@ def _check_security(handler_cls: type[WsHandler], ctx: _SecurityContext) -> dict
     if handler_cls.requires_loopback():
         if not ctx.remote_addr or not is_loopback_address(ctx.remote_addr):
             return {"code": "FORBIDDEN", "error": "Access denied"}
+
+    if ctx.principal is not None:
+        principal = ctx.principal
+        try:
+            active = (
+                principal.principal_type in handler_cls.accepted_principal_types()
+                and principal.handler_id == f"{handler_cls.__module__}.{handler_cls.__name__}"
+                and handler_cls.principal_is_active(principal)
+            )
+        except Exception:
+            active = False
+        return None if active else {"code": "SCOPE_DENIED", "error": "Access denied"}
 
     if handler_cls.requires_auth():
         from helpers import login
@@ -475,31 +523,75 @@ def register_ws_namespace(
 
     @socketio_server.on("connect", namespace=NAMESPACE)  # type: ignore
     async def _on_connect(sid, environ, auth):
+        restricted = isinstance(auth, dict) and "principal" in auth
+        principal = None
+        restricted_cls = None
         with webapp.request_context(environ):
-            origin_ok, origin_reason = validate_ws_origin(environ)
+            try:
+                origin_ok, origin_reason = validate_ws_origin(environ)
+            except (TypeError, ValueError):
+                origin_ok, origin_reason = False, "invalid_origin"
             if not origin_ok:
                 PrintStyle.warning(
                     f"WS connect rejected for {sid}: {origin_reason or 'invalid'}"
                 )
                 return False
 
+            if restricted:
+                # Presence is authoritative, including null/malformed proofs.
+                # Never fall back to ambient session/CSRF/API credentials.
+                try:
+                    if manager is None or set(auth) != {"handlers", "principal"}:
+                        return False
+                    paths = auth["handlers"]
+                    envelope = auth["principal"]
+                    if (
+                        not isinstance(paths, list) or len(paths) != 1
+                        or not isinstance(paths[0], str)
+                        or len(paths[0]) > 256
+                        or any(p in paths[0] for p in ("..", "\\", ":"))
+                        or paths[0].startswith("/")
+                        or not isinstance(envelope, dict)
+                        or not isinstance(envelope.get("type"), str)
+                    ):
+                        return False
+                    restricted_cls = _resolve_cached(paths[0])
+                    if (
+                        restricted_cls is None
+                        or envelope["type"] not in restricted_cls.accepted_principal_types()
+                    ):
+                        return False
+                    principal = restricted_cls.authenticate_principal(auth)
+                    if (
+                        not isinstance(principal, WsPrincipal)
+                        or principal.handler_path != paths[0]
+                        or principal.principal_type != envelope["type"]
+                    ):
+                        return False
+                except Exception:
+                    PrintStyle.warning("WS restricted authentication failed")
+                    return False
+
             ctx = _SecurityContext(
-                auth_hash=session.get("authentication"),
-                csrf_token=session.get("csrf_token"),
+                auth_hash=None if restricted else session.get("authentication"),
+                csrf_token=None if restricted else session.get("csrf_token"),
                 client_csrf_token=(
                     (auth.get("csrf_token") or auth.get("csrfToken"))
-                    if isinstance(auth, dict) else None
+                    if isinstance(auth, dict) and not restricted else None
                 ),
-                csrf_cookie=request.cookies.get(
+                csrf_cookie=None if restricted else request.cookies.get(
                     f"csrf_token_{runtime.get_runtime_id()}"
                 ),
                 remote_addr=str(request.remote_addr) if request.remote_addr else None,
                 api_key=(
                     (auth.get("api_key") or auth.get("apiKey"))
-                    if isinstance(auth, dict) else None
+                    if isinstance(auth, dict) and not restricted else None
                 ),
+                principal=principal,
             )
-            user_id = session.get("user_id") or "single_user"
+            user_id = None if restricted else session.get("user_id") or "single_user"
+            if restricted and _check_security(restricted_cls, ctx) is not None:
+                return False
 
             with _contexts_lock:
                 _ws_contexts[sid] = ctx
@@ -508,7 +600,19 @@ def register_ws_namespace(
         # connection tracking are available before handler on_connect runs
         # (extensions like StateSync depend on manager._dispatcher_loop).
         if manager is not None:
-            await manager.handle_connect(NAMESPACE, sid, user_id=user_id)
+            if principal is not None:
+                try:
+                    await manager.handle_connect(
+                        NAMESPACE, sid, principal=principal,
+                        principal_validator=restricted_cls.principal_is_active,
+                    )
+                except Exception:
+                    with _contexts_lock:
+                        _ws_contexts.pop(sid, None)
+                    PrintStyle.warning("WS restricted registration failed")
+                    return False
+            else:
+                await manager.handle_connect(NAMESPACE, sid, user_id=user_id)
 
         # Activate handlers declared in auth.handlers
         handler_paths: list[str] = []
@@ -519,6 +623,7 @@ def register_ws_namespace(
 
         activated: dict[str, WsHandler] = {}
         for path in handler_paths:
+            instance = None
             try:
                 handler_cls = _resolve_cached(path)
                 if handler_cls is None:
@@ -530,10 +635,26 @@ def register_ws_namespace(
                     socketio_server, lock,
                     manager=manager, namespace=NAMESPACE,
                 )
+                instance._principal = principal
+                instance._principal_sid = sid if principal else None
                 await instance.on_connect(sid)
                 activated[path] = instance
             except Exception as e:
-                PrintStyle.error(f"WS on_connect error ({path}): {format_error(e)}")
+                if restricted:
+                    PrintStyle.error("WS restricted activation failed")
+                    if instance is not None:
+                        try:
+                            await instance.on_disconnect(sid)
+                        except Exception:
+                            PrintStyle.error("WS restricted activation cleanup failed")
+                else:
+                    PrintStyle.error(f"WS on_connect error ({path}): {format_error(e)}")
+
+        if restricted and len(activated) != 1:
+            with _contexts_lock:
+                _ws_contexts.pop(sid, None)
+            await manager.handle_disconnect(NAMESPACE, sid)
+            return False
 
         with _contexts_lock:
             _active_handlers[sid] = activated
@@ -544,13 +665,19 @@ def register_ws_namespace(
     async def _on_disconnect(sid, reason=None):
         with _contexts_lock:
             activated = _active_handlers.pop(sid, {})
-            _ws_contexts.pop(sid, None)
+            ctx = _ws_contexts.get(sid)
 
         for path, instance in activated.items():
             try:
                 await instance.on_disconnect(sid)
             except Exception as e:
-                PrintStyle.error(f"WS on_disconnect error ({path}): {format_error(e)}")
+                if ctx and ctx.principal:
+                    PrintStyle.error("WS restricted disconnect cleanup failed")
+                else:
+                    PrintStyle.error(f"WS on_disconnect error ({path}): {format_error(e)}")
+
+        with _contexts_lock:
+            _ws_contexts.pop(sid, None)
 
         if manager is not None:
             await manager.handle_disconnect(NAMESPACE, sid)
@@ -558,6 +685,7 @@ def register_ws_namespace(
     @socketio_server.on("*", namespace=NAMESPACE)  # type: ignore
     async def _dispatch(event, sid, data):
         incoming = data if isinstance(data, dict) else {}
+        ctx = None
 
         try:
             with _contexts_lock:
@@ -565,6 +693,14 @@ def register_ws_namespace(
                 activated = dict(_active_handlers.get(sid, {}))
 
             correlation_id = incoming.get("correlationId") or uuid.uuid4().hex
+
+            if ctx and ctx.principal:
+                correlation_id = restricted_correlation_id(incoming.get("correlationId"))
+                incoming = dict(incoming, correlationId=correlation_id)
+                if event not in ctx.principal.inbound_events:
+                    if manager is not None:
+                        manager.record_scope_denial()
+                    return _error_response("SCOPE_DENIED", "Access denied", correlation_id)
 
             if ctx is None:
                 return _error_response("AUTH_REQUIRED",
@@ -579,6 +715,8 @@ def register_ws_namespace(
             for path, instance in activated.items():
                 error = _check_security(type(instance), ctx)
                 if error is not None:
+                    if ctx.principal and manager is not None:
+                        manager.record_scope_denial()
                     security_errors.append({
                         "handlerId": instance.identifier,
                         "ok": False,
@@ -625,7 +763,7 @@ def register_ws_namespace(
                             "data": result,
                         })
                 except Exception as e:
-                    error_text = format_error(e)
+                    error_text = "Restricted handler failed" if ctx.principal else format_error(e)
                     PrintStyle.error(f"WS handler error ({path}/{event}): {error_text}")
                     results.append({
                         "handlerId": instance.identifier,
@@ -637,6 +775,9 @@ def register_ws_namespace(
             return {"correlationId": correlation_id, "results": results}
 
         except Exception as e:
+            if ctx and ctx.principal:
+                PrintStyle.error("WS restricted dispatch failed")
+                return _error_response("INTERNAL_ERROR", "Internal server error", "")
             error_text = format_error(e)
             PrintStyle.error(f"WS dispatch error ({event}): {error_text}")
             return _error_response(

--- a/helpers/ws.py.dox.md
+++ b/helpers/ws.py.dox.md
@@ -36,6 +36,20 @@
 
 ## Runtime Contracts
 
+- Non-session authentication is explicit opt-in through `WsHandler` principal
+  hooks. Defaults accept no restricted principal. Origin validation runs first;
+  the presence of `auth.principal` is authoritative even when malformed, and
+  never falls back to ambient session, CSRF or API credentials. Restricted
+  activation requires one authenticated handler and a manager; it rolls back
+  on failure. Ordinary no-principal authentication remains unchanged.
+- Restricted security contexts and handler instances retain only an immutable
+  `WsPrincipal`, not proof material. A bound handler rejects a different SID.
+  Each inbound request rechecks credential liveness and the server-derived
+  event set before manager dispatch. Global fan-out skips restricted SIDs.
+  Disconnect preserves the identity during plugin cleanup, then removes it;
+  restricted exceptions are logged without their raw text.
+- The connector's initial principal adapter is hello-only and unadvertised;
+  these shared primitives do not assert operational browser readiness.
 - Helper modules own reusable framework APIs and must preserve public callers unless all callers, tests, and docs are updated together.
 - Update this file whenever public functions, classes, persistence behavior, path/security assumptions, side effects, or cross-module contracts change.
 - `WsHandler` defines `process(...)`.
@@ -59,6 +73,9 @@
 
 ## Verification
 
+- `tests/test_ws_restricted_principal.py` covers authoritative auth, origin
+  ordering, immutable identity, activation rollback, denial, redaction and
+  cleanup. Run alongside existing WebSocket security/CSRF/manager tests.
 - Run targeted tests for changed helper behavior; run security regressions for auth, filesystem, WebSocket, tunnel, upload, or secret-handling helpers.
 - Related tests observed by source search:
   - `tests/test_a0_connector_computer_use_metadata.py`

--- a/helpers/ws_manager.py
+++ b/helpers/ws_manager.py
@@ -16,6 +16,7 @@ from helpers.defer import DeferredTask
 from helpers.print_style import PrintStyle
 from helpers import runtime
 from helpers.ws import ConnectionIdentity, ConnectionNotFoundError, WsHandler, _ws_debug_enabled, ws_debug
+from helpers.ws_principal import WsPrincipal, WsScopeDeniedError, restricted_correlation_id
 
 
 # Event validation
@@ -221,6 +222,8 @@ class ConnectionInfo:
     sid: str
     connected_at: datetime = field(default_factory=_utcnow)
     last_activity: datetime = field(default_factory=_utcnow)
+    principal: WsPrincipal | None = None
+    principal_validator: Callable[[WsPrincipal], bool] | None = field(default=None, repr=False)
 
 
 @dataclass
@@ -267,6 +270,7 @@ class WsManager:
         self._dispatcher_loop: asyncio.AbstractEventLoop | None = None
         self._handler_worker: DeferredTask | None = None
         self._lifecycle_tasks: Set[asyncio.Task] = set()
+        self._scope_denials: Deque[dict[str, str]] = deque(maxlen=128)
 
     # Internal: development-only debug logging to avoid noise in production
     def _debug(self, message: str) -> None:
@@ -323,6 +327,8 @@ class WsManager:
         identity: ConnectionIdentity = (namespace, sid)
         with self.lock:
             if identity not in self.connections:
+                return False
+            if self.connections[identity].principal is not None:
                 return False
             self._diagnostic_watchers.add(identity)
         return True
@@ -557,6 +563,32 @@ class WsManager:
         handlers that have already passed security checks).
         """
         self._ensure_dispatcher_loop()
+        principal = self.principal_for_sid(namespace, sid)
+        if any(
+            h._principal is not None
+            and (h._principal is not principal or h._principal_sid != sid)
+            for h in handlers
+        ):
+            self.record_scope_denial()
+            return self._ack_error(
+                handler_id=self._identifier, code="SCOPE_DENIED",
+                message="Access denied", correlation_id="",
+            )
+        if principal is not None:
+            # Apply the same boundary even when callers bypass the namespace.
+            data = dict(data or {})
+            data["correlationId"] = restricted_correlation_id(data.get("correlationId"))
+            if not handlers or any(
+                h._principal is not principal or h._principal_sid != sid
+                or not principal.permits_inbound(event_type, h.identifier)
+                or not h.principal_is_active(principal)
+                for h in handlers
+            ):
+                self.record_scope_denial()
+                return self._ack_error(
+                    handler_id=self._identifier, code="SCOPE_DENIED",
+                    message="Access denied", correlation_id=data["correlationId"],
+                )
         incoming = dict(data or {})
         correlation_id = self._resolve_correlation_id(incoming)
 
@@ -580,17 +612,29 @@ class WsManager:
             info = self.connections.get((namespace, sid))
             if info:
                 info.last_activity = _utcnow()
+        if principal is not None and (info is None or info.principal is not principal):
+            return self._ack_error(
+                handler_id=self._identifier, code="SCOPE_DENIED",
+                message="Access denied", correlation_id=correlation_id,
+            )
 
         executions = await asyncio.gather(
             *[
-                self._invoke_handler(handler, event_type, dict(handler_payload), sid)
+                self._invoke_handler(handler, event_type, dict(handler_payload), sid, connection=info)
                 for handler in handlers
             ]
         )
 
         results = self._collect_results(
             executions, event_type, correlation_id, skip_none=True,
+            redacted=principal is not None,
         )
+
+        if principal is not None:
+            # Do not summarize values, keys, correlations or raw exceptions.
+            # This avoids turning development diagnostics into a second copy of
+            # sensitive browser traffic, including after a concurrent disconnect.
+            return {"correlationId": correlation_id, "results": results}
 
         await self._publish_diagnostic_event(
             lambda: {
@@ -624,6 +668,7 @@ class WsManager:
         correlation_id: str,
         *,
         skip_none: bool = False,
+        redacted: bool = False,
     ) -> List[dict[str, Any]]:
         """Build a result list from handler executions.
 
@@ -641,6 +686,7 @@ class WsManager:
 
             if isinstance(value, Exception):
                 PrintStyle.error(
+                    "Restricted WebSocket handler failed" if redacted else
                     f"Error in handler {handler.identifier} for '{event_type}' "
                     f"(correlation {correlation_id}): {value}"
                 )
@@ -649,7 +695,7 @@ class WsManager:
                         handler_id=handler.identifier,
                         code=ERR_HANDLER_ERROR,
                         message="Internal server error",
-                        details=str(value),
+                        details=None if redacted else str(value),
                         correlation_id=correlation_id,
                         duration_ms=duration_ms,
                     )
@@ -657,6 +703,14 @@ class WsManager:
                 continue
 
             if isinstance(value, WsResult):
+                if redacted and not value._ok:
+                    code = (value._error or {}).get("code")
+                    results.append(self._build_error_result(
+                        handler_id=handler.identifier,
+                        code=code if code in {"SCOPE_DENIED", "INVALID_REQUEST", "NOT_READY"} else ERR_HANDLER_ERROR,
+                        message="Restricted request failed", correlation_id=correlation_id,
+                    ))
+                    continue
                 results.append(
                     value.as_result(
                         handler_id=handler.identifier,
@@ -690,12 +744,28 @@ class WsManager:
         event_type: str,
         payload: dict[str, Any],
         sid: str,
+        *, connection: ConnectionInfo | None = None,
     ) -> _HandlerExecution:
         instrument = self._diagnostics_active()
         start = time.perf_counter() if instrument else None
+        async def invoke():
+            if connection is not None:
+                with self.lock:
+                    current = self.connections.get((connection.namespace, sid))
+                if current is not connection:
+                    return WsResult.error(code="SCOPE_DENIED", message="Access denied")
+                principal = connection.principal
+                if principal is not None and (
+                    handler._principal is not principal
+                    or handler._principal_sid != sid
+                    or not principal.permits_inbound(event_type, handler.identifier)
+                    or not handler.principal_is_active(principal)
+                ):
+                    return WsResult.error(code="SCOPE_DENIED", message="Access denied")
+            return await handler.process(event_type, payload, sid)
         try:
             value = await self._get_handler_worker().execute_inside(
-                handler.process, event_type, payload, sid
+                invoke
             )
         except Exception as exc:  # pragma: no cover - handled by caller
             duration_ms = (
@@ -708,21 +778,54 @@ class WsManager:
         return _HandlerExecution(handler, value, duration_ms)
 
     async def handle_connect(
-        self, namespace: str, sid: str, user_id: str | None = None
+        self, namespace: str, sid: str, user_id: str | None = None,
+        *, principal: WsPrincipal | None = None,
+        principal_validator: Callable[[WsPrincipal], bool] | None = None,
     ) -> None:
         self._ensure_dispatcher_loop()
         user_bucket = user_id or "single_user"
         identity: ConnectionIdentity = (namespace, sid)
         with self.lock:
-            self.connections[identity] = ConnectionInfo(namespace=namespace, sid=sid)
+            if identity in self.connections:
+                raise ValueError("Connection already registered")
+            self.connections[identity] = ConnectionInfo(
+                namespace=namespace, sid=sid, principal=principal,
+                principal_validator=principal_validator,
+            )
             self._known_sids.add(identity)
             self._disconnect_times.pop(identity, None)
-            self.sid_to_user[identity] = user_bucket
-            self.user_to_sids[self._ALL_USERS_BUCKET].add(identity)
-            self.user_to_sids[user_bucket].add(identity)
+            if principal is not None:
+                # No legacy buffers, user buckets, hooks, restart or lifecycle
+                # broadcasts are permitted for restricted sessions.
+                self.buffers.pop(identity, None)
+                stale = [
+                    other for other, info in self.connections.items()
+                    if other != identity and other[0] == namespace
+                    and info.principal is not None
+                    and info.principal.principal_type == principal.principal_type
+                    and info.principal.principal_id == principal.principal_id
+                ]
+                for other in stale:
+                    self.connections.pop(other, None)
+                    self._known_sids.discard(other)
+                    self.buffers.pop(other, None)
+                    self._disconnect_times.pop(other, None)
+                    self._diagnostic_watchers.discard(other)
+            else:
+                self.sid_to_user[identity] = user_bucket
+                self.user_to_sids[self._ALL_USERS_BUCKET].add(identity)
+                self.user_to_sids[user_bucket].add(identity)
             connection_count = sum(
                 1 for conn_identity in self.connections if conn_identity[0] == namespace
             )
+        if principal is not None:
+            for old_namespace, old_sid in stale:
+                try:
+                    await self.socketio.disconnect(old_sid, namespace=old_namespace)
+                except Exception:
+                    # The prior generation is already unauthorized locally.
+                    PrintStyle.warning("Restricted WebSocket stale transport cleanup failed")
+            return
         if _ws_debug_enabled():
             PrintStyle.info(f"WebSocket connected: namespace={namespace} sid={sid}")
         await self._run_lifecycle(namespace, lambda h: h.on_connect(sid))
@@ -763,7 +866,15 @@ class WsManager:
         self._ensure_dispatcher_loop()
         identity: ConnectionIdentity = (namespace, sid)
         with self.lock:
-            self.connections.pop(identity, None)
+            info = self.connections.pop(identity, None)
+            if info is None:
+                return
+            if info is not None and info.principal is not None:
+                self._known_sids.discard(identity)
+                self._disconnect_times.pop(identity, None)
+                self.buffers.pop(identity, None)
+                self._diagnostic_watchers.discard(identity)
+                return
             # Keep identity in _known_sids so emit_to buffers instead of raising;
             # record disconnect time for TTL-based cleanup
             self._disconnect_times[identity] = _utcnow()
@@ -815,6 +926,14 @@ class WsManager:
         handler_id: str | None = None,
     ) -> dict[str, Any]:
         self._ensure_dispatcher_loop()
+        if self.principal_for_sid(namespace, sid) is not None:
+            # Restricted clients only use their authenticated per-SID handler;
+            # never select handlers from the global registry.
+            self.record_scope_denial()
+            return self._ack_error(
+                handler_id=self._identifier, code="SCOPE_DENIED",
+                message="Access denied", correlation_id="", ack=ack,
+            )
         incoming = dict(data or {})
         correlation_id = self._resolve_correlation_id(incoming)
         self._debug(
@@ -942,7 +1061,7 @@ class WsManager:
 
         executions = await asyncio.gather(
             *[
-                self._invoke_handler(handler, event_type, dict(handler_payload), sid)
+                self._invoke_handler(handler, event_type, dict(handler_payload), sid, connection=info)
                 for handler in selected_handlers
             ]
         )
@@ -1099,8 +1218,8 @@ class WsManager:
         with self.lock:
             active_sids = [
                 conn_identity[1]
-                for conn_identity in self.connections.keys()
-                if conn_identity[0] == namespace
+                for conn_identity, info in self.connections.items()
+                if conn_identity[0] == namespace and info.principal is None
             ]
         if not active_sids:
             self._debug(
@@ -1208,7 +1327,17 @@ class WsManager:
         handler_id: str | None = None,
         correlation_id: str | None = None,
         diagnostic: bool = False,
+        expected_principal: WsPrincipal | None = None,
     ) -> None:
+        with self.lock:
+            connection = self.connections.get((namespace, sid))
+        principal = connection.principal if connection else None
+        if expected_principal is not None and principal is not expected_principal:
+            self.record_scope_denial()
+            raise WsScopeDeniedError("Restricted WebSocket identity mismatch")
+        if principal is not None and not principal.permits_outbound(event_type, handler_id):
+            self.record_scope_denial()
+            raise WsScopeDeniedError("Restricted WebSocket event denied")
         envelope = self._wrap_envelope(
             handler_id,
             data,
@@ -1231,19 +1360,20 @@ class WsManager:
                     known = False
 
         if connected:
-            self._debug(
-                "Emit to namespace=%s sid=%s event=%s eventId=%s correlationId=%s handlerId=%s"
-                % (
-                    namespace,
-                    sid,
-                    event_type,
-                    envelope.get("eventId"),
-                    envelope.get("correlationId"),
-                    envelope.get("handlerId"),
+            if principal is None:
+                self._debug(
+                    "Emit to namespace=%s sid=%s event=%s eventId=%s correlationId=%s handlerId=%s"
+                    % (
+                        namespace,
+                        sid,
+                        event_type,
+                        envelope.get("eventId"),
+                        envelope.get("correlationId"),
+                        envelope.get("handlerId"),
+                    )
                 )
-            )
             await self._run_on_dispatcher_loop(
-                self.socketio.emit(event_type, envelope, to=sid, namespace=namespace)
+                self._emit_for_connection(connection, event_type, envelope)
             )
             delivered = True
         else:
@@ -1259,7 +1389,7 @@ class WsManager:
                 )
             buffered = True
 
-        if not diagnostic:
+        if not diagnostic and principal is None:
             await self._publish_diagnostic_event(
                 lambda: {
                     "kind": "outbound",
@@ -1303,14 +1433,20 @@ class WsManager:
 
         targets: list[str] = []
         with self.lock:
-            current_identities = list(self.connections.keys())
-        for conn_identity in current_identities:
+            current_connections = list(self.connections.items())
+        permitted_connections = []
+        for conn_identity, connection in current_connections:
             if conn_identity[0] != namespace:
                 continue
             sid = conn_identity[1]
             if sid in excluded:
                 continue
+            # A broadcast has no per-context authorization. Even an allowlisted
+            # name must use explicit, handler-bound emit_to for restricted SIDs.
+            if connection.principal is not None:
+                continue
             targets.append(sid)
+            permitted_connections.append(connection)
 
         if targets:
             envelope = self._wrap_envelope(
@@ -1320,9 +1456,9 @@ class WsManager:
             )
             coros = [
                 self._run_on_dispatcher_loop(
-                    self.socketio.emit(event_type, envelope, to=sid, namespace=namespace)
+                    self._emit_for_connection(connection, event_type, envelope)
                 )
-                for sid in targets
+                for connection in permitted_connections
             ]
             await asyncio.gather(*coros)
 
@@ -1364,6 +1500,9 @@ class WsManager:
         correlation_id: str | None,
     ) -> None:
         namespace, sid = identity
+        info = self.connections.get(identity)
+        if identity not in self._known_sids or (info is not None and info.principal is not None):
+            return
         buffer = self.buffers[identity]
         buffer.append(
             BufferedEvent(
@@ -1384,6 +1523,11 @@ class WsManager:
 
     async def _flush_buffer(self, identity: ConnectionIdentity) -> None:
         self._ensure_dispatcher_loop()
+        with self.lock:
+            connection = self.connections.get(identity)
+        if connection is None or connection.principal is not None:
+            self.buffers.pop(identity, None)
+            return
         buffer = self.buffers.get(identity)
         if not buffer:
             return
@@ -1413,9 +1557,7 @@ class WsManager:
                 )
             )
             await self._run_on_dispatcher_loop(
-                self.socketio.emit(
-                    event.event_type, envelope, to=sid, namespace=namespace
-                )
+                self._emit_for_connection(connection, event.event_type, envelope)
             )
             delivered += 1
         if identity in self.buffers:
@@ -1424,6 +1566,41 @@ class WsManager:
             PrintStyle.info(
                 f"Flushed {delivered} buffered event(s) to namespace={namespace} sid={sid}"
             )
+
+    async def _emit_for_connection(self, connection, event_type, envelope) -> None:
+        # Authorization belongs to a connection generation, never just a SID.
+        # Run this check on the dispatcher loop immediately before transport.
+        if connection is None:
+            return
+        with self.lock:
+            if self.connections.get((connection.namespace, connection.sid)) is not connection:
+                return
+            principal = connection.principal
+            if principal is not None and not principal.permits_outbound(event_type, envelope.get("handlerId")):
+                raise WsScopeDeniedError("Restricted WebSocket event denied")
+        if principal is not None:
+            try:
+                active = connection.principal_validator is not None and connection.principal_validator(principal)
+            except Exception:
+                active = False
+            if not active:
+                self.record_scope_denial()
+                raise WsScopeDeniedError("Restricted WebSocket credential inactive")
+        with self.lock:
+            if self.connections.get((connection.namespace, connection.sid)) is not connection:
+                return
+        await self.socketio.emit(event_type, envelope, to=connection.sid, namespace=connection.namespace)
+
+    def record_scope_denial(self) -> None:
+        # Bounded local audit only; no attacker-supplied names, payload keys,
+        # correlation strings or proof/error material enters diagnostics.
+        with self.lock:
+            self._scope_denials.append({"code": "SCOPE_DENIED", "timestamp": self._timestamp()})
+
+    def principal_for_sid(self, namespace: str, sid: str) -> WsPrincipal | None:
+        with self.lock:
+            info = self.connections.get((namespace, sid))
+            return info.principal if info else None
 
     def _build_error_result(
         self,

--- a/helpers/ws_manager.py.dox.md
+++ b/helpers/ws_manager.py.dox.md
@@ -37,6 +37,22 @@
 
 ## Runtime Contracts
 
+- `ConnectionInfo` retains an immutable restricted principal and a server-owned
+  liveness callback. Restricted connections do not join legacy user buckets,
+  global lifecycle/dispatch, diagnostic watchers, broadcast fan-out, or buffers.
+  New authentication for the same principal invalidates the old SID before
+  transport disconnect. Unknown/duplicate disconnect callbacks are no-ops.
+- Incoming per-SID requests require the exact bound handler and current
+  credential. Outgoing direct sends require both event and handler allowlists
+  plus current credential validation; denial raises `WsScopeDeniedError`.
+  Sends and queued handler work bind to a specific `ConnectionInfo` generation,
+  so delayed work cannot cross a disconnect/replacement boundary.
+- Restricted payloads and raw handler errors are excluded from developer
+  diagnostics. Denials retain only a typed code and timestamp in a bounded
+  128-entry local audit deque. Raised exceptions and `WsResult.error` details
+  are redacted. No restricted reconnect buffering is implemented or permitted.
+- `handle_connect(..., principal=..., principal_validator=...)` is additive;
+  callers without a principal retain ordinary session and buffering behavior.
 - Helper modules own reusable framework APIs and must preserve public callers unless all callers, tests, and docs are updated together.
 - Update this file whenever public functions, classes, persistence behavior, path/security assumptions, side effects, or cross-module contracts change.
 - Observed side-effect areas: filesystem deletion, network calls, WebSocket state, settings/state persistence, scheduler state.
@@ -55,6 +71,11 @@
 
 ## Verification
 
+- `tests/test_ws_restricted_principal.py` covers direct/broadcast/replay denies,
+  duplicate disconnect, same-principal replacement, connection-generation
+  isolation, liveness, and error redaction. Run existing `test_ws_manager.py`
+  to prove legacy envelopes, diagnostics, buffers, filters and fan-out remain
+  compatible.
 - Run targeted tests for changed helper behavior; run security regressions for auth, filesystem, WebSocket, tunnel, upload, or secret-handling helpers.
 - Related tests observed by source search:
   - `tests/test_browser_agent_regressions.py`

--- a/helpers/ws_principal.py
+++ b/helpers/ws_principal.py
@@ -1,0 +1,45 @@
+"""Immutable, server-derived restrictions for non-session WebSocket clients."""
+
+from dataclasses import dataclass
+import re
+
+
+class WsScopeDeniedError(PermissionError):
+    """An internal emit attempted to cross a restricted socket boundary."""
+
+
+@dataclass(frozen=True, slots=True)
+class WsPrincipal:
+    principal_type: str
+    principal_id: str
+    subject_id: str
+    scopes: frozenset[str]
+    handler_path: str
+    handler_id: str
+    inbound_events: frozenset[str]
+    outbound_events: frozenset[str]
+    key_generation: int
+    diagnostic_mode: str = "bridge_redacted"
+
+    def __post_init__(self) -> None:
+        # Copy even server-supplied collections; frozen dataclasses alone do not
+        # protect mutable collection fields.
+        for name in ("scopes", "inbound_events", "outbound_events"):
+            object.__setattr__(self, name, frozenset(getattr(self, name)))
+        if self.diagnostic_mode != "bridge_redacted":
+            raise ValueError("Restricted principals require redacted diagnostics")
+
+    def permits_inbound(self, event: str, handler_id: str) -> bool:
+        return handler_id == self.handler_id and event in self.inbound_events
+
+    def permits_outbound(self, event: str, handler_id: str | None) -> bool:
+        return handler_id == self.handler_id and event in self.outbound_events
+
+
+def restricted_correlation_id(value: object) -> str:
+    """Never reflect arbitrary client payloads as correlation metadata."""
+    import uuid
+
+    if isinstance(value, str) and re.fullmatch(r"[A-Za-z0-9_-]{1,128}", value):
+        return value
+    return uuid.uuid4().hex

--- a/helpers/ws_principal.py.dox.md
+++ b/helpers/ws_principal.py.dox.md
@@ -1,0 +1,15 @@
+# Restricted WebSocket principal
+
+`WsPrincipal` is an immutable, server-derived identity and allowlist for a
+non-session WebSocket client. Collections are copied into frozensets. It holds
+no proof, nonce, signature, cookie, API key, or private key. The authenticating
+handler owns scope-to-event mapping and ongoing credential validation.
+
+Both event name and authenticated handler identity must match. Restricted
+clients never join ordinary user fan-out, global handler lifecycle/dispatch,
+diagnostic watchers, or reconnect buffers. `restricted_correlation_id` bounds
+client correlation metadata; bridge diagnostics must not retain even permitted
+correlation values or primitive payloads. Legacy clients use no principal and
+retain their existing authentication and event behavior.
+
+Verify with `tests/test_ws_restricted_principal.py` plus WebSocket regressions.

--- a/plugins/_a0_connector/AGENTS.md
+++ b/plugins/_a0_connector/AGENTS.md
@@ -24,6 +24,12 @@
 - Never re-add a connector prompt that the effective project/profile tool policy
   blocks.
 - Do not bypass WebSocket authentication or leak connector session data.
+- Browser bridge HTTP action/choice values must be strings before enum-set
+  lookup; malformed JSON values return no-store HTTP 400 without state access.
+- Production restricted handlers copy the WsManager-unwrapped payload and
+  remove only its sanitized `correlationId` before strict hello and application
+  decoding. Preserve the original transport payload for correlated ACKs and
+  reject every other extra document field; ordinary CLI dispatch is unchanged.
 - Advertise Launcher gateways additively through HTTP capability
   `launcher_gateway` and WebSocket feature `launcher_gateway_control`. Older
   ordinary CLI clients retain their existing protocol fields and behavior; do
@@ -54,6 +60,325 @@
   `connector_file_op_result` frames; resolve the pending file operation only
   after all chunks for the `op_id` are assembled.
 - Host browser status metadata may advertise `available_browsers` entries with browser ids, labels, CDP endpoints, status, and enabled state; keep older CLI payloads without those fields compatible.
+- Advertise the Chrome extension bridge foundation additively; do not advertise pairing or runtime capabilities before those implementations exist. Legacy Chrome bridge detection is read-only, descriptor-anchored, bounded, and symlink-safe, and is confirmed only by exact prototype name/version plus at least two independent structural markers with no unavailable inspection. Inspect canonical roots in runtime precedence order: a higher-priority present partial or unknown copy blocks a lower-priority confirmed copy. Missing roots are absent, but present incomplete roots are partial and inspection failures are unknown; both partial and unknown block cutover. Public cutover projections are versioned and allowlisted, contain no paths, URLs, identifiers, payloads, credentials, or raw errors, and must not claim quarantine, draining, purge, or activation before those effects are implemented.
+- Explicit legacy retirement is separate from read-only detection. Read
+  `helpers/browser_bridge_legacy_retirement.py.dox.md` and its protected API
+  DOX before editing its bounded process drain, journal, or request/tool guards.
+  Do not auto-retire on startup, replay interrupted work, touch legacy browser
+  tabs/credentials, or treat legacy disabling as production activation proof.
+- Legacy context/history migration is owned by
+  `helpers/browser_bridge_legacy_quarantine.py.dox.md`. Preserve removed values
+  in private recoverable quarantine before exact-owner redaction. Generic
+  persistence hooks and the bounded loaded-context sweep must not scan/delete
+  arbitrary user artifacts or imply Chrome-local storage cleanup.
+- Capability discovery may advertise `browser_extension_mv3_runtime_foundation` only when the schema helper is present. This is an effect-free contract/validation seam, not the negotiated `browser_extension_bridge_v1` runtime feature; it must not imply pairing, transport, dispatch, installation, or browser mutation readiness.
+- Browser bridge pairing uses the instance rollout gate plus the server-pinned `A0_BROWSER_BRIDGE_EXTENSION_ID` and optional canonical `A0_BROWSER_BRIDGE_SERVER_BASE_URL`. `browser_bridge_pairing` uses normal `ApiHandler` session authentication and CSRF for exact create/status/cancel actions; only create may return the five-minute 160-bit code, and pending secrets remain bounded process memory. `browser_bridge_exchange` is the sole public one-time-code boundary, with an exact 8 KiB request, duplicate-key rejection at every JSON object depth, five generic failed attempts per intent, coarse bounded source rates, constant-time digest comparison, and atomic consumption into an allowlisted durable Ed25519 public-key record. Both routes use no-store responses and browser-host-only Docker semantics. Pairing discovery advertises `browser_bridge_pairing_v1`; it does not establish signed-session or browser-runtime readiness. Those require the complete production admission path below.
+- The obsolete development bridge endpoints, credentials-as-authority, runtime
+  owner and UI are retired. Only the fixed production transport is accepted.
+  Do not migrate development keys or grants into production or delete private
+  stored records during startup. Old selectors must fail without fallback.
+- Browser bridge connector challenges accept only an active server-side bridge ID and a fresh 32-byte client nonce, then return a 60-second 32-byte server nonce. Challenge material and source-rate state are bounded process memory, and the first proof attempt consumes the challenge regardless of outcome. Verify the exact frozen proof with Ed25519 over fixed scalar-only RFC 8785 JCS bytes and derive the `browser_bridge` principal only from the active record. Signed sessions require WebSocket origin enforcement, ambient-cookie isolation, scoped handler activation, event filtering and disconnect cleanup; browser control additionally requires production runtime admission and reconciliation.
+- The scoped-session adapter accepts the exact singleton connector
+  proof envelope only after shared Origin validation. Recheck current server
+  URL/instance and extension pin at authentication, and gate, active record,
+  subject, extension pin, key generation and scopes during use. Bind only the
+  immutable shared principal; keep `requires_auth()` true. Restricted SIDs
+  never enter the legacy CLI registry or remote-tool metadata handlers.
+  Without an installed application it remains hello-only, returning no features
+  or exec configuration and reporting runtime readiness false. The composed
+  production application admits exact hello through its registry before any
+  other restricted dispatch; authentication alone never grants browser control.
+- The browser operation broker is a bounded, process-memory-only dispatch seam,
+  not runtime activation. It accepts authority and delivery only through
+  injected adapters, and never reads the legacy connector registry or trusts
+  hello metadata. Bind every pending operation/control immutably to the exact
+  restricted principal object, SID, bridge, load generation, context, browser
+  session, turn, action, and correlation IDs. Emit canonical nested browser
+  requests with additive `bridge_id` and `load_generation_id` (and
+  `browser_session_id` on cancel), validate all negotiated capabilities before
+  send, and settle only an exact echoed binding. Caller cancellation never
+  cancels the shared receipt future. Disconnect/send/deadline loss is
+  `OUTCOME_UNKNOWN` for mutations and controls; only read-only work may return a
+  retryable not-applied result. This seam correlates cancel, turn finalization,
+  and exact pending-navigation site resolution; retained navigation metadata
+  contains only target handle, canonical parameter hash, and destination origin.
+  Site controls require a server-owned decision preflight and remain bounded by
+  the pending operation deadline. Production composition supplies the attested
+  capability authorizer and exact restricted sender; the broker alone cannot
+  advertise or activate browser control.
+- Broker transport tasks are retained and bounded separately from pending
+  replies. Recheck current authority, negotiated capabilities, pending identity,
+  and the injected site/turn preflight immediately before send. Process-owned
+  deadlines survive waiter cancellation; a late response cannot bypass expiry.
+  Only exact immutable turn bindings may enumerate pending operations for
+  cancel-before-finalize cleanup.
+- Persistent Browser bridge site policy defaults to exact canonical HTTP(S)
+  origins keyed by current server instance, active bridge and server-derived
+  subject. Production additionally supports explicit `allow_all_websites` via
+  protected `set_mode`; it is never enabled by pairing or by an agent request.
+  Store v2 adds bounded bridge-scoped mode records; legacy v1 grants remain
+  unchanged. Project exact-origin grant IDs from the current mode generation
+  without storing visited origins. Disabling the mode withdraws those derived
+  grants while preserving individually saved sites. The protected, CSRF-checked
+  policy endpoint accepts only bounded `list`, `allow`, `revoke`, and `set_mode`
+  requests, resolves the
+  active bridge before every action, and fails closed on invalid or unavailable
+  durable state. Policy records never contain page URLs, content, operation
+  arguments, or request-selected authority. This foundation does not mint
+  one-operation approval receipts, dispatch Browser work, advertise runtime
+  readiness, or enable Browser control.
+- Saved browsing policy may automatically resolve only a genuine current
+  native navigation challenge through the ordinary exact `allow_once` control.
+  Retain its saved exact-origin grant ID and recheck it before control dispatch
+  and receipt settlement; mode withdrawal or generation replacement invalidates
+  that automatic choice. Never synthesize a native challenge, broaden its
+  document/lease/operation scope, or auto-approve consequential actions.
+- Consequential Browser action approval is a separate bounded, process-memory
+  seam. Register only an extension-issued challenge ID bound to the exact
+  current server-owned bridge principal, key and load generations, connector,
+  context, browser session, turn, action, operation, tab handle, document
+  identity and epoch, canonical parameter hash, target fingerprint, exact
+  origin, and consequential action class. The
+  protected decision endpoint accepts only `challenge_id` plus
+  `approve_once` or `decline`; it cannot create challenges or supply authority
+  bindings. Recheck the active bridge record, server-derived subject, and
+  current route at registration, decision, and receipt consumption. Receipts
+  expire within two minutes, authorize one exact consumption, and are denied
+  on mismatch, cancellation, turn finalization, disconnect, revocation, or
+  expiry. Production action authority supplies the exact route resolver and
+  control dispatch. Standalone repositories default closed and cannot advertise
+  readiness.
+- Browser bridge context access is a purpose-built seam, separate from the
+  legacy connector event projection. Bind advertised context IDs and
+  subscriptions to the exact immutable bridge principal object, connector SID,
+  and load generation, rechecking current route authority after every data
+  source call. Subscribe, read, and message authorization may target only IDs
+  advertised to that exact route. Project conversation text only from the
+  actual Agent Zero `input`, `user`, and `response` log types; all other known
+  log types may contribute only an allowlisted activity/status classification,
+  and unknown structures are dropped. Never project Browser/tool result
+  content, headings, kvps, scripts, selectors, paths, raw errors, page data, or
+  attachments. Keep pages bounded while preserving cursor, history pagination,
+  and completion state, and reject any nonempty source page that cannot advance
+  its cursor. The default route authorizer remains fail-closed; production
+  composition supplies registry authority and the separate context controller.
+  This access helper neither changes legacy projection nor grants runtime readiness.
+- The Browser bridge runtime registry is composed by the normal server-owned
+  production bootstrap only under available rollout and a pinned extension.
+  Normalize only the exact bounded v1 extension hello, and
+  treat its browser label, capabilities, versions, limits, installation, and
+  load generation as untrusted claims. Route admission requires a current
+  companion stable semantic version at or above the independent `2.12.0`
+  security floor (never a CLI-version equality or preview-version bypass), a
+  server-instance-scoped immutable principal verification and an independent
+  exact typed attestation that release trust, activation, legacy isolation,
+  operation/control/context/event/artifact/approval transports, session
+  lifecycle, and policy enforcement are all complete; both checks default
+  closed and are repeated during route resolution, broker authorization, and
+  result settlement. Bind one bounded route per server-derived bridge identity,
+  replace reconnects or generation changes only for the same principal
+  authority, remove old state before running fail-isolated exact-principal/SID/
+  generation cleanup, and never consult the legacy connector registry. Context
+  plus explicit `extension:<bridge_id>` selection must resolve before returning
+  `ValidatedExtensionRoute`. The broker sender may emit only Browser operation
+  and control events through shared `WsManager.emit_to` with the exact restricted
+  handler and expected principal; it never broadcasts or supplies a fallback.
+  Keep route admission and readiness denied while any complete-runtime
+  boundary or production attestation remains unavailable. Server release
+  approval requires the independently signed, bounded local policy and pinned
+  public root; presentation catalog metadata never supplies release trust.
+- Browser bridge text delivery targets only an existing context advertised to
+  the exact current principal, SID, and load generation. Persist a hash-only,
+  server/bridge/subject/context/client-message-bound hash reservation before
+  any log or model effect, recheck authority immediately before delivery, and
+  persist acceptance afterwards. Identical accepted reconnect replays return
+  the original acknowledgement without another effect; changed payloads
+  conflict, and reserved or uncertain delivery never retries automatically.
+  Durable records contain hashes and timestamps, not conversation text.
+  AgentContext owns the resulting task independently of presentation sockets;
+  no attachment paths, global context switch, or legacy connector fallback is
+  accepted. Message and queue receipts share `browser_bridge_journal`: new
+  records use individually indexed atomic KVP writes, with the bounded original
+  v1 records retained read-only as a fallback. Before the first indexed write,
+  atomically mark that journal schema v2 without altering its receipts; older
+  builds must reject it instead of overlooking new records during a downgrade.
+  Existing receipts are never
+  evicted; uncertain reservations never become fresh work. Disk use grows with
+  distinct request IDs, but lifetime count does not block new messages. Store
+  failures and malformed receipts remain fail-closed. Callers retain their lane
+  lock across reservation, effect and settlement; no cross-process transaction
+  or multi-worker ownership is introduced.
+  Injected journal adapters use KVP-shaped `load(key, default)` / `save(key,
+  value)` callbacks, including exact missing-default identity. Tests exercise
+  the same indexed writes and downgrade fence as production, not a second
+  whole-document storage implementation.
+- `browser_bridge_application` composes the implemented current-route registry,
+  exact context controllers, once-only messages, critical-event receiver, and
+  Browser lifecycle/broker services under one explicit server owner. Its
+  dispatcher resolves the retained generation from the exact principal/SID,
+  never a client-selected route; unsupported event lanes fail closed and never
+  enter legacy connector handlers. Route retirement removes lookup authority
+  before negative lease/projection cleanup, and explicit disconnect awaits only
+  presentation and artifact teardown. Artifact frames resolve only an exact
+  pending operation whose action matches the output purpose, and private spool
+  access additionally requires the same still-active turn and current route.
+  Verified output consumption may outlive operation settlement, never turn or
+  route authority. Construction does not broaden authentication, install
+  the Browser factory, advertise capabilities, or attest missing transports.
+- Restricted queue dispatch reuses Core message_queue only for exact owned
+  text entries, with advertise-before-message checks, hash-only durable
+  reservations, bounded projections and no global queue clear. Local approval
+  dispatch derives the current route and subject, then requires exact retained
+  principal/SID/load/profile inside the site/action repository lock. Their
+  helper sidecar DOX defines the strict bodies and uncertain outcome behavior.
+  Neither lane enters legacy connector handlers. runtime_boundaries reports
+  only implemented owned lanes; artifact requires output plus the concrete
+  input source/sender/ACK/consent/sink composition, not output support alone.
+- `browser_bridge_bootstrap` is the only optional process-global owner for a
+  fully composed Browser bridge application. Importing it installs nothing.
+  The enabled connector's `webui_server_start` hook installs the configured
+  owner inside each ASGI lifespan before serving requests and registers
+  manager-qualified retirement on that lifespan's shutdown stack. Startup
+  retries install afresh only after the prior owner retires. Core retains the legacy
+  HTTP retirement guard regardless of connector enablement.
+  Without an explicit binding, newly authenticated principals remain
+  hello-only and the existing unavailable response is unchanged. With a
+  binding, freeze the full bridge-only inbound/outbound event sets into the
+  immutable principal, atomically register exact hello through that owner, and
+  route every other restricted event only to its dispatcher. Missing owners,
+  stale principals, and unadmitted SIDs fail closed without legacy fallback.
+  Successful hello returns negotiated capabilities, exact typed activation
+  evidence, and a transport-private server/bridge/SID/key/load binding only
+  after current admission. It never returns exec configuration, context state,
+  proof/key material, raw claims, or subject identity. Do not expose the
+  connector binding in WebUI/status. Replacement or removal must use the exact
+  async owner-retirement path: hide it from new routing, await application
+  cleanup, then clear the site API binding. Never synchronously unbind or
+  replace an installed owner, construct an application from a request, or treat
+  installation as a cutover/activation bypass. Binding additionally requires
+  that the application has explicitly acquired its exact Browser factory and
+  lifecycle ownership; construction alone is not installation. Retirement
+  withdraws only those owned seams before route cleanup. An exact same
+  principal/SID/load hello replay refreshes server admission without invoking
+  disconnect cleanup. Only successful exact reconciliation promotion may
+  schedule already-durable finalizations; neither initial nor provisional
+  repeated hello may replay them.
+- Runtime admission additionally requires an immutable activation attestation
+  from independent server-owned selection, heartbeat, subject/profile and
+  legacy-cutover checks, bound to exact principal/server/SID/load/install and
+  negotiated features. Aggregate ready flags or client hello fields cannot
+  substitute. Evidence is valid for at most 30 seconds, is reevaluated at route
+  lookup, and serializes only the frozen activation projection after matching.
+- Browser bridge context-event control is an isolated exact-route presentation
+  lane. Accept only strict list, subscribe, unsubscribe, and existing-context
+  text requests; empty artifact/candidate placeholders convey no authority.
+  Emit only bounded projected snapshot, event, and completion frames through
+  shared `emit_to` with the exact restricted principal, SID, load generation,
+  and handler. Preserve source and history cursors, recheck the current route
+  around reads and delivery, and include the source update cursor separately
+  from each stable item sequence on live events. Do not publish a page-end
+  cursor until its last visible event is emitted. Retain at most one poller per exact
+  route/context. Healthy subscriptions remain live until explicit unsubscribe,
+  disconnect, route loss, or source failure; cleanup cancels the presentation
+  reader only and never the AgentContext task. The production application wires
+  this controller only to admitted, reconciled restricted routes; the unbound
+  bootstrap remains hello-only.
+- Critical Browser bridge events use a separate durable hash-only receipt lane.
+  Accept only the exact critical `lease.changed`, `turn.finalized`, and
+  `challenge.required` site/action envelopes
+  for the current server-owned principal, SID, key/load generation, and
+  `browser.operate` scope. Persist event-ID and canonical-event hashes before
+  any callback, invoke only idempotent negative lease invalidation or an
+  informational finalization observer, or exact site/action-challenge registrar, then
+  advance the durable cursor across applied contiguous sequences only. A site
+  registration failure is replayable and cannot advance the cursor. Passive lease creation never grants or
+  invalidates authority, callback failure never advances the cursor, gaps never
+  ACK forward, and old-generation replay cannot replace current state. Emit the
+  generation-qualified highest-contiguous ACK only through exact restricted
+  `emit_to`; never persist event payloads or treat finalization notice as a
+  control-result receipt. Keep unsupported critical kinds and production
+  activation fail-closed.
+- Consequential click/TYPE authority composes the bounded once-only approval
+  receipt only after matching the exact current pending action, canonical
+  parameter hash, owned lease digests/origin, semantic document ID/epoch, and
+  requested ref. TYPE retains only its verified UTF-8 text digest and binds the
+  immutable sensitive-text classification through event, receipt, control, and
+  grant; raw text exists only in the transient operation transport.
+  The protected API accepts only a context-qualified safe list request or
+  challenge ID plus `decline`/`approve_once`; the request context only selects
+  current agent0 project/profile configuration, while pending results omit
+  context and Browser IDs, and include only the server-owned `click`/`type`
+  discriminator. Recheck the server-selected exact extension bridge
+  throughout challenge and control lifecycle. Consume the hidden receipt after a final current-route preflight
+  and immediately before queuing one exact resolution control. Keep the control
+  task process-owned, same-choice replay idempotent, changed-choice replay
+  denied, and all authority operation-only and bounded by the live operation,
+  challenge, and two-minute ceiling. Do not persist or expose typed text, text
+  digests, refs, raw page data, full URLs, target hashes, receipts, or grants,
+  and do not infer TYPE or readiness from approval support alone.
+- Site-origin runtime authority is separate from durable saved-site policy and
+  general consequential-action approval. Register a `site`/`navigate`
+  challenge only after matching its exact current broker operation, retained
+  canonical parameter hash and destination origin, owned lease-handle digests,
+  and recomputed generation/document target fingerprint. The protected site
+  decision endpoint derives the subject and accepts only challenge ID plus
+  `deny`, `allow_once`, or `allow_turn`; its list exposes only canonical origin,
+  action class, server-generated summary, fixed options, and expiry. Retain no
+  full URL or extension summary. Mint no grant until the exact correlated
+  resolution result arrives. Operation grants authorize only their original
+  live ticket. Turn grants require an injected exact live-turn check and current
+  server/principal/SID/load/context/session/turn route, expire within two hours,
+  and auto-resolve only a fresh challenge that matches that same current grant.
+  Finalization, disconnect, revocation, mismatch, and expiry remove authority.
+  Keep state and retained resolution tasks bounded, global binding explicitly
+  unavailable without its application owner, and responses no-store. Site
+  permission never substitutes for production activation.
+- Browser companion release metadata is a read-only, normally authenticated and CSRF-protected WebUI projection of server-pinned public catalog data. Advertise only `browser_companion_release_metadata` for endpoint discovery; that feature does not assert installer, pairing, release, or browser-runtime readiness. Use the distinct `a0.browser-bridge.release-metadata.v1` presentation contract, report only `available` or `unavailable`, and keep `install_ready: false` because Core does not verify release bytes. The endpoint is unavailable until canonical catalog URLs, catalog-key fingerprint, protocol/trust compatibility, the independent non-lowerable server companion security floor, and the complete signed delivery artifact matrix validate. Reject malformed/nonempty request bodies and request-supplied URLs, paths, extension IDs, or overrides; never expose raw configuration, signing/private keys, server credentials, or native paths, and never download or install anything in the Agent Zero or Docker runtime. Every projection must identify the user's browser host as the install target. Core validates presentation metadata shape and compatibility only; the browser-host installer/CLI verifies the detached catalog signature against its own pinned public root and verifies artifact bytes before execution.
+- Browser reconciliation uses a distinct process-owned binding for the exact
+  fixed transport profile, principal object, connector SID, load generation,
+  and control ID. Validate the complete bounded extension snapshot, but retain
+  only redacted counts; never adopt peer lease/provider claims, settle pending
+  actions, apply embedded critical events, or ACK their cursors. Recheck exact
+  route authority throughout request and result handling. Atomic route
+  promotion must run synchronously inside matching broker settlement before its
+  future is delivered, without awaits or blocking and with consistent owner
+  lock ordering. A following FIFO event still has no authority unless that
+  compare-and-promote succeeded. Caller cancellation does not cancel the owned
+  reconciliation task; the production route owner remains responsible for retiring
+  provisional routes and disconnecting broker tickets. This helper creates no
+  principal, admission, selection, Browser factory, or activation.
+- Browser bridge artifacts use a separate bounded, process-memory receiver with
+  generated private spools; never reuse the generic connector file assembler.
+  Bind every transfer to the exact immutable bridge principal object, connector
+  SID, key/load generation, context, browser session, turn, action, operation,
+  artifact, direction, and standard purpose. Revalidate the injected current
+  route before begin, append, completion, and the single authorized consume;
+  authorization loss deletes the exact spool. Require ordered 192 KiB-or-less
+  chunks, a declaration no larger than 25 MiB, and exact final byte count and
+  SHA-256 before exposing a pathless descriptor. Delete spools on consume,
+  abort, expiry, disconnect, revocation, or receiver shutdown. This private
+  assembler does not wire transport, materialize chat media, or advertise
+  Browser runtime readiness.
+- The Browser artifact transport controller accepts only strict output
+  `screenshot` and `download` begin/chunk/end/abort frames. Resolve a
+  server-owned pending-operation `ArtifactBinding`, then compare the principal
+  object and every SID, generation, bridge, context, session, turn, action,
+  operation, artifact, direction, and purpose echo before touching a spool.
+  Re-resolve that pending binding after each receiver transition and purge the
+  exact transfer without acknowledging if operation authority disappeared.
+  Decode only canonical standard base64 chunks within the 192 KiB raw and 768
+  KiB frame limits. Acknowledge progress, a verified pathless descriptor, or a
+  bounded typed abort only through exact-principal `emit_to`; never infer a
+  duplicate chunk. One controller-owned expiry task starts on first accepted
+  begin and stops when globally idle. Disconnect cleanup targets only the exact
+  principal/SID/generation, while controller close owns receiver shutdown.
+  The complementary input sender is wired to exact restricted ACK dispatch,
+  binds immutable server bytes to a current upload operation and live turn,
+  and requires the server-owned source/site preflight. Await the exact broker
+  wait_dispatched barrier before the first input frame. It bounds each frame
+  and transfer and never retries uncertain sends. Native defers the operation
+  until verified input completion; extension one-use external-side-effect
+  consent remains required before setting the visible, empty single-file field.
 - Model preset definitions exposed through v1 are global; project arguments select scope but never create project-owned definitions. Model switcher state reports the effective main, utility, and embedding models and preserves embedding-change notifications.
 - The protected v1 `agent_editor` route delegates to the bundled Agent Editor
   API and must not define another profile schema or write profile files itself.
@@ -61,8 +386,66 @@
   catalog rather than applying connector-specific visibility rules.
 - Computer Use receipts describe transport success unless the connector returns explicit effect evidence. Linux target-bound typing requires a verified active/focused `window_id`; window activation uses focus, never a press action on an application or window node. Do not retry an identical failed Computer Use call.
 - Accepted WebSocket user-message replay metadata may include attachment basenames only; strip paths, query strings, fragments, and bytes before logging them in `kvps`.
+- Protected Browser bridge inventory uses the normal authenticated and
+  CSRF-protected `ApiHandler` boundary and remains available when rollout is
+  disabled or the configured extension pin changes, because credential cleanup
+  cannot depend on activation. List/detail records only for the current server
+  and subject, projecting `bridge_id`, safe display name, state, key generation,
+  and creation/authentication/revocation times; never expose public/private key
+  material, companion/extension/server identifiers, SIDs, scopes, URLs, or
+  browser data. Revoke idempotently under the pairing store lock shared with
+  exchange and authentication updates, preserving the first revocation time.
+  After durable denial, request exact matching restricted Socket.IO sessions to
+  disconnect through the framework callback; a failed callback is reported only
+  as pending server-session cleanup. Neither outcome claims native-key deletion,
+  browser-action cancellation, lease finalization, or Chrome tab closure.
 
 ## Work Guidance
+
+- The protected site-authority API also projects the production Browser
+  service's separately owned first-open requests. `open-site-` IDs select that
+  server-only lane; no native challenge, resolution control or receipt is
+  fabricated. See the API and `extension_first_open` sidecars. Exact route
+  retirement withdraws its pending requests and temporary grants before they
+  can authorize further work. Only its explicit `allow_site` decision writes
+  exact-origin saved policy from retained server/bridge/subject/origin fields;
+  successful persistence/readback precedes waiter release. Native navigation
+  decision enums remain unchanged.
+
+- Private production handshake/reconciliation diagnostics log only a fixed
+  allowlist of stage/failure symbols, at most five entries per symbol per
+  process. Never include identities, exception text, peer payloads or paths;
+  these logs are diagnostic observations, not readiness authority.
+
+- Production hello transport admission stays provisional until an exact
+  process-owned reconciliation promotes the route. The first repeated hello
+  starts reconciliation only after the initial native ACK has been consumed;
+  initial hello sends no controls. Pending finalizations replay only after
+  promotion. Current context/operation/status authority requires promotion,
+  whereas exact reconcile settlement is allowed while provisional. Retain no
+  peer lease authority; replacement and failed reconciliation fail closed.
+
+- Production selection supports one explicit global default through the
+  protected selection API, independent of a loaded chat. Exact previous-default
+  fencing, active-pair validation and global-only readback are mandatory;
+  project/profile overrides remain untouched. A global default may satisfy
+  hello selection evidence, but each context operation still requires its own
+  effective selection and existing site/action consent. See selection and
+  runtime-owner helper/API sidecars for the strict projection contracts.
+
+- `browser_bridge_setup` is a normally authenticated, CSRF-protected read-only
+  WebUI projection of enabled production extension identity and configured
+  installer links. See its API/helper sidecars. Release presentation input v1
+  requires all nine artifacts; v2 requires sorted unique nonempty known platforms
+  and the exact union of complete groups. Neither is catalog-signature proof;
+  host verification remains mandatory and unsupported OS links remain absent.
+
+- `browser_bridge_credentials` owns interruption-safe public-key generation
+  rotation under the pairing lock; its sidecar documents exact-key CAS and
+  expiry. `browser_bridge_credential_control` owns current-production-principal
+  rotation/status/self-revoke dispatch, durable denial before process-owned
+  negative socket cleanup. The native private-key workflow is independently
+  required and neither helper supplies release or activation evidence.
 
 - Coordinate connector runtime changes with API, tools, prompts, and WebUI viewer behavior together.
 

--- a/plugins/_a0_connector/api/browser_bridge_approval.py
+++ b/plugins/_a0_connector/api/browser_bridge_approval.py
@@ -1,0 +1,170 @@
+"""POST /api/plugins/_a0_connector/browser_bridge_approval."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from helpers.api import ApiHandler, Request, Response
+from plugins._a0_connector.helpers.browser_bridge_approval import (
+    APPROVAL_CHOICES,
+    BROWSER_BRIDGE_APPROVAL_CONTRACT,
+    BROWSER_BRIDGE_APPROVAL_VERSION,
+    MAX_APPROVAL_REQUEST_BYTES,
+    BrowserBridgeApprovalError,
+    validate_approval_identifier,
+)
+from plugins._a0_connector.helpers.browser_bridge_action_authority import (
+    BrowserBridgeActionAuthorityError,
+    BrowserBridgeActionAuthorityUnavailable,
+    get_browser_bridge_action_authority,
+)
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    SUBJECT_ID,
+    parse_unique_json_object,
+)
+from plugins._a0_connector.helpers.browser_bridge_selection import selected_bridge
+
+
+class BrowserBridgeApproval(ApiHandler):
+    """Record one protected user decision for an existing exact challenge."""
+
+    async def handle_request(self, request: Request) -> Response:
+        document = _read_bounded_document(request)
+        if document is None:
+            return _invalid()
+        return await self._dispatch(document)
+
+    async def process(self, input: dict, request: Request) -> Response:
+        if _unsupported_body(input, request):
+            return _invalid()
+        return await self._dispatch(input)
+
+    async def _dispatch(self, input: dict[str, Any]) -> Response:
+        if input.get("action") == "list":
+            if set(input) != {"action", "context_id"}:
+                return _invalid()
+            try:
+                context_id = validate_approval_identifier(
+                    input.get("context_id"), field_name="context_id"
+                )
+            except BrowserBridgeApprovalError:
+                return _invalid()
+            bridge_id = selected_bridge(context_id)
+            if bridge_id is None:
+                return _json_response({**_base_response(), "challenges": []})
+            try:
+                challenges = get_browser_bridge_action_authority().list_pending(
+                    subject_id=SUBJECT_ID,
+                    context_id=context_id,
+                    bridge_id=bridge_id,
+                )
+            except BrowserBridgeActionAuthorityUnavailable:
+                return _unavailable(status=503)
+            except Exception:
+                return _unavailable(status=503)
+            return _json_response(
+                {
+                    **_base_response(),
+                    "challenges": [dict(challenge) for challenge in challenges],
+                }
+            )
+        if set(input) != {"challenge_id", "choice"}:
+            return _invalid()
+        try:
+            challenge_id = validate_approval_identifier(
+                input.get("challenge_id"),
+                field_name="challenge_id",
+            )
+        except BrowserBridgeApprovalError:
+            return _invalid()
+        choice = input.get("choice")
+        if not isinstance(choice, str) or choice not in APPROVAL_CHOICES:
+            return _invalid()
+        try:
+            decision = await get_browser_bridge_action_authority().decide(
+                subject_id=SUBJECT_ID,
+                challenge_id=challenge_id,
+                choice=choice,
+            )
+        except (BrowserBridgeApprovalError, BrowserBridgeActionAuthorityError):
+            return _invalid()
+        except BrowserBridgeActionAuthorityUnavailable:
+            return _unavailable(status=409)
+        except Exception:
+            return _unavailable(status=503)
+        return _json_response({**_base_response(), **decision.as_public_dict()})
+
+
+def _base_response() -> dict[str, Any]:
+    return {
+        "contract": BROWSER_BRIDGE_APPROVAL_CONTRACT,
+        "approval_version": BROWSER_BRIDGE_APPROVAL_VERSION,
+        "browser_control_ready": False,
+    }
+
+
+def _unsupported_body(input: Any, request: Request | None) -> bool:
+    if not isinstance(input, dict):
+        return True
+    if request is None:
+        return False
+    raw_data = bytes(getattr(request, "data", b"") or b"")
+    content_length = getattr(request, "content_length", None)
+    if isinstance(content_length, int) and content_length > MAX_APPROVAL_REQUEST_BYTES:
+        return True
+    if not raw_data:
+        return False
+    return (
+        len(raw_data) > MAX_APPROVAL_REQUEST_BYTES
+        or not bool(getattr(request, "is_json", False))
+        or parse_unique_json_object(raw_data) is None
+    )
+
+
+def _read_bounded_document(request: Request) -> dict[str, Any] | None:
+    content_length = getattr(request, "content_length", None)
+    if (
+        isinstance(content_length, int)
+        and not 1 <= content_length <= MAX_APPROVAL_REQUEST_BYTES
+    ):
+        return None
+    if not bool(getattr(request, "is_json", False)):
+        return None
+    stream = getattr(request, "stream", None)
+    if stream is None or not hasattr(stream, "read"):
+        return None
+    try:
+        raw_data = stream.read(MAX_APPROVAL_REQUEST_BYTES + 1)
+    except Exception:
+        return None
+    if (
+        not isinstance(raw_data, bytes)
+        or not raw_data
+        or len(raw_data) > MAX_APPROVAL_REQUEST_BYTES
+    ):
+        return None
+    return parse_unique_json_object(raw_data)
+
+
+def _invalid() -> Response:
+    return _json_response({"error": "invalid_approval_request"}, status=400)
+
+
+def _unavailable(*, status: int) -> Response:
+    return _json_response(
+        {
+            **_base_response(),
+            "error": "browser_bridge_approval_unavailable",
+        },
+        status=status,
+    )
+
+
+def _json_response(payload: dict[str, Any], *, status: int = 200) -> Response:
+    return Response(
+        response=json.dumps(payload, separators=(",", ":")),
+        status=status,
+        mimetype="application/json",
+        headers={"Cache-Control": "no-store"},
+    )

--- a/plugins/_a0_connector/api/browser_bridge_approval.py.dox.md
+++ b/plugins/_a0_connector/api/browser_bridge_approval.py.dox.md
@@ -1,0 +1,66 @@
+# browser_bridge_approval.py DOX
+
+## Purpose
+
+- Own `POST /api/plugins/_a0_connector/browser_bridge_approval`.
+- List safe consequential-action prompts for the extension bridge selected by
+  one current chat and record one explicit WebUI decision for an existing
+  challenge.
+
+## Ownership
+
+- `BrowserBridgeApproval` owns the authenticated, CSRF-checked decision boundary and its no-store response.
+- `plugins/_a0_connector/helpers/browser_bridge_approval.py` owns the exact
+  once-only receipt primitive.
+- `plugins/_a0_connector/helpers/browser_bridge_action_authority.py` owns
+  current operation/lease/document validation, safe listing, decision
+  idempotency, receipt consumption, control correlation, and lifecycle cleanup.
+
+## Local Contracts
+
+- Accept only `{action: "list", context_id}` or `{challenge_id, choice}` with
+  `choice` equal to `approve_once` or `decline` in a bounded,
+  duplicate-key-free JSON body. Reject non-string choices with HTTP 400 before
+  resolving authority; array/object values must not raise enum-lookup errors.
+- Treat list `context_id` only as a selection hint. Resolve its current
+  `host_required` `extension:<bridge>` choice from the exact AgentContext agent0
+  project/profile configuration before retrieving the optional authority.
+  Missing, container, or unselected contexts return the same successful empty
+  list; a selected bridge with no authority remains unavailable.
+- Never accept bridge, generation, context, browser-session, turn, action, operation, origin, action-class, target, or parameter bindings from this request.
+- Pending projections contain only challenge ID, server-owned action
+  discriminator (`click` or `type`), canonical origin, action class, fixed
+  options, and expiry. Context and bridge are server-side filters and are never
+  reflected as Browser viewer IDs or submitted decision authority.
+- Require the active paired bridge, server-derived subject, key generation,
+  connector, load generation, context, session, turn, action, operation, tab
+  handle, retained parameter hash, owned lease digests/origin, semantic
+  document identity/epoch, and requested semantic ref to remain exact.
+- Approval receipts are process-memory-only, expire within two minutes and at current-turn termination, and authorize exactly one matching consumption.
+- TYPE receipts bind the exact immutable sensitive-text classification and
+  verified text digest. The endpoint never receives or returns the typed text,
+  digest, ref, or target fingerprint.
+- `approve_once` consumes the hidden receipt after a final current-route check
+  and immediately before queuing one exact `browser.resolve_challenge` control.
+  The process-owned control task and exact correlated result do not convert the
+  WebUI acknowledgement into proof that the click succeeded.
+- Disconnect, cancellation, turn finalization, revocation, expiry, or any binding mismatch destroys approval authority.
+- A changed project/profile extension selection destroys approval authority;
+  selection is rechecked at registration, decision, receipt, and queued-control
+  authorization boundaries.
+- Responses are allowlisted and `Cache-Control: no-store`. This foundation does not create challenges from HTTP, infer approval from natural-language text, persist page or operation payloads, dispatch control events, or advertise Browser runtime readiness.
+
+## Work Guidance
+
+- Compose the controller only from the runtime broker, exact route/turn
+  verifiers, owned lease/document indexes, and restricted control sender; never
+  make a permissive resolver fallback.
+- Keep durable site policy and persistent origin decisions in `browser_bridge_policy`, not this endpoint.
+
+## Verification
+
+- Run `pytest tests/test_browser_bridge_action_authority.py`.
+
+## Child DOX Index
+
+No child DOX files.

--- a/plugins/_a0_connector/api/browser_bridge_bridges.py
+++ b/plugins/_a0_connector/api/browser_bridge_bridges.py
@@ -1,0 +1,212 @@
+"""POST /api/plugins/_a0_connector/browser_bridge_bridges."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from helpers import runtime
+from helpers.api import ApiHandler, Request, Response
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    BROWSER_BRIDGE_INVENTORY_CONTRACT,
+    BROWSER_BRIDGE_TRUST_VERSION,
+    MAX_REQUEST_BYTES,
+    SUBJECT_ID,
+    BrowserBridgePairingError,
+    BrowserBridgePairingUnavailable,
+    BrowserBridgePublicRecord,
+    get_browser_bridge_pairing_store,
+    parse_unique_json_object,
+    validate_identifier,
+)
+
+
+class BrowserBridgeBridges(ApiHandler):
+    """List, inspect, or durably revoke current-subject bridge records."""
+
+    async def handle_request(self, request: Request) -> Response:
+        document = _read_bounded_document(request)
+        if document is None:
+            return _invalid()
+        return await self._dispatch(document)
+
+    async def process(self, input: dict, request: Request) -> Response:
+        if _unsupported_body(input, request):
+            return _invalid()
+        return await self._dispatch(input)
+
+    async def _dispatch(self, input: dict[str, Any]) -> Response:
+        action = input.get("action")
+        expected = {"action"} if action == "list" else {"action", "bridge_id"}
+        if not isinstance(action, str) or action not in {"list", "detail", "revoke"} or set(input) != expected:
+            return _invalid()
+        bridge_id: str | None = None
+        if action != "list":
+            try:
+                bridge_id = validate_identifier(
+                    input.get("bridge_id"),
+                    field_name="bridge_id",
+                )
+            except BrowserBridgePairingError:
+                return _invalid()
+
+        try:
+            store = get_browser_bridge_pairing_store()
+            server_instance_id = runtime.get_persistent_id()
+            if action == "list":
+                records = store.list_bridge_records(
+                    server_instance_id=server_instance_id,
+                    subject_id=SUBJECT_ID,
+                )
+                return _json_response(
+                    {
+                        **_base_response(),
+                        "bridges": [record.as_public_dict() for record in records],
+                    }
+                )
+            if action == "detail":
+                record = store.bridge_record(
+                    bridge_id=bridge_id,
+                    server_instance_id=server_instance_id,
+                    subject_id=SUBJECT_ID,
+                )
+                if record is None:
+                    return _not_found()
+                return _json_response(
+                    {**_base_response(), "bridge": record.as_public_dict()}
+                )
+
+            revocation = store.revoke_bridge(
+                bridge_id=bridge_id,
+                server_instance_id=server_instance_id,
+                subject_id=SUBJECT_ID,
+            )
+        except (BrowserBridgePairingError, BrowserBridgePairingUnavailable):
+            return _unavailable()
+        except Exception:
+            return _unavailable()
+        if revocation is None:
+            return _not_found()
+
+        # Authorization is already durably denied. Transport cleanup is best
+        # effort and cannot roll that state back or turn the response into a
+        # claim about native credentials, Chrome tabs, actions, or leases.
+        cleanup = await _disconnect_restricted_sessions(revocation.bridge)
+        return _json_response(
+            {
+                **_base_response(),
+                "revoked": True,
+                "already_revoked": revocation.already_revoked,
+                "bridge": revocation.bridge.as_public_dict(),
+                "server_session_cleanup": cleanup,
+            }
+        )
+
+
+async def _disconnect_restricted_sessions(
+    record: BrowserBridgePublicRecord,
+) -> str:
+    """Request exact matching restricted Socket.IO sessions to disconnect."""
+    try:
+        from helpers.ws_manager import get_shared_ws_manager
+
+        manager = get_shared_ws_manager()
+        with manager.lock:
+            targets = [
+                identity
+                for identity, info in manager.connections.items()
+                if info.principal is not None
+                and info.principal.principal_type == "browser_bridge"
+                and info.principal.principal_id == record.bridge_id
+                and info.principal.subject_id == SUBJECT_ID
+            ]
+    except Exception:
+        return "pending"
+
+    complete = True
+    for namespace, sid in targets:
+        try:
+            # The Socket.IO disconnect callback owns normal manager/handler
+            # cleanup. Do not edit the manager registry behind its back.
+            await manager.socketio.disconnect(sid, namespace=namespace)
+        except Exception:
+            complete = False
+    return "completed" if complete else "pending"
+
+
+def _base_response() -> dict[str, Any]:
+    return {
+        "contract": BROWSER_BRIDGE_INVENTORY_CONTRACT,
+        "trust_version": BROWSER_BRIDGE_TRUST_VERSION,
+        "browser_control_ready": False,
+    }
+
+
+def _unsupported_body(input: Any, request: Request | None) -> bool:
+    if not isinstance(input, dict):
+        return True
+    if request is None:
+        return False
+    raw_data = bytes(getattr(request, "data", b"") or b"")
+    content_length = getattr(request, "content_length", None)
+    if isinstance(content_length, int) and content_length > MAX_REQUEST_BYTES:
+        return True
+    if not raw_data:
+        return False
+    return (
+        len(raw_data) > MAX_REQUEST_BYTES
+        or not bool(getattr(request, "is_json", False))
+        or parse_unique_json_object(raw_data) is None
+    )
+
+
+def _read_bounded_document(request: Request) -> dict[str, Any] | None:
+    content_length = getattr(request, "content_length", None)
+    if (
+        isinstance(content_length, int)
+        and not 1 <= content_length <= MAX_REQUEST_BYTES
+    ):
+        return None
+    if not bool(getattr(request, "is_json", False)):
+        return None
+    stream = getattr(request, "stream", None)
+    if stream is None or not hasattr(stream, "read"):
+        return None
+    try:
+        raw_data = stream.read(MAX_REQUEST_BYTES + 1)
+    except Exception:
+        return None
+    if (
+        not isinstance(raw_data, bytes)
+        or not raw_data
+        or len(raw_data) > MAX_REQUEST_BYTES
+    ):
+        return None
+    return parse_unique_json_object(raw_data)
+
+
+def _invalid() -> Response:
+    return _json_response({"error": "invalid_bridge_inventory_request"}, status=400)
+
+
+def _not_found() -> Response:
+    return _json_response(
+        {**_base_response(), "error": "browser_bridge_not_found"},
+        status=404,
+    )
+
+
+def _unavailable() -> Response:
+    return _json_response(
+        {**_base_response(), "error": "browser_bridge_inventory_unavailable"},
+        status=503,
+    )
+
+
+def _json_response(payload: dict[str, Any], *, status: int = 200) -> Response:
+    return Response(
+        response=json.dumps(payload, separators=(",", ":")),
+        status=status,
+        mimetype="application/json",
+        headers={"Cache-Control": "no-store"},
+    )

--- a/plugins/_a0_connector/api/browser_bridge_challenge.py
+++ b/plugins/_a0_connector/api/browser_bridge_challenge.py
@@ -1,0 +1,123 @@
+"""POST /api/plugins/_a0_connector/browser_bridge_challenge."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from helpers import runtime
+from helpers.api import Request, Response
+import plugins._a0_connector.api.v1.base as connector_base
+from plugins._a0_connector.helpers.browser_bridge_auth import (
+    BrowserBridgeChallengeFailed,
+    BrowserBridgeChallengeUnavailable,
+    get_browser_bridge_challenge_store,
+)
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    BROWSER_BRIDGE_TRUST_CONTRACT,
+    BROWSER_BRIDGE_TRUST_VERSION,
+    MAX_REQUEST_BYTES,
+    BrowserBridgePairingError,
+    coarse_source_key,
+    parse_unique_json_object,
+    server_base_url_for_request,
+)
+from plugins._browser.helpers.bridge_foundation import get_browser_bridge_gate
+
+
+_CHALLENGE_KEYS = {"trust_version", "bridge_id", "client_nonce"}
+
+
+class BrowserBridgeChallenge(connector_base.PublicConnectorApiHandler):
+    """Issue one memory-only challenge for an active bridge credential."""
+
+    async def handle_request(self, request: Request) -> Response:
+        document = _read_bounded_document(request)
+        if document is None:
+            return _failure()
+        return await self._dispatch(document, request)
+
+    async def process(self, input: dict, request: Request) -> Response:
+        if _unsupported_body(input, request) or set(input) != _CHALLENGE_KEYS:
+            return _failure()
+        return await self._dispatch(input, request)
+
+    async def _dispatch(self, input: dict, request: Request) -> Response:
+        if (
+            set(input) != _CHALLENGE_KEYS
+            or get_browser_bridge_gate().state not in {"preview", "available"}
+        ):
+            return _failure()
+        try:
+            challenge = get_browser_bridge_challenge_store().issue(
+                input,
+                source_key=coarse_source_key(
+                    getattr(request, "remote_addr", None)
+                ),
+                server_instance_id=runtime.get_persistent_id(),
+                server_base_url=server_base_url_for_request(request),
+            )
+        except (BrowserBridgeChallengeFailed, BrowserBridgePairingError):
+            return _failure()
+        except BrowserBridgeChallengeUnavailable:
+            return _failure(status=503)
+        except Exception:
+            return _failure(status=503)
+        return _json_response(challenge.as_public_dict())
+
+
+def _unsupported_body(input: Any, request: Request | None) -> bool:
+    if not isinstance(input, dict):
+        return True
+    if request is None:
+        return False
+    raw_data = bytes(getattr(request, "data", b"") or b"")
+    content_length = getattr(request, "content_length", None)
+    if isinstance(content_length, int) and content_length > MAX_REQUEST_BYTES:
+        return True
+    if not raw_data or len(raw_data) > MAX_REQUEST_BYTES:
+        return True
+    if not bool(getattr(request, "is_json", False)):
+        return True
+    return parse_unique_json_object(raw_data) is None
+
+
+def _read_bounded_document(request: Request) -> dict[str, Any] | None:
+    content_length = getattr(request, "content_length", None)
+    if (
+        isinstance(content_length, int)
+        and (content_length < 1 or content_length > MAX_REQUEST_BYTES)
+    ):
+        return None
+    if not bool(getattr(request, "is_json", False)):
+        return None
+    stream = getattr(request, "stream", None)
+    if stream is None or not hasattr(stream, "read"):
+        return None
+    try:
+        raw_data = stream.read(MAX_REQUEST_BYTES + 1)
+    except Exception:
+        return None
+    if not isinstance(raw_data, bytes) or not raw_data or len(raw_data) > MAX_REQUEST_BYTES:
+        return None
+    return parse_unique_json_object(raw_data)
+
+
+def _failure(*, status: int = 400) -> Response:
+    return _json_response(
+        {
+            "contract": BROWSER_BRIDGE_TRUST_CONTRACT,
+            "trust_version": BROWSER_BRIDGE_TRUST_VERSION,
+            "error": "bridge_challenge_failed",
+        },
+        status=status,
+    )
+
+
+def _json_response(payload: dict[str, Any], *, status: int = 200) -> Response:
+    return Response(
+        response=json.dumps(payload, separators=(",", ":")),
+        status=status,
+        mimetype="application/json",
+        headers={"Cache-Control": "no-store"},
+    )

--- a/plugins/_a0_connector/api/browser_bridge_challenge.py.dox.md
+++ b/plugins/_a0_connector/api/browser_bridge_challenge.py.dox.md
@@ -1,0 +1,46 @@
+# browser_bridge_challenge.py DOX
+
+## Purpose
+
+- Own `POST /api/plugins/_a0_connector/browser_bridge_challenge`.
+- Issue a 60-second, memory-only connector challenge for one active Browser
+  bridge credential.
+
+## Ownership
+
+- `BrowserBridgeChallenge` owns the purpose-built unauthenticated HTTP boundary
+  and its generic no-store response.
+- `plugins/_a0_connector/helpers/browser_bridge_auth.py` owns exact challenge,
+  nonce, source-rate, expiry, canonical proof, signature, and one-time consume
+  rules.
+
+## Local Contracts
+
+- Accept exactly trust version, active `bridge_id`, and a fresh 32-byte client
+  nonce encoded as unpadded base64url. Bound request bodies to 8 KiB and reject
+  duplicate JSON keys before challenge validation.
+- Challenges are process-memory only, expire after 60 seconds, and are consumed
+  on the first proof attempt whether verification succeeds or fails.
+- Nonexistent, revoked, malformed, mismatched, expired, and rate-limited inputs
+  use generic public failures and never expose credential records or raw errors.
+- Successful proof uses Ed25519 over the fixed scalar-only RFC 8785 JCS object,
+  returns a server-derived `browser_bridge` principal projection, and records
+  the authentication time. It does not accept cookies, API keys, bearer tokens,
+  client-selected scopes, handlers, protocols, or key generations.
+- Responses use `Cache-Control: no-store`. The route remains unavailable while
+  the Browser bridge rollout gate is disabled.
+
+## Work Guidance
+
+- Do not advertise `browser_bridge_challenge_v1` or connect this principal to
+  `/ws` until origin validation, ambient-cookie isolation, scoped handler
+  activation, event filtering, disconnect cleanup, and negotiation tests land
+  together.
+
+## Verification
+
+- Run `pytest tests/test_browser_bridge_challenge_foundation.py`.
+
+## Child DOX Index
+
+No child DOX files.

--- a/plugins/_a0_connector/api/browser_bridge_exchange.py
+++ b/plugins/_a0_connector/api/browser_bridge_exchange.py
@@ -1,0 +1,126 @@
+"""POST /api/plugins/_a0_connector/browser_bridge_exchange."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from helpers.api import Request, Response
+import plugins._a0_connector.api.v1.base as connector_base
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    MAX_REQUEST_BYTES,
+    BrowserBridgePairingExchangeFailed,
+    BrowserBridgePairingUnavailable,
+    coarse_source_key,
+    configured_extension_id,
+    get_browser_bridge_pairing_store,
+    parse_unique_json_object,
+)
+from plugins._browser.helpers.bridge_foundation import get_browser_bridge_gate
+
+
+_EXCHANGE_KEYS = {
+    "trust_version",
+    "pairing_code",
+    "server_base_url",
+    "extension_id",
+    "companion_instance_id",
+    "public_key",
+}
+
+
+class BrowserBridgeExchange(connector_base.PublicConnectorApiHandler):
+    """Consume one pairing code without ambient WebUI authority."""
+
+    async def handle_request(self, request: Request) -> Response:
+        document = _read_bounded_document(request)
+        if document is None:
+            return _failure()
+        return await self._dispatch(document, request)
+
+    async def process(self, input: dict, request: Request) -> Response:
+        if (
+            _unsupported_body(input, request)
+            or set(input) != _EXCHANGE_KEYS
+        ):
+            return _failure()
+        return await self._dispatch(input, request)
+
+    async def _dispatch(self, input: dict, request: Request) -> Response:
+        expected_extension_id = configured_extension_id()
+        if (
+            set(input) != _EXCHANGE_KEYS
+            or get_browser_bridge_gate().state not in {"preview", "available"}
+            or expected_extension_id is None
+            or input.get("extension_id") != expected_extension_id
+        ):
+            return _failure()
+        try:
+            exchange = get_browser_bridge_pairing_store().exchange(
+                input,
+                source_key=coarse_source_key(getattr(request, "remote_addr", None)),
+            )
+        except BrowserBridgePairingExchangeFailed:
+            return _failure()
+        except BrowserBridgePairingUnavailable:
+            return _failure(status=503)
+        except Exception:
+            return _failure(status=503)
+        return _json_response(exchange.as_public_dict())
+
+
+def _unsupported_body(input: Any, request: Request | None) -> bool:
+    if not isinstance(input, dict):
+        return True
+    if request is None:
+        return False
+    raw_data = bytes(getattr(request, "data", b"") or b"")
+    content_length = getattr(request, "content_length", None)
+    if isinstance(content_length, int) and content_length > MAX_REQUEST_BYTES:
+        return True
+    if not raw_data or len(raw_data) > MAX_REQUEST_BYTES:
+        return True
+    if not bool(getattr(request, "is_json", False)):
+        return True
+    return parse_unique_json_object(raw_data) is None
+
+
+def _read_bounded_document(request: Request) -> dict[str, Any] | None:
+    content_length = getattr(request, "content_length", None)
+    if (
+        isinstance(content_length, int)
+        and (content_length < 1 or content_length > MAX_REQUEST_BYTES)
+    ):
+        return None
+    if not bool(getattr(request, "is_json", False)):
+        return None
+    stream = getattr(request, "stream", None)
+    if stream is None or not hasattr(stream, "read"):
+        return None
+    try:
+        raw_data = stream.read(MAX_REQUEST_BYTES + 1)
+    except Exception:
+        return None
+    if not isinstance(raw_data, bytes) or not raw_data or len(raw_data) > MAX_REQUEST_BYTES:
+        return None
+    return parse_unique_json_object(raw_data)
+
+
+def _failure(*, status: int = 400) -> Response:
+    return _json_response(
+        {
+            "contract": "a0.browser-bridge.trust.v1",
+            "trust_version": 1,
+            "error": "pairing_exchange_failed",
+        },
+        status=status,
+    )
+
+
+def _json_response(payload: dict[str, Any], *, status: int = 200) -> Response:
+    return Response(
+        response=json.dumps(payload, separators=(",", ":")),
+        status=status,
+        mimetype="application/json",
+        headers={"Cache-Control": "no-store"},
+    )

--- a/plugins/_a0_connector/api/browser_bridge_exchange.py.dox.md
+++ b/plugins/_a0_connector/api/browser_bridge_exchange.py.dox.md
@@ -1,0 +1,46 @@
+# browser_bridge_exchange.py DOX
+
+## Purpose
+
+- Own `POST /api/plugins/_a0_connector/browser_bridge_exchange`.
+- Atomically exchange one short-lived pairing code for a server-side public-key
+  bridge record.
+
+## Ownership
+
+- `BrowserBridgeExchange` owns the purpose-built unauthenticated exchange HTTP
+  boundary and its generic no-store response.
+- `plugins/_a0_connector/helpers/browser_bridge_pairing.py` owns exact schema,
+  identity, public-key, attempt, expiry, source-rate, and persistence rules.
+
+## Local Contracts
+
+- This endpoint deliberately uses `PublicConnectorApiHandler`: the single-use
+  pairing code replaces ambient WebUI authentication and CSRF for this route
+  only. It grants no session cookie, API key, bearer credential, or private key.
+- Accept exactly trust version, pairing code, normalized server base URL,
+  server-pinned extension ID, companion instance ID, and an Ed25519 raw
+  base64url public key. Bound request bodies to 8 KiB and reject duplicate JSON
+  object keys at every depth before exchange validation.
+- Nonexistent, expired, consumed, malformed, mismatched, and attempt-exhausted
+  pairing inputs return the same `pairing_exchange_failed` response. Never
+  include input values or exception text.
+- Successful exchange persists only the allowlisted public bridge record and
+  returns fixed browser-bridge scopes and non-secret identity. It continues to
+  report connector-session and browser-control readiness as false until the
+  signed proof and negotiated extension runtime are implemented.
+- Responses use `Cache-Control: no-store`. The route is disabled when the
+  instance rollout gate or server-pinned extension ID is unavailable.
+
+## Work Guidance
+
+- Keep signed connector challenge/proof activation in its own later security
+  frontier; do not advertise challenge or browser-control features here.
+
+## Verification
+
+- Run `pytest tests/test_browser_bridge_pairing_foundation.py`.
+
+## Child DOX Index
+
+No child DOX files.

--- a/plugins/_a0_connector/api/browser_bridge_legacy_retirement.py
+++ b/plugins/_a0_connector/api/browser_bridge_legacy_retirement.py
@@ -1,0 +1,32 @@
+"""Protected explicit prototype retirement; never a v1 activation endpoint."""
+from helpers.api import ApiHandler, Request, Response
+from plugins._a0_connector.api.browser_bridge_pairing import _read_bounded_document, _json_response
+from plugins._a0_connector.helpers.browser_bridge_legacy_retirement import get_legacy_retirement
+
+
+class BrowserBridgeLegacyRetirement(ApiHandler):
+    async def handle_request(self, request: Request) -> Response:
+        document = _read_bounded_document(request)
+        if document is None:
+            return _json_response({"error": "invalid_retirement_request"}, status=400)
+        return await self.process(document, request)
+
+    async def process(self, input: dict, request: Request) -> Response:
+        if type(input) is not dict:
+            return _json_response({"error": "invalid_retirement_request"}, status=400)
+        owner = get_legacy_retirement()
+        if input == {"action": "status"}:
+            return _json_response(owner.status())
+        if set(input) == {"action", "confirmed_all_legacy_scopes", "offset"} and input.get("action") == "quarantine" and input.get("confirmed_all_legacy_scopes") is True:
+            from plugins._a0_connector.helpers.browser_bridge_legacy_quarantine import sweep_loaded
+            try:
+                return _json_response(sweep_loaded(input["offset"]))
+            except Exception:
+                return _json_response({"error": "legacy_quarantine_incomplete"}, status=409)
+        if input != {"action": "retire", "confirmed_all_legacy_scopes": True} or type(input.get("confirmed_all_legacy_scopes")) is not bool:
+            return _json_response({"error": "invalid_retirement_request"}, status=400)
+        try:
+            result = await owner.retire()
+            return _json_response(result, status=200 if result["state"] == "legacy_disabled" else 409)
+        except Exception:
+            return _json_response({"error": "migration_incomplete", "status": owner.status()}, status=409)

--- a/plugins/_a0_connector/api/browser_bridge_legacy_retirement.py.dox.md
+++ b/plugins/_a0_connector/api/browser_bridge_legacy_retirement.py.dox.md
@@ -1,0 +1,18 @@
+# Legacy retirement API
+
+Normal `ApiHandler` session authentication and CSRF checks are mandatory; this
+is not an API-key or extension-facing endpoint. Strict bounded unique-key JSON
+accepts exactly `{ "action": "status" }` or
+`{ "action": "retire", "confirmed_all_legacy_scopes": true }`.
+It also accepts exactly `{ "action": "quarantine",
+"confirmed_all_legacy_scopes": true, "offset": 0 }` for a bounded page of
+currently loaded contexts after retirement began. The offset is an integer
+from zero through 10,000, not a caller-supplied context/path. Quarantine replies
+contain safe counts and the next offset only; read the quarantine helper DOX
+for recoverability, lazy dormant-chat handling and scope limits.
+
+Status is read-only and redacted. Retirement explicitly stops all scopes of the
+confirmed prototype through `browser_bridge_legacy_retirement`; it never
+selects or activates bridge v1. The response is no-store; malformed input is
+400, blocked/incomplete retirement is 409, completed legacy disabling is 200.
+Never expose underlying exceptions, paths, legacy credentials or payloads.

--- a/plugins/_a0_connector/api/browser_bridge_pairing.py
+++ b/plugins/_a0_connector/api/browser_bridge_pairing.py
@@ -1,0 +1,208 @@
+"""POST /api/plugins/_a0_connector/browser_bridge_pairing."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from helpers import runtime
+from helpers.api import ApiHandler, Request, Response, session
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    MAX_REQUEST_BYTES,
+    BrowserBridgePairingError,
+    BrowserBridgePairingUnavailable,
+    build_browser_bridge_pairing_foundation_status,
+    configured_extension_id,
+    get_browser_bridge_pairing_store,
+    pairing_owner_id,
+    parse_unique_json_object,
+    server_base_url_for_request,
+    validate_display_name,
+    validate_identifier,
+)
+from plugins._browser.helpers.bridge_foundation import get_browser_bridge_gate
+
+
+class BrowserBridgePairing(ApiHandler):
+    """Create, inspect, or cancel one WebUI-session pairing intent."""
+
+    async def handle_request(self, request: Request) -> Response:
+        document = _read_bounded_document(request)
+        if document is None:
+            return _json_response(
+                {"error": "invalid_pairing_request"},
+                status=400,
+            )
+        return await self._dispatch(document, request)
+
+    async def process(self, input: dict, request: Request) -> Response:
+        if _unsupported_body(input, request):
+            return _json_response(
+                {"error": "invalid_pairing_request"},
+                status=400,
+            )
+        return await self._dispatch(input, request)
+
+    async def _dispatch(self, input: dict, request: Request) -> Response:
+        action = input.get("action")
+        if action == "create":
+            if set(input) != {"action", "display_name"}:
+                return _json_response(
+                    {"error": "invalid_pairing_request"},
+                    status=400,
+                )
+            try:
+                validate_display_name(input.get("display_name"))
+            except BrowserBridgePairingError:
+                return _json_response(
+                    {"error": "invalid_pairing_request"},
+                    status=400,
+                )
+            return self._create(input, request)
+        if action == "status":
+            if set(input) != {"action"}:
+                return _json_response(
+                    {"error": "invalid_pairing_request"},
+                    status=400,
+                )
+            return self._status()
+        if action == "cancel":
+            if set(input) != {"action", "pairing_id"}:
+                return _json_response(
+                    {"error": "invalid_pairing_request"},
+                    status=400,
+                )
+            try:
+                validate_identifier(
+                    input.get("pairing_id"),
+                    field_name="pairing_id",
+                )
+            except BrowserBridgePairingError:
+                return _json_response(
+                    {"error": "invalid_pairing_request"},
+                    status=400,
+                )
+            return self._cancel(input)
+        return _json_response({"error": "invalid_pairing_request"}, status=400)
+
+    def _create(self, input: dict[str, Any], request: Request) -> Response:
+        gate = get_browser_bridge_gate()
+        foundation = build_browser_bridge_pairing_foundation_status(gate)
+        if not foundation["pairing_create_enabled"]:
+            return _json_response(
+                {
+                    "error": "pairing_unavailable",
+                    "status": foundation,
+                },
+                status=409,
+            )
+        extension_id = configured_extension_id()
+        if extension_id is None:
+            return _json_response(
+                {"error": "pairing_unavailable", "status": foundation},
+                status=409,
+            )
+        try:
+            owner_id = pairing_owner_id(session, create=True)
+            if owner_id is None:
+                raise BrowserBridgePairingUnavailable("pairing owner unavailable")
+            creation = get_browser_bridge_pairing_store().create(
+                owner_id=owner_id,
+                server_instance_id=runtime.get_persistent_id(),
+                server_base_url=server_base_url_for_request(request),
+                extension_id=extension_id,
+                display_name=input.get("display_name"),
+            )
+        except BrowserBridgePairingError:
+            return _json_response({"error": "pairing_unavailable"}, status=409)
+        except Exception:
+            return _json_response({"error": "pairing_unavailable"}, status=503)
+        return _json_response(creation.as_public_dict(), status=201)
+
+    def _status(self) -> Response:
+        gate = get_browser_bridge_gate()
+        foundation = build_browser_bridge_pairing_foundation_status(gate)
+        try:
+            status = get_browser_bridge_pairing_store().status(
+                owner_id=pairing_owner_id(session, create=False),
+                server_instance_id=runtime.get_persistent_id(),
+            )
+        except Exception:
+            status = {
+                "contract": foundation["contract"],
+                "trust_version": foundation["trust_version"],
+                "state": "repair_required",
+                "reason_code": "pairing_status_unavailable",
+                "pairing_code_present": False,
+                "native_runtime_location": "user_browser_host",
+                "docker_install_target": False,
+                "connector_session_ready": False,
+                "browser_control_ready": False,
+            }
+        status["server_pairing_enabled"] = foundation["pairing_create_enabled"]
+        return _json_response(status)
+
+    def _cancel(self, input: dict[str, Any]) -> Response:
+        store = get_browser_bridge_pairing_store()
+        try:
+            canceled = store.cancel(
+                owner_id=pairing_owner_id(session, create=False),
+                pairing_id=input.get("pairing_id"),
+            )
+            status = store.status(
+                owner_id=pairing_owner_id(session, create=False),
+                server_instance_id=runtime.get_persistent_id(),
+            )
+        except Exception:
+            return _json_response({"error": "pairing_unavailable"}, status=503)
+        status["canceled"] = canceled
+        status["server_pairing_enabled"] = build_browser_bridge_pairing_foundation_status(
+            get_browser_bridge_gate()
+        )["pairing_create_enabled"]
+        return _json_response(status)
+
+
+def _unsupported_body(input: Any, request: Request | None) -> bool:
+    if not isinstance(input, dict):
+        return True
+    if request is None:
+        return False
+    raw_data = bytes(getattr(request, "data", b"") or b"")
+    content_length = getattr(request, "content_length", None)
+    if isinstance(content_length, int) and content_length > MAX_REQUEST_BYTES:
+        return True
+    if not raw_data:
+        return False
+    if len(raw_data) > MAX_REQUEST_BYTES or not bool(getattr(request, "is_json", False)):
+        return True
+    return parse_unique_json_object(raw_data) is None
+
+
+def _read_bounded_document(request: Request) -> dict[str, Any] | None:
+    content_length = getattr(request, "content_length", None)
+    if (
+        isinstance(content_length, int)
+        and (content_length < 1 or content_length > MAX_REQUEST_BYTES)
+    ):
+        return None
+    if not bool(getattr(request, "is_json", False)):
+        return None
+    stream = getattr(request, "stream", None)
+    if stream is None or not hasattr(stream, "read"):
+        return None
+    try:
+        raw_data = stream.read(MAX_REQUEST_BYTES + 1)
+    except Exception:
+        return None
+    if not isinstance(raw_data, bytes) or not raw_data or len(raw_data) > MAX_REQUEST_BYTES:
+        return None
+    return parse_unique_json_object(raw_data)
+
+
+def _json_response(payload: dict[str, Any], *, status: int = 200) -> Response:
+    return Response(
+        response=json.dumps(payload, separators=(",", ":")),
+        status=status,
+        mimetype="application/json",
+        headers={"Cache-Control": "no-store"},
+    )

--- a/plugins/_a0_connector/api/browser_bridge_pairing.py.dox.md
+++ b/plugins/_a0_connector/api/browser_bridge_pairing.py.dox.md
@@ -1,0 +1,50 @@
+# browser_bridge_pairing.py DOX
+
+## Purpose
+
+- Own `POST /api/plugins/_a0_connector/browser_bridge_pairing`.
+- Create, inspect, and cancel one pending Browser bridge pairing intent for the
+  current authenticated WebUI/A0 CLI session.
+
+## Ownership
+
+- `BrowserBridgePairing` owns the `create`, `status`, and `cancel` request
+  actions and their no-store HTTP responses.
+- `plugins/_a0_connector/helpers/browser_bridge_pairing.py` owns validation,
+  expiry, rate limits, exchange, and public bridge-record persistence.
+
+## Local Contracts
+
+- Use `ApiHandler` directly so normal session authentication and CSRF remain
+  mandatory even when Agent Zero login is disabled. Do not use
+  `ProtectedConnectorApiHandler`, which disables CSRF for legacy connector
+  clients.
+- Accept exactly `{action: create, display_name}`,
+  `{action: status}`, or `{action: cancel, pairing_id}` with a bounded JSON
+  request. Reject duplicate JSON object keys at every depth before dispatch.
+  Reject arbitrary extension IDs, server URLs, scopes, keys, or overrides from
+  this authenticated presentation route.
+- `create` is unavailable unless the instance rollout gate is `preview` or
+  `available` and `A0_BROWSER_BRIDGE_EXTENSION_ID` contains an exact pinned
+  Chrome extension ID. The external Agent Zero base URL comes from the request
+  origin/host or the server-owned `A0_BROWSER_BRIDGE_SERVER_BASE_URL` override.
+- Responses use `Cache-Control: no-store`. Only the creation response contains
+  the one-time code. Status, cancel, logs, and persistent state never contain
+  it.
+- Every response identifies the native runtime as belonging to the user's
+  browser host, never the Agent Zero Docker container. Pairing does not imply a
+  proven connector session or active browser control.
+
+## Work Guidance
+
+- Keep UI orchestration and QR/copy rendering outside this handler.
+- Do not add pairing material to query strings, URLs, environment variables,
+  logs, analytics, or persistent KVP state.
+
+## Verification
+
+- Run `pytest tests/test_browser_bridge_pairing_foundation.py`.
+
+## Child DOX Index
+
+No child DOX files.

--- a/plugins/_a0_connector/api/browser_bridge_policy.py
+++ b/plugins/_a0_connector/api/browser_bridge_policy.py
@@ -1,0 +1,165 @@
+"""POST /api/plugins/_a0_connector/browser_bridge_policy."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from helpers import runtime
+from helpers.api import ApiHandler, Request, Response
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    BrowserBridgePairingError,
+    get_browser_bridge_pairing_store,
+    parse_unique_json_object,
+    validate_identifier,
+)
+from plugins._a0_connector.helpers.browser_bridge_policy import (
+    BROWSER_BRIDGE_POLICY_CONTRACT,
+    BROWSER_BRIDGE_POLICY_VERSION,
+    MAX_POLICY_REQUEST_BYTES,
+    BrowserBridgePolicyError,
+    BrowserBridgePolicyUnavailable,
+    get_browser_bridge_policy_repository,
+)
+
+
+class BrowserBridgePolicy(ApiHandler):
+    """Manage saved exact sites or explicit production all-websites access."""
+
+    async def handle_request(self, request: Request) -> Response:
+        document = _read_bounded_document(request)
+        if document is None:
+            return _invalid()
+        return await self._dispatch(document)
+
+    async def process(self, input: dict, request: Request) -> Response:
+        if _unsupported_body(input, request):
+            return _invalid()
+        return await self._dispatch(input)
+
+    async def _dispatch(self, input: dict[str, Any]) -> Response:
+        action = input.get("action")
+        expected = (
+            {"action", "bridge_id"}
+            if action == "list"
+            else {"action", "bridge_id", "site_mode"} if action == "set_mode"
+            else {"action", "bridge_id", "origin"}
+        )
+        if not isinstance(action, str) or action not in {"list", "allow", "revoke", "set_mode"} or set(input) != expected:
+            return _invalid()
+        try:
+            bridge_id = validate_identifier(input.get("bridge_id"), field_name="bridge_id")
+        except BrowserBridgePairingError:
+            return _invalid()
+        server_instance_id = runtime.get_persistent_id()
+        try:
+            record = get_browser_bridge_pairing_store().active_bridge_record(
+                bridge_id=bridge_id,
+                server_instance_id=server_instance_id,
+            )
+        except Exception:
+            return _unavailable(status=503)
+        if record is None:
+            return _unavailable(status=409)
+
+        repository = get_browser_bridge_policy_repository()
+        try:
+            subject_id = validate_identifier(
+                record.get("subject_id") if isinstance(record, dict) else None,
+                field_name="subject_id",
+            )
+            identity = {
+                "server_instance_id": server_instance_id,
+                "bridge_id": bridge_id,
+                "subject_id": subject_id,
+            }
+            if action == "allow":
+                repository.allow(**identity, origin=input.get("origin"))
+            elif action == "revoke":
+                revoked = repository.revoke(**identity, origin=input.get("origin"))
+            elif action == "set_mode":
+                repository.set_site_mode(**identity, site_mode=input.get("site_mode"))
+            grants = repository.list_grants(**identity)
+            site_mode = repository.site_mode(**identity)
+        except BrowserBridgePolicyUnavailable:
+            return _unavailable(status=503)
+        except BrowserBridgePolicyError:
+            return _invalid()
+        except Exception:
+            return _unavailable(status=503)
+        return _json_response(
+            {
+                "contract": BROWSER_BRIDGE_POLICY_CONTRACT,
+                "policy_version": BROWSER_BRIDGE_POLICY_VERSION,
+                "site_mode": site_mode,
+                "bridge_id": bridge_id,
+                "grants": [grant.as_public_dict() for grant in grants],
+                **({"revoked": revoked} if action == "revoke" else {}),
+                "operation_grants_enabled": False,
+                "browser_control_ready": False,
+            }
+        )
+
+
+def _unsupported_body(input: Any, request: Request | None) -> bool:
+    if not isinstance(input, dict):
+        return True
+    if request is None:
+        return False
+    raw_data = bytes(getattr(request, "data", b"") or b"")
+    content_length = getattr(request, "content_length", None)
+    if isinstance(content_length, int) and content_length > MAX_POLICY_REQUEST_BYTES:
+        return True
+    if not raw_data:
+        return False
+    return (
+        len(raw_data) > MAX_POLICY_REQUEST_BYTES
+        or not bool(getattr(request, "is_json", False))
+        or parse_unique_json_object(raw_data) is None
+    )
+
+
+def _read_bounded_document(request: Request) -> dict[str, Any] | None:
+    content_length = getattr(request, "content_length", None)
+    if isinstance(content_length, int) and not 1 <= content_length <= MAX_POLICY_REQUEST_BYTES:
+        return None
+    if not bool(getattr(request, "is_json", False)):
+        return None
+    stream = getattr(request, "stream", None)
+    if stream is None or not hasattr(stream, "read"):
+        return None
+    try:
+        raw_data = stream.read(MAX_POLICY_REQUEST_BYTES + 1)
+    except Exception:
+        return None
+    if (
+        not isinstance(raw_data, bytes)
+        or not raw_data
+        or len(raw_data) > MAX_POLICY_REQUEST_BYTES
+    ):
+        return None
+    return parse_unique_json_object(raw_data)
+
+
+def _invalid() -> Response:
+    return _json_response({"error": "invalid_policy_request"}, status=400)
+
+
+def _unavailable(*, status: int) -> Response:
+    return _json_response(
+        {
+            "contract": BROWSER_BRIDGE_POLICY_CONTRACT,
+            "policy_version": BROWSER_BRIDGE_POLICY_VERSION,
+            "error": "browser_bridge_policy_unavailable",
+        },
+        status=status,
+    )
+
+
+def _json_response(payload: dict[str, Any], *, status: int = 200) -> Response:
+    return Response(
+        response=json.dumps(payload, separators=(",", ":")),
+        status=status,
+        mimetype="application/json",
+        headers={"Cache-Control": "no-store"},
+    )

--- a/plugins/_a0_connector/api/browser_bridge_policy.py.dox.md
+++ b/plugins/_a0_connector/api/browser_bridge_policy.py.dox.md
@@ -1,0 +1,43 @@
+# browser_bridge_policy.py DOX
+
+## Purpose
+
+- Own `POST /api/plugins/_a0_connector/browser_bridge_policy`.
+- Manage persistent exact-origin allow decisions for one currently active Browser bridge.
+
+## Ownership
+
+- `BrowserBridgePolicy` owns protected `list`, `allow`, `revoke`, and production `set_mode` actions and no-store response projection.
+- `plugins/_a0_connector/helpers/browser_bridge_policy.py` owns canonical origin validation, bounded durable persistence, and fail-closed lookup.
+
+## Local Contracts
+
+- Use `ApiHandler` directly so normal WebUI session authentication and CSRF are mandatory.
+- Reject non-string actions with HTTP 400 before reading pairing or policy state.
+- Accept only `{action: list, bridge_id}`, `{action: allow, bridge_id, origin}`, or `{action: revoke, bridge_id, origin}` in a bounded duplicate-key-free JSON body.
+- Also accept exactly `{action: set_mode, bridge_id, site_mode}`, where mode is
+  `ask_per_site` or `allow_all_websites`. The latter is explicit persistent
+  browsing permission for this server/subject/bridge only, never action
+  approval. Read back successful persistence before returning the mode.
+  Default remains `ask_per_site`; development cannot set or adopt this mode.
+- Resolve the exact active bridge record for the current server instance before reading or mutating its policy. Derive the subject from that record; never accept server or subject identity from the request.
+- Site identity is a normalized HTTP(S) origin only. Reject userinfo, paths, query strings, fragments, wildcards, restricted schemes, malformed hosts, and ambiguous encodings.
+- Responses are allowlisted and `Cache-Control: no-store`. This foundation never creates consequential-action receipts, dispatches browser work, or advertises runtime readiness.
+- Response contract/version stay v1 with the two recognized site-mode values.
+  Internal store v2 adds at most 128 all-websites owner records, validates the
+  entire document, and continues reading legacy v1 exact grants. Each mode
+  generation derives distinct exact-origin grant IDs; visited URLs/origins
+  are not accumulated. Disabling removes only that mode, not saved sites.
+
+## Work Guidance
+
+- Keep Browser Settings presentation and one-operation approval challenges outside this endpoint.
+- Do not include page URLs, titles, content, request arguments, or raw exceptions in policy records or responses.
+
+## Verification
+
+- Run `pytest tests/test_browser_bridge_policy_foundation.py`.
+
+## Child DOX Index
+
+No child DOX files.

--- a/plugins/_a0_connector/api/browser_bridge_selection.py
+++ b/plugins/_a0_connector/api/browser_bridge_selection.py
@@ -1,0 +1,101 @@
+"""Normally authenticated and CSRF-protected production Browser selection."""
+
+import json
+
+from helpers.api import ApiHandler, Request, Response
+from plugins._a0_connector.helpers.browser_bridge_pairing import MAX_REQUEST_BYTES, parse_unique_json_object
+from plugins._a0_connector.helpers.browser_bridge_selection import (
+    selected_bridge, select_bridge_for_context, default_selected_bridge, select_default_bridge,
+)
+
+
+class BrowserBridgeSelection(ApiHandler):
+    async def handle_request(self, request: Request) -> Response:
+        if not request.is_json:
+            return _response({"error": "invalid_selection_request"}, 400)
+        raw = request.stream.read(MAX_REQUEST_BYTES + 1)
+        document = parse_unique_json_object(raw) if 0 < len(raw) <= MAX_REQUEST_BYTES else None
+        return await self._dispatch(document)
+
+    async def process(self, input: dict, request: Request) -> Response:
+        # Raw HTTP requests always use the duplicate-key rejecting boundary.
+        if request is not None:
+            return await self.handle_request(request)
+        return await self._dispatch(input)
+
+    async def _dispatch(self, value) -> Response:
+        if not isinstance(value, dict):
+            return _response({"error": "invalid_selection_request"}, 400)
+        action = value.get("action")
+        if not isinstance(action, str):
+            return _response({"error": "invalid_selection_request"}, 400)
+        if action in {"default_status", "use_default", "clear_default"}:
+            return self._default_dispatch(value)
+        expected = (
+            {"action", "context_id", "bridge_id"} if action == "use"
+            else {"action", "context_id", "expected_bridge_id"} if action == "clear"
+            else {"action", "context_id"}
+        )
+        if action not in {"use", "clear", "status"} or set(value) != expected:
+            return _response({"error": "invalid_selection_request"}, 400)
+        from plugins._a0_connector.helpers.browser_bridge_pairing import validate_identifier
+        from plugins._a0_connector.helpers.browser_bridge_bootstrap import get_browser_bridge_application
+        try:
+            context_id = validate_identifier(value["context_id"], field_name="context_id")
+            if action == "use":
+                bridge_id = validate_identifier(value["bridge_id"], field_name="bridge_id")
+                select_bridge_for_context(context_id, bridge_id)
+            elif action == "clear":
+                expected_bridge_id = validate_identifier(value["expected_bridge_id"], field_name="bridge_id")
+                select_bridge_for_context(context_id, None, expected_bridge_id=expected_bridge_id)
+            bridge_id = selected_bridge(context_id)
+            application = get_browser_bridge_application()
+            route = (
+                application.registry.resolve_extension_route(context_id, bridge_id)
+                if application is not None and bridge_id is not None else None
+            )
+        except ValueError:
+            return _response({"error": "invalid_selection_request"}, 400)
+        except Exception:
+            return _response({"error": "browser_runtime_unavailable"}, 409)
+        return _response({
+            "contract": "a0.browser-bridge.selection.v1", "context_id": context_id,
+            "bridge_id": bridge_id, "selected": bridge_id is not None,
+            "browser_control_ready": route is not None,
+            "reconnect_required": bridge_id is not None and route is None,
+        })
+
+    def _default_dispatch(self, value) -> Response:
+        action = value["action"]
+        keys = ({"action", "bridge_id", "expected_bridge_id"} if action == "use_default"
+                else {"action", "expected_bridge_id"} if action == "clear_default" else {"action"})
+        if set(value) != keys:
+            return _response({"error": "invalid_selection_request"}, 400)
+        from plugins._a0_connector.helpers.browser_bridge_pairing import validate_identifier
+        from plugins._a0_connector.helpers.browser_bridge_bootstrap import get_browser_bridge_application
+        try:
+            if action != "default_status":
+                previous = value["expected_bridge_id"]
+                if previous is not None or action == "clear_default":
+                    previous = validate_identifier(previous, field_name="bridge_id")
+                bridge = (validate_identifier(value["bridge_id"], field_name="bridge_id")
+                          if action == "use_default" else None)
+                select_default_bridge(bridge, expected_bridge_id=previous)
+            bridge = default_selected_bridge()
+            application = get_browser_bridge_application()
+            ready = bool(bridge is not None and application is not None
+                         and application.registry.current_bridge_ready(bridge))
+        except ValueError:
+            return _response({"error": "invalid_selection_request"}, 400)
+        except Exception:
+            return _response({"error": "browser_runtime_unavailable"}, 409)
+        return _response({
+            "contract": "a0.browser-bridge.default-selection.v1", "bridge_id": bridge,
+            "selected": bridge is not None, "browser_control_ready": ready,
+            "reconnect_required": bridge is not None and not ready,
+        })
+
+
+def _response(payload: dict, status: int = 200) -> Response:
+    return Response(json.dumps(payload, separators=(",", ":")), status=status,
+                    mimetype="application/json", headers={"Cache-Control": "no-store"})

--- a/plugins/_a0_connector/api/browser_bridge_selection.py.dox.md
+++ b/plugins/_a0_connector/api/browser_bridge_selection.py.dox.md
@@ -1,0 +1,26 @@
+# Production Browser selection API
+
+Normal ApiHandler authentication and CSRF remain mandatory. Strict bounded
+duplicate-key-rejecting JSON accepts `status`, `use`, `clear` with context ID;
+`use` additionally takes a paired bridge ID; `clear` requires `expected_bridge_id`
+checked under the mutation lock before any retirement/write. No server identity, subject,
+credential, policy, or readiness is accepted from the request.
+Non-string actions return HTTP 400 before default or context dispatch.
+
+`use` requires the installed production owner, available rollout, current
+server/subject active pairing and pinned extension. The helper writes only
+Browser's real project scope and checks exact readback. Changing or clearing
+selection retires the prior bridge route before configuration effects.
+
+No-store status is ready only from exact current admitted route resolution;
+selection alone returns reconnect-required, never ready.
+
+Global actions have no context prerequisite: `default_status` accepts only
+action; `use_default` requires bridge_id and nullable expected_bridge_id;
+`clear_default` requires nonnull expected_bridge_id. Both writes compare the
+exact previous global default under the helper lock. They preserve every scoped
+override. The strict `a0.browser-bridge.default-selection.v1` response has only
+contract, bridge_id, selected, browser_control_ready, reconnect_required.
+Readiness is a boolean-only current admitted bridge lookup, not context or
+operation authorization. Invalid shapes return 400; unavailable or stale
+mutations return 409 with the existing bounded error. All responses are no-store.

--- a/plugins/_a0_connector/api/browser_bridge_setup.py
+++ b/plugins/_a0_connector/api/browser_bridge_setup.py
@@ -1,0 +1,14 @@
+"""Authenticated, CSRF-protected public browser setup guidance."""
+import json
+
+from helpers.api import ApiHandler, Request, Response
+from plugins._a0_connector.api.v1.browser_companion_release import _has_unsupported_body
+from plugins._a0_connector.helpers.browser_bridge_setup import browser_bridge_setup_status
+
+
+class BrowserBridgeSetup(ApiHandler):
+    async def process(self, input: dict, request: Request) -> Response:
+        if not isinstance(input, dict) or input or _has_unsupported_body(request):
+            return Response('{"error":"request_body_not_supported"}', status=400, mimetype="application/json")
+        return Response(json.dumps(browser_bridge_setup_status(), separators=(",", ":")),
+                        mimetype="application/json", headers={"Cache-Control": "no-store"})

--- a/plugins/_a0_connector/api/browser_bridge_setup.py.dox.md
+++ b/plugins/_a0_connector/api/browser_bridge_setup.py.dox.md
@@ -1,0 +1,5 @@
+# Browser setup WebUI API
+
+`POST /api/plugins/_a0_connector/browser_bridge_setup` accepts an empty JSON object only under the normal session authentication and CSRF protection. Use `ApiHandler`, not the connector API-key/loopback override handler. Reject nonempty/malformed bodies, including bodies hidden by generic API parsing, through the existing bounded metadata request validator.
+
+Return only the helper's `a0.browser-bridge.setup.v1` public projection with `Cache-Control: no-store`. This endpoint reads configured release links; it never fetches or verifies catalog/artifact bytes, changes settings, enables browser control, installs inside Docker, or accepts caller-selected URLs. See the helper sidecar for fail-closed gate, per-OS and host-verification semantics.

--- a/plugins/_a0_connector/api/browser_bridge_site_authority.py
+++ b/plugins/_a0_connector/api/browser_bridge_site_authority.py
@@ -1,0 +1,195 @@
+"""POST /api/plugins/_a0_connector/browser_bridge_site_authority."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from helpers.api import ApiHandler, Request, Response
+from plugins._browser.helpers.extension_first_open import current_first_open_authority, FirstOpenDenied
+from plugins._a0_connector.helpers.browser_bridge_approval import (
+    BrowserBridgeApprovalError,
+    validate_approval_identifier,
+)
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    SUBJECT_ID,
+    parse_unique_json_object,
+)
+from plugins._a0_connector.helpers.browser_bridge_selection import selected_bridge
+from plugins._a0_connector.helpers.browser_bridge_site_authority import (
+    MAX_SITE_AUTHORITY_REQUEST_BYTES,
+    SITE_AUTHORITY_CONTRACT,
+    SITE_AUTHORITY_VERSION,
+    SITE_DECISIONS,
+    BrowserBridgeSiteAuthorityError,
+    BrowserBridgeSiteAuthorityUnavailable,
+    get_browser_bridge_site_authority_repository,
+)
+
+
+class BrowserBridgeSiteAuthority(ApiHandler):
+    """List safe site prompts or relay one explicit protected decision."""
+
+    async def handle_request(self, request: Request) -> Response:
+        document = _read_bounded_document(request)
+        if document is None:
+            return _invalid()
+        return await self._dispatch(document)
+
+    async def process(self, input: dict, request: Request) -> Response:
+        if _unsupported_body(input, request):
+            return _invalid()
+        return await self._dispatch(input)
+
+    async def _dispatch(self, value: dict[str, Any]) -> Response:
+        action = value.get("action")
+        if action == "list":
+            if set(value) != {"action", "context_id"}:
+                return _invalid()
+            try:
+                context_id = validate_approval_identifier(
+                    value.get("context_id"), field_name="context_id"
+                )
+            except BrowserBridgeApprovalError:
+                return _invalid()
+            bridge_id = selected_bridge(context_id)
+            if bridge_id is None:
+                return _json_response({**_base_response(), "challenges": []})
+            try:
+                challenges = get_browser_bridge_site_authority_repository().list_pending(
+                    subject_id=SUBJECT_ID,
+                    context_id=context_id,
+                    bridge_id=bridge_id,
+                )
+                first_open = current_first_open_authority()
+                if first_open is not None:
+                    challenges = tuple(challenges) + first_open.list_pending(
+                        subject_id=SUBJECT_ID, context_id=context_id, bridge_id=bridge_id)
+                challenges = sorted(challenges, key=lambda item: item["expires_at_ms"])[:128]
+            except BrowserBridgeSiteAuthorityError:
+                return _invalid()
+            except BrowserBridgeSiteAuthorityUnavailable:
+                return _unavailable(status=503)
+            except Exception:
+                return _unavailable(status=503)
+            return _json_response(
+                {
+                    **_base_response(),
+                    "challenges": [dict(challenge) for challenge in challenges],
+                }
+            )
+
+        if action != "decide" or set(value) != {
+            "action",
+            "challenge_id",
+            "decision",
+        }:
+            return _invalid()
+        decision = value.get("decision")
+        is_first_open = isinstance(value.get("challenge_id"), str) and value["challenge_id"].startswith("open-site-")
+        if not isinstance(decision, str) or decision not in (SITE_DECISIONS | {"allow_site"} if is_first_open else SITE_DECISIONS):
+            return _invalid()
+        if is_first_open:
+            try:
+                challenge_id = validate_approval_identifier(value["challenge_id"], field_name="challenge_id")
+                first_open = current_first_open_authority()
+                if first_open is None:
+                    return _unavailable(status=409)
+                result = first_open.decide(subject_id=SUBJECT_ID, challenge_id=challenge_id, decision=decision)
+                return _json_response({**_base_response(), **result})
+            except (BrowserBridgeApprovalError, FirstOpenDenied):
+                return _invalid()
+            except Exception:
+                return _unavailable(status=503)
+        try:
+            result = await get_browser_bridge_site_authority_repository().decide(
+                subject_id=SUBJECT_ID,
+                challenge_id=value.get("challenge_id"),
+                decision=decision,
+            )
+        except BrowserBridgeSiteAuthorityError:
+            return _invalid()
+        except BrowserBridgeSiteAuthorityUnavailable:
+            return _unavailable(status=409)
+        except Exception:
+            return _unavailable(status=503)
+        return _json_response({**_base_response(), **result.as_public_dict()})
+
+
+def _base_response() -> dict[str, Any]:
+    return {
+        "contract": SITE_AUTHORITY_CONTRACT,
+        "authority_version": SITE_AUTHORITY_VERSION,
+        "browser_control_ready": False,
+    }
+
+
+def _unsupported_body(input: Any, request: Request | None) -> bool:
+    if not isinstance(input, dict):
+        return True
+    if request is None:
+        return False
+    raw_data = bytes(getattr(request, "data", b"") or b"")
+    content_length = getattr(request, "content_length", None)
+    if (
+        isinstance(content_length, int)
+        and content_length > MAX_SITE_AUTHORITY_REQUEST_BYTES
+    ):
+        return True
+    if not raw_data:
+        return False
+    return (
+        len(raw_data) > MAX_SITE_AUTHORITY_REQUEST_BYTES
+        or not bool(getattr(request, "is_json", False))
+        or parse_unique_json_object(raw_data) is None
+    )
+
+
+def _read_bounded_document(request: Request) -> dict[str, Any] | None:
+    content_length = getattr(request, "content_length", None)
+    if (
+        isinstance(content_length, int)
+        and not 1 <= content_length <= MAX_SITE_AUTHORITY_REQUEST_BYTES
+    ):
+        return None
+    if not bool(getattr(request, "is_json", False)):
+        return None
+    stream = getattr(request, "stream", None)
+    if stream is None or not hasattr(stream, "read"):
+        return None
+    try:
+        raw_data = stream.read(MAX_SITE_AUTHORITY_REQUEST_BYTES + 1)
+    except Exception:
+        return None
+    if (
+        not isinstance(raw_data, bytes)
+        or not raw_data
+        or len(raw_data) > MAX_SITE_AUTHORITY_REQUEST_BYTES
+    ):
+        return None
+    return parse_unique_json_object(raw_data)
+
+
+def _invalid() -> Response:
+    return _json_response(
+        {"error": "invalid_site_authority_request"}, status=400
+    )
+
+
+def _unavailable(*, status: int) -> Response:
+    return _json_response(
+        {
+            **_base_response(),
+            "error": "browser_bridge_site_authority_unavailable",
+        },
+        status=status,
+    )
+
+
+def _json_response(payload: dict[str, Any], *, status: int = 200) -> Response:
+    return Response(
+        response=json.dumps(payload, separators=(",", ":")),
+        status=status,
+        mimetype="application/json",
+        headers={"Cache-Control": "no-store"},
+    )

--- a/plugins/_a0_connector/api/browser_bridge_site_authority.py.dox.md
+++ b/plugins/_a0_connector/api/browser_bridge_site_authority.py.dox.md
@@ -1,0 +1,62 @@
+# browser_bridge_site_authority.py DOX
+
+## Purpose
+
+- Own `POST /api/plugins/_a0_connector/browser_bridge_site_authority`.
+- List safe pending site prompts and relay one explicit protected-user choice.
+
+## Ownership
+
+- `BrowserBridgeSiteAuthority` owns the authenticated, CSRF-checked, no-store
+  presentation boundary.
+- `helpers/browser_bridge_site_authority.py` owns exact current-operation and
+  lease validation, idempotent decisions, retained resolution tasks, and
+  operation/turn origin grants.
+- Browser runtime composition owns installing the otherwise unavailable global
+  repository and wiring broker, lease-index, route, and lifecycle adapters.
+
+## Local Contracts
+
+- Accept exactly `{action: "list", context_id}` or
+  `{action: "decide", challenge_id, decision}` with `decision` equal to `deny`,
+  `allow_once`, or `allow_turn` in a bounded duplicate-key-free JSON body.
+  Only production `open-site-` requests additionally accept `allow_site`.
+- Treat list `context_id` only as a selection hint and derive the selected
+  extension bridge from current AgentContext agent0 project/profile config.
+  Missing, container, or unselected contexts return a successful empty list
+  before the optional authority is retrieved.
+- Derive the subject and every bridge, route, operation, lease, document,
+  fingerprint, origin, grant, and control field from current server state.
+- Recheck that exact context/bridge selection at challenge registration,
+  decision, turn-grant lookup, and queued-control authorization; a changed
+  selection withdraws authority.
+- An exact current turn grant may resolve a newly registered matching challenge
+  without another prompt, but it still uses a fresh correlated control and
+  cannot authorize another turn, route, origin, or an operation-only grant.
+- List only challenge ID, canonical origin, `navigate` or production `open` action class,
+  server-generated summary, exact options, and expiry. A decision response may
+  additionally expose its stable control ID and accepted status.
+- Never accept or expose authority bindings, full URLs, handles, hashes,
+  digests, raw extension summary text, page data, or grant internals.
+- Responses are allowlisted and `Cache-Control: no-store`. This endpoint does
+  not create challenges, infer choices from natural-language text, persist
+  Browser data, advertise readiness, or activate the Browser bridge.
+- Production `open-site-` IDs belong to `extension_first_open`, not the native
+  navigate challenge repository. Merge its current context/bridge prompts into
+  the bounded 128-item list. Resolve these IDs only against the installed
+  service's exact retained request; missing or stale IDs never fall back to
+  native receipt handling. The compatible `control_id` response field contains
+  an opaque `open-decision-` decision identifier, not a native control or receipt.
+  Only explicit `allow_site` persists saved exact-origin policy through the
+  composed helper, from retained authority fields, before waiter release.
+  Once/turn decisions never persist policy. This HTTP endpoint cannot create
+  requests; only the server Browser operation path may do so. Native navigate
+  request options remain the original three-choice list.
+
+## Verification
+
+- Run `pytest tests/test_browser_bridge_site_authority.py`.
+
+## Child DOX Index
+
+No child DOX files.

--- a/plugins/_a0_connector/api/v1/browser_companion_release.py
+++ b/plugins/_a0_connector/api/v1/browser_companion_release.py
@@ -1,0 +1,44 @@
+"""POST /api/plugins/_a0_connector/v1/browser_companion_release."""
+
+from __future__ import annotations
+
+import json
+
+from helpers.api import ApiHandler, Request, Response
+from plugins._a0_connector.helpers.browser_companion_release import (
+    browser_companion_release_status,
+)
+
+
+class BrowserCompanionRelease(ApiHandler):
+    """Return configured public presentation metadata, not release proof."""
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        if not isinstance(input, dict) or input or _has_unsupported_body(request):
+            return Response(
+                response=(
+                    '{"error":"request_body_not_supported",'
+                    '"message":"Release metadata is configured by the Agent Zero server."}'
+                ),
+                status=400,
+                mimetype="application/json",
+            )
+        return browser_companion_release_status()
+
+
+def _has_unsupported_body(request: Request | None) -> bool:
+    if request is None:
+        return False
+    raw_data = bytes(getattr(request, "data", b"") or b"")
+    content_length = getattr(request, "content_length", None)
+    if isinstance(content_length, int) and content_length > 1024:
+        return True
+    if not raw_data:
+        return False
+    if len(raw_data) > 1024 or not bool(getattr(request, "is_json", False)):
+        return True
+    try:
+        document = json.loads(raw_data)
+    except (TypeError, ValueError, UnicodeError, RecursionError):
+        return True
+    return not isinstance(document, dict) or bool(document)

--- a/plugins/_a0_connector/api/v1/browser_companion_release.py.dox.md
+++ b/plugins/_a0_connector/api/v1/browser_companion_release.py.dox.md
@@ -1,0 +1,39 @@
+# Browser Companion Release Metadata API
+
+## Purpose
+
+- Expose configured, non-secret Browser companion presentation metadata to an authenticated WebUI session. This endpoint does not establish cryptographic pinning.
+- Keep Docker/WebUI delivery separate from installation on the user's browser host.
+
+## Request and response
+
+- Route: `POST /api/plugins/_a0_connector/v1/browser_companion_release`.
+- Request body: empty JSON object only. Request-supplied URLs, paths, extension IDs, artifacts, or overrides are rejected.
+- Response contract: `a0.browser-bridge.release-metadata.v1`, schema version 1. It references `a0.browser-bridge.install.v1` separately and always reports `install_ready: false`.
+- Capability discovery name: `browser_companion_release_metadata`. Its presence means only that this endpoint contract exists; it does not advertise a configured release, installer, pairing, or browser runtime.
+- An `available` response contains only allowlisted public catalog, compatibility, release, digest, size, target, and download metadata. Available means that the configured presentation metadata passed bounded shape, canonical URL, complete-matrix, and server-compatibility checks; it never means installation is ready. Agent Zero Core has not verified the detached catalog signature or artifact bytes.
+- Missing, invalid, incomplete, or incompatible server metadata returns `state: unavailable` with no catalog, release, or artifacts.
+- Input presentation schema 1 keeps the exact nine-artifact matrix and rejects a
+  `platforms` field. Input schema 2 requires a nonempty, sorted, unique list of
+  known `linux`, `macos`, `windows` platforms and the exact union of complete
+  artifact groups for those platforms. No omitted-platform artifact, duplicate,
+  partial group or placeholder is accepted. The public response remains schema
+  1 of the existing presentation contract; neither input is a signed catalog or
+  proves cryptographic verification. This lets a genuine Mac-only release be
+  presented without claiming Windows/Linux artifacts exist.
+
+## Security and side effects
+
+- Uses `ApiHandler` directly because this is a same-origin WebUI endpoint: session authentication and CSRF protection are both required. `ProtectedConnectorApiHandler` is intentionally not used because it disables CSRF for connector-client routes; API-key and loopback overrides are not added. Nonempty malformed JSON is rejected from raw request bytes even when the generic API parser supplied an empty dictionary.
+- Reads only the three documented server environment values through the companion-release helper.
+- Treats the configured release JSON as a strict presentation envelope, not as the signed release catalog. It intentionally excludes catalog-only extension origins and other native registration data.
+- Enforces the compiled server floor `2.12.0` independently of supplied metadata; metadata may raise the effective floor but cannot lower it.
+- Never returns raw environment data, private/signing keys, server credentials, extension IDs, native-host paths, user paths, or exception text.
+- Performs no download, install, filesystem write, subprocess, Docker mutation, pairing, or browser operation.
+- Every response states that delivery targets the user's browser host and that Docker installation is unsupported.
+- Every response states that the browser-host installer/CLI must verify the detached catalog signature against its own pinned public root and verify the selected artifact before execution.
+
+## Verification
+
+- Run `pytest tests/test_browser_companion_release_metadata.py`.
+- Keep invalid-field, secret-sentinel, compatibility, complete-artifact-matrix, request-body rejection, and authentication/CSRF contract assertions green.

--- a/plugins/_a0_connector/api/v1/browser_runtime.py
+++ b/plugins/_a0_connector/api/v1/browser_runtime.py
@@ -25,8 +25,34 @@ def _normalize_requested_backend(value: object) -> str:
 
 
 def _normalize_host_browser_selection(value: object) -> str:
-    raw = _string(value).lower().replace(" ", "_")
-    return "".join(ch for ch in raw if ch.isalnum() or ch in {"_", "-", ":", ".", "/"})[:200]
+    from plugins._browser.helpers.config import normalize_host_browser_selection
+
+    return normalize_host_browser_selection(value)
+
+
+def _extension_selection_kind(value: object) -> str:
+    from plugins._browser.helpers.config import parse_extension_browser_selection
+
+    try:
+        parsed = parse_extension_browser_selection(value)
+    except ValueError:
+        return "invalid"
+    return "valid" if parsed is not None else "not_extension"
+
+
+def _extension_selection_error(value: object) -> str:
+    selection_kind = _extension_selection_kind(value)
+    if selection_kind == "invalid":
+        return (
+            '{"error":"invalid_extension_browser_selection",'
+            '"message":"The reserved extension browser selection is invalid."}'
+        )
+    if selection_kind == "valid":
+        return (
+            '{"error":"browser_extension_bridge_unavailable",'
+            '"message":"Pairing and explicit activation are not available in this release."}'
+        )
+    return ""
 
 
 def _normalize_profile_mode(value: object) -> str:
@@ -65,6 +91,7 @@ class BrowserRuntime(connector_base.ProtectedConnectorApiHandler):
 
         settings = self._load_browser_config(project_name)
         if action == "set":
+            current_settings = dict(settings)
             runtime_backend = _normalize_requested_backend(input.get("runtime_backend"))
             if not runtime_backend:
                 return Response(
@@ -74,8 +101,11 @@ class BrowserRuntime(connector_base.ProtectedConnectorApiHandler):
                 )
             settings["runtime_backend"] = runtime_backend
             if "host_browser_selection" in input or "browser_selection" in input:
+                requested_selection = input.get(
+                    "host_browser_selection", input.get("browser_selection")
+                )
                 settings["host_browser_selection"] = _normalize_host_browser_selection(
-                    input.get("host_browser_selection", input.get("browser_selection"))
+                    requested_selection
                 )
             if "host_browser_profile_mode" in input or "profile_mode" in input:
                 profile_mode = _normalize_profile_mode(
@@ -91,6 +121,27 @@ class BrowserRuntime(connector_base.ProtectedConnectorApiHandler):
             settings["host_browser_profile_mode"] = (
                 _normalize_profile_mode(settings.get("host_browser_profile_mode")) or "existing"
             )
+            from plugins._browser.helpers.config import (
+                validate_extension_browser_selection_change,
+            )
+
+            try:
+                validate_extension_browser_selection_change(
+                    proposed_value=settings.get("host_browser_selection"),
+                    current_value=current_settings.get("host_browser_selection"),
+                    proposed_runtime_backend=runtime_backend,
+                    current_runtime_backend=current_settings.get("runtime_backend"),
+                )
+            except ValueError:
+                extension_selection_error = _extension_selection_error(
+                    settings.get("host_browser_selection")
+                )
+                return Response(
+                    response=extension_selection_error
+                    or '{"error":"invalid_extension_browser_selection"}',
+                    status=400,
+                    mimetype="application/json",
+                )
             self._save_browser_config(project_name, settings)
 
         runtime_backend = settings.get("runtime_backend") or "container"

--- a/plugins/_a0_connector/api/v1/capabilities.py
+++ b/plugins/_a0_connector/api/v1/capabilities.py
@@ -33,6 +33,22 @@ _BASE_FEATURES = [
 ]
 
 _OPTIONAL_FEATURES: dict[str, tuple[str, ...]] = {
+    "browser_bridge_pairing_v1": (
+        "plugins._a0_connector.api.browser_bridge_pairing",
+        "plugins._a0_connector.api.browser_bridge_exchange",
+        "plugins._a0_connector.helpers.browser_bridge_pairing",
+    ),
+    "browser_companion_release_metadata": (
+        "plugins._a0_connector.api.v1.browser_companion_release",
+        "plugins._a0_connector.helpers.browser_companion_release",
+    ),
+    "browser_extension_bridge_foundation": (
+        "plugins._browser.helpers.bridge_foundation",
+        "plugins._a0_connector.helpers.browser_bridge_cutover",
+    ),
+    "browser_extension_mv3_runtime_foundation": (
+        "plugins._browser.helpers.mv3_runtime_foundation",
+    ),
     "settings_get": ("helpers.settings", "helpers.subagents"),
     "settings_set": ("helpers.settings", "helpers.subagents"),
     "agent_profile_set": ("api.agent_profile_set",),

--- a/plugins/_a0_connector/api/ws_connector.py
+++ b/plugins/_a0_connector/api/ws_connector.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import unquote, urlsplit
 
@@ -75,6 +76,7 @@ _SNAPSHOT_REPLAY_PAGE_SIZE = 50
 _TAIL_HISTORY_PAGE_SIZE = 100
 _LIVE_STREAM_PAGE_SIZE = 100
 _ATTACHMENT_METADATA_DECODE_LIMIT = 3
+_BRIDGE_ERROR_CODE = re.compile(r"[A-Z][A-Z0-9_]{0,63}")
 
 
 def _attachment_log_metadata(attachments: list[str]) -> dict[str, list[str]]:
@@ -105,6 +107,25 @@ def _attachment_log_metadata(attachments: list[str]) -> dict[str, list[str]]:
     return {"attachments": names} if names else {}
 
 
+def _browser_bridge_error(error: Exception, *, hello: bool) -> WsResult:
+    """Project only a bounded symbolic bridge failure, never exception text."""
+
+    candidate = getattr(error, "code", None)
+    code = (
+        candidate
+        if isinstance(candidate, str) and _BRIDGE_ERROR_CODE.fullmatch(candidate)
+        else ("INVALID_HELLO" if hello else "BRIDGE_REQUEST_FAILED")
+    )
+    return WsResult.error(
+        code=code,
+        message=(
+            "Browser bridge hello rejected"
+            if hello
+            else "Browser bridge request rejected"
+        ),
+    )
+
+
 class WsConnector(WsHandler):
     _streaming_tasks: ClassVar[dict[tuple[str, str], asyncio.Task[None]]] = {}
 
@@ -120,11 +141,42 @@ class WsConnector(WsHandler):
     def requires_api_key(cls) -> bool:
         return False
 
+    @classmethod
+    def accepted_principal_types(cls) -> frozenset[str]:
+        return frozenset({"browser_bridge"})
+
+    @classmethod
+    def authenticate_principal(cls, auth: dict):
+        from plugins._a0_connector.helpers.browser_bridge_session import authenticate
+        return authenticate(auth, handler_id=f"{cls.__module__}.{cls.__name__}")
+
+    @classmethod
+    def principal_is_active(cls, principal) -> bool:
+        from plugins._a0_connector.helpers.browser_bridge_session import is_active
+        return is_active(principal)
+
     async def on_connect(self, sid: str) -> None:
+        if self.principal_for_sid(sid) is not None:
+            return
         register_sid(sid)
         PrintStyle.debug(f"[a0-connector] /ws connected: {sid}")
 
     async def on_disconnect(self, sid: str) -> None:
+        principal = self.principal_for_sid(sid)
+        if principal is not None:
+            from plugins._a0_connector.helpers.browser_bridge_bootstrap import (
+                get_browser_bridge_application,
+            )
+
+            application = get_browser_bridge_application()
+            if application is not None:
+                try:
+                    await application.disconnect(principal, sid)
+                except Exception:
+                    # The shared manager owns socket teardown. Browser cleanup
+                    # is fail-isolated and can grant no authority on failure.
+                    pass
+            return
         contexts = unregister_sid(sid)
         for context_id in contexts:
             self._cancel_streaming(sid, context_id)
@@ -162,6 +214,54 @@ class WsConnector(WsHandler):
         data: dict[str, Any],
         sid: str,
     ) -> dict[str, Any] | WsResult | None:
+        principal = self.principal_for_sid(sid)
+        if principal is not None:
+            if (
+                self._principal_sid != sid
+                or self.manager.principal_for_sid(self.namespace, sid) is not principal
+                or not principal.permits_inbound(event, self.identifier)
+                or not self.principal_is_active(principal)
+            ):
+                return WsResult.error(code="SCOPE_DENIED", message="Access denied")
+            from plugins._a0_connector.helpers.browser_bridge_bootstrap import (
+                admitted_hello_projection,
+                get_browser_bridge_application,
+                register_browser_bridge_hello,
+            )
+            from plugins._a0_connector.helpers.browser_bridge_session import hello
+
+            # WsManager owns and sanitizes this transport correlation field.
+            # Strict bridge documents must not receive envelope metadata; keep
+            # the manager's original payload intact for the correlated ACK.
+            document = dict(data)
+            document.pop("correlationId", None)
+            application = get_browser_bridge_application()
+            if application is None:
+                if event == "connector_hello":
+                    return hello(document)
+                return WsResult.error(
+                    code="RUNTIME_NOT_ADMITTED",
+                    message="Browser bridge runtime is not admitted",
+                )
+            if event == "connector_hello":
+                try:
+                    route = register_browser_bridge_hello(
+                        principal=principal,
+                        connector_sid=sid,
+                        data=document,
+                    )
+                    if route is None:
+                        return hello(document)
+                    return admitted_hello_projection(route)
+                except Exception as error:
+                    from plugins._a0_connector.helpers.browser_bridge_application import record_production_browser_stage
+
+                    record_production_browser_stage("HELLO_REJECTED")
+                    return _browser_bridge_error(error, hello=True)
+            try:
+                return await application.dispatch(principal, sid, event, document)
+            except Exception as error:
+                return _browser_bridge_error(error, hello=False)
         if event == "connector_hello":
             self._store_remote_tool_metadata(data, sid)
             self._associate_declared_context(data, sid)

--- a/plugins/_a0_connector/extensions/python/_functions/agent/Agent/get_tool/start/_05_legacy_browser_retirement.py
+++ b/plugins/_a0_connector/extensions/python/_functions/agent/Agent/get_tool/start/_05_legacy_browser_retirement.py
@@ -1,0 +1,11 @@
+from helpers.extension import Extension
+from plugins._a0_connector.helpers.browser_bridge_legacy_retirement import get_legacy_retirement, LegacyRetirementDenied
+
+
+class BlockRetiredLegacyBrowserTool(Extension):
+    def execute(self, data: dict, **kwargs):
+        args = data.get("args", ())
+        named = data.get("kwargs", {})
+        name = named.get("name", args[1] if isinstance(args, tuple) and len(args) > 1 else None)
+        if name == "chrome_bridge" and get_legacy_retirement().blocked():
+            data["exception"] = LegacyRetirementDenied("legacy_bridge_retired")

--- a/plugins/_a0_connector/extensions/python/_functions/helpers/persist_chat/_deserialize_context/start/_05_legacy_quarantine.py
+++ b/plugins/_a0_connector/extensions/python/_functions/helpers/persist_chat/_deserialize_context/start/_05_legacy_quarantine.py
@@ -1,0 +1,9 @@
+from helpers.extension import Extension
+from plugins._a0_connector.helpers.browser_bridge_legacy_quarantine import enabled, quarantine_document
+
+
+class QuarantineLegacyDocument(Extension):
+    def execute(self, data: dict, **kwargs):
+        if enabled():
+            document = data["kwargs"].get("data", data["args"][0] if data["args"] else None)
+            quarantine_document(document)

--- a/plugins/_a0_connector/extensions/python/_functions/helpers/persist_chat/_serialize_context/start/_05_legacy_quarantine.py
+++ b/plugins/_a0_connector/extensions/python/_functions/helpers/persist_chat/_serialize_context/start/_05_legacy_quarantine.py
@@ -1,0 +1,9 @@
+from helpers.extension import Extension
+from plugins._a0_connector.helpers.browser_bridge_legacy_quarantine import enabled, quarantine_context
+
+
+class QuarantineLegacyContext(Extension):
+    def execute(self, data: dict, **kwargs):
+        if enabled():
+            context = data["kwargs"].get("context", data["args"][0] if data["args"] else None)
+            quarantine_context(context)

--- a/plugins/_a0_connector/extensions/python/webui_server_start/_10_browser_runtime.py
+++ b/plugins/_a0_connector/extensions/python/webui_server_start/_10_browser_runtime.py
@@ -1,0 +1,13 @@
+from helpers.extension import Extension
+from plugins._a0_connector.helpers.browser_bridge_runtime_owner import (
+    install_configured_browser_runtime,
+    retire_configured_browser_runtime,
+)
+
+
+class BrowserRuntime(Extension):
+    def execute(self, runtime, shutdown, **kwargs):
+        if install_configured_browser_runtime(runtime.ws_manager):
+            shutdown.push_async_callback(
+                retire_configured_browser_runtime, manager=runtime.ws_manager,
+            )

--- a/plugins/_a0_connector/helpers/browser_bridge_action_authority.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_action_authority.py
@@ -1,0 +1,1463 @@
+"""Once-only consequential-action authority for exact pending Browser clicks.
+
+The extension may report a locally detected action risk, but that report grants
+nothing.  This controller validates the event against Core's retained operation,
+owned lease and semantic-document projection, records only an explicit protected
+user choice, consumes one exact receipt, and owns the correlated resolution task.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from dataclasses import dataclass, field
+import hashlib
+import re
+import threading
+import time
+from typing import Any, Awaitable, Callable, Mapping
+import uuid
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_approval import (
+    MAX_APPROVAL_TTL_MS,
+    ApprovalConsumeStatus,
+    ApprovalDecisionStatus,
+    BrowserActionDataClassification,
+    BrowserApprovalBinding,
+    BrowserApprovalRoute,
+    BrowserBridgeApprovalRepository,
+    NO_ACTION_DATA_CLASSIFICATION,
+)
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    BrowserBridgeContextRoute,
+)
+from plugins._a0_connector.helpers.browser_bridge_events import (
+    ActionChallengeNotice,
+    TYPE_CHALLENGE_SUMMARY,
+    UPLOAD_CHALLENGE_SUMMARY,
+)
+from plugins._a0_connector.helpers.browser_bridge_operations import (
+    BrokerCompletion,
+    ControlTicket,
+    OperationBinding,
+    OperationTicket,
+)
+from plugins._a0_connector.helpers.browser_bridge_policy import (
+    BrowserBridgePolicyError,
+    normalize_site_origin,
+)
+from plugins._a0_connector.helpers.browser_bridge_selection import (
+    selection_current as server_selection_current,
+)
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+    require_transport_principal_identity,
+)
+
+
+ACTION_AUTHORITY_CONTRACT = "a0.browser-bridge.approval.v1"
+ACTION_AUTHORITY_VERSION = 1
+MAX_ACTION_CHALLENGES = 128
+MAX_ACTION_DECISIONS = 128
+MAX_ACTION_TOMBSTONES = 2_048
+DEFAULT_ACTION_RESOLUTION_TIMEOUT_MS = 10_000
+
+ACTION_CHOICES = frozenset({"decline", "approve_once"})
+ACTION_OPTIONS = ("decline", "approve_once")
+ACTION_CLASSES = frozenset(
+    {"sensitive_input", "external_side_effect", "unknown"}
+)
+
+_NATIVE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+_CORE_ID = re.compile(r"[A-Za-z0-9_-]{1,128}")
+_DIGEST = re.compile(r"[a-f0-9]{64}")
+
+
+class BrowserBridgeActionAuthorityError(ValueError):
+    """An action challenge, choice, or dependency value is invalid."""
+
+
+class BrowserBridgeActionAuthorityUnavailable(RuntimeError):
+    """Exact current consequential-action authority cannot be established."""
+
+
+@dataclass(frozen=True, slots=True)
+class ActionDocumentBinding:
+    """Safe server-owned semantic document identity for one leased tab."""
+
+    document_id: str
+    document_epoch: int
+    refs: frozenset[str]
+
+    def __post_init__(self) -> None:
+        _identifier(self.document_id, "document_id")
+        if not _safe_integer(self.document_epoch):
+            raise BrowserBridgeActionAuthorityError("invalid document_epoch")
+        refs = frozenset(self.refs)
+        if not refs or len(refs) > 20_000:
+            raise BrowserBridgeActionAuthorityError("invalid document refs")
+        for ref in refs:
+            _identifier(ref, "ref")
+        object.__setattr__(self, "refs", refs)
+
+
+@dataclass(frozen=True, slots=True)
+class ActionChallenge:
+    challenge_id: str
+    server_instance_id: str
+    route: BrowserBridgeContextRoute = field(repr=False)
+    operation: OperationTicket = field(repr=False)
+    approval_binding: BrowserApprovalBinding = field(repr=False)
+    origin: str
+    action_class: str
+    data_classification: BrowserActionDataClassification = field(repr=False)
+    canonical_parameter_hash: str = field(repr=False)
+    target_fingerprint: str = field(repr=False)
+    lease_id_digest: str = field(repr=False)
+    browser_id_digest: str = field(repr=False)
+    document_id: str = field(repr=False)
+    document_epoch: int = field(repr=False)
+    created_at_ms: int
+    expires_at_ms: int
+    event_hash: str = field(repr=False)
+
+    def as_public_dict(self) -> dict[str, Any]:
+        return {
+            "challenge_id": self.challenge_id,
+            "action": self.operation.action,
+            "origin": self.origin,
+            "action_class": self.action_class,
+            "options": list(ACTION_OPTIONS),
+            "expires_at_ms": self.expires_at_ms,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ActionDecision:
+    challenge: ActionChallenge = field(repr=False)
+    choice: str
+    control_id: str
+    action_grant_id: str | None = field(default=None, repr=False)
+    receipt_id: str | None = field(default=None, repr=False)
+    decided_at_ms: int = 0
+    control_expires_at_ms: int = 0
+
+    @property
+    def challenge_id(self) -> str:
+        return self.challenge.challenge_id
+
+    @property
+    def decision(self) -> str:
+        return "approved" if self.choice == "approve_once" else "declined"
+
+    def as_public_dict(self) -> dict[str, Any]:
+        return {
+            "challenge_id": self.challenge_id,
+            "decision": self.decision,
+            "control_id": self.control_id,
+            "status": "accepted",
+        }
+
+    def resolution(self) -> dict[str, Any]:
+        challenge = self.challenge
+        operation = challenge.operation
+        grant = None
+        if self.choice == "approve_once":
+            grant = {
+                "action_grant_id": self.action_grant_id,
+                "scope": "operation",
+                "origin": challenge.origin,
+                "action_class": challenge.action_class,
+                "canonical_parameter_hash": challenge.canonical_parameter_hash,
+                "target_fingerprint": challenge.target_fingerprint,
+                "data_classification": (
+                    challenge.data_classification.as_wire_value()
+                ),
+                "expires_at_ms": self.control_expires_at_ms,
+            }
+        return {
+            "challenge_id": challenge.challenge_id,
+            "tab_handle": operation.target_tab_handle,
+            "document_id": challenge.document_id,
+            "document_epoch": challenge.document_epoch,
+            "canonical_parameter_hash": challenge.canonical_parameter_hash,
+            "target_fingerprint": challenge.target_fingerprint,
+            "origin": challenge.origin,
+            "action_class": challenge.action_class,
+            "data_classification": challenge.data_classification.as_wire_value(),
+            "decision": self.choice,
+            "grant": grant,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ActionAuthorityInvalidationSummary:
+    challenges: int
+    decisions: int
+
+
+CurrentOperation = Callable[..., OperationTicket | None]
+RemainingOperation = Callable[[OperationTicket], int]
+LeaseResolver = Callable[[OperationBinding, str], Any | None]
+DocumentResolver = Callable[
+    [OperationBinding, str], ActionDocumentBinding | Any | None
+]
+RouteVerifier = Callable[[BrowserBridgeContextRoute], bool]
+BeginResolution = Callable[..., Awaitable[ControlTicket]]
+WaitControl = Callable[[ControlTicket], Awaitable[BrokerCompletion]]
+
+
+class BrowserBridgeActionAuthority:
+    """Validate action challenges and resolve one exact pending operation."""
+
+    def __init__(
+        self,
+        *,
+        current_operation: CurrentOperation | None = None,
+        remaining_operation_ms: RemainingOperation | None = None,
+        lease_for: LeaseResolver | None = None,
+        document_for: DocumentResolver | None = None,
+        route_verifier: RouteVerifier | None = None,
+        turn_current: Callable[[OperationBinding], bool] | None = None,
+        selection_current: Callable[[str, str], bool] | None = None,
+        begin_resolution: BeginResolution | None = None,
+        wait_control: WaitControl | None = None,
+        server_instance_id: Callable[[], str] | None = None,
+        approval_repository: BrowserBridgeApprovalRepository | None = None,
+        approval_record_loader: Callable[
+            [str, str], Mapping[str, Any] | None
+        ]
+        | None = None,
+        clock_ms: Callable[[], int] | None = None,
+        control_id_factory: Callable[[], str] | None = None,
+        grant_id_factory: Callable[[], str] | None = None,
+        max_challenges: int = MAX_ACTION_CHALLENGES,
+        max_decisions: int = MAX_ACTION_DECISIONS,
+        max_tombstones: int = MAX_ACTION_TOMBSTONES,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        for value, maximum, name in (
+            (max_challenges, MAX_ACTION_CHALLENGES, "challenge"),
+            (max_decisions, MAX_ACTION_DECISIONS, "decision"),
+            (max_tombstones, MAX_ACTION_TOMBSTONES, "tombstone"),
+        ):
+            if type(value) is not int or not 1 <= value <= maximum:
+                raise ValueError(f"invalid action {name} bound")
+        self._current_operation = current_operation or _no_operation
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        self._remaining_operation_ms = remaining_operation_ms or (
+            lambda _operation: 0
+        )
+        self._lease_for = lease_for or (lambda _binding, _handle: None)
+        self._document_for = document_for or (lambda _binding, _handle: None)
+        self._route_verifier = route_verifier or (lambda _route: False)
+        self._turn_current = turn_current or (lambda _binding: False)
+        self._selection_current = selection_current or server_selection_current
+        self._begin_resolution = begin_resolution or _resolution_unavailable
+        self._wait_control = wait_control or _wait_unavailable
+        self._server_instance_id = server_instance_id or _server_unavailable
+        self._clock_ms = clock_ms or (lambda: time.time_ns() // 1_000_000)
+        self._control_id_factory = control_id_factory or (
+            lambda: uuid.uuid4().hex
+        )
+        self._grant_id_factory = grant_id_factory or (lambda: str(uuid.uuid4()))
+        self._approval_repository = approval_repository or (
+            BrowserBridgeApprovalRepository(
+                route_authorizer=self.approval_route_current,
+                active_record_loader=approval_record_loader,
+                server_instance_id_loader=self._server_instance_id,
+                clock_ms=self._clock_ms,
+                transport_profile=self._transport_profile,
+            )
+        )
+        if not isinstance(self._approval_repository, BrowserBridgeApprovalRepository):
+            raise ValueError("invalid approval repository")
+        if (
+            self._approval_repository.transport_profile is not self._transport_profile
+        ):
+            raise ValueError("approval repository transport mismatch")
+        self._max_challenges = max_challenges
+        self._max_decisions = max_decisions
+        self._max_tombstones = max_tombstones
+        self._challenges: dict[str, ActionChallenge] = {}
+        self._operation_challenges: dict[tuple[Any, ...], str] = {}
+        self._decisions: dict[str, ActionDecision] = {}
+        self._decision_outcomes: dict[str, str] = {}
+        self._armed_decisions: set[str] = set()
+        self._tombstones: dict[str, str] = {}
+        self._tombstone_order: deque[str] = deque()
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._closed = False
+        self._lock = threading.RLock()
+
+    @property
+    def pending_count(self) -> int:
+        with self._lock:
+            return len(self._challenges)
+
+    @property
+    def resolution_task_count(self) -> int:
+        with self._lock:
+            return len(self._tasks)
+
+    def ready_for(self, binding: OperationBinding) -> bool:
+        """Report only whether the controller can validate a future challenge."""
+
+        if not _operation_binding_valid(binding, self._transport_profile):
+            return False
+        route = BrowserBridgeContextRoute(
+            binding.principal,
+            binding.connector_sid,
+            binding.load_generation_id,
+            self._transport_profile,
+        )
+        try:
+            with self._lock:
+                return bool(
+                    not self._closed
+                    and self._server_id()
+                    and self._route_current(route)
+                    and self._turn_current(binding) is True
+                    and self._selected(binding)
+                )
+        except Exception:
+            return False
+
+    def challenge_ready(self, binding: OperationBinding) -> bool:
+        """Compatibility spelling for callers composed before runtime wiring."""
+
+        return self.ready_for(binding)
+
+    def approval_route_current(self, route: BrowserApprovalRoute) -> bool:
+        """Exact route authorizer for the underlying once-only receipt store."""
+
+        if not isinstance(route, BrowserApprovalRoute):
+            return False
+        try:
+            if self._closed or route.server_instance_id != self._server_id():
+                return False
+            context_route = BrowserBridgeContextRoute(
+                route.principal,
+                route.connector_sid,
+                route.load_generation_id,
+                self._transport_profile,
+            )
+            if not self._route_current(context_route):
+                return False
+            operation = self._current_operation(
+                principal=route.principal,
+                connector_sid=route.connector_sid,
+                load_generation_id=route.load_generation_id,
+                op_id=route.op_id,
+            )
+            if not isinstance(operation, OperationTicket):
+                return False
+            document = self._current_document(operation)
+            lease = self._lease_for(operation.binding, route.tab_handle)
+            classification = _operation_classification(operation)
+            return bool(
+                self._turn_current(operation.binding) is True
+                and self._selected(operation.binding)
+                and
+                operation.binding.context_id == route.context_id
+                and operation.binding.browser_session_id
+                == route.browser_session_id
+                and operation.binding.turn_id == route.turn_id
+                and operation.binding.action_id == route.action_id
+                and operation.action in {"click", "type", "upload_file"}
+                and operation.target_tab_handle == route.tab_handle
+                and operation.target_ref in document.refs
+                and operation.expected_action_class in ACTION_CLASSES
+                and classification is not None
+                and document.document_id == route.document_id
+                and document.document_epoch == route.document_epoch
+                and lease is not None
+                and getattr(lease, "tab_handle", None) == route.tab_handle
+                and self._remaining(operation) > 0
+            )
+        except Exception:
+            return False
+
+    def register_event(self, notice: ActionChallengeNotice) -> None:
+        self.register_challenge(notice)
+
+    def register_challenge(self, notice: ActionChallengeNotice) -> ActionChallenge:
+        _validate_notice(notice, self._transport_profile)
+        now = self._now()
+        event_hash = _notice_hash(notice)
+        with self._lock:
+            self._ensure_open_locked()
+            self._expire_locked(now)
+            existing = self._challenges.get(notice.challenge_id)
+            if existing is not None:
+                if existing.event_hash == event_hash and self._challenge_current(existing):
+                    return existing
+                self._invalidate_challenge_locked(existing, "mismatch")
+                raise BrowserBridgeActionAuthorityUnavailable(
+                    "action challenge mismatch"
+                )
+            decision = self._decisions.get(notice.challenge_id)
+            if decision is not None:
+                if (
+                    decision.challenge.event_hash == event_hash
+                    and self._challenge_current(decision.challenge)
+                ):
+                    return decision.challenge
+                raise BrowserBridgeActionAuthorityUnavailable(
+                    "action challenge is terminal"
+                )
+            if notice.challenge_id in self._tombstones:
+                raise BrowserBridgeActionAuthorityUnavailable(
+                    "action challenge is terminal"
+                )
+            if len(self._challenges) >= self._max_challenges:
+                raise BrowserBridgeActionAuthorityUnavailable(
+                    "action challenge limit reached"
+                )
+            operation, lease, document, remaining = self._resolve_notice(notice)
+            if (
+                notice.expires_at_ms <= now
+                or notice.expires_at_ms - now > MAX_APPROVAL_TTL_MS
+            ):
+                raise BrowserBridgeActionAuthorityUnavailable(
+                    "action challenge expired"
+                )
+            operation_key = _operation_key(operation)
+            if operation_key in self._operation_challenges:
+                raise BrowserBridgeActionAuthorityUnavailable(
+                    "operation already has an action challenge"
+                )
+            expires_at_ms = min(
+                notice.expires_at_ms,
+                now + remaining,
+                now + MAX_APPROVAL_TTL_MS,
+            )
+            server_id = self._server_id()
+            approval_route = BrowserApprovalRoute(
+                server_instance_id=server_id,
+                principal=notice.principal,
+                connector_sid=notice.connector_sid,
+                load_generation_id=notice.load_generation_id,
+                context_id=notice.context_id,
+                browser_session_id=notice.browser_session_id,
+                turn_id=notice.turn_id,
+                action_id=notice.action_id,
+                op_id=notice.op_id,
+                tab_handle=operation.target_tab_handle,
+                document_id=document.document_id,
+                document_epoch=document.document_epoch,
+                transport_profile=self._transport_profile,
+            )
+            approval_binding = BrowserApprovalBinding(
+                route=approval_route,
+                canonical_parameter_hash=notice.canonical_parameter_hash,
+                target_fingerprint=notice.target_fingerprint,
+                origin=notice.origin,
+                action_class=notice.action_class,
+                data_classification=notice.data_classification,
+            )
+            self._approval_repository.register_challenge(
+                notice.challenge_id,
+                approval_binding,
+                timeout_ms=expires_at_ms - now,
+            )
+            challenge = ActionChallenge(
+                challenge_id=notice.challenge_id,
+                server_instance_id=server_id,
+                route=BrowserBridgeContextRoute(
+                    notice.principal,
+                    notice.connector_sid,
+                    notice.load_generation_id,
+                    self._transport_profile,
+                ),
+                operation=operation,
+                approval_binding=approval_binding,
+                origin=normalize_site_origin(getattr(lease, "origin", None)),
+                action_class=notice.action_class,
+                data_classification=notice.data_classification,
+                canonical_parameter_hash=notice.canonical_parameter_hash,
+                target_fingerprint=notice.target_fingerprint,
+                lease_id_digest=notice.lease_id_digest,
+                browser_id_digest=notice.browser_id_digest,
+                document_id=document.document_id,
+                document_epoch=document.document_epoch,
+                created_at_ms=now,
+                expires_at_ms=expires_at_ms,
+                event_hash=event_hash,
+            )
+            self._challenges[challenge.challenge_id] = challenge
+            self._operation_challenges[operation_key] = challenge.challenge_id
+            return challenge
+
+    def list_pending(
+        self,
+        *,
+        subject_id: Any,
+        context_id: Any | None = None,
+        bridge_id: Any | None = None,
+    ) -> tuple[dict[str, Any], ...]:
+        subject = _identifier(subject_id, "subject_id")
+        context, bridge = _list_scope(context_id, bridge_id)
+        now = self._now()
+        with self._lock:
+            self._ensure_open_locked()
+            self._expire_locked(now)
+            result: list[dict[str, Any]] = []
+            for challenge in tuple(self._challenges.values()):
+                if challenge.route.principal.subject_id != subject:
+                    continue
+                binding = challenge.operation.binding
+                if context is not None and (
+                    binding.context_id != context or binding.bridge_id != bridge
+                ):
+                    continue
+                if not self._challenge_current(challenge):
+                    self._invalidate_challenge_locked(challenge, "invalidated")
+                    continue
+                result.append(challenge.as_public_dict())
+            result.sort(key=lambda item: (item["expires_at_ms"], item["challenge_id"]))
+            return tuple(result)
+
+    async def decide(
+        self,
+        *,
+        subject_id: Any,
+        challenge_id: Any,
+        choice: Any,
+        expected_route: BrowserBridgeContextRoute | None = None,
+    ) -> ActionDecision:
+        subject = _identifier(subject_id, "subject_id")
+        challenge_key = _identifier(challenge_id, "challenge_id")
+        if choice not in ACTION_CHOICES:
+            raise BrowserBridgeActionAuthorityError("invalid action choice")
+        now = self._now()
+        with self._lock:
+            self._ensure_open_locked()
+            self._expire_locked(now)
+            existing = self._decisions.get(challenge_key)
+            retained = existing.challenge if existing is not None else self._challenges.get(challenge_key)
+            if expected_route is not None and (
+                retained is None
+                or retained.route.principal is not expected_route.principal
+                or retained.route.connector_sid != expected_route.connector_sid
+                or retained.route.load_generation_id != expected_route.load_generation_id
+                or retained.route.transport_profile is not expected_route.transport_profile
+                or not self._challenge_current(retained)
+            ):
+                raise BrowserBridgeActionAuthorityUnavailable("action challenge unavailable")
+            if existing is not None:
+                if (
+                    existing.challenge.route.principal.subject_id == subject
+                    and existing.choice == choice
+                    and self._selected(existing.challenge.operation.binding)
+                ):
+                    return existing
+                raise BrowserBridgeActionAuthorityUnavailable(
+                    "action challenge already decided"
+                )
+            challenge = self._challenges.get(challenge_key)
+            if (
+                challenge is None
+                or challenge.route.principal.subject_id != subject
+                or not self._challenge_current(challenge)
+            ):
+                if challenge is not None:
+                    self._invalidate_challenge_locked(challenge, "invalidated")
+                raise BrowserBridgeActionAuthorityUnavailable(
+                    "action challenge unavailable"
+                )
+            return self._start_decision_locked(challenge, choice, now=now)
+
+    def cancel_operation(
+        self, operation: OperationTicket
+    ) -> ActionAuthorityInvalidationSummary:
+        if not isinstance(operation, OperationTicket):
+            raise BrowserBridgeActionAuthorityError("invalid browser operation")
+        return self._invalidate_matching(
+            lambda challenge: challenge.operation is operation
+        )
+
+    def finalize_turn(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: Any,
+        load_generation_id: Any,
+        context_id: Any,
+        browser_session_id: Any,
+        turn_id: Any,
+    ) -> ActionAuthorityInvalidationSummary:
+        values = _lifecycle_values(
+            principal,
+            connector_sid,
+            load_generation_id,
+            context_id,
+            browser_session_id,
+            turn_id,
+        )
+        return self._invalidate_matching(
+            lambda challenge: _challenge_turn(challenge) == values
+        )
+
+    def disconnect(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: Any,
+        load_generation_id: Any,
+    ) -> ActionAuthorityInvalidationSummary:
+        if not isinstance(principal, WsPrincipal):
+            raise BrowserBridgeActionAuthorityError("invalid bridge principal")
+        sid = _identifier(connector_sid, "connector_sid")
+        generation = _identifier(load_generation_id, "load_generation_id")
+        return self._invalidate_matching(
+            lambda challenge: (
+                challenge.route.principal is principal
+                and challenge.route.connector_sid == sid
+                and challenge.route.load_generation_id == generation
+            )
+        )
+
+    def revoke_bridge(
+        self,
+        *,
+        server_instance_id: Any,
+        bridge_id: Any,
+        subject_id: Any,
+    ) -> ActionAuthorityInvalidationSummary:
+        server = _identifier(server_instance_id, "server_instance_id")
+        bridge = _identifier(bridge_id, "bridge_id")
+        subject = _identifier(subject_id, "subject_id")
+        return self._invalidate_matching(
+            lambda challenge: (
+                challenge.server_instance_id == server
+                and challenge.route.principal.principal_id == bridge
+                and challenge.route.principal.subject_id == subject
+            )
+        )
+
+    def expire(
+        self, now_ms: int | None = None
+    ) -> ActionAuthorityInvalidationSummary:
+        now = self._now() if now_ms is None else _timestamp(now_ms)
+        with self._lock:
+            return self._expire_locked(now)
+
+    async def close(self) -> ActionAuthorityInvalidationSummary:
+        with self._lock:
+            if self._closed:
+                return ActionAuthorityInvalidationSummary(0, 0)
+            self._closed = True
+            summary = self._invalidate_all_locked("closed")
+            tasks = tuple(self._tasks.values())
+            self._tasks.clear()
+            for task in tasks:
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        return summary
+
+    async def _resolve_decision(self, decision: ActionDecision) -> None:
+        try:
+            with self._lock:
+                if not self._decision_current_locked(decision, require_armed=False):
+                    raise BrowserBridgeActionAuthorityUnavailable(
+                        "action decision is stale"
+                    )
+                if decision.choice == "approve_once":
+                    if decision.receipt_id is None:
+                        raise BrowserBridgeActionAuthorityUnavailable(
+                            "action receipt unavailable"
+                        )
+                    consumed = self._approval_repository.consume(
+                        decision.receipt_id,
+                        binding=decision.challenge.approval_binding,
+                    )
+                    if consumed != ApprovalConsumeStatus.CONSUMED:
+                        raise BrowserBridgeActionAuthorityUnavailable(
+                            "action receipt unavailable"
+                        )
+                if not self._decision_current_locked(decision, require_armed=False):
+                    raise BrowserBridgeActionAuthorityUnavailable(
+                        "action decision is stale"
+                    )
+                self._armed_decisions.add(decision.challenge_id)
+            timeout_ms = min(
+                DEFAULT_ACTION_RESOLUTION_TIMEOUT_MS,
+                self._remaining(decision.challenge.operation),
+                max(0, decision.control_expires_at_ms - self._now()),
+            )
+            if timeout_ms <= 0:
+                raise BrowserBridgeActionAuthorityUnavailable(
+                    "action resolution expired"
+                )
+            ticket = await self._begin_resolution(
+                decision.challenge.operation,
+                control_id=decision.control_id,
+                resolution=decision.resolution(),
+                authorization_current=lambda: self._decision_current(decision),
+                timeout_ms=timeout_ms,
+            )
+            if not isinstance(ticket, ControlTicket):
+                raise BrowserBridgeActionAuthorityUnavailable(
+                    "action resolution unavailable"
+                )
+            completion = await self._wait_control(ticket)
+            if not _matching_completion(decision, completion):
+                raise BrowserBridgeActionAuthorityUnavailable(
+                    "action resolution failed"
+                )
+            with self._lock:
+                if self._decisions.get(decision.challenge_id) is decision:
+                    self._decision_outcomes[decision.challenge_id] = "resolved"
+                    self._armed_decisions.discard(decision.challenge_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            with self._lock:
+                if self._decisions.get(decision.challenge_id) is decision:
+                    self._decision_outcomes[decision.challenge_id] = "failed"
+                    self._armed_decisions.discard(decision.challenge_id)
+
+    def _start_decision_locked(
+        self,
+        challenge: ActionChallenge,
+        choice: str,
+        *,
+        now: int,
+    ) -> ActionDecision:
+        if len(self._decisions) >= self._max_decisions:
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action decision limit reached"
+            )
+        remaining = self._remaining(challenge.operation)
+        control_expires_at_ms = min(
+            challenge.expires_at_ms,
+            now + remaining,
+            now + MAX_APPROVAL_TTL_MS,
+        )
+        if control_expires_at_ms <= now:
+            self._invalidate_challenge_locked(challenge, "expired")
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action challenge expired"
+            )
+        control_id = self._fresh_id(
+            self._control_id_factory, "control_id", core=True
+        )
+        grant_id = (
+            self._fresh_id(self._grant_id_factory, "action_grant_id", core=False)
+            if choice == "approve_once"
+            else None
+        )
+        approval = self._approval_repository.decide(
+            challenge.challenge_id,
+            choice=choice,
+            current_route=challenge.approval_binding.route,
+            surface="webui",
+        )
+        expected_status = (
+            ApprovalDecisionStatus.APPROVED
+            if choice == "approve_once"
+            else ApprovalDecisionStatus.DECLINED
+        )
+        if approval.status != expected_status or (
+            choice == "approve_once" and approval.receipt is None
+        ):
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action approval unavailable"
+            )
+        decision = ActionDecision(
+            challenge=challenge,
+            choice=choice,
+            control_id=control_id,
+            action_grant_id=grant_id,
+            receipt_id=(
+                approval.receipt.receipt_id if approval.receipt is not None else None
+            ),
+            decided_at_ms=now,
+            control_expires_at_ms=control_expires_at_ms,
+        )
+        self._challenges.pop(challenge.challenge_id, None)
+        self._decisions[challenge.challenge_id] = decision
+        self._decision_outcomes[challenge.challenge_id] = "resolving"
+        task = asyncio.create_task(
+            self._resolve_decision(decision),
+            name=f"browser-bridge-action:{challenge.challenge_id}",
+        )
+        self._tasks[challenge.challenge_id] = task
+        task.add_done_callback(self._resolution_finished)
+        return decision
+
+    def _resolve_notice(
+        self, notice: ActionChallengeNotice
+    ) -> tuple[OperationTicket, Any, ActionDocumentBinding, int]:
+        route = BrowserBridgeContextRoute(
+            notice.principal,
+            notice.connector_sid,
+            notice.load_generation_id,
+            self._transport_profile,
+        )
+        if not self._route_current(route):
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action route unavailable"
+            )
+        operation = self._lookup_operation(notice)
+        if not isinstance(operation, OperationTicket):
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action operation unavailable"
+            )
+        binding = operation.binding
+        classification = _operation_classification(operation)
+        if (
+            binding.principal is not notice.principal
+            or binding.connector_sid != notice.connector_sid
+            or binding.load_generation_id != notice.load_generation_id
+            or binding.context_id != notice.context_id
+            or binding.browser_session_id != notice.browser_session_id
+            or binding.turn_id != notice.turn_id
+            or binding.action_id != notice.action_id
+            or binding.op_id != notice.op_id
+            or operation.action not in {"click", "type", "upload_file"}
+            or not operation.target_tab_handle
+            or not operation.target_ref
+            or operation.expected_action_class != notice.action_class
+            or classification is None
+            or classification != notice.data_classification
+            or (
+                operation.action == "type"
+                and notice.summary != TYPE_CHALLENGE_SUMMARY
+            )
+            or (operation.action == "upload_file" and notice.summary != UPLOAD_CHALLENGE_SUMMARY)
+            or operation.canonical_parameter_hash
+            != notice.canonical_parameter_hash
+            or self._turn_current(binding) is not True
+            or not self._selected(binding)
+        ):
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action operation mismatch"
+            )
+        remaining = self._remaining(operation)
+        if remaining <= 0:
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action operation expired"
+            )
+        lease = self._lease_for(binding, operation.target_tab_handle)
+        try:
+            lease_origin = normalize_site_origin(getattr(lease, "origin", None))
+        except Exception:
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action lease mismatch"
+            ) from None
+        if (
+            lease is None
+            or getattr(lease, "tab_handle", None) != operation.target_tab_handle
+            or lease_origin != notice.origin
+            or _hash_identifier(getattr(lease, "lease_id", None))
+            != notice.lease_id_digest
+            or _hash_identifier(getattr(lease, "tab_handle", None))
+            != notice.browser_id_digest
+        ):
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action lease mismatch"
+            )
+        document = self._current_document(operation)
+        if (
+            document.document_id != notice.document_id
+            or document.document_epoch != notice.document_epoch
+            or operation.target_ref not in document.refs
+        ):
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action document mismatch"
+            )
+        return operation, lease, document, remaining
+
+    def _challenge_current(self, challenge: ActionChallenge) -> bool:
+        try:
+            if (
+                self._server_id() != challenge.server_instance_id
+                or not self._route_current(challenge.route)
+                or not self._selected(challenge.operation.binding)
+            ):
+                return False
+            operation = self._current_ticket(challenge.operation)
+            classification = _operation_classification(challenge.operation)
+            if (
+                operation is not challenge.operation
+                or self._remaining(operation) <= 0
+                or self._turn_current(operation.binding) is not True
+            ):
+                return False
+            lease = self._lease_for(operation.binding, operation.target_tab_handle)
+            document = self._current_document(operation)
+            return bool(
+                lease is not None
+                and getattr(lease, "tab_handle", None)
+                == operation.target_tab_handle
+                and normalize_site_origin(getattr(lease, "origin", None))
+                == challenge.origin
+                and _hash_identifier(getattr(lease, "lease_id", None))
+                == challenge.lease_id_digest
+                and _hash_identifier(getattr(lease, "tab_handle", None))
+                == challenge.browser_id_digest
+                and document.document_id == challenge.document_id
+                and document.document_epoch == challenge.document_epoch
+                and operation.target_ref in document.refs
+                and operation.expected_action_class == challenge.action_class
+                and classification == challenge.data_classification
+                and operation.canonical_parameter_hash
+                == challenge.canonical_parameter_hash
+            )
+        except Exception:
+            return False
+
+    def _selected(self, binding: OperationBinding) -> bool:
+        try:
+            return self._selection_current(
+                binding.context_id, binding.bridge_id
+            ) is True
+        except Exception:
+            return False
+
+    def _decision_current(self, decision: ActionDecision) -> bool:
+        with self._lock:
+            return self._decision_current_locked(decision, require_armed=True)
+
+    def _decision_current_locked(
+        self, decision: ActionDecision, *, require_armed: bool
+    ) -> bool:
+        return bool(
+            not self._closed
+            and self._decisions.get(decision.challenge_id) is decision
+            and self._decision_outcomes.get(decision.challenge_id) == "resolving"
+            and self._now() < decision.control_expires_at_ms
+            and (
+                not require_armed
+                or decision.challenge_id in self._armed_decisions
+            )
+            and self._challenge_current(decision.challenge)
+        )
+
+    def _current_document(self, operation: OperationTicket) -> ActionDocumentBinding:
+        value = self._document_for(
+            operation.binding, operation.target_tab_handle
+        )
+        if isinstance(value, ActionDocumentBinding):
+            return value
+        try:
+            return ActionDocumentBinding(
+                document_id=getattr(value, "document_id"),
+                document_epoch=getattr(value, "document_epoch"),
+                refs=frozenset(getattr(value, "refs")),
+            )
+        except Exception:
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action document unavailable"
+            ) from None
+
+    def _lookup_operation(
+        self, notice: ActionChallengeNotice
+    ) -> OperationTicket | None:
+        try:
+            return self._current_operation(
+                principal=notice.principal,
+                connector_sid=notice.connector_sid,
+                load_generation_id=notice.load_generation_id,
+                op_id=notice.op_id,
+            )
+        except Exception:
+            return None
+
+    def _current_ticket(
+        self, operation: OperationTicket
+    ) -> OperationTicket | None:
+        binding = operation.binding
+        try:
+            return self._current_operation(
+                principal=binding.principal,
+                connector_sid=binding.connector_sid,
+                load_generation_id=binding.load_generation_id,
+                op_id=binding.op_id,
+            )
+        except Exception:
+            return None
+
+    def _remaining(self, operation: OperationTicket) -> int:
+        try:
+            value = self._remaining_operation_ms(operation)
+        except Exception:
+            return 0
+        if type(value) is not int or not 0 <= value <= MAX_APPROVAL_TTL_MS:
+            return 0
+        return value
+
+    def _route_current(self, route: BrowserBridgeContextRoute) -> bool:
+        try:
+            return self._route_verifier(route) is True
+        except Exception:
+            return False
+
+    def _server_id(self) -> str:
+        try:
+            return _identifier(self._server_instance_id(), "server_instance_id")
+        except Exception:
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action server unavailable"
+            ) from None
+
+    def _fresh_id(
+        self,
+        factory: Callable[[], str],
+        field_name: str,
+        *,
+        core: bool,
+    ) -> str:
+        try:
+            value = (
+                _core_identifier(factory(), field_name)
+                if core
+                else _identifier(factory(), field_name)
+            )
+        except Exception:
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action identity unavailable"
+            ) from None
+        used = {
+            decision.control_id for decision in self._decisions.values()
+        } | {
+            decision.action_grant_id
+            for decision in self._decisions.values()
+            if decision.action_grant_id is not None
+        }
+        if value in used:
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action identity collision"
+            )
+        return value
+
+    def _invalidate_matching(
+        self, predicate: Callable[[ActionChallenge], bool]
+    ) -> ActionAuthorityInvalidationSummary:
+        with self._lock:
+            challenges = [
+                challenge
+                for challenge in self._challenges.values()
+                if predicate(challenge)
+            ]
+            decisions = [
+                decision
+                for decision in self._decisions.values()
+                if predicate(decision.challenge)
+            ]
+            for challenge in challenges:
+                self._invalidate_challenge_locked(challenge, "invalidated")
+            for decision in decisions:
+                self._invalidate_decision_locked(decision, "invalidated")
+            return ActionAuthorityInvalidationSummary(
+                len(challenges), len(decisions)
+            )
+
+    def _expire_locked(self, now: int) -> ActionAuthorityInvalidationSummary:
+        challenges = [
+            challenge
+            for challenge in self._challenges.values()
+            if challenge.expires_at_ms <= now
+        ]
+        decisions = [
+            decision
+            for decision in self._decisions.values()
+            if decision.control_expires_at_ms <= now
+        ]
+        for challenge in challenges:
+            self._invalidate_challenge_locked(challenge, "expired")
+        for decision in decisions:
+            self._invalidate_decision_locked(decision, "expired")
+        self._approval_repository.expire(now)
+        return ActionAuthorityInvalidationSummary(
+            len(challenges), len(decisions)
+        )
+
+    def _invalidate_challenge_locked(
+        self, challenge: ActionChallenge, reason: str
+    ) -> None:
+        if self._challenges.get(challenge.challenge_id) is not challenge:
+            return
+        self._challenges.pop(challenge.challenge_id, None)
+        self._operation_challenges.pop(_operation_key(challenge.operation), None)
+        self._approval_repository.cancel_operation(challenge.approval_binding.route)
+        self._remember_locked(challenge.challenge_id, reason)
+
+    def _invalidate_decision_locked(
+        self, decision: ActionDecision, reason: str
+    ) -> None:
+        if self._decisions.get(decision.challenge_id) is not decision:
+            return
+        self._decisions.pop(decision.challenge_id, None)
+        self._decision_outcomes.pop(decision.challenge_id, None)
+        self._armed_decisions.discard(decision.challenge_id)
+        self._operation_challenges.pop(
+            _operation_key(decision.challenge.operation), None
+        )
+        self._approval_repository.cancel_operation(
+            decision.challenge.approval_binding.route
+        )
+        self._remember_locked(decision.challenge_id, reason)
+
+    def _invalidate_all_locked(
+        self, reason: str
+    ) -> ActionAuthorityInvalidationSummary:
+        challenges = tuple(self._challenges.values())
+        decisions = tuple(self._decisions.values())
+        for challenge in challenges:
+            self._invalidate_challenge_locked(challenge, reason)
+        for decision in decisions:
+            self._invalidate_decision_locked(decision, reason)
+        return ActionAuthorityInvalidationSummary(
+            len(challenges), len(decisions)
+        )
+
+    def _remember_locked(self, challenge_id: str, reason: str) -> None:
+        if challenge_id in self._tombstones:
+            return
+        self._tombstones[challenge_id] = reason
+        self._tombstone_order.append(challenge_id)
+        while len(self._tombstone_order) > self._max_tombstones:
+            self._tombstones.pop(self._tombstone_order.popleft(), None)
+
+    def _resolution_finished(self, task: asyncio.Task[None]) -> None:
+        with self._lock:
+            for challenge_id, current in tuple(self._tasks.items()):
+                if current is task:
+                    self._tasks.pop(challenge_id, None)
+                    break
+        try:
+            task.exception()
+        except asyncio.CancelledError:
+            pass
+
+    def _ensure_open_locked(self) -> None:
+        if self._closed:
+            raise BrowserBridgeActionAuthorityUnavailable(
+                "action authority closed"
+            )
+
+    def _now(self) -> int:
+        return _timestamp(self._clock_ms())
+
+
+def _matching_completion(
+    decision: ActionDecision, completion: BrokerCompletion
+) -> bool:
+    return bool(
+        isinstance(completion, BrokerCompletion)
+        and completion.ok is True
+        and completion.result
+        == {
+            "contract_version": ACTION_AUTHORITY_VERSION,
+            "control_id": decision.control_id,
+            "challenge_id": decision.challenge_id,
+            "status": "resolved",
+            "decision": decision.choice,
+        }
+    )
+
+
+def _validate_notice(
+    notice: Any,
+    transport_profile: BrowserBridgeTransportProfile,
+) -> ActionChallengeNotice:
+    if not isinstance(notice, ActionChallengeNotice):
+        raise BrowserBridgeActionAuthorityError("invalid action challenge")
+    principal = notice.principal
+    try:
+        require_transport_principal_identity(principal, transport_profile)
+    except ValueError:
+        raise BrowserBridgeActionAuthorityError("invalid bridge principal") from None
+    if (
+        not {"browser.operate", "browser.control", "browser.approval"}
+        <= principal.scopes
+    ):
+        raise BrowserBridgeActionAuthorityError("invalid bridge principal")
+    for field_name in (
+        "connector_sid",
+        "load_generation_id",
+        "context_id",
+        "browser_session_id",
+        "turn_id",
+        "action_id",
+        "op_id",
+        "challenge_id",
+        "document_id",
+    ):
+        _identifier(getattr(notice, field_name), field_name)
+    for field_name in (
+        "canonical_parameter_hash",
+        "target_fingerprint",
+        "lease_id_digest",
+        "browser_id_digest",
+    ):
+        value = getattr(notice, field_name, None)
+        if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+            raise BrowserBridgeActionAuthorityError(f"invalid {field_name}")
+    try:
+        origin = normalize_site_origin(notice.origin)
+    except BrowserBridgePolicyError as error:
+        raise BrowserBridgeActionAuthorityError("invalid action origin") from error
+    if (
+        origin != notice.origin
+        or not isinstance(notice.action_class, str)
+        or notice.action_class not in ACTION_CLASSES
+        or not isinstance(
+            notice.data_classification, BrowserActionDataClassification
+        )
+        or (
+            notice.data_classification.kind == "text"
+            and notice.action_class != "sensitive_input"
+        )
+        or not _safe_integer(notice.document_epoch)
+        or not _safe_integer(notice.expires_at_ms, positive=True)
+        or not isinstance(notice.summary, str)
+        or not notice.summary
+        or not notice.summary.isprintable()
+        or len(_utf8(notice.summary)) > 512
+    ):
+        raise BrowserBridgeActionAuthorityError("invalid action challenge")
+    return notice
+
+
+def _notice_hash(notice: ActionChallengeNotice) -> str:
+    summary_hash = hashlib.sha256(_utf8(notice.summary)).hexdigest()
+    values = (
+        id(notice.principal),
+        notice.connector_sid,
+        notice.load_generation_id,
+        notice.context_id,
+        notice.browser_session_id,
+        notice.turn_id,
+        notice.action_id,
+        notice.op_id,
+        notice.challenge_id,
+        notice.origin,
+        notice.action_class,
+        notice.canonical_parameter_hash,
+        notice.target_fingerprint,
+        notice.lease_id_digest,
+        notice.browser_id_digest,
+        notice.document_id,
+        notice.document_epoch,
+        summary_hash,
+        notice.data_classification,
+        notice.expires_at_ms,
+    )
+    return hashlib.sha256(repr(values).encode("utf-8")).hexdigest()
+
+
+def _operation_classification(
+    operation: OperationTicket,
+) -> BrowserActionDataClassification | None:
+    if operation.action == "click" and operation.text_sha256 is None:
+        return NO_ACTION_DATA_CLASSIFICATION
+    if operation.action == "upload_file" and operation.expected_action_class == "external_side_effect" and operation.text_sha256 is None:
+        return NO_ACTION_DATA_CLASSIFICATION
+    if (
+        operation.action == "type"
+        and operation.expected_action_class == "sensitive_input"
+        and isinstance(operation.text_sha256, str)
+        and _DIGEST.fullmatch(operation.text_sha256) is not None
+    ):
+        try:
+            return BrowserActionDataClassification(
+                "text", "sensitive", operation.text_sha256
+            )
+        except Exception:
+            return None
+    return None
+
+
+def _operation_binding_valid(
+    binding: OperationBinding,
+    transport_profile: BrowserBridgeTransportProfile,
+) -> bool:
+    principal = getattr(binding, "principal", None)
+    try:
+        require_transport_principal_identity(principal, transport_profile)
+    except ValueError:
+        return False
+    if (
+        not isinstance(binding, OperationBinding)
+        or not {"browser.operate", "browser.control", "browser.approval"}
+        <= principal.scopes
+    ):
+        return False
+    try:
+        for field_name in (
+            "connector_sid",
+            "load_generation_id",
+            "context_id",
+            "browser_session_id",
+            "turn_id",
+            "action_id",
+            "op_id",
+        ):
+            _identifier(getattr(binding, field_name), field_name)
+    except BrowserBridgeActionAuthorityError:
+        return False
+    return True
+
+
+def _operation_key(operation: OperationTicket) -> tuple[Any, ...]:
+    binding = operation.binding
+    return (
+        id(binding.principal),
+        binding.connector_sid,
+        binding.load_generation_id,
+        binding.context_id,
+        binding.browser_session_id,
+        binding.turn_id,
+        binding.action_id,
+        binding.op_id,
+    )
+
+
+def _challenge_turn(challenge: ActionChallenge) -> tuple[Any, ...]:
+    binding = challenge.operation.binding
+    return (
+        id(binding.principal),
+        binding.connector_sid,
+        binding.load_generation_id,
+        binding.context_id,
+        binding.browser_session_id,
+        binding.turn_id,
+    )
+
+
+def _lifecycle_values(
+    principal: WsPrincipal,
+    connector_sid: Any,
+    load_generation_id: Any,
+    context_id: Any,
+    browser_session_id: Any,
+    turn_id: Any,
+) -> tuple[Any, ...]:
+    if not isinstance(principal, WsPrincipal):
+        raise BrowserBridgeActionAuthorityError("invalid bridge principal")
+    return (
+        id(principal),
+        _identifier(connector_sid, "connector_sid"),
+        _identifier(load_generation_id, "load_generation_id"),
+        _identifier(context_id, "context_id"),
+        _identifier(browser_session_id, "browser_session_id"),
+        _identifier(turn_id, "turn_id"),
+    )
+
+
+def _hash_identifier(value: Any) -> str | None:
+    if not isinstance(value, str) or _NATIVE_ID.fullmatch(value) is None:
+        return None
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _safe_integer(value: Any, *, positive: bool = False) -> bool:
+    return bool(
+        not isinstance(value, bool)
+        and isinstance(value, int)
+        and (1 if positive else 0) <= value <= 2**53 - 1
+    )
+
+
+def _identifier(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or _NATIVE_ID.fullmatch(value) is None:
+        raise BrowserBridgeActionAuthorityError(f"invalid {field_name}")
+    return value
+
+
+def _list_scope(
+    context_id: Any | None, bridge_id: Any | None
+) -> tuple[str | None, str | None]:
+    if context_id is None and bridge_id is None:
+        return None, None
+    if context_id is None or bridge_id is None:
+        raise BrowserBridgeActionAuthorityError("incomplete action list scope")
+    return (
+        _identifier(context_id, "context_id"),
+        _identifier(bridge_id, "bridge_id"),
+    )
+
+
+def _core_identifier(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or _CORE_ID.fullmatch(value) is None:
+        raise BrowserBridgeActionAuthorityError(f"invalid {field_name}")
+    return value
+
+
+def _timestamp(value: Any) -> int:
+    if not _safe_integer(value):
+        raise BrowserBridgeActionAuthorityUnavailable(
+            "action authority clock unavailable"
+        )
+    return value
+
+
+def _utf8(value: Any) -> bytes:
+    if not isinstance(value, str):
+        raise BrowserBridgeActionAuthorityError("invalid action summary")
+    try:
+        return value.encode("utf-8")
+    except UnicodeError:
+        raise BrowserBridgeActionAuthorityError("invalid action summary") from None
+
+
+def _no_operation(**_kwargs: Any) -> None:
+    return None
+
+
+async def _resolution_unavailable(
+    *_args: Any, **_kwargs: Any
+) -> ControlTicket:
+    raise BrowserBridgeActionAuthorityUnavailable(
+        "action resolution unavailable"
+    )
+
+
+async def _wait_unavailable(_ticket: ControlTicket) -> BrokerCompletion:
+    raise BrowserBridgeActionAuthorityUnavailable(
+        "action resolution unavailable"
+    )
+
+
+def _server_unavailable() -> str:
+    raise BrowserBridgeActionAuthorityUnavailable("action server unavailable")
+
+
+_authority: BrowserBridgeActionAuthority | None = None
+_authority_lock = threading.Lock()
+
+
+def bind_browser_bridge_action_authority(
+    authority: BrowserBridgeActionAuthority | None,
+) -> None:
+    """Install or clear the server-owned controller for the protected API."""
+
+    if authority is not None and not isinstance(
+        authority, BrowserBridgeActionAuthority
+    ):
+        raise BrowserBridgeActionAuthorityError("invalid action authority")
+    global _authority
+    with _authority_lock:
+        _authority = authority
+
+
+def get_browser_bridge_action_authority() -> BrowserBridgeActionAuthority:
+    with _authority_lock:
+        authority = _authority
+    if authority is None:
+        raise BrowserBridgeActionAuthorityUnavailable(
+            "action authority unavailable"
+        )
+    return authority

--- a/plugins/_a0_connector/helpers/browser_bridge_action_authority.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_action_authority.py.dox.md
@@ -1,0 +1,71 @@
+# browser_bridge_action_authority.py DOX
+
+## Purpose
+
+- Convert one exact, current consequential click or TYPE challenge into a bounded
+  protected-user decision and correlated resolution control.
+- Compose the existing once-only approval receipt primitive without creating a
+  reusable or persistent action grant.
+
+## Trusted inputs
+
+- `ActionChallengeNotice` comes only from the authenticated critical-event
+  receiver after exact envelope decoding.
+- The current operation, remaining deadline, route/turn status, owned lease,
+  semantic document/ref projection, active pairing record, and server instance
+  are injected server-side. None may be reconstructed from the WebUI request.
+- Core retains the action, semantic ref, expected action class, and canonical
+  parameter hash. TYPE additionally retains only the verified exact UTF-8 text
+  digest, never the text. It binds the extension-issued target fingerprint to
+  that exact operation/document but does not derive page data it cannot
+  independently observe.
+
+## Public API projection
+
+- Repository list callers may supply an exact server-derived context/bridge
+  filter. List entries contain only challenge ID, canonical origin, action
+  (`click`, `type`, or `upload_file`), action class, fixed `decline`/`approve_once` options, and
+  expiry; they never reuse container Browser viewer IDs.
+- Decisions accept only challenge ID and choice. Same-choice replay returns the
+  same cached control identity; changed-choice replay fails closed.
+- The companion-local adapter additionally supplies a server-resolved
+  `expected_route`; compare exact principal object, SID, load and profile under
+  the challenge lock for initial and replayed decisions. HTTP callers retain
+  their authenticated subject plus current selection checks.
+- `accepted` means the process-owned control task was installed. It does not
+  prove that the browser effect ran.
+
+## Authority and lifecycle
+
+- `approve_once` consumes the exact hidden receipt after a final current-route,
+  server-selection, operation, lease, document, and ref preflight and
+  immediately before queuing one `browser.resolve_challenge`.
+- Click binds immutable classification `none`. TYPE binds the complete immutable
+  `{kind: text, sensitivity: sensitive, text_sha256}` classification throughout
+  event registration, receipt consumption, resolution, and operation grant.
+- Upload binds classification `none`, exact `external_side_effect`, a fixed
+  file-sharing warning, and the canonical parameter hash containing the
+  registered input artifact ID, MIME type, length and prefixed SHA-256 digest.
+  The native private file path never enters Core or this authority repository.
+- The wire grant is operation-scoped and expires no later than the challenge,
+  pending operation, or two-minute ceiling.
+- Cancellation, finalization, disconnect, revocation, project/profile selection
+  change, document/lease mismatch, expiry, close, or uncertain/mismatched
+  control completion withdraws authority.
+- Challenge, decision, task, receipt, and tombstone registries are bounded.
+  Typed text, page text, DOM, ref values, full URLs, raw payloads, receipts, and
+  grants are neither persisted nor logged.
+
+## Non-goals
+
+- This controller does not infer risk or approval from model/user text, create
+  challenges through HTTP, authorize later operations, advertise capabilities,
+  install runtime ownership, or enable production activation.
+
+## Verification
+
+- Run `pytest tests/test_browser_bridge_action_authority.py`.
+
+## Child DOX Index
+
+No child DOX files.

--- a/plugins/_a0_connector/helpers/browser_bridge_application.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_application.py
@@ -1,0 +1,502 @@
+"""Server-owned composition of the implemented bridge controllers.
+
+This is not an activation switch. Typed transport admission and all release/
+cutover prerequisites are required for a provisional route. Exact reconciliation
+must promote it before context or browser-operation authority exists. No legacy
+registry is used.
+"""
+
+import asyncio
+import logging
+import threading
+import uuid
+from typing import Any, Callable
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_context import BrowserBridgeContextAccess, BrowserBridgeContextRoute
+from plugins._a0_connector.helpers.browser_bridge_context_controller import BrowserBridgeContextController
+from plugins._a0_connector.helpers.browser_bridge_events import BrowserBridgeCriticalEventReceiver
+from plugins._a0_connector.helpers.browser_bridge_artifacts import ArtifactBinding, BrowserBridgeArtifactReceiver
+from plugins._a0_connector.helpers.browser_bridge_artifact_controller import BrowserBridgeArtifactController
+from plugins._a0_connector.helpers.browser_bridge_artifact_sender import BrowserBridgeArtifactSender
+from plugins._a0_connector.helpers.browser_bridge_site_authority import BrowserBridgeSiteAuthorityRepository
+from plugins._a0_connector.helpers.browser_bridge_action_authority import BrowserBridgeActionAuthority
+from plugins._a0_connector.helpers.browser_bridge_messages import BrowserBridgeMessageDispatcher
+from plugins._a0_connector.helpers.browser_bridge_queue import BrowserBridgeQueueController, QUEUE_EVENTS
+from plugins._a0_connector.helpers.browser_bridge_local_approval import BrowserBridgeLocalApprovalController
+from plugins._a0_connector.helpers.browser_bridge_credential_control import BrowserBridgeCredentialController
+from plugins._a0_connector.helpers.browser_bridge_policy import BrowserBridgePolicyRepository
+from plugins._a0_connector.helpers.browser_bridge_operations import ReconciliationBinding
+from plugins._a0_connector.helpers.browser_bridge_reconciliation import (
+    BrowserBridgeReconciliationController, ReconciliationSnapshot, ExpectedReconciliationContext,
+)
+from plugins._a0_connector.helpers.browser_bridge_runtime import (
+    BrowserBridgeRuntimeRegistry, BrowserBridgeRuntimeDenied, restricted_browser_sender,
+)
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+)
+from plugins._browser.helpers.extension_services import ExtensionBrowserServices
+from plugins._browser.helpers.extension_artifacts import ExtensionScreenshotMaterializer
+from plugins._browser.helpers.extension_sessions import ExtensionSessionLifecycle, TURN_ACTIVE
+
+
+_CONTEXT_EVENTS = frozenset({
+    "connector_context_list", "connector_subscribe_context",
+    "connector_unsubscribe_context", "connector_send_message",
+})
+
+_STAGE_CODES = frozenset({
+    "INITIAL_HELLO_ADMITTED", "RENEWED_HELLO_OBSERVED", "HELLO_REJECTED",
+    "RECONCILIATION_STARTED", "RECONCILIATION_SUCCEEDED", "RECONCILIATION_RESULT_RECEIVED",
+    "RECONCILIATION_RESULT_REJECTED", "RECONCILIATION_TIMEOUT", "RECONCILIATION_CONNECTION_LOST",
+    "RECONCILIATION_SCOPE_DENIED", "RECONCILIATION_INVALID_SNAPSHOT", "RECONCILIATION_INVALID_REQUEST",
+    "RECONCILIATION_CAPACITY", "RECONCILIATION_OTHER_FAILURE",
+    "RECONCILIATION_INVALID_STATE", "RECONCILIATION_UNSUPPORTED_CAPABILITY",
+    "RECONCILIATION_INTERNAL_ERROR", "RECONCILIATION_OUTCOME_UNKNOWN",
+    "ADMISSION_OWNER_UNAVAILABLE", "ADMISSION_SOCKET_MISMATCH", "ADMISSION_PRINCIPAL_REJECTED",
+    "ADMISSION_EXTENSION_MISMATCH", "ADMISSION_ROLLOUT_DISABLED", "ADMISSION_SELECTION_MISSING",
+    "ADMISSION_HEARTBEAT_REJECTED", "ADMISSION_LEGACY_PRESENT", "ADMISSION_BOUNDARY_MISSING",
+    "ADMISSION_RELEASE_UNVERIFIED", "ADMISSION_RELEASE_MISMATCH", "ADMISSION_CHECK_EXCEPTION",
+    "RECONCILIATION_START_SCOPE_LOST", "RECONCILIATION_SNAPSHOT_SCOPE_LOST",
+    "RECONCILIATION_BROKER_SCOPE_LOST", "RECONCILIATION_PENDING_SCOPE_LOST",
+    "RECONCILIATION_SETTLEMENT_SCOPE_LOST",
+})
+_stage_counts = {}
+_stage_lock = threading.Lock()
+
+
+def record_production_browser_stage(code):
+    """Private bounded diagnostics: fixed symbols only, never peer data."""
+    if not isinstance(code, str) or code not in _STAGE_CODES:
+        return
+    with _stage_lock:
+        count = _stage_counts.get(code, 0)
+        if count >= 5:
+            return
+        _stage_counts[code] = count + 1
+    logging.getLogger(__name__).warning("Browser bridge stage: %s", code)
+
+
+def _record_reconciliation_failure(error):
+    categories = {
+        "TIMEOUT": "RECONCILIATION_TIMEOUT", "DEADLINE_EXCEEDED": "RECONCILIATION_TIMEOUT",
+        "CONNECTION_LOST": "RECONCILIATION_CONNECTION_LOST", "SCOPE_DENIED": "RECONCILIATION_SCOPE_DENIED",
+        "RECONCILE_RESULT_INVALID": "RECONCILIATION_INVALID_SNAPSHOT",
+        "RECONCILE_REQUEST_INVALID": "RECONCILIATION_INVALID_REQUEST",
+        "RECONCILIATION_CAPACITY": "RECONCILIATION_CAPACITY",
+        "INVALID_STATE": "RECONCILIATION_INVALID_STATE",
+        "UNSUPPORTED_CAPABILITY": "RECONCILIATION_UNSUPPORTED_CAPABILITY",
+        "INTERNAL_ERROR": "RECONCILIATION_INTERNAL_ERROR",
+        "OUTCOME_UNKNOWN": "RECONCILIATION_OUTCOME_UNKNOWN",
+    }
+    candidate = getattr(error, "code", None)
+    record_production_browser_stage(categories.get(candidate, "RECONCILIATION_OTHER_FAILURE")
+                                    if isinstance(candidate, str) else "RECONCILIATION_OTHER_FAILURE")
+
+
+class BrowserBridgeApplication:
+    """One owner for route, context, operation, event and cleanup state.
+
+    Dependencies are supplied by authenticated server bootstrap, never an API
+    request. Construction does not install Browser selection, broaden principal
+    events, advertise readiness, or mutate the live Docker instance.
+    """
+
+    def __init__(self, *, manager: Any, server_instance_id: Callable[[], str],
+                 lifecycle: ExtensionSessionLifecycle, active_principal_verifier,
+                 admission_evaluator, context_authorizer,
+                 context_data_source=None, policy_repository=None,
+                 message_load=None, message_save=None, message_deliver=None,
+                 event_load=None, event_save=None, artifact_spool_parent=None,
+                 approval_record_loader=None, selection_current=None,
+                 queue_context_get=None, queue_service=None, queue_load=None,
+                 queue_save=None, queue_mark_dirty=None,
+                 transport_profile: BrowserBridgeTransportProfile =
+                 PRODUCTION_BROWSER_BRIDGE_TRANSPORT) -> None:
+        self.transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        self.registry = BrowserBridgeRuntimeRegistry(
+            sender=restricted_browser_sender(
+                manager, transport_profile=self.transport_profile
+            ),
+            active_principal_verifier=active_principal_verifier,
+            admission_evaluator=admission_evaluator,
+            context_authorizer=context_authorizer,
+            cleanup_callbacks=(self._retire_projection,),
+            transport_profile=self.transport_profile,
+        )
+        self.access = BrowserBridgeContextAccess(
+            data_source=context_data_source,
+            route_authorizer=self.registry.authorize_context_route,
+            transport_profile=self.transport_profile,
+        )
+        policy_repository = policy_repository or BrowserBridgePolicyRepository(
+            transport_profile=self.transport_profile
+        )
+        if policy_repository.transport_profile is not self.transport_profile:
+            raise RuntimeError("Browser bridge policy transport mismatch")
+        self.browser = ExtensionBrowserServices(
+            lifecycle=lifecycle, broker=self.registry.broker,
+            route_resolver=self.registry.resolve_extension_route,
+            policy_repository=policy_repository,
+            server_instance_id=server_instance_id(),
+            transport_profile=self.transport_profile,
+        )
+        self.messages = BrowserBridgeMessageDispatcher(
+            access=self.access, server_instance_id=server_instance_id,
+            load=message_load, save=message_save, deliver=message_deliver,
+            transport_profile=self.transport_profile,
+        )
+        self.sites = BrowserBridgeSiteAuthorityRepository(
+            current_operation=self.registry.broker.current_operation,
+            remaining_operation_ms=self.registry.broker.remaining_operation_ms,
+            lease_for=self.browser.leases.lease_for,
+            route_verifier=self.registry.authorize_context_route,
+            begin_resolution=self.registry.broker.begin_site_resolution,
+            wait_control=self.registry.broker.wait_control,
+            server_instance_id=server_instance_id, turn_current=self._turn_current,
+            selection_current=selection_current,
+            saved_origin_grant=lambda binding, origin: self._saved_site_grant(
+                policy_repository, server_instance_id(), binding, origin),
+            transport_profile=self.transport_profile,
+        )
+        self.browser.site_authority = self.sites
+        self.actions = BrowserBridgeActionAuthority(
+            current_operation=self.registry.broker.current_operation,
+            remaining_operation_ms=self.registry.broker.remaining_operation_ms,
+            lease_for=self.browser.leases.lease_for, document_for=self.browser.leases.document_for,
+            route_verifier=self.registry.authorize_context_route, turn_current=self._turn_current,
+            begin_resolution=self.registry.broker.begin_action_resolution,
+            wait_control=self.registry.broker.wait_control, server_instance_id=server_instance_id,
+            approval_record_loader=approval_record_loader,
+            selection_current=selection_current,
+            transport_profile=self.transport_profile,
+        )
+        self.browser.action_authority = self.actions
+        self.local_approvals = BrowserBridgeLocalApprovalController(
+            actions=self.actions, sites=self.sites,
+            current=self.registry.authorize_context_route,
+        )
+        self.queues = BrowserBridgeQueueController(
+            access=self.access, messages=self.messages, manager=manager,
+            server_instance_id=server_instance_id, context_get=queue_context_get,
+            queue_service=queue_service, load=queue_load, save=queue_save,
+            mark_dirty=queue_mark_dirty,
+        )
+        self.contexts = BrowserBridgeContextController(
+            access=self.access, messages=self.messages, manager=manager,
+            route_authorizer=self.registry.authorize_context_route,
+            transport_profile=self.transport_profile,
+            queue_projection=self.queues.project,
+        )
+        self.credentials = BrowserBridgeCredentialController(
+            manager=manager, current=self.registry.authorize_context_route,
+            server_instance_id=server_instance_id, retire_bridge=self.registry.retire_bridge,
+        )
+        self.artifact_receiver = BrowserBridgeArtifactReceiver(
+            spool_parent=artifact_spool_parent, authorizer=self._artifact_current,
+            transport_profile=self.transport_profile,
+        )
+        self.artifacts = BrowserBridgeArtifactController(
+            receiver=self.artifact_receiver, binding_resolver=self._artifact_binding,
+            manager=manager,
+            transport_profile=self.transport_profile,
+        )
+        self.input_artifacts = BrowserBridgeArtifactSender(
+            manager=manager, authorizer=self._input_artifact_current,
+        )
+        self.browser.input_artifact_sender = self.input_artifacts
+        self.browser.artifact_materializer = ExtensionScreenshotMaterializer(
+            receiver=self.artifact_receiver, lease_for=self.browser.leases.lease_for,
+            current=self._artifact_current,
+        )
+        self.events = BrowserBridgeCriticalEventReceiver(
+            manager=manager, server_instance_id=server_instance_id,
+            current_route_verifier=self.registry.authorize_context_route,
+            invalidate_lease=self.browser.invalidate_lease_event,
+            register_site_challenge=self.sites.register_event,
+            register_action_challenge=self.actions.register_event,
+            # Informational only. Cleanup settles exclusively via control result.
+            observe_finalization=lambda _notice: None,
+            load=event_load, save=event_save,
+            transport_profile=self.transport_profile,
+        )
+        self._state_lock = threading.RLock()
+        self._closed = False
+        self._reconciliation_tasks = {}
+        self.reconciliation = BrowserBridgeReconciliationController(
+            broker=self.registry.broker, snapshot_source=self._reconciliation_snapshot,
+            route_current=self.registry.route_current_for_reconciliation,
+            promote=self.registry.promote_reconciled, transport_profile=self.transport_profile,
+        )
+        self._bootstrap_bound = False
+
+    def _saved_site_grant(self, policy, server_id, binding, origin):
+        if not self._turn_current(binding):
+            return None
+        grant = policy.active_grant(server_instance_id=server_id,
+            bridge_id=binding.bridge_id, subject_id=binding.principal.subject_id, origin=origin)
+        return grant.grant_id if grant is not None else None
+
+    @property
+    def installed(self) -> bool:
+        with self._state_lock:
+            return not self._closed and self.browser.installed
+
+    def runtime_boundaries(self) -> frozenset[str]:
+        """Report implemented owned boundaries, never an activation attestation.
+
+        Input/output transfer, source selection and one-use upload consent are
+        composed independently of release and cutover. Those remain the
+        startup owner's responsibility, never a claim from a transport peer.
+        """
+        if not self.installed:
+            return frozenset()
+        return frozenset({"operation", "control", "context", "event", "artifact", "approval", "lifecycle", "policy"})
+
+    def install(self, *, submitter=None) -> tuple[str, ...]:
+        """Explicitly acquire the Browser lifecycle/factory process seams."""
+
+        with self._state_lock:
+            if self._closed:
+                raise RuntimeError("Browser bridge application is closed")
+            return self.browser.install(submitter=submitter)
+
+    def claim_bootstrap_binding(self) -> bool:
+        """Claim this installed instance for the one optional process owner."""
+
+        with self._state_lock:
+            if self._closed or not self.browser.installed:
+                raise RuntimeError("Browser bridge application is not installed")
+            if self._bootstrap_bound:
+                return False
+            self._bootstrap_bound = True
+            return True
+
+    def register_hello(self, *, principal: WsPrincipal, connector_sid: str,
+                       data: object):
+        """Admit one exact route and replay only durable pending cleanup."""
+
+        if not self.installed:
+            raise BrowserBridgeRuntimeDenied("RUNTIME_NOT_INSTALLED")
+        previous = self.registry.current_sid_route(principal, connector_sid)
+        route = self.registry.register_hello(
+            principal=principal,
+            connector_sid=connector_sid,
+            data=data,
+        )
+        current = self.registry.current_sid_route(principal, connector_sid)
+        if current is not route:
+            raise BrowserBridgeRuntimeDenied("RUNTIME_NOT_ADMITTED")
+        record_production_browser_stage("RENEWED_HELLO_OBSERVED" if previous is not None and previous.hello == route.hello
+                                        else "INITIAL_HELLO_ADMITTED")
+        # Native sends a repeated hello only after consuming its initial ACK.
+        # Initial admission publishes no controls: production native cannot
+        # receive a control while it is still waiting for that first ACK.
+        if (previous is not None and previous.hello == route.hello
+                and not self.registry.current_bridge_ready(route.bridge_id)):
+            self._start_reconciliation(route)
+        return route
+
+    def _start_reconciliation(self, route):
+        binding = ReconciliationBinding(route.principal, route.connector_sid,
+                                        route.load_generation_id, uuid.uuid4().hex,
+                                        self.transport_profile)
+        key = (id(route.principal), route.connector_sid, route.load_generation_id)
+        with self._state_lock:
+            if self._closed or key in self._reconciliation_tasks:
+                return
+            if not self.registry.begin_reconciliation(binding):
+                return
+            try:
+                task = self.reconciliation.start(binding, expected_install_instance_id=route.hello.install_instance_id)
+            except Exception as error:
+                _record_reconciliation_failure(error)
+                self.registry.retire_sid(route.principal, route.connector_sid)
+                raise
+            self._reconciliation_tasks[key] = task
+            record_production_browser_stage("RECONCILIATION_STARTED")
+            task.add_done_callback(lambda done: self._reconciliation_finished(key, binding, done))
+
+    def _reconciliation_snapshot(self, binding):
+        if not self.registry.route_current_for_reconciliation(binding):
+            raise BrowserBridgeRuntimeDenied("RUNTIME_NOT_ADMITTED")
+        contexts = tuple(
+            ExpectedReconciliationContext(session.context_id, session.browser_session_id,
+                tuple(turn.turn_id for turn in session.turns if turn.state == TURN_ACTIVE))
+            for session in self.browser.lifecycle.registry.sessions()
+            if session.bridge_id == binding.bridge_id and any(turn.state == TURN_ACTIVE for turn in session.turns)
+        )
+        controls = tuple(intent.control_id for intent in self.browser.lifecycle.registry.pending_finalizations()
+                         if intent.bridge_id == binding.bridge_id)
+        return ReconciliationSnapshot(expected_contexts=contexts, known_control_ids=controls)
+
+    def _reconciliation_finished(self, key, binding, task):
+        with self._state_lock:
+            if self._reconciliation_tasks.get(key) is task:
+                self._reconciliation_tasks.pop(key, None)
+        try:
+            task.result()
+        except BaseException as error:
+            _record_reconciliation_failure(error)
+            current = self.registry.current_sid_route(binding.principal, binding.connector_sid)
+            if current is not None and current.load_generation_id == binding.load_generation_id:
+                self.registry.retire_sid(binding.principal, binding.connector_sid)
+        else:
+            if self.registry.route_current_for_reconciliation(binding):
+                record_production_browser_stage("RECONCILIATION_SUCCEEDED")
+                self.browser.lifecycle.replay_pending()
+
+    def _retire_projection(self, principal, sid, generation) -> None:
+        if self.browser.first_open_authority is not None:
+            self.browser.first_open_authority.retire(lambda binding: (
+                binding.principal is principal and binding.connector_sid == sid
+                and binding.load_generation_id == generation))
+        self.input_artifacts.retire(principal=principal, connector_sid=sid, load_generation_id=generation)
+        self.access.disconnect(principal=principal, connector_sid=sid, load_generation_id=generation)
+        self.browser.leases.invalidate(principal=principal, connector_sid=sid, load_generation_id=generation)
+        self.sites.disconnect(principal=principal, connector_sid=sid, load_generation_id=generation)
+        self.actions.disconnect(principal=principal, connector_sid=sid, load_generation_id=generation)
+        self.artifact_receiver.disconnect(principal=principal, connector_sid=sid, load_generation_id=generation)
+        # Existing presentation pollers see the absent route on their next
+        # bounded tick. Explicit disconnect below additionally awaits teardown.
+
+    def _artifact_current(self, binding: ArtifactBinding) -> bool:
+        if not self.registry.authorize_artifact_binding(binding):
+            return False
+        return self._turn_current(binding)
+
+    def _input_artifact_current(self, binding: ArtifactBinding) -> bool:
+        if binding.direction != "input" or binding.purpose != "upload_file" or not self._artifact_current(binding):
+            return False
+        operation = self.registry.broker.current_operation(
+            principal=binding.principal, connector_sid=binding.connector_sid,
+            load_generation_id=binding.load_generation_id, op_id=binding.op_id,
+        )
+        if operation is None or operation.action != "upload_file":
+            return False
+        if any(getattr(operation.binding, key) != getattr(binding, key) for key in (
+            "context_id", "browser_session_id", "turn_id", "action_id", "op_id",
+        )):
+            return False
+        # This exact source permit permits host staging only; the extension's
+        # later one-use upload challenge is still required before a site effect.
+        consent = getattr(self.browser, "authorize_input_artifact", None)
+        return callable(consent) and consent(binding) is True
+
+    def _turn_current(self, binding) -> bool:
+        active = self.browser.lifecycle.registry.active_turn_binding(
+            context_id=binding.context_id, turn_id=binding.turn_id,
+        )
+        return bool(active is not None and active.bridge_id == binding.bridge_id
+                    and active.browser_session_id == binding.browser_session_id)
+
+    def _artifact_binding(self, lookup) -> ArtifactBinding | None:
+        operation = self.registry.broker.current_operation(
+            principal=lookup.route.principal, connector_sid=lookup.route.connector_sid,
+            load_generation_id=lookup.route.load_generation_id, op_id=lookup.op_id,
+        )
+        if operation is None or lookup.direction != "output" or operation.action != lookup.purpose:
+            return None
+        source = operation.binding
+        if any(getattr(source, name) != getattr(lookup, name) for name in (
+            "bridge_id", "load_generation_id", "context_id", "browser_session_id", "turn_id", "action_id", "op_id",
+        )):
+            return None
+        binding = ArtifactBinding(
+            source.principal, source.connector_sid, source.load_generation_id, source.bridge_id,
+            source.context_id, source.browser_session_id, source.turn_id, source.action_id, source.op_id,
+            lookup.artifact_id, lookup.direction, lookup.purpose,
+            transport_profile=self.transport_profile,
+        )
+        return binding if self._artifact_current(binding) else None
+
+    async def dispatch(self, principal: WsPrincipal, sid: str, event: str, document: Any) -> dict[str, Any]:
+        if not isinstance(principal, WsPrincipal) or not principal.permits_inbound(event, principal.handler_id):
+            raise BrowserBridgeRuntimeDenied("EVENT_NOT_ALLOWED")
+        if not isinstance(document, dict):
+            raise BrowserBridgeRuntimeDenied("INVALID_STATE")
+        route = self.registry.current_sid_route(principal, sid)
+        if route is None:
+            raise BrowserBridgeRuntimeDenied("RUNTIME_NOT_ADMITTED")
+        context_route = BrowserBridgeContextRoute(
+            principal,
+            sid,
+            route.load_generation_id,
+            self.transport_profile,
+        )
+        if event in _CONTEXT_EVENTS:
+            return await self.contexts.dispatch(event, context_route, document)
+        if event in QUEUE_EVENTS:
+            return await self.queues.dispatch(event, context_route, document)
+        if event == "connector_bridge_credential_control":
+            return await self.credentials.dispatch(context_route, document)
+        if event == "connector_browser_approval_decision":
+            return await self.local_approvals.dispatch(context_route, document)
+        if event == "connector_browser_event":
+            return await self.events.receive(context_route, document)
+        if event == "connector_browser_artifact_chunk":
+            return await self.artifacts.receive(context_route, document)
+        if event == "connector_browser_artifact_ack":
+            return await self.input_artifacts.receive_ack(context_route, document)
+        if event in {"connector_browser_op_result", "connector_browser_control_result"}:
+            reconciling = event == "connector_browser_control_result" and document.get("method") == "browser.reconcile"
+            if reconciling:
+                record_production_browser_stage("RECONCILIATION_RESULT_RECEIVED")
+            settle = self.registry.settle_operation if event == "connector_browser_op_result" else self.registry.settle_control
+            status = settle(principal=principal, connector_sid=sid,
+                            load_generation_id=route.load_generation_id, payload=document)
+            if reconciling and status != "settled":
+                record_production_browser_stage("RECONCILIATION_RESULT_REJECTED")
+            return {"contract_version": 1, "status": status}
+        # Unsupported controls never enter a broad callback or legacy handler.
+        raise BrowserBridgeRuntimeDenied("EVENT_NOT_IMPLEMENTED")
+
+    async def disconnect(self, principal: WsPrincipal, sid: str) -> bool:
+        route = self.registry.retire_sid(principal, sid)
+        if route is None:
+            return False
+        await self.contexts.disconnect(principal=principal, connector_sid=sid,
+                                       load_generation_id=route.load_generation_id)
+        await self.artifacts.disconnect(principal=principal, connector_sid=sid,
+                                        load_generation_id=route.load_generation_id)
+        return True
+
+    async def close(self, *, _bootstrap_retirement: bool = False) -> None:
+        with self._state_lock:
+            if self._bootstrap_bound and not _bootstrap_retirement:
+                raise RuntimeError(
+                    "retire the bound Browser bridge application explicitly"
+                )
+            self._closed = True
+        # First make Browser hooks/factory inert and durably stage tracked turn
+        # cleanup while this application's exact admitted routes still exist.
+        try:
+            self.browser.uninstall()
+        except Exception:
+            # A competing owner is never cleared to make shutdown look clean.
+            # Route withdrawal below still makes this application unusable.
+            pass
+        for route in self.registry.retire_all():
+            await self.contexts.disconnect(principal=route.principal, connector_sid=route.connector_sid,
+                                           load_generation_id=route.load_generation_id)
+        # Retirement disconnects retained broker tickets; their process-owned
+        # tasks settle without cancellation or replay of uncertain controls.
+        with self._state_lock:
+            tasks = tuple(self._reconciliation_tasks.values())
+        for task in tasks:
+            async def join(owned=task):
+                await asyncio.gather(owned, return_exceptions=True)
+            if task.get_loop() is asyncio.get_running_loop():
+                await join()
+            elif task.get_loop().is_running():
+                await asyncio.wrap_future(asyncio.run_coroutine_threadsafe(join(), task.get_loop()))
+        await self.sites.close()
+        await self.actions.close()
+        await self.artifacts.close()
+        await self.input_artifacts.close()
+        await self.credentials.close()

--- a/plugins/_a0_connector/helpers/browser_bridge_approval.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_approval.py
@@ -1,0 +1,862 @@
+"""Bounded once-only approval challenges for consequential Browser actions.
+
+This module owns only process-memory challenge and receipt state. It does not
+infer approval from text, persist sensitive operation data, dispatch controls,
+or advertise Browser runtime readiness.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+import re
+import threading
+import time
+from typing import Any, Callable, Mapping
+import uuid
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_pairing import validate_identifier
+from plugins._a0_connector.helpers.browser_bridge_policy import (
+    BrowserBridgePolicyError,
+    normalize_site_origin,
+)
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+    require_transport_principal_identity,
+)
+
+
+BROWSER_BRIDGE_APPROVAL_CONTRACT = "a0.browser-bridge.approval.v1"
+BROWSER_BRIDGE_APPROVAL_VERSION = 1
+MAX_APPROVAL_REQUEST_BYTES = 8 * 1024
+MAX_APPROVAL_TTL_MS = 120_000
+MAX_PENDING_APPROVAL_CHALLENGES = 128
+MAX_PENDING_APPROVAL_RECEIPTS = 128
+MAX_APPROVAL_TERMINAL_RECORDS = 2_048
+MAX_ROUTE_IDENTIFIER_BYTES = 256
+
+APPROVAL_CHOICES = frozenset({"approve_once", "decline"})
+APPROVAL_SURFACES = frozenset({"webui", "side_panel"})
+CONSEQUENTIAL_ACTION_CLASSES = frozenset(
+    {"sensitive_input", "external_side_effect", "unknown"}
+)
+
+_NATIVE_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+_SHA256_HEX = re.compile(r"[0-9a-f]{64}")
+
+
+class BrowserBridgeApprovalError(ValueError):
+    """An approval binding or caller input is invalid."""
+
+
+class BrowserBridgeApprovalUnavailable(RuntimeError):
+    """Approval authority is absent, stale, ambiguous, or at capacity."""
+
+
+class ApprovalDecisionStatus:
+    APPROVED = "approved"
+    DECLINED = "declined"
+    EXPIRED = "expired"
+    INVALIDATED = "invalidated"
+    ALREADY_RESOLVED = "already_resolved"
+    NOT_FOUND = "not_found"
+
+
+class ApprovalConsumeStatus:
+    CONSUMED = "consumed"
+    EXPIRED = "expired"
+    INVALIDATED = "invalidated"
+    ALREADY_CONSUMED = "already_consumed"
+    NOT_FOUND = "not_found"
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserActionDataClassification:
+    """Immutable internal form of the exact click/type wire union."""
+
+    kind: str
+    sensitivity: str | None = None
+    text_sha256: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind == "none":
+            if self.sensitivity is not None or self.text_sha256 is not None:
+                raise BrowserBridgeApprovalError("invalid action data classification")
+            return
+        if (
+            self.kind != "text"
+            or self.sensitivity != "sensitive"
+            or not isinstance(self.text_sha256, str)
+            or _SHA256_HEX.fullmatch(self.text_sha256) is None
+        ):
+            raise BrowserBridgeApprovalError("invalid action data classification")
+
+    def as_wire_value(self) -> str | dict[str, str]:
+        if self.kind == "none":
+            return "none"
+        assert self.text_sha256 is not None
+        return {
+            "kind": "text",
+            "sensitivity": "sensitive",
+            "text_sha256": self.text_sha256,
+        }
+
+
+NO_ACTION_DATA_CLASSIFICATION = BrowserActionDataClassification("none")
+
+
+def parse_action_data_classification(
+    value: Any,
+) -> BrowserActionDataClassification:
+    """Parse the exact wire union without retaining a mutable request object."""
+
+    if value == "none" and isinstance(value, str):
+        return NO_ACTION_DATA_CLASSIFICATION
+    if not isinstance(value, dict) or set(value) != {
+        "kind",
+        "sensitivity",
+        "text_sha256",
+    }:
+        raise BrowserBridgeApprovalError("invalid action data classification")
+    return BrowserActionDataClassification(
+        kind=value.get("kind"),
+        sensitivity=value.get("sensitivity"),
+        text_sha256=value.get("text_sha256"),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserApprovalRoute:
+    """Exact server-owned route for one currently pending Browser operation."""
+
+    server_instance_id: str
+    principal: WsPrincipal
+    connector_sid: str
+    load_generation_id: str
+    context_id: str
+    browser_session_id: str
+    turn_id: str
+    action_id: str
+    op_id: str
+    tab_handle: str
+    document_id: str
+    document_epoch: int
+    transport_profile: BrowserBridgeTransportProfile = (
+        PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    )
+
+    def __post_init__(self) -> None:
+        _validate_route(self)
+
+    @property
+    def bridge_id(self) -> str:
+        return self.principal.principal_id
+
+    @property
+    def subject_id(self) -> str:
+        return self.principal.subject_id
+
+    @property
+    def key_generation(self) -> int:
+        return self.principal.key_generation
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserApprovalBinding:
+    route: BrowserApprovalRoute
+    canonical_parameter_hash: str
+    target_fingerprint: str
+    origin: str
+    action_class: str
+    data_classification: BrowserActionDataClassification = (
+        NO_ACTION_DATA_CLASSIFICATION
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.route, BrowserApprovalRoute):
+            raise BrowserBridgeApprovalError("invalid approval route")
+        _digest(self.canonical_parameter_hash, "canonical parameter hash")
+        _digest(self.target_fingerprint, "target fingerprint")
+        if self.action_class not in CONSEQUENTIAL_ACTION_CLASSES:
+            raise BrowserBridgeApprovalError("invalid consequential action class")
+        if not isinstance(
+            self.data_classification, BrowserActionDataClassification
+        ) or (
+            self.data_classification.kind == "text"
+            and self.action_class != "sensitive_input"
+        ):
+            raise BrowserBridgeApprovalError("invalid action data classification")
+        try:
+            canonical_origin = normalize_site_origin(self.origin)
+        except BrowserBridgePolicyError as error:
+            raise BrowserBridgeApprovalError("invalid approval origin") from error
+        object.__setattr__(self, "origin", canonical_origin)
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserApprovalChallenge:
+    challenge_id: str
+    binding: BrowserApprovalBinding = field(repr=False)
+    created_at_ms: int
+    expires_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserApprovalReceipt:
+    receipt_id: str
+    challenge_id: str
+    binding: BrowserApprovalBinding = field(repr=False)
+    approving_surface: str
+    decided_at_ms: int
+    expires_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserApprovalDecision:
+    challenge_id: str
+    status: str
+    receipt: BrowserApprovalReceipt | None = field(default=None, repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserApprovalInvalidationSummary:
+    challenges: int
+    receipts: int
+
+
+RouteAuthorizer = Callable[[BrowserApprovalRoute], bool]
+ActiveRecordLoader = Callable[[str, str], Mapping[str, Any] | None]
+ServerInstanceIdLoader = Callable[[], str]
+
+
+class BrowserBridgeApprovalRepository:
+    """Atomic bounded registry for one-operation approval authority."""
+
+    def __init__(
+        self,
+        *,
+        route_authorizer: RouteAuthorizer | None = None,
+        active_record_loader: ActiveRecordLoader | None = None,
+        server_instance_id_loader: ServerInstanceIdLoader | None = None,
+        clock_ms: Callable[[], int] | None = None,
+        receipt_id_factory: Callable[[], str] | None = None,
+        max_pending_challenges: int = MAX_PENDING_APPROVAL_CHALLENGES,
+        max_pending_receipts: int = MAX_PENDING_APPROVAL_RECEIPTS,
+        max_terminal_records: int = MAX_APPROVAL_TERMINAL_RECORDS,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        if min(max_pending_challenges, max_pending_receipts, max_terminal_records) < 1:
+            raise ValueError("approval repository bounds must be positive")
+        self._route_authorizer = route_authorizer or (lambda _route: False)
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        self._active_record_loader = active_record_loader or _load_active_record
+        self._server_instance_id_loader = (
+            server_instance_id_loader or _load_server_instance_id
+        )
+        self._clock_ms = clock_ms or (lambda: time.time_ns() // 1_000_000)
+        self._receipt_id_factory = receipt_id_factory or (lambda: str(uuid.uuid4()))
+        self._max_pending_challenges = max_pending_challenges
+        self._max_pending_receipts = max_pending_receipts
+        self._max_terminal_records = max_terminal_records
+        self._challenges: dict[str, BrowserApprovalChallenge] = {}
+        self._operation_challenges: dict[tuple[Any, ...], str] = {}
+        self._receipts: dict[str, BrowserApprovalReceipt] = {}
+        self._challenge_terminal: dict[str, str] = {}
+        self._challenge_terminal_order: deque[str] = deque()
+        self._receipt_terminal: dict[str, str] = {}
+        self._receipt_terminal_order: deque[str] = deque()
+        self._lock = threading.RLock()
+
+    @property
+    def pending_challenge_count(self) -> int:
+        with self._lock:
+            return len(self._challenges)
+
+    @property
+    def transport_profile(self) -> BrowserBridgeTransportProfile:
+        return self._transport_profile
+
+    @property
+    def pending_receipt_count(self) -> int:
+        with self._lock:
+            return len(self._receipts)
+
+    def register_challenge(
+        self,
+        challenge_id: Any,
+        binding: BrowserApprovalBinding,
+        *,
+        timeout_ms: int,
+    ) -> BrowserApprovalChallenge:
+        safe_challenge_id = _native_identifier(challenge_id, "challenge_id")
+        binding = _binding(binding)
+        self._require_profile(binding.route)
+        timeout_ms = _timeout(timeout_ms)
+        now = self._now()
+        with self._lock:
+            self._expire_locked(now)
+            existing = self._challenges.get(safe_challenge_id)
+            if existing is not None:
+                if (
+                    _same_binding(existing.binding, binding)
+                    and self._route_is_current(binding.route)
+                ):
+                    return existing
+                self._invalidate_challenge_locked(existing)
+                raise BrowserBridgeApprovalUnavailable("approval challenge mismatch")
+            if safe_challenge_id in self._challenge_terminal:
+                raise BrowserBridgeApprovalUnavailable("approval challenge is terminal")
+            operation_key = _operation_key(binding.route)
+            prior_id = self._operation_challenges.get(operation_key)
+            if prior_id is not None:
+                prior = self._challenges.get(prior_id)
+                if prior is not None:
+                    self._invalidate_challenge_locked(prior)
+                raise BrowserBridgeApprovalUnavailable("operation challenge conflict")
+            if len(self._challenges) >= self._max_pending_challenges:
+                raise BrowserBridgeApprovalUnavailable("approval challenge limit reached")
+            if not self._route_is_current(binding.route):
+                raise BrowserBridgeApprovalUnavailable("approval route is unavailable")
+            challenge = BrowserApprovalChallenge(
+                challenge_id=safe_challenge_id,
+                binding=binding,
+                created_at_ms=now,
+                expires_at_ms=now + timeout_ms,
+            )
+            self._challenges[safe_challenge_id] = challenge
+            self._operation_challenges[operation_key] = safe_challenge_id
+            return challenge
+
+    def decide(
+        self,
+        challenge_id: Any,
+        *,
+        choice: Any,
+        current_route: BrowserApprovalRoute,
+        surface: str,
+    ) -> BrowserApprovalDecision:
+        safe_challenge_id = _native_identifier(challenge_id, "challenge_id")
+        if choice not in APPROVAL_CHOICES:
+            raise BrowserBridgeApprovalError("invalid approval choice")
+        if surface not in APPROVAL_SURFACES:
+            raise BrowserBridgeApprovalError("invalid approving surface")
+        if not isinstance(current_route, BrowserApprovalRoute):
+            raise BrowserBridgeApprovalError("invalid approval route")
+        self._require_profile(current_route)
+        now = self._now()
+        with self._lock:
+            self._expire_locked(now)
+            terminal = self._challenge_terminal.get(safe_challenge_id)
+            if terminal is not None:
+                status = (
+                    ApprovalDecisionStatus.EXPIRED
+                    if terminal == ApprovalDecisionStatus.EXPIRED
+                    else ApprovalDecisionStatus.ALREADY_RESOLVED
+                )
+                return BrowserApprovalDecision(safe_challenge_id, status)
+            challenge = self._challenges.get(safe_challenge_id)
+            if challenge is None:
+                return BrowserApprovalDecision(
+                    safe_challenge_id,
+                    ApprovalDecisionStatus.NOT_FOUND,
+                )
+            if (
+                not _same_route(challenge.binding.route, current_route)
+                or not self._route_is_current(current_route)
+            ):
+                self._invalidate_challenge_locked(challenge)
+                return BrowserApprovalDecision(
+                    safe_challenge_id,
+                    ApprovalDecisionStatus.INVALIDATED,
+                )
+            if choice == "decline":
+                self._remove_challenge_locked(
+                    challenge,
+                    terminal=ApprovalDecisionStatus.DECLINED,
+                )
+                return BrowserApprovalDecision(
+                    safe_challenge_id,
+                    ApprovalDecisionStatus.DECLINED,
+                )
+            if len(self._receipts) >= self._max_pending_receipts:
+                self._invalidate_challenge_locked(challenge)
+                raise BrowserBridgeApprovalUnavailable("approval receipt limit reached")
+            receipt_id = self._fresh_receipt_id_locked()
+            receipt = BrowserApprovalReceipt(
+                receipt_id=receipt_id,
+                challenge_id=safe_challenge_id,
+                binding=challenge.binding,
+                approving_surface=surface,
+                decided_at_ms=now,
+                expires_at_ms=now + MAX_APPROVAL_TTL_MS,
+            )
+            self._receipts[receipt_id] = receipt
+            self._remove_challenge_locked(
+                challenge,
+                terminal=ApprovalDecisionStatus.APPROVED,
+            )
+            return BrowserApprovalDecision(
+                safe_challenge_id,
+                ApprovalDecisionStatus.APPROVED,
+                receipt,
+            )
+
+    def consume(
+        self,
+        receipt_id: Any,
+        *,
+        binding: BrowserApprovalBinding,
+    ) -> str:
+        safe_receipt_id = _native_identifier(receipt_id, "receipt_id")
+        binding = _binding(binding)
+        self._require_profile(binding.route)
+        now = self._now()
+        with self._lock:
+            self._expire_locked(now)
+            terminal = self._receipt_terminal.get(safe_receipt_id)
+            if terminal is not None:
+                return (
+                    ApprovalConsumeStatus.ALREADY_CONSUMED
+                    if terminal == ApprovalConsumeStatus.CONSUMED
+                    else terminal
+                )
+            receipt = self._receipts.get(safe_receipt_id)
+            if receipt is None:
+                return ApprovalConsumeStatus.NOT_FOUND
+            if (
+                not _same_binding(receipt.binding, binding)
+                or not self._route_is_current(binding.route)
+            ):
+                self._remove_receipt_locked(
+                    receipt,
+                    terminal=ApprovalConsumeStatus.INVALIDATED,
+                )
+                return ApprovalConsumeStatus.INVALIDATED
+            self._remove_receipt_locked(
+                receipt,
+                terminal=ApprovalConsumeStatus.CONSUMED,
+            )
+            return ApprovalConsumeStatus.CONSUMED
+
+    def cancel_operation(
+        self,
+        route: BrowserApprovalRoute,
+    ) -> BrowserApprovalInvalidationSummary:
+        route = _route(route)
+        self._require_profile(route)
+        return self._invalidate_matching(
+            lambda candidate: _same_route(candidate, route)
+        )
+
+    def finalize_turn(
+        self,
+        route: BrowserApprovalRoute,
+    ) -> BrowserApprovalInvalidationSummary:
+        route = _route(route)
+        self._require_profile(route)
+        return self._invalidate_matching(
+            lambda candidate: _same_turn(candidate, route)
+        )
+
+    def disconnect(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: Any,
+        load_generation_id: Any,
+    ) -> BrowserApprovalInvalidationSummary:
+        safe_sid = _route_identifier(connector_sid, "connector_sid")
+        safe_generation = _native_identifier(
+            load_generation_id,
+            "load_generation_id",
+        )
+        if not isinstance(principal, WsPrincipal):
+            raise BrowserBridgeApprovalError("invalid bridge principal")
+        return self._invalidate_matching(
+            lambda candidate: (
+                candidate.principal is principal
+                and candidate.connector_sid == safe_sid
+                and candidate.load_generation_id == safe_generation
+            )
+        )
+
+    def revoke_bridge(
+        self,
+        *,
+        server_instance_id: Any,
+        bridge_id: Any,
+        subject_id: Any,
+    ) -> BrowserApprovalInvalidationSummary:
+        safe_server = _pairing_identifier(server_instance_id, "server_instance_id")
+        safe_bridge = _pairing_identifier(bridge_id, "bridge_id")
+        safe_subject = _pairing_identifier(subject_id, "subject_id")
+        return self._invalidate_matching(
+            lambda candidate: (
+                candidate.server_instance_id == safe_server
+                and candidate.bridge_id == safe_bridge
+                and candidate.subject_id == safe_subject
+            )
+        )
+
+    def expire(self, now_ms: int | None = None) -> BrowserApprovalInvalidationSummary:
+        now = self._now() if now_ms is None else _timestamp(now_ms)
+        with self._lock:
+            return self._expire_locked(now)
+
+    def _invalidate_matching(
+        self,
+        predicate: Callable[[BrowserApprovalRoute], bool],
+    ) -> BrowserApprovalInvalidationSummary:
+        challenges: list[BrowserApprovalChallenge] = []
+        receipts: list[BrowserApprovalReceipt] = []
+        with self._lock:
+            challenges.extend(
+                challenge
+                for challenge in self._challenges.values()
+                if predicate(challenge.binding.route)
+            )
+            receipts.extend(
+                receipt
+                for receipt in self._receipts.values()
+                if predicate(receipt.binding.route)
+            )
+            for challenge in challenges:
+                self._invalidate_challenge_locked(challenge)
+            for receipt in receipts:
+                self._remove_receipt_locked(
+                    receipt,
+                    terminal=ApprovalConsumeStatus.INVALIDATED,
+                )
+        return BrowserApprovalInvalidationSummary(len(challenges), len(receipts))
+
+    def _route_is_current(self, route: BrowserApprovalRoute) -> bool:
+        try:
+            if (
+                self._server_instance_id_loader() != route.server_instance_id
+                or self._route_authorizer(route) is not True
+            ):
+                return False
+            record = self._active_record_loader(
+                route.server_instance_id,
+                route.bridge_id,
+            )
+        except Exception:
+            return False
+        if not isinstance(record, Mapping):
+            return False
+        scopes = record.get("scopes")
+        return (
+            record.get("state") == "active"
+            and record.get("server_instance_id") == route.server_instance_id
+            and record.get("bridge_id") == route.bridge_id
+            and record.get("subject_id") == route.subject_id
+            and record.get("key_generation") == route.key_generation
+            and isinstance(scopes, list)
+            and frozenset(scopes) == route.principal.scopes
+            and "browser.approval" in scopes
+        )
+
+    def _expire_locked(self, now: int) -> BrowserApprovalInvalidationSummary:
+        challenges = [
+            challenge
+            for challenge in self._challenges.values()
+            if challenge.expires_at_ms <= now
+        ]
+        receipts = [
+            receipt
+            for receipt in self._receipts.values()
+            if receipt.expires_at_ms <= now
+        ]
+        for challenge in challenges:
+            self._remove_challenge_locked(
+                challenge,
+                terminal=ApprovalDecisionStatus.EXPIRED,
+            )
+        for receipt in receipts:
+            self._remove_receipt_locked(
+                receipt,
+                terminal=ApprovalConsumeStatus.EXPIRED,
+            )
+        return BrowserApprovalInvalidationSummary(len(challenges), len(receipts))
+
+    def _invalidate_challenge_locked(self, challenge: BrowserApprovalChallenge) -> None:
+        self._remove_challenge_locked(
+            challenge,
+            terminal=ApprovalDecisionStatus.INVALIDATED,
+        )
+
+    def _remove_challenge_locked(
+        self,
+        challenge: BrowserApprovalChallenge,
+        *,
+        terminal: str,
+    ) -> None:
+        if self._challenges.get(challenge.challenge_id) is not challenge:
+            return
+        self._challenges.pop(challenge.challenge_id, None)
+        self._operation_challenges.pop(_operation_key(challenge.binding.route), None)
+        self._remember_terminal_locked(
+            challenge.challenge_id,
+            terminal,
+            self._challenge_terminal,
+            self._challenge_terminal_order,
+        )
+
+    def _remove_receipt_locked(
+        self,
+        receipt: BrowserApprovalReceipt,
+        *,
+        terminal: str,
+    ) -> None:
+        if self._receipts.get(receipt.receipt_id) is not receipt:
+            return
+        self._receipts.pop(receipt.receipt_id, None)
+        self._remember_terminal_locked(
+            receipt.receipt_id,
+            terminal,
+            self._receipt_terminal,
+            self._receipt_terminal_order,
+        )
+
+    def _fresh_receipt_id_locked(self) -> str:
+        try:
+            receipt_id = _native_identifier(
+                self._receipt_id_factory(),
+                "receipt_id",
+            )
+        except Exception as error:
+            raise BrowserBridgeApprovalUnavailable(
+                "approval receipt identity unavailable"
+            ) from error
+        if receipt_id in self._receipts or receipt_id in self._receipt_terminal:
+            raise BrowserBridgeApprovalUnavailable("approval receipt identity collision")
+        return receipt_id
+
+    def _remember_terminal_locked(
+        self,
+        item_id: str,
+        status: str,
+        statuses: dict[str, str],
+        order: deque[str],
+    ) -> None:
+        if item_id in statuses:
+            return
+        statuses[item_id] = status
+        order.append(item_id)
+        while len(order) > self._max_terminal_records:
+            statuses.pop(order.popleft(), None)
+
+    def _now(self) -> int:
+        return _timestamp(self._clock_ms())
+
+    def _require_profile(self, route: BrowserApprovalRoute) -> None:
+        if route.transport_profile is not self._transport_profile:
+            raise BrowserBridgeApprovalUnavailable("approval route is unavailable")
+
+
+def _binding(value: Any) -> BrowserApprovalBinding:
+    if not isinstance(value, BrowserApprovalBinding):
+        raise BrowserBridgeApprovalError("invalid approval binding")
+    return value
+
+
+def _route(value: Any) -> BrowserApprovalRoute:
+    if not isinstance(value, BrowserApprovalRoute):
+        raise BrowserBridgeApprovalError("invalid approval route")
+    return value
+
+
+def _validate_route(route: BrowserApprovalRoute) -> None:
+    _pairing_identifier(route.server_instance_id, "server_instance_id")
+    principal = route.principal
+    try:
+        profile = require_browser_bridge_transport_profile(route.transport_profile)
+        require_transport_principal_identity(principal, profile)
+    except ValueError:
+        raise BrowserBridgeApprovalError("invalid bridge principal") from None
+    if (
+        "browser.approval" not in principal.scopes
+        or type(principal.key_generation) is not int
+        or principal.key_generation < 1
+    ):
+        raise BrowserBridgeApprovalError("invalid bridge principal")
+    _pairing_identifier(principal.principal_id, "bridge_id")
+    _pairing_identifier(principal.subject_id, "subject_id")
+    _route_identifier(route.connector_sid, "connector_sid")
+    _native_identifier(route.load_generation_id, "load_generation_id")
+    for name in (
+        "context_id",
+        "browser_session_id",
+        "turn_id",
+        "action_id",
+        "op_id",
+        "tab_handle",
+        "document_id",
+    ):
+        _route_identifier(getattr(route, name), name)
+    if (
+        isinstance(route.document_epoch, bool)
+        or not isinstance(route.document_epoch, int)
+        or route.document_epoch < 0
+    ):
+        raise BrowserBridgeApprovalError("invalid document_epoch")
+
+
+def _same_binding(
+    expected: BrowserApprovalBinding,
+    candidate: BrowserApprovalBinding,
+) -> bool:
+    return (
+        _same_route(expected.route, candidate.route)
+        and expected.canonical_parameter_hash == candidate.canonical_parameter_hash
+        and expected.target_fingerprint == candidate.target_fingerprint
+        and expected.origin == candidate.origin
+        and expected.action_class == candidate.action_class
+        and expected.data_classification == candidate.data_classification
+    )
+
+
+def _same_route(expected: BrowserApprovalRoute, candidate: BrowserApprovalRoute) -> bool:
+    return (
+        expected.principal is candidate.principal
+        and expected.transport_profile is candidate.transport_profile
+        and expected.server_instance_id == candidate.server_instance_id
+        and expected.connector_sid == candidate.connector_sid
+        and expected.load_generation_id == candidate.load_generation_id
+        and expected.context_id == candidate.context_id
+        and expected.browser_session_id == candidate.browser_session_id
+        and expected.turn_id == candidate.turn_id
+        and expected.action_id == candidate.action_id
+        and expected.op_id == candidate.op_id
+        and expected.tab_handle == candidate.tab_handle
+        and expected.document_id == candidate.document_id
+        and expected.document_epoch == candidate.document_epoch
+    )
+
+
+def _same_turn(expected: BrowserApprovalRoute, candidate: BrowserApprovalRoute) -> bool:
+    return (
+        expected.principal is candidate.principal
+        and expected.server_instance_id == candidate.server_instance_id
+        and expected.connector_sid == candidate.connector_sid
+        and expected.load_generation_id == candidate.load_generation_id
+        and expected.context_id == candidate.context_id
+        and expected.browser_session_id == candidate.browser_session_id
+        and expected.turn_id == candidate.turn_id
+    )
+
+
+def _operation_key(route: BrowserApprovalRoute) -> tuple[Any, ...]:
+    return (
+        id(route.principal),
+        route.server_instance_id,
+        route.connector_sid,
+        route.load_generation_id,
+        route.context_id,
+        route.browser_session_id,
+        route.turn_id,
+        route.action_id,
+        route.op_id,
+        route.tab_handle,
+        route.document_id,
+        route.document_epoch,
+    )
+
+
+def _pairing_identifier(value: Any, field_name: str) -> str:
+    try:
+        return validate_identifier(value, field_name=field_name)
+    except Exception as error:
+        raise BrowserBridgeApprovalError(f"invalid {field_name}") from error
+
+
+def _route_identifier(value: Any, field_name: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or not value.isprintable()
+    ):
+        raise BrowserBridgeApprovalError(f"invalid {field_name}")
+    try:
+        size = len(value.encode("utf-8"))
+    except UnicodeError:
+        raise BrowserBridgeApprovalError(f"invalid {field_name}") from None
+    if size > MAX_ROUTE_IDENTIFIER_BYTES:
+        raise BrowserBridgeApprovalError(f"invalid {field_name}")
+    return value
+
+
+def _native_identifier(value: Any, field_name: str) -> str:
+    value = _route_identifier(value, field_name)
+    if _NATIVE_IDENTIFIER.fullmatch(value) is None:
+        raise BrowserBridgeApprovalError(f"invalid {field_name}")
+    return value
+
+
+def validate_approval_identifier(value: Any, *, field_name: str) -> str:
+    """Validate one native-protocol approval identifier."""
+
+    return _native_identifier(value, field_name)
+
+
+def _digest(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or _SHA256_HEX.fullmatch(value) is None:
+        raise BrowserBridgeApprovalError(f"invalid {field_name}")
+    return value
+
+
+def _timeout(value: Any) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 1 <= value <= MAX_APPROVAL_TTL_MS
+    ):
+        raise BrowserBridgeApprovalError("invalid approval timeout")
+    return value
+
+
+def _timestamp(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise BrowserBridgeApprovalUnavailable("approval clock unavailable")
+    return value
+
+
+def _load_active_record(
+    server_instance_id: str,
+    bridge_id: str,
+) -> Mapping[str, Any] | None:
+    from plugins._a0_connector.helpers.browser_bridge_pairing import (
+        get_browser_bridge_pairing_store,
+    )
+
+    return get_browser_bridge_pairing_store().active_bridge_record(
+        bridge_id=bridge_id,
+        server_instance_id=server_instance_id,
+    )
+
+
+def _load_server_instance_id() -> str:
+    from helpers import runtime
+
+    return runtime.get_persistent_id()
+
+
+_repository: BrowserBridgeApprovalRepository | None = None
+_repository_lock = threading.Lock()
+
+
+def get_browser_bridge_approval_repository() -> BrowserBridgeApprovalRepository:
+    global _repository
+    if _repository is None:
+        with _repository_lock:
+            if _repository is None:
+                _repository = BrowserBridgeApprovalRepository()
+    return _repository

--- a/plugins/_a0_connector/helpers/browser_bridge_artifact_controller.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_artifact_controller.py
@@ -1,0 +1,642 @@
+"""Exact-route transport controller for Browser bridge output artifacts.
+
+The controller validates the connector wire shape, resolves authority through
+an injected pending-operation binding, and delegates private spooling to
+``BrowserBridgeArtifactReceiver``.  It does not materialize artifacts, support
+input uploads, wire a WebSocket handler, or advertise Browser runtime readiness.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+from dataclasses import dataclass
+import json
+import re
+from typing import Any, Callable
+
+from helpers.ws_principal import WsPrincipal, restricted_correlation_id
+from plugins._a0_connector.helpers.browser_bridge_artifacts import (
+    MAX_ARTIFACT_BYTES,
+    MAX_CHUNK_BYTES,
+    ArtifactBinding,
+    ArtifactCleanupSummary,
+    ArtifactDescriptor,
+    ArtifactProgress,
+    BrowserBridgeArtifactError,
+    BrowserBridgeArtifactReceiver,
+)
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    BrowserBridgeContextRoute,
+)
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+)
+
+
+CONTRACT_VERSION = 1
+WS_NAMESPACE = PRODUCTION_BROWSER_BRIDGE_TRANSPORT.namespace
+RESTRICTED_HANDLER_ID = PRODUCTION_BROWSER_BRIDGE_TRANSPORT.handler_id
+ARTIFACT_CHUNK_EVENT = "connector_browser_artifact_chunk"
+ARTIFACT_ACK_EVENT = "connector_browser_artifact_ack"
+
+MAX_NATIVE_FRAME_BYTES = 768 * 1024
+MAX_BASE64_CHUNK_BYTES = 256 * 1024
+MAX_SAFE_INTEGER = 2**53 - 1
+MAX_EMIT_TIMEOUT_SECONDS = 10.0
+DEFAULT_EMIT_TIMEOUT_SECONDS = 5.0
+MIN_EXPIRY_INTERVAL_SECONDS = 0.01
+MAX_EXPIRY_INTERVAL_SECONDS = 60.0
+DEFAULT_EXPIRY_INTERVAL_SECONDS = 1.0
+
+_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+_SHA256 = re.compile(r"sha256:[a-f0-9]{64}")
+_MIME_TYPE = re.compile(
+    r"[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}/"
+    r"[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}"
+)
+
+_COMMON_KEYS = frozenset(
+    {
+        "contract_version",
+        "phase",
+        "bridge_id",
+        "load_generation_id",
+        "context_id",
+        "browser_session_id",
+        "turn_id",
+        "action_id",
+        "op_id",
+        "artifact_id",
+        "direction",
+        "purpose",
+    }
+)
+_PHASE_KEYS = {
+    "begin": frozenset({"mime_type", "byte_count", "sha256"}),
+    "chunk": frozenset({"chunk_index", "data_base64"}),
+    "end": frozenset(),
+    "abort": frozenset({"reason_code"}),
+}
+_OUTPUT_PURPOSES = frozenset({"screenshot", "download"})
+_SENDER_ABORT_REASONS = frozenset(
+    {
+        "ARTIFACT_TOO_LARGE",
+        "CANCELED",
+        "CONNECTION_LOST",
+        "DEADLINE_EXCEEDED",
+        "INTERNAL_ERROR",
+        "OUTCOME_UNKNOWN",
+    }
+)
+_RECEIVER_ABORT_REASONS = frozenset(
+    {
+        "ARTIFACT_ALREADY_COMPLETE",
+        "ARTIFACT_DIGEST_INVALID",
+        "ARTIFACT_ID_REUSED",
+        "ARTIFACT_INTEGRITY_MISMATCH",
+        "ARTIFACT_MIME_INVALID",
+        "ARTIFACT_NOT_COMPLETE",
+        "ARTIFACT_NOT_FOUND",
+        "ARTIFACT_REGISTRY_FULL",
+        "ARTIFACT_SIZE_INVALID",
+        "ARTIFACT_SIZE_MISMATCH",
+        "ARTIFACT_SPOOL_FULL",
+        "ARTIFACT_TERMINAL",
+        "CHUNK_OUT_OF_ORDER",
+        "CHUNK_SIZE_INVALID",
+        "CLOCK_UNAVAILABLE",
+        "IDEMPOTENCY_CONFLICT",
+        "SPOOL_UNAVAILABLE",
+    }
+)
+
+
+class BrowserBridgeArtifactControllerError(ValueError):
+    """An artifact frame or controller dependency is invalid."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+class BrowserBridgeArtifactControllerDenied(PermissionError):
+    """The exact route or pending operation lacks artifact authority."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactBindingLookup:
+    """Untrusted lookup keys; the resolver must return server-owned authority."""
+
+    route: BrowserBridgeContextRoute
+    bridge_id: str
+    load_generation_id: str
+    context_id: str
+    browser_session_id: str
+    turn_id: str
+    action_id: str
+    op_id: str
+    artifact_id: str
+    direction: str
+    purpose: str
+
+
+ArtifactBindingResolver = Callable[[ArtifactBindingLookup], ArtifactBinding | None]
+
+
+class BrowserBridgeArtifactController:
+    """Receive, validate, spool, and acknowledge output artifact frames."""
+
+    def __init__(
+        self,
+        *,
+        receiver: BrowserBridgeArtifactReceiver[Any],
+        binding_resolver: ArtifactBindingResolver,
+        manager: Any,
+        expiry_interval_seconds: float = DEFAULT_EXPIRY_INTERVAL_SECONDS,
+        emit_timeout_seconds: float = DEFAULT_EMIT_TIMEOUT_SECONDS,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        if not isinstance(receiver, BrowserBridgeArtifactReceiver):
+            raise BrowserBridgeArtifactControllerError("INVALID_ARTIFACT_RECEIVER")
+        if not callable(binding_resolver):
+            raise BrowserBridgeArtifactControllerError("INVALID_BINDING_RESOLVER")
+        if not callable(getattr(manager, "emit_to", None)):
+            raise BrowserBridgeArtifactControllerError("INVALID_WEBSOCKET_MANAGER")
+        if (
+            isinstance(expiry_interval_seconds, bool)
+            or not isinstance(expiry_interval_seconds, (int, float))
+            or not MIN_EXPIRY_INTERVAL_SECONDS
+            <= float(expiry_interval_seconds)
+            <= MAX_EXPIRY_INTERVAL_SECONDS
+        ):
+            raise BrowserBridgeArtifactControllerError("INVALID_EXPIRY_INTERVAL")
+        if (
+            isinstance(emit_timeout_seconds, bool)
+            or not isinstance(emit_timeout_seconds, (int, float))
+            or not 0 < float(emit_timeout_seconds) <= MAX_EMIT_TIMEOUT_SECONDS
+        ):
+            raise BrowserBridgeArtifactControllerError("INVALID_EMIT_TIMEOUT")
+        self._receiver = receiver
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        if getattr(receiver, "_transport_profile", None) is not self._transport_profile:
+            raise BrowserBridgeArtifactControllerError("INVALID_ARTIFACT_RECEIVER")
+        self._binding_resolver = binding_resolver
+        self._manager = manager
+        self._expiry_interval_seconds = float(expiry_interval_seconds)
+        self._emit_timeout_seconds = float(emit_timeout_seconds)
+        self._lock = asyncio.Lock()
+        self._expiry_task: asyncio.Task[None] | None = None
+        self._closed = False
+
+    @property
+    def expiry_task_active(self) -> bool:
+        task = self._expiry_task
+        return task is not None and not task.done()
+
+    async def receive(
+        self,
+        route: BrowserBridgeContextRoute,
+        document: Any,
+    ) -> dict[str, Any]:
+        route = _route(route)
+        _require_transport_scope(route, self._transport_profile)
+        request, decoded = _frame(document, route)
+        lookup = ArtifactBindingLookup(
+            route=route,
+            bridge_id=request["bridge_id"],
+            load_generation_id=request["load_generation_id"],
+            context_id=request["context_id"],
+            browser_session_id=request["browser_session_id"],
+            turn_id=request["turn_id"],
+            action_id=request["action_id"],
+            op_id=request["op_id"],
+            artifact_id=request["artifact_id"],
+            direction=request["direction"],
+            purpose=request["purpose"],
+        )
+        phase = request["phase"]
+
+        async with self._lock:
+            if self._closed:
+                raise BrowserBridgeArtifactControllerError("CONTROLLER_CLOSED")
+            binding = self._resolve_binding(lookup)
+            try:
+                if phase == "begin":
+                    outcome: ArtifactProgress | ArtifactDescriptor | bool = (
+                        await asyncio.to_thread(
+                            self._receiver.begin,
+                            binding,
+                            byte_count=request["byte_count"],
+                            sha256=request["sha256"],
+                            mime_type=request["mime_type"],
+                        )
+                    )
+                    self._ensure_expiry_task_locked()
+                elif phase == "chunk":
+                    outcome = await asyncio.to_thread(
+                        self._receiver.append,
+                        binding,
+                        chunk_index=request["chunk_index"],
+                        data=decoded,
+                    )
+                elif phase == "end":
+                    outcome = await asyncio.to_thread(
+                        self._receiver.complete, binding
+                    )
+                    self._ensure_expiry_task_locked()
+                else:
+                    outcome = await asyncio.to_thread(
+                        self._receiver.abort, binding
+                    )
+            except BrowserBridgeArtifactError as error:
+                if error.code == "SCOPE_DENIED":
+                    raise BrowserBridgeArtifactControllerDenied(
+                        "STALE_ARTIFACT_BINDING"
+                    ) from None
+                if error.code == "RECEIVER_CLOSED":
+                    raise BrowserBridgeArtifactControllerError(
+                        "CONTROLLER_CLOSED"
+                    ) from None
+                if error.code not in _RECEIVER_ABORT_REASONS:
+                    raise BrowserBridgeArtifactControllerError(
+                        "ARTIFACT_TRANSFER_FAILED"
+                    ) from None
+                acknowledgement = _abort_ack(binding, phase, error.code)
+            else:
+                acknowledgement = _acknowledgement(
+                    binding, phase, request, outcome
+                )
+            try:
+                self._resolve_binding(lookup)
+            except BrowserBridgeArtifactControllerDenied:
+                try:
+                    await asyncio.to_thread(self._receiver.abort, binding)
+                except BrowserBridgeArtifactError:
+                    pass
+                raise
+            if self._receiver.active_count == 0:
+                self._stop_expiry_task_locked()
+
+        await self._emit_ack(route, acknowledgement)
+        return acknowledgement
+
+    async def disconnect(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: Any,
+        load_generation_id: Any,
+    ) -> ArtifactCleanupSummary:
+        if not isinstance(principal, WsPrincipal):
+            raise BrowserBridgeArtifactControllerError("INVALID_ROUTE")
+        sid = _identifier(connector_sid, "connector_sid")
+        generation = _identifier(load_generation_id, "load_generation_id")
+        async with self._lock:
+            if self._closed:
+                return ArtifactCleanupSummary(0, 0)
+            summary = await asyncio.to_thread(
+                self._receiver.disconnect,
+                principal=principal,
+                connector_sid=sid,
+                load_generation_id=generation,
+            )
+            if self._receiver.active_count == 0:
+                self._stop_expiry_task_locked()
+            return summary
+
+    async def close(self) -> ArtifactCleanupSummary:
+        async with self._lock:
+            if self._closed:
+                return ArtifactCleanupSummary(0, 0)
+            self._closed = True
+            task = self._stop_expiry_task_locked()
+            summary = await asyncio.to_thread(self._receiver.close)
+        if task is not None:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        return summary
+
+    def _resolve_binding(self, lookup: ArtifactBindingLookup) -> ArtifactBinding:
+        try:
+            binding = self._binding_resolver(lookup)
+        except Exception:
+            binding = None
+        if (
+            not isinstance(binding, ArtifactBinding)
+            or binding.transport_profile is not self._transport_profile
+            or not _binding_matches(binding, lookup)
+        ):
+            raise BrowserBridgeArtifactControllerDenied(
+                "ARTIFACT_BINDING_UNAVAILABLE"
+            )
+        return binding
+
+    async def _emit_ack(
+        self,
+        route: BrowserBridgeContextRoute,
+        acknowledgement: dict[str, Any],
+    ) -> None:
+        try:
+            await asyncio.wait_for(
+                self._manager.emit_to(
+                    self._transport_profile.namespace,
+                    route.connector_sid,
+                    ARTIFACT_ACK_EVENT,
+                    acknowledgement,
+                    handler_id=self._transport_profile.handler_id,
+                    correlation_id=restricted_correlation_id(
+                        acknowledgement["op_id"]
+                    ),
+                    expected_principal=route.principal,
+                ),
+                timeout=self._emit_timeout_seconds,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            raise BrowserBridgeArtifactControllerError(
+                "ARTIFACT_ACK_FAILED"
+            ) from None
+
+    def _ensure_expiry_task_locked(self) -> None:
+        task = self._expiry_task
+        if task is None or task.done():
+            self._expiry_task = asyncio.create_task(
+                self._expiry_loop(), name="browser-bridge-artifact-expiry"
+            )
+
+    def _stop_expiry_task_locked(self) -> asyncio.Task[None] | None:
+        task = self._expiry_task
+        self._expiry_task = None
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
+            return task
+        return None
+
+    async def _expiry_loop(self) -> None:
+        current = asyncio.current_task()
+        try:
+            while True:
+                await asyncio.sleep(self._expiry_interval_seconds)
+                async with self._lock:
+                    if self._closed or self._expiry_task is not current:
+                        return
+                    try:
+                        await asyncio.to_thread(self._receiver.expire)
+                    except BrowserBridgeArtifactError as error:
+                        if error.code == "RECEIVER_CLOSED":
+                            return
+                        # Clock failures do not widen authority or delete an
+                        # unexpired transfer.  Retry only on the bounded sweep.
+                    except Exception:
+                        # A cleanup dependency cannot terminate the only expiry
+                        # owner while private transfers remain registered.
+                        pass
+                    if self._receiver.active_count == 0:
+                        self._expiry_task = None
+                        return
+        except asyncio.CancelledError:
+            return
+        finally:
+            if self._expiry_task is current:
+                self._expiry_task = None
+
+
+def _frame(
+    value: Any,
+    route: BrowserBridgeContextRoute,
+) -> tuple[dict[str, Any], bytes]:
+    if not isinstance(value, dict) or len(value) > 16:
+        raise BrowserBridgeArtifactControllerError("INVALID_ARTIFACT_FRAME")
+    request = dict(value)
+    request.pop("correlationId", None)
+    phase = request.get("phase")
+    if (
+        not isinstance(phase, str)
+        or phase not in _PHASE_KEYS
+        or set(request) != _COMMON_KEYS | _PHASE_KEYS[phase]
+    ):
+        raise BrowserBridgeArtifactControllerError("INVALID_ARTIFACT_FRAME")
+    if type(request.get("contract_version")) is not int or request[
+        "contract_version"
+    ] != CONTRACT_VERSION:
+        raise BrowserBridgeArtifactControllerError("VERSION_MISMATCH")
+    for field in (
+        "bridge_id",
+        "load_generation_id",
+        "context_id",
+        "browser_session_id",
+        "turn_id",
+        "action_id",
+        "op_id",
+        "artifact_id",
+    ):
+        request[field] = _identifier(request[field], field)
+    if (
+        request["bridge_id"] != route.principal.principal_id
+        or request["load_generation_id"] != route.load_generation_id
+    ):
+        raise BrowserBridgeArtifactControllerDenied("ARTIFACT_ROUTE_MISMATCH")
+    if (
+        request.get("direction") != "output"
+        or not isinstance(request.get("purpose"), str)
+        or request["purpose"] not in _OUTPUT_PURPOSES
+    ):
+        raise BrowserBridgeArtifactControllerDenied(
+            "ARTIFACT_DIRECTION_UNAVAILABLE"
+        )
+
+    decoded = b""
+    if phase == "begin":
+        if not _safe_integer(request["byte_count"]) or request[
+            "byte_count"
+        ] > MAX_ARTIFACT_BYTES:
+            raise BrowserBridgeArtifactControllerError("ARTIFACT_SIZE_INVALID")
+        if not isinstance(request["sha256"], str) or _SHA256.fullmatch(
+            request["sha256"]
+        ) is None:
+            raise BrowserBridgeArtifactControllerError("ARTIFACT_DIGEST_INVALID")
+        if not isinstance(request["mime_type"], str) or _MIME_TYPE.fullmatch(
+            request["mime_type"]
+        ) is None:
+            raise BrowserBridgeArtifactControllerError("ARTIFACT_MIME_INVALID")
+    elif phase == "chunk":
+        if not _safe_integer(request["chunk_index"]):
+            raise BrowserBridgeArtifactControllerError("INVALID_CHUNK_INDEX")
+        decoded = _canonical_base64(request["data_base64"])
+    elif phase == "abort":
+        if (
+            not isinstance(request["reason_code"], str)
+            or request["reason_code"] not in _SENDER_ABORT_REASONS
+        ):
+            raise BrowserBridgeArtifactControllerError("INVALID_ABORT_REASON")
+
+    # Every variable-length field has already been bounded before this
+    # serialization, so the frame check cannot allocate from attacker-sized
+    # nested input.
+    try:
+        encoded = json.dumps(
+            request, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+    except (TypeError, ValueError, UnicodeError):
+        raise BrowserBridgeArtifactControllerError(
+            "INVALID_ARTIFACT_FRAME"
+        ) from None
+    if len(encoded) > MAX_NATIVE_FRAME_BYTES:
+        raise BrowserBridgeArtifactControllerError("ARTIFACT_FRAME_TOO_LARGE")
+    return request, decoded
+
+
+def _canonical_base64(value: Any) -> bytes:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > MAX_BASE64_CHUNK_BYTES
+        or not value.isascii()
+    ):
+        raise BrowserBridgeArtifactControllerError("CHUNK_SIZE_INVALID")
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError):
+        raise BrowserBridgeArtifactControllerError("INVALID_CHUNK_BASE64") from None
+    if (
+        not decoded
+        or len(decoded) > MAX_CHUNK_BYTES
+        or base64.b64encode(decoded).decode("ascii") != value
+    ):
+        raise BrowserBridgeArtifactControllerError("INVALID_CHUNK_BASE64")
+    return decoded
+
+
+def _acknowledgement(
+    binding: ArtifactBinding,
+    phase: str,
+    request: dict[str, Any],
+    outcome: ArtifactProgress | ArtifactDescriptor | bool,
+) -> dict[str, Any]:
+    result = _ack_binding(binding, phase)
+    if phase in {"begin", "chunk"}:
+        if not isinstance(outcome, ArtifactProgress):
+            raise BrowserBridgeArtifactControllerError("INVALID_RECEIVER_RESULT")
+        result.update(
+            {
+                "status": outcome.status,
+                "next_chunk_index": outcome.next_chunk_index,
+                "received_bytes": outcome.received_bytes,
+            }
+        )
+    elif phase == "end":
+        if not isinstance(outcome, ArtifactDescriptor):
+            raise BrowserBridgeArtifactControllerError("INVALID_RECEIVER_RESULT")
+        result.update({"status": "complete", "descriptor": outcome.as_dict()})
+    else:
+        if not isinstance(outcome, bool):
+            raise BrowserBridgeArtifactControllerError("INVALID_RECEIVER_RESULT")
+        result.update(
+            {"status": "aborted", "reason_code": request["reason_code"]}
+        )
+    return result
+
+
+def _abort_ack(
+    binding: ArtifactBinding, phase: str, reason_code: str
+) -> dict[str, Any]:
+    result = _ack_binding(binding, phase)
+    result.update({"status": "aborted", "reason_code": reason_code})
+    return result
+
+
+def _ack_binding(binding: ArtifactBinding, phase: str) -> dict[str, Any]:
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "phase": phase,
+        "bridge_id": binding.bridge_id,
+        "load_generation_id": binding.load_generation_id,
+        "context_id": binding.context_id,
+        "browser_session_id": binding.browser_session_id,
+        "turn_id": binding.turn_id,
+        "action_id": binding.action_id,
+        "op_id": binding.op_id,
+        "artifact_id": binding.artifact_id,
+        "direction": binding.direction,
+        "purpose": binding.purpose,
+    }
+
+
+def _binding_matches(
+    binding: ArtifactBinding, lookup: ArtifactBindingLookup
+) -> bool:
+    return (
+        binding.principal is lookup.route.principal
+        and binding.connector_sid == lookup.route.connector_sid
+        and binding.load_generation_id == lookup.route.load_generation_id
+        and all(
+            getattr(binding, field) == getattr(lookup, field)
+            for field in (
+                "bridge_id",
+                "load_generation_id",
+                "context_id",
+                "browser_session_id",
+                "turn_id",
+                "action_id",
+                "op_id",
+                "artifact_id",
+                "direction",
+                "purpose",
+            )
+        )
+        and binding.contract_version == CONTRACT_VERSION
+    )
+
+
+def _require_transport_scope(
+    route: BrowserBridgeContextRoute,
+    transport_profile: BrowserBridgeTransportProfile,
+) -> None:
+    profile = require_browser_bridge_transport_profile(transport_profile)
+    principal = route.principal
+    if (
+        route.transport_profile is not profile
+        or "browser.artifact" not in principal.scopes
+        or not principal.permits_inbound(
+            ARTIFACT_CHUNK_EVENT, profile.handler_id
+        )
+        or not principal.permits_outbound(
+            ARTIFACT_ACK_EVENT, profile.handler_id
+        )
+    ):
+        raise BrowserBridgeArtifactControllerDenied("SCOPE_DENIED")
+
+
+def _route(value: Any) -> BrowserBridgeContextRoute:
+    if not isinstance(value, BrowserBridgeContextRoute):
+        raise BrowserBridgeArtifactControllerError("INVALID_ROUTE")
+    return value
+
+
+def _identifier(value: Any, field: str) -> str:
+    if not isinstance(value, str) or _IDENTIFIER.fullmatch(value) is None:
+        raise BrowserBridgeArtifactControllerError(f"INVALID_{field.upper()}")
+    return value
+
+
+def _safe_integer(value: Any) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, int)
+        and 0 <= value <= MAX_SAFE_INTEGER
+    )

--- a/plugins/_a0_connector/helpers/browser_bridge_artifact_sender.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_artifact_sender.py
@@ -1,0 +1,172 @@
+"""Bounded, exact-route Core-to-browser input transfer with correlated ACKs."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from dataclasses import dataclass
+import hashlib
+import re
+from typing import Callable
+
+from plugins._a0_connector.helpers.browser_bridge_artifacts import (
+    ArtifactBinding, ArtifactDescriptor, MAX_ARTIFACT_BYTES, MAX_CHUNK_BYTES,
+)
+from plugins._a0_connector.helpers.browser_bridge_artifact_controller import _ack_binding
+from plugins._a0_connector.helpers.browser_bridge_context import BrowserBridgeContextRoute
+from plugins._a0_connector.helpers.browser_bridge_transport import PRODUCTION_BROWSER_BRIDGE_TRANSPORT as PROFILE
+
+
+class BrowserBridgeArtifactSendError(RuntimeError):
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(slots=True)
+class _Pending:
+    binding: ArtifactBinding
+    expected: dict
+    future: asyncio.Future
+
+
+class BrowserBridgeArtifactSender:
+    """Send only server-supplied bytes for a currently authorized input binding.
+
+    This class accepts no path, guessed artifact reference, page authority, or
+    caller-selected principal. Its injected application authorizer must include
+    exact operation, current turn, site and upload-consent checks.
+    """
+
+    def __init__(self, *, manager, authorizer: Callable[[ArtifactBinding], bool],
+                 frame_timeout: float = 8.0):
+        if not callable(authorizer) or not callable(getattr(manager, "emit_to", None)):
+            raise TypeError("input artifact dependencies unavailable")
+        if not isinstance(frame_timeout, (int, float)) or isinstance(frame_timeout, bool) or not 0 < frame_timeout <= 10:
+            raise ValueError("invalid input artifact timeout")
+        self._manager = manager
+        self._authorizer = authorizer
+        self._frame_timeout = frame_timeout
+        self._pending: dict[str, _Pending] = {}
+        self._tasks: dict[str, tuple[ArtifactBinding, asyncio.Task, int]] = {}
+        self._used_ids: set[str] = set()
+        self._closed = False
+
+    def _current(self, binding: ArtifactBinding) -> bool:
+        try:
+            return bool(
+                not self._closed and isinstance(binding, ArtifactBinding)
+                and binding.transport_profile is PROFILE
+                and binding.direction == "input" and binding.purpose == "upload_file"
+                and binding.principal.permits_inbound("connector_browser_artifact_ack", PROFILE.handler_id)
+                and self._authorizer(binding) is True
+            )
+        except Exception:
+            return False
+
+    async def send(self, binding: ArtifactBinding, *, data: bytes,
+                   mime_type: str) -> ArtifactDescriptor:
+        if (
+            not self._current(binding) or not isinstance(data, bytes)
+            or not 0 < len(data) <= MAX_ARTIFACT_BYTES
+            or not isinstance(mime_type, str)
+            or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}", mime_type) is None
+        ):
+            raise BrowserBridgeArtifactSendError("INPUT_ARTIFACT_DENIED")
+        if binding.artifact_id in self._used_ids or len(self._used_ids) >= 2048 or len(self._tasks) >= 16 or sum(item[2] for item in self._tasks.values()) + len(data) > 100 * 1024 * 1024:
+            raise BrowserBridgeArtifactSendError("INPUT_ARTIFACT_CAPACITY")
+        self._used_ids.add(binding.artifact_id)
+        task = asyncio.create_task(self._send_owned(binding, data, mime_type))
+        self._tasks[binding.artifact_id] = (binding, task, len(data))
+        def settled(done):
+            current = self._tasks.get(binding.artifact_id)
+            if current is not None and current[1] is done:
+                self._tasks.pop(binding.artifact_id, None)
+            if not done.cancelled():
+                done.exception()
+        task.add_done_callback(settled)
+        # Caller cancellation cannot duplicate or abandon a half-sent transfer.
+        return await asyncio.shield(task)
+
+    async def _send_owned(self, binding, data, mime_type):
+        descriptor = ArtifactDescriptor(binding.artifact_id, mime_type, len(data),
+                                        "sha256:" + hashlib.sha256(data).hexdigest(), "upload_file")
+        try:
+            async with asyncio.timeout(120):
+                await self._frame(binding, "begin", {
+                    "mime_type": mime_type, "byte_count": len(data), "sha256": descriptor.sha256,
+                }, {"status": "accepted", "next_chunk_index": 0, "received_bytes": 0})
+                offset, index = 0, 0
+                while offset < len(data):
+                    chunk = data[offset:offset + MAX_CHUNK_BYTES]
+                    await self._frame(binding, "chunk", {
+                        "chunk_index": index, "data_base64": base64.b64encode(chunk).decode("ascii"),
+                    }, {"status": "accepted", "next_chunk_index": index + 1, "received_bytes": offset + len(chunk)})
+                    offset += len(chunk)
+                    index += 1
+                await self._frame(binding, "end", {}, {"status": "complete", "descriptor": descriptor.as_dict()})
+                return descriptor
+        except asyncio.CancelledError:
+            raise
+        except TimeoutError:
+            raise BrowserBridgeArtifactSendError("INPUT_ARTIFACT_OUTCOME_UNKNOWN") from None
+        except BrowserBridgeArtifactSendError:
+            raise
+        except Exception:
+            raise BrowserBridgeArtifactSendError("INPUT_ARTIFACT_OUTCOME_UNKNOWN") from None
+        finally:
+            self._pending.pop(binding.artifact_id, None)
+            self._tasks.pop(binding.artifact_id, None)
+
+    async def _frame(self, binding, phase, extra, expected):
+        if not self._current(binding):
+            raise BrowserBridgeArtifactSendError("INPUT_ARTIFACT_AUTHORITY_LOST")
+        common = _ack_binding(binding, phase)
+        future = asyncio.get_running_loop().create_future()
+        pending = _Pending(binding, common | expected, future)
+        self._pending[binding.artifact_id] = pending
+        try:
+            async with asyncio.timeout(self._frame_timeout):
+                await self._manager.emit_to(
+                    PROFILE.namespace, binding.connector_sid, "connector_browser_artifact_chunk",
+                    common | extra, handler_id=PROFILE.handler_id,
+                    correlation_id=binding.artifact_id, expected_principal=binding.principal,
+                )
+                await future
+            if not self._current(binding):
+                raise BrowserBridgeArtifactSendError("INPUT_ARTIFACT_AUTHORITY_LOST")
+        finally:
+            if self._pending.get(binding.artifact_id) is pending:
+                self._pending.pop(binding.artifact_id, None)
+
+    async def receive_ack(self, route: BrowserBridgeContextRoute, document: object) -> dict:
+        if not isinstance(route, BrowserBridgeContextRoute) or not isinstance(document, dict):
+            raise BrowserBridgeArtifactSendError("INVALID_INPUT_ARTIFACT_ACK")
+        value = dict(document)
+        value.pop("correlationId", None)
+        artifact_id = value.get("artifact_id")
+        pending = self._pending.get(artifact_id) if isinstance(artifact_id, str) else None
+        if (
+            pending is None or pending.future.done()
+            or pending.binding.principal is not route.principal
+            or pending.binding.connector_sid != route.connector_sid
+            or pending.binding.load_generation_id != route.load_generation_id
+            or route.transport_profile is not PROFILE
+            or not self._current(pending.binding)
+            or value != pending.expected
+        ):
+            raise BrowserBridgeArtifactSendError("INVALID_INPUT_ARTIFACT_ACK")
+        pending.future.set_result(None)
+        return {"contract_version": 1, "status": "accepted"}
+
+    def retire(self, *, principal, connector_sid, load_generation_id) -> None:
+        for binding, task, _size in tuple(self._tasks.values()):
+            if binding.principal is principal and binding.connector_sid == connector_sid and binding.load_generation_id == load_generation_id:
+                task.get_loop().call_soon_threadsafe(task.cancel)
+
+    async def close(self) -> None:
+        self._closed = True
+        tasks = [item[1] for item in self._tasks.values()]
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)

--- a/plugins/_a0_connector/helpers/browser_bridge_artifact_sender.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_artifact_sender.py.dox.md
@@ -1,0 +1,24 @@
+# Core input artifact sender
+
+`BrowserBridgeArtifactSender.send` accepts only server-provided immutable bytes
+and an exact typed input/upload_file binding, never a file path or a client
+artifact claim. It bounds transfers to 25 MiB each, 16 concurrent transfers and
+100 MiB aggregate. Ordered 192 KiB frames each require their exact ACK within
+eight seconds; the whole process-owned transfer expires within two minutes.
+
+ACK reception is installed in the restricted application dispatcher and matches
+the exact principal object, SID, generation, context/session/turn/action/op/artifact,
+phase, byte offset, chunk position and final digest descriptor. Forged, duplicate,
+stale and cross-route ACKs cannot advance the transfer. Send and settlement
+recheck the application authorizer. Caller cancellation does not cancel an
+owned transfer; exact route retirement and owner shutdown do. No auto retry or
+remote upload success is inferred from transport completion.
+
+Application authorization requires the current broker upload operation, exact
+live turn and the server-owned source/site preflight. The caller must await
+`broker.wait_dispatched(ticket)` before staging: successful socket dispatch is
+ordering evidence, not operation completion. Native retains the corresponding
+operation until its exact artifact is complete; the extension independently
+requires one-use site-sharing consent before its concrete file-input effect.
+Transport completion alone never authorizes that effect. Full artifact readiness
+requires this source registry and consumer composition, not output screenshots.

--- a/plugins/_a0_connector/helpers/browser_bridge_artifacts.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_artifacts.py
@@ -1,0 +1,866 @@
+"""Private, bounded artifact receiver for the frozen browser bridge protocol.
+
+The receiver is process-only and inactive without an injected current-route
+authorizer.  It does not reuse the legacy connector chunk assembler, expose
+spool paths, wire Socket.IO events, or advertise browser runtime readiness.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+import hashlib
+import os
+from pathlib import Path
+import re
+import stat
+import tempfile
+import threading
+import time
+from typing import Any, BinaryIO, Callable, Generic, TypeVar
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+    require_transport_principal_identity,
+)
+
+
+CONTRACT_VERSION = 1
+ARTIFACT_CHUNK_EVENT = "connector_browser_artifact_chunk"
+MAX_ARTIFACT_BYTES = 25 * 1024 * 1024
+MAX_CHUNK_BYTES = 192 * 1024
+MAX_IDENTIFIER_BYTES = 256
+MAX_MIME_TYPE_BYTES = 256
+MAX_PURPOSE_BYTES = 128
+DEFAULT_TTL_MS = 120_000
+DEFAULT_TOMBSTONE_TTL_MS = 300_000
+DEFAULT_MAX_ARTIFACTS = 16
+DEFAULT_MAX_TOTAL_SPOOL_BYTES = 100 * 1024 * 1024
+DEFAULT_MAX_TOMBSTONES = 2_048
+HARD_MAX_ARTIFACTS = 128
+HARD_MAX_TOTAL_SPOOL_BYTES = 256 * 1024 * 1024
+HARD_MAX_TOMBSTONES = 8_192
+HARD_MAX_TTL_MS = 10 * 60 * 1_000
+
+ARTIFACT_DIRECTIONS = frozenset({"output", "input"})
+OUTPUT_PURPOSES = frozenset({"screenshot", "download"})
+INPUT_PURPOSES = frozenset({"upload_file"})
+ARTIFACT_PURPOSES = OUTPUT_PURPOSES | INPUT_PURPOSES
+
+_SHA256_RE = re.compile(r"sha256:[0-9a-f]{64}")
+_PURPOSE_RE = re.compile(r"[a-z][a-z0-9._-]{0,127}")
+_MIME_TYPE_RE = re.compile(
+    r"[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}/"
+    r"[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}"
+)
+
+
+class BrowserBridgeArtifactError(RuntimeError):
+    """Typed, redacted artifact failure suitable for a transport abort."""
+
+    def __init__(self, code: str, *, aborted: bool = False) -> None:
+        super().__init__(code)
+        self.code = code
+        self.aborted = aborted
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactBinding:
+    """Every authority and operation dimension for one artifact transfer."""
+
+    principal: WsPrincipal
+    connector_sid: str
+    load_generation_id: str
+    bridge_id: str
+    context_id: str
+    browser_session_id: str
+    turn_id: str
+    action_id: str
+    op_id: str
+    artifact_id: str
+    direction: str
+    purpose: str
+    contract_version: int = CONTRACT_VERSION
+    transport_profile: BrowserBridgeTransportProfile = (
+        PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    )
+
+    def __post_init__(self) -> None:
+        if type(self.contract_version) is not int or self.contract_version != 1:
+            raise BrowserBridgeArtifactError("VERSION_MISMATCH")
+        principal = self.principal
+        try:
+            profile = require_browser_bridge_transport_profile(
+                self.transport_profile
+            )
+            require_transport_principal_identity(principal, profile)
+        except ValueError:
+            raise BrowserBridgeArtifactError("SCOPE_DENIED") from None
+        if "browser.artifact" not in principal.scopes:
+            raise BrowserBridgeArtifactError("SCOPE_DENIED")
+        for field in (
+            "connector_sid",
+            "load_generation_id",
+            "bridge_id",
+            "context_id",
+            "browser_session_id",
+            "turn_id",
+            "action_id",
+            "op_id",
+            "artifact_id",
+        ):
+            _identifier(getattr(self, field))
+        if self.bridge_id != principal.principal_id:
+            raise BrowserBridgeArtifactError("SCOPE_DENIED")
+        if self.direction not in ARTIFACT_DIRECTIONS:
+            raise BrowserBridgeArtifactError("INVALID_DIRECTION")
+        purpose = _bounded_ascii_token(
+            self.purpose,
+            max_bytes=MAX_PURPOSE_BYTES,
+            pattern=_PURPOSE_RE,
+            code="INVALID_PURPOSE",
+        )
+        if purpose not in ARTIFACT_PURPOSES:
+            raise BrowserBridgeArtifactError("INVALID_PURPOSE")
+        if (
+            self.direction == "output"
+            and purpose not in OUTPUT_PURPOSES
+        ) or (
+            self.direction == "input"
+            and purpose not in INPUT_PURPOSES
+        ):
+            raise BrowserBridgeArtifactError("INVALID_PURPOSE")
+        permits_event = (
+            principal.permits_inbound(ARTIFACT_CHUNK_EVENT, principal.handler_id)
+            if self.direction == "output"
+            else principal.permits_outbound(
+                ARTIFACT_CHUNK_EVENT, principal.handler_id
+            )
+        )
+        if not permits_event:
+            raise BrowserBridgeArtifactError("SCOPE_DENIED")
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactProgress:
+    artifact_id: str
+    status: str
+    next_chunk_index: int
+    received_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactDescriptor:
+    """Verified public result metadata. It intentionally has no spool path."""
+
+    artifact_id: str
+    mime_type: str
+    byte_count: int
+    sha256: str
+    purpose: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_id": self.artifact_id,
+            "mime_type": self.mime_type,
+            "byte_count": self.byte_count,
+            "sha256": self.sha256,
+            "purpose": self.purpose,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactCleanupSummary:
+    artifacts: int
+    reserved_bytes: int
+
+
+@dataclass(slots=True)
+class _Transfer:
+    binding: ArtifactBinding
+    byte_count: int
+    sha256: str
+    mime_type: str
+    path: Path
+    writer: BinaryIO | None
+    reader: BinaryIO | None
+    digest: Any
+    received_bytes: int
+    next_chunk_index: int
+    state: str
+    expires_at_ms: int
+    descriptor: ArtifactDescriptor | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _Tombstone:
+    binding: ArtifactBinding
+    status: str
+    expires_at_ms: int
+
+
+T = TypeVar("T")
+CurrentRouteAuthorizer = Callable[[ArtifactBinding], bool]
+ArtifactConsumer = Callable[[BinaryIO, ArtifactDescriptor], T]
+
+
+class BrowserBridgeArtifactReceiver(Generic[T]):
+    """Strict artifact state machine with private single-use spools."""
+
+    def __init__(
+        self,
+        *,
+        spool_parent: str | os.PathLike[str] | None = None,
+        authorizer: CurrentRouteAuthorizer | None = None,
+        clock_ms: Callable[[], int] | None = None,
+        ttl_ms: int = DEFAULT_TTL_MS,
+        tombstone_ttl_ms: int = DEFAULT_TOMBSTONE_TTL_MS,
+        max_artifacts: int = DEFAULT_MAX_ARTIFACTS,
+        max_total_spool_bytes: int = DEFAULT_MAX_TOTAL_SPOOL_BYTES,
+        max_tombstones: int = DEFAULT_MAX_TOMBSTONES,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        _constructor_bound(ttl_ms, 1, HARD_MAX_TTL_MS, "ttl_ms")
+        _constructor_bound(
+            tombstone_ttl_ms, 1, HARD_MAX_TTL_MS, "tombstone_ttl_ms"
+        )
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        _constructor_bound(
+            max_artifacts, 1, HARD_MAX_ARTIFACTS, "max_artifacts"
+        )
+        _constructor_bound(
+            max_total_spool_bytes,
+            1,
+            HARD_MAX_TOTAL_SPOOL_BYTES,
+            "max_total_spool_bytes",
+        )
+        _constructor_bound(
+            max_tombstones, 1, HARD_MAX_TOMBSTONES, "max_tombstones"
+        )
+        parent = None if spool_parent is None else Path(spool_parent)
+        if parent is not None:
+            try:
+                metadata = os.lstat(parent)
+            except OSError:
+                raise ValueError("spool_parent must be an existing directory") from None
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+                raise ValueError("spool_parent must be a non-symlink directory")
+            parent = parent.resolve(strict=True)
+        self._root = Path(
+            tempfile.mkdtemp(prefix="a0-browser-artifacts-", dir=parent)
+        )
+        os.chmod(self._root, 0o700)
+        self._authorizer = authorizer or (lambda _binding: False)
+        self._clock_ms = clock_ms or (lambda: time.monotonic_ns() // 1_000_000)
+        self._ttl_ms = ttl_ms
+        self._tombstone_ttl_ms = tombstone_ttl_ms
+        self._max_artifacts = max_artifacts
+        self._max_total_spool_bytes = max_total_spool_bytes
+        self._max_tombstones = max_tombstones
+        self._transfers: dict[str, _Transfer] = {}
+        self._tombstones: dict[str, _Tombstone] = {}
+        self._tombstone_order: deque[str] = deque()
+        self._reserved_bytes = 0
+        self._closed = False
+        self._lock = threading.RLock()
+
+    @property
+    def active_count(self) -> int:
+        with self._lock:
+            return len(self._transfers)
+
+    @property
+    def transport_profile(self) -> BrowserBridgeTransportProfile:
+        return self._transport_profile
+
+    @property
+    def reserved_bytes(self) -> int:
+        with self._lock:
+            return self._reserved_bytes
+
+    def begin(
+        self,
+        binding: ArtifactBinding,
+        *,
+        byte_count: int,
+        sha256: str,
+        mime_type: str,
+    ) -> ArtifactProgress:
+        binding = self._binding(binding)
+        byte_count = _byte_count(byte_count)
+        sha256 = _sha256(sha256)
+        mime_type = _mime_type(mime_type)
+        with self._lock:
+            now = self._now_locked()
+            self._ensure_open_locked()
+            self._authorize_request_locked(binding, now)
+            tombstone = self._tombstones.get(binding.artifact_id)
+            if tombstone is not None:
+                raise BrowserBridgeArtifactError("ARTIFACT_ID_REUSED")
+            existing = self._transfers.get(binding.artifact_id)
+            if existing is not None:
+                if (
+                    existing.byte_count != byte_count
+                    or existing.sha256 != sha256
+                    or existing.mime_type != mime_type
+                ):
+                    raise BrowserBridgeArtifactError("IDEMPOTENCY_CONFLICT")
+                return self._progress(existing, "duplicate")
+            if len(self._transfers) >= self._max_artifacts:
+                raise BrowserBridgeArtifactError("ARTIFACT_REGISTRY_FULL")
+            if self._reserved_bytes + byte_count > self._max_total_spool_bytes:
+                raise BrowserBridgeArtifactError("ARTIFACT_SPOOL_FULL")
+
+            try:
+                descriptor, raw_path = tempfile.mkstemp(
+                    prefix=".artifact-", suffix=".spool", dir=self._root
+                )
+                os.chmod(raw_path, 0o600)
+                writer = os.fdopen(descriptor, "wb", buffering=0)
+            except Exception:
+                try:
+                    if "descriptor" in locals():
+                        os.close(descriptor)
+                except OSError:
+                    pass
+                try:
+                    if "raw_path" in locals():
+                        os.unlink(raw_path)
+                except OSError:
+                    pass
+                raise BrowserBridgeArtifactError("SPOOL_UNAVAILABLE") from None
+
+            transfer = _Transfer(
+                binding=binding,
+                byte_count=byte_count,
+                sha256=sha256,
+                mime_type=mime_type,
+                path=Path(raw_path),
+                writer=writer,
+                reader=None,
+                digest=hashlib.sha256(),
+                received_bytes=0,
+                next_chunk_index=0,
+                state="receiving",
+                expires_at_ms=now + self._ttl_ms,
+            )
+            self._transfers[binding.artifact_id] = transfer
+            self._reserved_bytes += byte_count
+            return self._progress(transfer, "accepted")
+
+    def append(
+        self,
+        binding: ArtifactBinding,
+        *,
+        chunk_index: int,
+        data: bytes,
+    ) -> ArtifactProgress:
+        binding = self._binding(binding)
+        with self._lock:
+            now = self._now_locked()
+            self._ensure_open_locked()
+            self._authorize_request_locked(binding, now)
+            transfer = self._transfer_locked(binding)
+            if transfer.state != "receiving":
+                raise BrowserBridgeArtifactError("ARTIFACT_ALREADY_COMPLETE")
+            if (
+                type(chunk_index) is not int
+                or chunk_index < 0
+                or chunk_index != transfer.next_chunk_index
+            ):
+                self._abort_locked(transfer, "aborted", now)
+                raise BrowserBridgeArtifactError("CHUNK_OUT_OF_ORDER", aborted=True)
+            if not isinstance(data, bytes) or not data or len(data) > MAX_CHUNK_BYTES:
+                self._abort_locked(transfer, "aborted", now)
+                raise BrowserBridgeArtifactError("CHUNK_SIZE_INVALID", aborted=True)
+            if transfer.received_bytes + len(data) > transfer.byte_count:
+                self._abort_locked(transfer, "aborted", now)
+                raise BrowserBridgeArtifactError("ARTIFACT_SIZE_MISMATCH", aborted=True)
+            try:
+                if transfer.writer is None:
+                    raise OSError("closed writer")
+                written = transfer.writer.write(data)
+                if written != len(data):
+                    raise OSError("short spool write")
+            except Exception:
+                self._abort_locked(transfer, "aborted", now)
+                raise BrowserBridgeArtifactError("SPOOL_UNAVAILABLE", aborted=True) from None
+            transfer.digest.update(data)
+            transfer.received_bytes += len(data)
+            transfer.next_chunk_index += 1
+            return self._progress(transfer, "accepted")
+
+    def complete(self, binding: ArtifactBinding) -> ArtifactDescriptor:
+        binding = self._binding(binding)
+        with self._lock:
+            now = self._now_locked()
+            self._ensure_open_locked()
+            self._authorize_request_locked(binding, now)
+            transfer = self._transfer_locked(binding)
+            if (
+                transfer.state in {"complete", "consuming"}
+                and transfer.descriptor is not None
+            ):
+                return transfer.descriptor
+            actual_digest = f"sha256:{transfer.digest.hexdigest()}"
+            if (
+                transfer.received_bytes != transfer.byte_count
+                or actual_digest != transfer.sha256
+            ):
+                self._abort_locked(transfer, "aborted", now)
+                raise BrowserBridgeArtifactError(
+                    "ARTIFACT_INTEGRITY_MISMATCH", aborted=True
+                )
+            try:
+                if transfer.writer is None:
+                    raise OSError("closed writer")
+                transfer.writer.flush()
+                file_descriptor = transfer.writer.fileno()
+                metadata = os.fstat(file_descriptor)
+                if not stat.S_ISREG(metadata.st_mode):
+                    raise OSError("spool is not a regular file")
+                if metadata.st_size != transfer.byte_count:
+                    self._abort_locked(transfer, "aborted", now)
+                    raise BrowserBridgeArtifactError(
+                        "ARTIFACT_INTEGRITY_MISMATCH", aborted=True
+                    )
+                os.fsync(file_descriptor)
+                transfer.writer.close()
+            except BrowserBridgeArtifactError:
+                raise
+            except Exception:
+                self._abort_locked(transfer, "aborted", now)
+                raise BrowserBridgeArtifactError("SPOOL_UNAVAILABLE", aborted=True) from None
+            transfer.writer = None
+            transfer.state = "complete"
+            transfer.expires_at_ms = now + self._ttl_ms
+            transfer.descriptor = ArtifactDescriptor(
+                artifact_id=binding.artifact_id,
+                mime_type=transfer.mime_type,
+                byte_count=transfer.byte_count,
+                sha256=transfer.sha256,
+                purpose=binding.purpose,
+            )
+            return transfer.descriptor
+
+    def abort(self, binding: ArtifactBinding) -> bool:
+        binding = self._binding(binding)
+        with self._lock:
+            now = self._now_locked()
+            self._ensure_open_locked()
+            self._expire_locked(now)
+            transfer = self._transfers.get(binding.artifact_id)
+            if transfer is None:
+                tombstone = self._tombstones.get(binding.artifact_id)
+                if tombstone is not None and not _same_binding(
+                    tombstone.binding, binding
+                ):
+                    raise BrowserBridgeArtifactError("SCOPE_DENIED")
+                return False
+            if not _same_binding(transfer.binding, binding):
+                raise BrowserBridgeArtifactError("SCOPE_DENIED")
+            self._abort_locked(transfer, "aborted", now)
+            return True
+
+    def consume(
+        self,
+        binding: ArtifactBinding,
+        consumer: ArtifactConsumer[T],
+    ) -> T:
+        binding = self._binding(binding)
+        if not callable(consumer):
+            raise BrowserBridgeArtifactError("INVALID_CONSUMER")
+        with self._lock:
+            now = self._now_locked()
+            self._ensure_open_locked()
+            self._authorize_request_locked(binding, now)
+            transfer = self._transfer_locked(binding)
+            if transfer.state != "complete" or transfer.descriptor is None:
+                raise BrowserBridgeArtifactError("ARTIFACT_NOT_COMPLETE")
+            transfer.state = "consuming"
+            path = transfer.path
+            descriptor = transfer.descriptor
+
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        stream: BinaryIO | None = None
+        file_descriptor: int | None = None
+        exposed = False
+        try:
+            file_descriptor = os.open(path, flags)
+            metadata = os.fstat(file_descriptor)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_size != descriptor.byte_count
+            ):
+                os.close(file_descriptor)
+                file_descriptor = None
+                raise BrowserBridgeArtifactError(
+                    "ARTIFACT_INTEGRITY_MISMATCH", aborted=True
+                )
+            stream = os.fdopen(file_descriptor, "rb", buffering=0)
+            file_descriptor = None
+            with self._lock:
+                self._ensure_open_locked()
+                if self._transfers.get(binding.artifact_id) is not transfer:
+                    raise BrowserBridgeArtifactError("ARTIFACT_TERMINAL")
+                transfer.reader = stream
+                now = self._now_locked()
+                # Opening the private file can race with credential revocation;
+                # authorize again at the final boundary before exposing bytes.
+                self._authorize_request_locked(binding, now)
+                if self._transfers.get(binding.artifact_id) is not transfer:
+                    raise BrowserBridgeArtifactError("ARTIFACT_TERMINAL")
+                exposed = True
+            return consumer(stream, descriptor)
+        except BrowserBridgeArtifactError:
+            raise
+        except Exception:
+            if not exposed:
+                raise BrowserBridgeArtifactError("SPOOL_UNAVAILABLE") from None
+            raise
+        finally:
+            with self._lock:
+                if self._transfers.get(binding.artifact_id) is transfer:
+                    try:
+                        finished_at = self._now_locked()
+                    except BrowserBridgeArtifactError:
+                        finished_at = transfer.expires_at_ms
+                    self._abort_locked(
+                        transfer,
+                        "consumed" if exposed else "aborted",
+                        finished_at,
+                    )
+            if stream is not None:
+                try:
+                    stream.close()
+                except Exception:
+                    pass
+            elif file_descriptor is not None:
+                try:
+                    os.close(file_descriptor)
+                except OSError:
+                    pass
+            _unlink(path)
+
+    def expire(self, now_ms: int | None = None) -> ArtifactCleanupSummary:
+        with self._lock:
+            self._ensure_open_locked()
+            now = self._now_locked() if now_ms is None else _timestamp(now_ms)
+            return self._expire_locked(now)
+
+    def disconnect(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: str,
+        load_generation_id: str,
+    ) -> ArtifactCleanupSummary:
+        _identifier(connector_sid)
+        _identifier(load_generation_id)
+        with self._lock:
+            self._ensure_open_locked()
+            now = self._now_locked()
+            transfers = [
+                transfer
+                for transfer in self._transfers.values()
+                if transfer.binding.principal is principal
+                and transfer.binding.connector_sid == connector_sid
+                and transfer.binding.load_generation_id == load_generation_id
+            ]
+            return self._cleanup_locked(transfers, "disconnected", now)
+
+    def revoke_bridge(
+        self, *, bridge_id: str, key_generation: int
+    ) -> ArtifactCleanupSummary:
+        bridge_id = _identifier(bridge_id)
+        if type(key_generation) is not int or key_generation < 1:
+            raise BrowserBridgeArtifactError("INVALID_KEY_GENERATION")
+        with self._lock:
+            self._ensure_open_locked()
+            now = self._now_locked()
+            transfers = [
+                transfer
+                for transfer in self._transfers.values()
+                if transfer.binding.bridge_id == bridge_id
+                and transfer.binding.principal.key_generation == key_generation
+            ]
+            return self._cleanup_locked(transfers, "revoked", now)
+
+    def close(self) -> ArtifactCleanupSummary:
+        with self._lock:
+            if self._closed:
+                return ArtifactCleanupSummary(0, 0)
+            try:
+                now = self._now_locked()
+            except BrowserBridgeArtifactError:
+                now = 0
+            summary = self._cleanup_locked(
+                list(self._transfers.values()), "closed", now
+            )
+            self._closed = True
+            self._tombstones.clear()
+            self._tombstone_order.clear()
+            try:
+                for child in self._root.iterdir():
+                    metadata = os.lstat(child)
+                    if stat.S_ISREG(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+                        _unlink(child)
+                os.rmdir(self._root)
+            except Exception:
+                # Every known spool has already been unlinked. Cleanup failure
+                # must not resurrect state or leak a host path through errors.
+                pass
+            return summary
+
+    def __enter__(self) -> BrowserBridgeArtifactReceiver[T]:
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        self.close()
+
+    def _binding(self, binding: ArtifactBinding) -> ArtifactBinding:
+        if (
+            not isinstance(binding, ArtifactBinding)
+            or binding.transport_profile is not self._transport_profile
+        ):
+            raise BrowserBridgeArtifactError("INVALID_BINDING")
+        return binding
+
+    def _authorize_locked(
+        self,
+        binding: ArtifactBinding,
+        *,
+        transfer: _Transfer | None = None,
+        now: int | None = None,
+    ) -> None:
+        try:
+            allowed = self._authorizer(binding) is True
+        except Exception:
+            allowed = False
+        if allowed:
+            return
+        if transfer is not None and _same_binding(transfer.binding, binding):
+            self._abort_locked(
+                transfer,
+                "authorization_lost",
+                self._now_locked() if now is None else now,
+            )
+            raise BrowserBridgeArtifactError("SCOPE_DENIED", aborted=True)
+        raise BrowserBridgeArtifactError("SCOPE_DENIED")
+
+    def _authorize_request_locked(
+        self, binding: ArtifactBinding, now: int
+    ) -> None:
+        """Authorize one exact request before observing or advancing its state."""
+
+        transfer = self._transfers.get(binding.artifact_id)
+        if transfer is not None and not _same_binding(transfer.binding, binding):
+            raise BrowserBridgeArtifactError("SCOPE_DENIED")
+        tombstone = self._tombstones.get(binding.artifact_id)
+        if tombstone is not None and not _same_binding(tombstone.binding, binding):
+            raise BrowserBridgeArtifactError("SCOPE_DENIED")
+        self._authorize_locked(binding, transfer=transfer, now=now)
+        self._expire_locked(now)
+
+    def _transfer_locked(self, binding: ArtifactBinding) -> _Transfer:
+        transfer = self._transfers.get(binding.artifact_id)
+        if transfer is None:
+            tombstone = self._tombstones.get(binding.artifact_id)
+            if tombstone is not None:
+                if not _same_binding(tombstone.binding, binding):
+                    raise BrowserBridgeArtifactError("SCOPE_DENIED")
+                raise BrowserBridgeArtifactError("ARTIFACT_TERMINAL")
+            raise BrowserBridgeArtifactError("ARTIFACT_NOT_FOUND")
+        if not _same_binding(transfer.binding, binding):
+            raise BrowserBridgeArtifactError("SCOPE_DENIED")
+        return transfer
+
+    def _abort_locked(self, transfer: _Transfer, status: str, now: int) -> None:
+        current = self._transfers.get(transfer.binding.artifact_id)
+        if current is not transfer:
+            return
+        self._transfers.pop(transfer.binding.artifact_id, None)
+        self._reserved_bytes -= transfer.byte_count
+        if transfer.writer is not None:
+            try:
+                transfer.writer.close()
+            except Exception:
+                pass
+            transfer.writer = None
+        if transfer.reader is not None:
+            try:
+                transfer.reader.close()
+            except Exception:
+                pass
+            transfer.reader = None
+        _unlink(transfer.path)
+        self._remember_locked(transfer.binding, status, now)
+
+    def _cleanup_locked(
+        self, transfers: list[_Transfer], status: str, now: int
+    ) -> ArtifactCleanupSummary:
+        count = 0
+        reserved = 0
+        for transfer in transfers:
+            if self._transfers.get(transfer.binding.artifact_id) is not transfer:
+                continue
+            count += 1
+            reserved += transfer.byte_count
+            self._abort_locked(transfer, status, now)
+        return ArtifactCleanupSummary(count, reserved)
+
+    def _expire_locked(self, now: int) -> ArtifactCleanupSummary:
+        expired = [
+            transfer
+            for transfer in self._transfers.values()
+            if transfer.expires_at_ms <= now
+        ]
+        summary = self._cleanup_locked(expired, "expired", now)
+        self._prune_tombstones_locked(now)
+        return summary
+
+    def _remember_locked(
+        self, binding: ArtifactBinding, status: str, now: int
+    ) -> None:
+        artifact_id = binding.artifact_id
+        if artifact_id not in self._tombstones:
+            self._tombstone_order.append(artifact_id)
+        self._tombstones[artifact_id] = _Tombstone(
+            binding=binding,
+            status=status,
+            expires_at_ms=now + self._tombstone_ttl_ms,
+        )
+        self._prune_tombstones_locked(now)
+        while len(self._tombstone_order) > self._max_tombstones:
+            stale_id = self._tombstone_order.popleft()
+            self._tombstones.pop(stale_id, None)
+
+    def _prune_tombstones_locked(self, now: int) -> None:
+        while self._tombstone_order:
+            artifact_id = self._tombstone_order[0]
+            tombstone = self._tombstones.get(artifact_id)
+            if tombstone is not None and tombstone.expires_at_ms > now:
+                break
+            self._tombstone_order.popleft()
+            self._tombstones.pop(artifact_id, None)
+
+    def _now_locked(self) -> int:
+        try:
+            return _timestamp(self._clock_ms())
+        except Exception:
+            raise BrowserBridgeArtifactError("CLOCK_UNAVAILABLE") from None
+
+    def _ensure_open_locked(self) -> None:
+        if self._closed:
+            raise BrowserBridgeArtifactError("RECEIVER_CLOSED")
+
+    @staticmethod
+    def _progress(transfer: _Transfer, status: str) -> ArtifactProgress:
+        return ArtifactProgress(
+            artifact_id=transfer.binding.artifact_id,
+            status=status,
+            next_chunk_index=transfer.next_chunk_index,
+            received_bytes=transfer.received_bytes,
+        )
+
+
+def _same_binding(left: ArtifactBinding, right: ArtifactBinding) -> bool:
+    return left.principal is right.principal and all(
+        getattr(left, field) == getattr(right, field)
+        for field in (
+            "connector_sid",
+            "load_generation_id",
+            "bridge_id",
+            "context_id",
+            "browser_session_id",
+            "turn_id",
+            "action_id",
+            "op_id",
+            "artifact_id",
+            "direction",
+            "purpose",
+            "contract_version",
+            "transport_profile",
+        )
+    )
+
+
+def _identifier(value: Any) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or len(value.encode("utf-8")) > MAX_IDENTIFIER_BYTES
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+    ):
+        raise BrowserBridgeArtifactError("INVALID_BINDING")
+    return value
+
+
+def _bounded_ascii_token(
+    value: Any,
+    *,
+    max_bytes: int,
+    pattern: re.Pattern[str],
+    code: str,
+) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value.encode("utf-8")) > max_bytes
+        or pattern.fullmatch(value) is None
+    ):
+        raise BrowserBridgeArtifactError(code)
+    return value
+
+
+def _byte_count(value: Any) -> int:
+    if type(value) is not int or not 0 <= value <= MAX_ARTIFACT_BYTES:
+        raise BrowserBridgeArtifactError("ARTIFACT_SIZE_INVALID")
+    return value
+
+
+def _sha256(value: Any) -> str:
+    return _bounded_ascii_token(
+        value,
+        max_bytes=71,
+        pattern=_SHA256_RE,
+        code="ARTIFACT_DIGEST_INVALID",
+    )
+
+
+def _mime_type(value: Any) -> str:
+    return _bounded_ascii_token(
+        value,
+        max_bytes=MAX_MIME_TYPE_BYTES,
+        pattern=_MIME_TYPE_RE,
+        code="ARTIFACT_MIME_INVALID",
+    )
+
+
+def _timestamp(value: Any) -> int:
+    if type(value) is not int or value < 0:
+        raise BrowserBridgeArtifactError("CLOCK_UNAVAILABLE")
+    return value
+
+
+def _constructor_bound(value: Any, minimum: int, maximum: int, field: str) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise ValueError(f"{field} is outside its hard bound")
+    return value
+
+
+def _unlink(path: Path | str) -> None:
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass

--- a/plugins/_a0_connector/helpers/browser_bridge_auth.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_auth.py
@@ -1,0 +1,504 @@
+"""One-time Ed25519 proof foundation for Browser bridge connector sessions.
+
+Challenge material is bounded process memory only. Successful verification
+returns a scoped principal projection; it does not activate a WebSocket handler.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import re
+import secrets
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping
+
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    BROWSER_BRIDGE_TRUST_VERSION,
+    CONNECTOR_PROTOCOL,
+    BrowserBridgePairingError,
+    BrowserBridgePairingUnavailable,
+    get_browser_bridge_pairing_store,
+    normalize_server_base_url,
+    validate_identifier,
+)
+
+
+BRIDGE_CONNECTOR_HANDLER = "plugins/_a0_connector/ws_connector"
+CHALLENGE_TTL_MS = 60 * 1000
+CHALLENGE_NONCE_BYTES = 32
+CHALLENGE_SIGNATURE_BYTES = 64
+MAX_PENDING_CHALLENGES = 256
+CHALLENGE_SOURCE_RATE_WINDOW_MS = 60 * 1000
+CHALLENGE_SOURCE_RATE_MAX = 20
+MAX_CHALLENGE_SOURCE_BUCKETS = 256
+
+_BASE64URL_32_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
+_BASE64URL_64_RE = re.compile(r"^[A-Za-z0-9_-]{86}$")
+_PROOF_KEYS = {
+    "aud",
+    "bridge_id",
+    "challenge_id",
+    "client_nonce",
+    "handler",
+    "protocol",
+    "server_base_url",
+    "server_nonce",
+    "trust_version",
+}
+
+
+class BrowserBridgeAuthError(ValueError):
+    """Internal proof error; public callers must return a generic failure."""
+
+
+class BrowserBridgeChallengeFailed(BrowserBridgeAuthError):
+    pass
+
+
+class BrowserBridgeChallengeUnavailable(BrowserBridgeAuthError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserBridgeChallenge:
+    challenge_id: str
+    server_nonce: str = field(repr=False)
+    server_instance_id: str = field(repr=False)
+    server_base_url: str
+    expires_at_ms: int
+
+    def as_public_dict(self) -> dict[str, Any]:
+        return {
+            "trust_version": BROWSER_BRIDGE_TRUST_VERSION,
+            "challenge_id": self.challenge_id,
+            "server_nonce": self.server_nonce,
+            "server_instance_id": self.server_instance_id,
+            "server_base_url": self.server_base_url,
+            "expires_at_ms": self.expires_at_ms,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserBridgePrincipal:
+    principal_type: str
+    bridge_id: str
+    server_instance_id: str
+    subject_id: str
+    extension_id: str
+    companion_instance_id: str
+    key_generation: int
+    scopes: tuple[str, ...]
+    authenticated_at_ms: int
+
+    def as_security_context_dict(self) -> dict[str, Any]:
+        return {
+            "principal_type": self.principal_type,
+            "bridge_id": self.bridge_id,
+            "server_instance_id": self.server_instance_id,
+            "subject_id": self.subject_id,
+            "extension_id": self.extension_id,
+            "companion_instance_id": self.companion_instance_id,
+            "key_generation": self.key_generation,
+            "scopes": list(self.scopes),
+            "authenticated_at_ms": self.authenticated_at_ms,
+        }
+
+
+@dataclass(slots=True)
+class _PendingChallenge:
+    challenge_id: str
+    bridge_id: str
+    client_nonce: str = field(repr=False)
+    server_nonce: str = field(repr=False)
+    server_instance_id: str = field(repr=False)
+    server_base_url: str
+    created_at_ms: int
+    expires_at_ms: int
+
+
+@dataclass(slots=True)
+class _SourceRate:
+    window_started_at_ms: int
+    attempts: int
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _random_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _base64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _decode_base64url(value: Any, *, size: int) -> bytes:
+    pattern = _BASE64URL_32_RE if size == 32 else _BASE64URL_64_RE
+    if not isinstance(value, str) or pattern.fullmatch(value) is None:
+        raise BrowserBridgeChallengeFailed("bridge authentication failed")
+    try:
+        decoded = base64.b64decode(
+            value + ("=" if size == 32 else "=="),
+            altchars=b"-_",
+            validate=True,
+        )
+    except (binascii.Error, ValueError) as error:
+        raise BrowserBridgeChallengeFailed("bridge authentication failed") from error
+    if len(decoded) != size:
+        raise BrowserBridgeChallengeFailed("bridge authentication failed")
+    return decoded
+
+
+def canonical_proof_bytes(proof: Any) -> bytes:
+    """Return RFC 8785-equivalent bytes for the fixed scalar-only v1 proof."""
+
+    if not isinstance(proof, Mapping) or set(proof) != _PROOF_KEYS:
+        raise BrowserBridgeChallengeFailed("bridge authentication failed")
+    if (
+        type(proof.get("trust_version")) is not int
+        or proof.get("trust_version") != BROWSER_BRIDGE_TRUST_VERSION
+    ):
+        raise BrowserBridgeChallengeFailed("bridge authentication failed")
+    try:
+        for key in {
+            "aud",
+            "bridge_id",
+            "challenge_id",
+            "handler",
+            "protocol",
+        }:
+            validate_identifier(proof.get(key), field_name=key)
+        normalize_server_base_url(proof.get("server_base_url"))
+        _decode_base64url(proof.get("client_nonce"), size=CHALLENGE_NONCE_BYTES)
+        _decode_base64url(proof.get("server_nonce"), size=CHALLENGE_NONCE_BYTES)
+    except BrowserBridgePairingError as error:
+        raise BrowserBridgeChallengeFailed("bridge authentication failed") from error
+    try:
+        return json.dumps(
+            dict(proof),
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    except (TypeError, ValueError, UnicodeError) as error:
+        raise BrowserBridgeChallengeFailed("bridge authentication failed") from error
+
+
+class BrowserBridgeChallengeStore:
+    """Issue and atomically consume bounded one-time connector challenges."""
+
+    def __init__(
+        self,
+        *,
+        record_lookup: Callable[[str, str], dict[str, Any] | None] | None = None,
+        record_authenticated: Callable[[str, int, int], None] | None = None,
+        record_candidates: Callable[[str, str], tuple[dict[str, Any], ...]] | None = None,
+        record_verified: Callable[[dict[str, Any], int], None] | None = None,
+        clock_ms: Callable[[], int] = _now_ms,
+        random_bytes: Callable[[int], bytes] = secrets.token_bytes,
+        id_factory: Callable[[], str] = _random_uuid,
+    ) -> None:
+        self._record_lookup = record_lookup or _active_record
+        self._record_authenticated = record_authenticated or _mark_authenticated
+        if (record_candidates is None) != (record_verified is None):
+            raise TypeError("candidate lookup and verified-key commit must be paired")
+        default_owner = record_lookup is None and record_authenticated is None
+        self._record_candidates = record_candidates or (_authentication_records if default_owner else None)
+        self._record_verified = record_verified or (_accept_verified_key if default_owner else None)
+        self._clock_ms = clock_ms
+        self._random_bytes = random_bytes
+        self._id_factory = id_factory
+        self._pending: dict[str, _PendingChallenge] = {}
+        self._source_rates: dict[str, _SourceRate] = {}
+        self._lock = threading.RLock()
+
+    def issue(
+        self,
+        request: Any,
+        *,
+        source_key: str,
+        server_instance_id: Any,
+        server_base_url: Any,
+    ) -> BrowserBridgeChallenge:
+        now = self._clock_ms()
+        with self._lock:
+            self._expire_locked(now)
+            if not self._allow_source_locked(source_key, now):
+                raise BrowserBridgeChallengeFailed("bridge challenge failed")
+            if not isinstance(request, Mapping) or set(request) != {
+                "trust_version",
+                "bridge_id",
+                "client_nonce",
+            }:
+                raise BrowserBridgeChallengeFailed("bridge challenge failed")
+            if (
+                type(request.get("trust_version")) is not int
+                or request.get("trust_version") != BROWSER_BRIDGE_TRUST_VERSION
+            ):
+                raise BrowserBridgeChallengeFailed("bridge challenge failed")
+            try:
+                bridge_id = validate_identifier(
+                    request.get("bridge_id"),
+                    field_name="bridge_id",
+                )
+                safe_server_id = validate_identifier(
+                    server_instance_id,
+                    field_name="server_instance_id",
+                )
+                safe_base_url = normalize_server_base_url(server_base_url)
+                client_nonce = request.get("client_nonce")
+                _decode_base64url(client_nonce, size=CHALLENGE_NONCE_BYTES)
+                record = self._record_lookup(bridge_id, safe_server_id)
+            except (BrowserBridgePairingError, BrowserBridgePairingUnavailable):
+                raise BrowserBridgeChallengeFailed("bridge challenge failed")
+            except BrowserBridgeChallengeFailed:
+                raise
+            except Exception as error:
+                raise BrowserBridgeChallengeUnavailable(
+                    "bridge challenge unavailable"
+                ) from error
+            if record is None:
+                raise BrowserBridgeChallengeFailed("bridge challenge failed")
+            if len(self._pending) >= MAX_PENDING_CHALLENGES:
+                raise BrowserBridgeChallengeUnavailable("bridge challenge unavailable")
+
+            challenge_id = validate_identifier(
+                self._id_factory(),
+                field_name="challenge_id",
+            )
+            if challenge_id in self._pending:
+                raise BrowserBridgeChallengeUnavailable("challenge identity collision")
+            entropy = self._random_bytes(CHALLENGE_NONCE_BYTES)
+            if not isinstance(entropy, bytes) or len(entropy) != CHALLENGE_NONCE_BYTES:
+                raise BrowserBridgeChallengeUnavailable("secure entropy unavailable")
+            server_nonce = _base64url(entropy)
+            pending = _PendingChallenge(
+                challenge_id=challenge_id,
+                bridge_id=bridge_id,
+                client_nonce=client_nonce,
+                server_nonce=server_nonce,
+                server_instance_id=safe_server_id,
+                server_base_url=safe_base_url,
+                created_at_ms=now,
+                expires_at_ms=now + CHALLENGE_TTL_MS,
+            )
+            self._pending[challenge_id] = pending
+            return BrowserBridgeChallenge(
+                challenge_id=challenge_id,
+                server_nonce=server_nonce,
+                server_instance_id=safe_server_id,
+                server_base_url=safe_base_url,
+                expires_at_ms=pending.expires_at_ms,
+            )
+
+    def verify(self, *, proof: Any, signature: Any) -> BrowserBridgePrincipal:
+        now = self._clock_ms()
+        with self._lock:
+            self._expire_locked(now)
+            if not isinstance(proof, Mapping):
+                raise BrowserBridgeChallengeFailed("bridge authentication failed")
+            raw_challenge_id = proof.get("challenge_id")
+            try:
+                challenge_id = validate_identifier(
+                    raw_challenge_id,
+                    field_name="challenge_id",
+                )
+            except BrowserBridgePairingError as error:
+                raise BrowserBridgeChallengeFailed(
+                    "bridge authentication failed"
+                ) from error
+            pending = self._pending.pop(challenge_id, None)
+            if pending is None:
+                raise BrowserBridgeChallengeFailed("bridge authentication failed")
+
+            try:
+                record = self._record_lookup(
+                    pending.bridge_id,
+                    pending.server_instance_id,
+                )
+                if record is None or not self._matches_pending(proof, pending):
+                    raise BrowserBridgeChallengeFailed("bridge authentication failed")
+                signature_bytes = _decode_base64url(
+                    signature,
+                    size=CHALLENGE_SIGNATURE_BYTES,
+                )
+                candidates = self._record_candidates(pending.bridge_id, pending.server_instance_id) if self._record_candidates else (record,)
+                if not isinstance(candidates, tuple) or not 1 <= len(candidates) <= 2:
+                    raise BrowserBridgeChallengeFailed("bridge authentication failed")
+                message = canonical_proof_bytes(proof)
+                verified = None
+                for candidate in candidates:
+                    if any(candidate.get(k) != record.get(k) for k in ("bridge_id", "server_instance_id", "subject_id", "extension_id", "companion_instance_id", "scopes")):
+                        raise BrowserBridgeChallengeFailed("bridge authentication failed")
+                    try:
+                        _verify_ed25519(_decode_public_key(candidate.get("public_key")), signature_bytes, message)
+                    except BrowserBridgeChallengeFailed:
+                        continue
+                    verified = candidate
+                    break
+                if verified is None:
+                    raise BrowserBridgeChallengeFailed("bridge authentication failed")
+                record = verified
+                authenticated_at_ms = self._clock_ms()
+                if self._record_verified:
+                    self._record_verified(record, authenticated_at_ms)
+                else:
+                    self._record_authenticated(pending.bridge_id, record["key_generation"], authenticated_at_ms)
+            except BrowserBridgeChallengeFailed:
+                raise
+            except Exception as error:
+                raise BrowserBridgeChallengeFailed(
+                    "bridge authentication failed"
+                ) from error
+
+            return BrowserBridgePrincipal(
+                principal_type="browser_bridge",
+                bridge_id=record["bridge_id"],
+                server_instance_id=record["server_instance_id"],
+                subject_id=record["subject_id"],
+                extension_id=record["extension_id"],
+                companion_instance_id=record["companion_instance_id"],
+                key_generation=record["key_generation"],
+                scopes=tuple(record["scopes"]),
+                authenticated_at_ms=authenticated_at_ms,
+            )
+
+    def invalidate_bridge(self, bridge_id: str, server_instance_id: str) -> None:
+        with self._lock:
+            for challenge_id, pending in tuple(self._pending.items()):
+                if pending.bridge_id == bridge_id and pending.server_instance_id == server_instance_id:
+                    self._pending.pop(challenge_id, None)
+
+    @staticmethod
+    def _matches_pending(proof: Mapping[str, Any], pending: _PendingChallenge) -> bool:
+        if set(proof) != _PROOF_KEYS:
+            return False
+        if type(proof.get("trust_version")) is not int:
+            return False
+        try:
+            normalized_base_url = normalize_server_base_url(
+                proof.get("server_base_url")
+            )
+        except BrowserBridgePairingError:
+            return False
+        return (
+            proof.get("trust_version") == BROWSER_BRIDGE_TRUST_VERSION
+            and proof.get("aud") == pending.server_instance_id
+            and proof.get("bridge_id") == pending.bridge_id
+            and proof.get("challenge_id") == pending.challenge_id
+            and proof.get("client_nonce") == pending.client_nonce
+            and proof.get("handler") == BRIDGE_CONNECTOR_HANDLER
+            and proof.get("protocol") == CONNECTOR_PROTOCOL
+            and normalized_base_url == pending.server_base_url
+            and proof.get("server_nonce") == pending.server_nonce
+        )
+
+    def _expire_locked(self, now: int) -> None:
+        for challenge_id, pending in tuple(self._pending.items()):
+            if pending.expires_at_ms <= now:
+                self._pending.pop(challenge_id, None)
+        for source_key, rate in tuple(self._source_rates.items()):
+            if rate.window_started_at_ms + CHALLENGE_SOURCE_RATE_WINDOW_MS <= now:
+                self._source_rates.pop(source_key, None)
+
+    def _allow_source_locked(self, source_key: Any, now: int) -> bool:
+        try:
+            safe_source = validate_identifier(source_key, field_name="source_key")
+        except BrowserBridgePairingError as error:
+            raise BrowserBridgeChallengeFailed("bridge challenge failed") from error
+        rate = self._source_rates.get(safe_source)
+        if (
+            rate is None
+            or rate.window_started_at_ms + CHALLENGE_SOURCE_RATE_WINDOW_MS <= now
+        ):
+            if len(self._source_rates) >= MAX_CHALLENGE_SOURCE_BUCKETS:
+                oldest = min(
+                    self._source_rates,
+                    key=lambda key: self._source_rates[key].window_started_at_ms,
+                )
+                self._source_rates.pop(oldest, None)
+            self._source_rates[safe_source] = _SourceRate(now, 1)
+            return True
+        rate.attempts += 1
+        return rate.attempts <= CHALLENGE_SOURCE_RATE_MAX
+
+
+def _decode_public_key(value: Any) -> bytes:
+    if not isinstance(value, Mapping) or set(value) != {
+        "algorithm",
+        "encoding",
+        "value",
+    }:
+        raise BrowserBridgeChallengeFailed("bridge authentication failed")
+    if value.get("algorithm") != "Ed25519" or value.get("encoding") != "raw-base64url":
+        raise BrowserBridgeChallengeFailed("bridge authentication failed")
+    return _decode_base64url(value.get("value"), size=CHALLENGE_NONCE_BYTES)
+
+
+def _verify_ed25519(public_key: bytes, signature: bytes, message: bytes) -> None:
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PublicKey,
+        )
+    except Exception as error:
+        raise BrowserBridgeChallengeUnavailable(
+            "bridge authentication unavailable"
+        ) from error
+    try:
+        Ed25519PublicKey.from_public_bytes(public_key).verify(signature, message)
+    except InvalidSignature as error:
+        raise BrowserBridgeChallengeFailed("bridge authentication failed") from error
+    except Exception as error:
+        raise BrowserBridgeChallengeUnavailable(
+            "bridge authentication unavailable"
+        ) from error
+
+
+def _active_record(bridge_id: str, server_instance_id: str) -> dict[str, Any] | None:
+    return get_browser_bridge_pairing_store().active_bridge_record(
+        bridge_id=bridge_id,
+        server_instance_id=server_instance_id,
+    )
+
+
+def _authentication_records(bridge_id: str, server_instance_id: str) -> tuple[dict[str, Any], ...]:
+    from plugins._a0_connector.helpers.browser_bridge_credentials import get_browser_bridge_credential_store
+    return get_browser_bridge_credential_store().authentication_records(bridge_id, server_instance_id)
+
+
+def _accept_verified_key(record: dict[str, Any], authenticated_at_ms: int) -> None:
+    from plugins._a0_connector.helpers.browser_bridge_credentials import get_browser_bridge_credential_store
+    get_browser_bridge_credential_store().accept_verified_key(record, authenticated_at_ms)
+
+
+def _mark_authenticated(
+    bridge_id: str,
+    key_generation: int,
+    authenticated_at_ms: int,
+) -> None:
+    get_browser_bridge_pairing_store().mark_bridge_authenticated(
+        bridge_id=bridge_id,
+        key_generation=key_generation,
+        authenticated_at_ms=authenticated_at_ms,
+    )
+
+
+_challenge_store: BrowserBridgeChallengeStore | None = None
+_challenge_store_lock = threading.Lock()
+
+
+def get_browser_bridge_challenge_store() -> BrowserBridgeChallengeStore:
+    global _challenge_store
+    with _challenge_store_lock:
+        if _challenge_store is None:
+            _challenge_store = BrowserBridgeChallengeStore()
+        return _challenge_store

--- a/plugins/_a0_connector/helpers/browser_bridge_bootstrap.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_bootstrap.py
@@ -1,0 +1,192 @@
+"""Explicit process owner for the optional Browser bridge application.
+
+Importing this module does not construct or install a runtime.  The server
+bootstrap must bind one fully composed application; absent that binding,
+authentication remains hello-only and the protected site API remains
+unavailable.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_runtime import (
+    CONNECTOR_PROTOCOL,
+    REQUIRED_INBOUND_EVENTS,
+    REQUIRED_OUTBOUND_EVENTS,
+    BrowserBridgeRuntimeRoute,
+)
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+)
+from plugins._a0_connector.helpers.browser_bridge_site_authority import (
+    bind_browser_bridge_site_authority_repository,
+)
+from plugins._a0_connector.helpers.browser_bridge_action_authority import (
+    bind_browser_bridge_action_authority,
+)
+
+if TYPE_CHECKING:
+    from plugins._a0_connector.helpers.browser_bridge_application import (
+        BrowserBridgeApplication,
+    )
+
+
+_HELLO_INBOUND_EVENTS = frozenset({"connector_hello"})
+_NO_OUTBOUND_EVENTS = frozenset()
+_application: BrowserBridgeApplication | None = None
+_retiring = False
+_lock = threading.RLock()
+
+
+def bind_browser_bridge_application(
+    application: BrowserBridgeApplication | None,
+) -> None:
+    """Install or clear the one explicitly server-owned application."""
+
+    if application is not None:
+        from plugins._a0_connector.helpers.browser_bridge_application import (
+            BrowserBridgeApplication,
+        )
+
+        if not isinstance(application, BrowserBridgeApplication):
+            raise TypeError("invalid Browser bridge application")
+        if not application.installed:
+            raise RuntimeError("Browser bridge application is not installed")
+    global _application
+    with _lock:
+        current = _application
+        if _retiring:
+            raise RuntimeError("Browser bridge application is retiring")
+        if current is not None and application is not None and current is not application:
+            raise RuntimeError("Browser bridge application is already installed")
+        if current is not None and application is None:
+            raise RuntimeError("retire the Browser bridge application explicitly")
+        if application is not None:
+            application.claim_bootstrap_binding()
+        _application = application
+        bind_browser_bridge_site_authority_repository(
+            application.sites if application is not None else None
+        )
+        bind_browser_bridge_action_authority(application.actions if application is not None else None)
+
+
+def get_browser_bridge_application() -> BrowserBridgeApplication | None:
+    with _lock:
+        application = None if _retiring else _application
+        return (
+            application
+            if application is not None and application.installed
+            else None
+        )
+
+
+def browser_bridge_principal_events(
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Freeze event authority according to the application binding at auth."""
+
+    with _lock:
+        if _application is None or _retiring or not _application.installed:
+            return _HELLO_INBOUND_EVENTS, _NO_OUTBOUND_EVENTS
+        return REQUIRED_INBOUND_EVENTS, REQUIRED_OUTBOUND_EVENTS
+
+
+def register_browser_bridge_hello(
+    *,
+    principal: WsPrincipal,
+    connector_sid: str,
+    data: object,
+) -> BrowserBridgeRuntimeRoute | None:
+    """Atomically select the installed owner and register one exact hello."""
+
+    with _lock:
+        application = _application
+        if application is None or _retiring:
+            return None
+        return application.register_hello(
+            principal=principal,
+            connector_sid=connector_sid,
+            data=data,
+        )
+
+
+async def retire_browser_bridge_application(
+    application: BrowserBridgeApplication,
+) -> bool:
+    """Withdraw one exact owner, await its cleanup, then clear API binding."""
+
+    global _application, _retiring
+    with _lock:
+        if _application is not application or _retiring:
+            return False
+        _retiring = True
+    try:
+        await application.close(_bootstrap_retirement=True)
+    finally:
+        with _lock:
+            if _application is application:
+                _application = None
+                bind_browser_bridge_site_authority_repository(None)
+                bind_browser_bridge_action_authority(None)
+            _retiring = False
+    return True
+
+
+def admitted_hello_projection(
+    route: BrowserBridgeRuntimeRoute,
+) -> dict[str, object]:
+    """Return the exact authenticated transport projection for one route."""
+
+    if not isinstance(route, BrowserBridgeRuntimeRoute):
+        raise TypeError("invalid Browser bridge runtime route")
+    principal = route.principal
+    hello = route.hello
+    if (
+        not isinstance(principal, WsPrincipal)
+        or route.transport_profile is not PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        or route.bridge_id != hello.bridge_id
+        or route.load_generation_id != hello.load_generation_id
+    ):
+        raise TypeError("invalid Browser bridge runtime route")
+    return {
+        "protocol": CONNECTOR_PROTOCOL,
+        "principal_type": "browser_bridge",
+        "features": sorted(hello.outer_features),
+        "connector_session_ready": True,
+        "browser_control_ready": True,
+        "activation": route.activation.as_wire_dict(),
+        "connector_binding": {
+            "server_instance_id": route.server_instance_id,
+            "bridge_id": route.bridge_id,
+            "connector_sid": route.connector_sid,
+            "key_generation": principal.key_generation,
+            "load_generation_id": route.load_generation_id,
+        },
+        "host_browser": {
+            "supported": True,
+            "enabled": True,
+            "status": "ready",
+            "backend_id": "chrome_extension",
+            "browser_id": route.browser_id,
+            "browser_label": hello.browser_label,
+            "contract_version": hello.contract_version,
+            "features": ["browser_extension_bridge_v1"],
+            "capabilities": {
+                "actions": sorted(hello.actions),
+                "features": sorted(hello.features),
+                "limits": dict(hello.limits),
+            },
+            "extension": {
+                "version": hello.extension_version,
+                "manifest_version": 3,
+                "load_generation_id": hello.load_generation_id,
+            },
+            "companion": {
+                "version": hello.companion_version,
+                "platform": hello.companion_platform,
+                "arch": hello.companion_arch,
+            },
+        },
+    }

--- a/plugins/_a0_connector/helpers/browser_bridge_context.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_context.py
@@ -1,0 +1,812 @@
+"""Bridge-only context authorization and privacy-preserving log projection.
+
+This module is intentionally separate from the legacy connector event bridge.
+It does not subscribe sockets, send messages, emit events, or activate any
+browser-bridge runtime surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import math
+import re
+import threading
+from typing import Any, Callable, Mapping, Protocol, Sequence
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+    require_transport_principal_identity,
+)
+
+
+MAX_ADVERTISED_CONTEXTS = 64
+MAX_CONTEXT_SUBSCRIPTIONS = 32
+MAX_CONTEXT_PAGE_EVENTS = 50
+MAX_CONTEXT_LABEL_BYTES = 256
+MAX_CONTEXT_TEXT_BYTES = 8 * 1024
+MAX_CONTEXT_IDENTIFIER_BYTES = 256
+MAX_CONTEXT_CURSOR = 2**53 - 1
+
+_NATIVE_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+_MESSAGE_TYPES = {"input": "user", "user": "user", "response": "assistant"}
+_ACTIVITY_TYPES: dict[str, tuple[str, str]] = {
+    "agent": ("assistant_work", "working"),
+    "browser": ("browser", "updated"),
+    "code_exe": ("code", "updated"),
+    "subagent": ("subagent", "updated"),
+    "error": ("status", "failed"),
+    "hint": ("status", "updated"),
+    "info": ("status", "updated"),
+    "progress": ("status", "working"),
+    "tool": ("tool", "updated"),
+    "mcp": ("tool", "updated"),
+    "util": ("status", "updated"),
+    "warning": ("status", "warning"),
+}
+_COMPLETION_STATUSES = frozenset({"completed", "canceled", "failed"})
+
+
+class BrowserBridgeContextError(ValueError):
+    """A context request or source value is invalid."""
+
+
+class BrowserBridgeContextDenied(PermissionError):
+    """The exact bridge route has no authority for the context operation."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+class BrowserBridgeContextUnavailable(RuntimeError):
+    """Current route or read-only context state cannot be established safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserBridgeContextRoute:
+    principal: WsPrincipal
+    connector_sid: str
+    load_generation_id: str
+    transport_profile: BrowserBridgeTransportProfile = (
+        PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    )
+
+    def __post_init__(self) -> None:
+        principal = self.principal
+        try:
+            profile = require_browser_bridge_transport_profile(
+                self.transport_profile
+            )
+            require_transport_principal_identity(principal, profile)
+            if type(principal.key_generation) is not int or principal.key_generation < 1:
+                raise ValueError("invalid key generation")
+        except ValueError:
+            raise BrowserBridgeContextError("invalid bridge principal")
+        _identifier(principal.principal_id, "bridge_id")
+        _identifier(principal.subject_id, "subject_id")
+        _identifier(self.connector_sid, "connector_sid")
+        _native_identifier(self.load_generation_id, "load_generation_id")
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserContextSourceSummary:
+    context_id: str
+    label: str
+    kind: str
+    status: str
+    created_at_ms: int
+    updated_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserContextSourcePage:
+    entries: tuple[Any, ...]
+    last_sequence: int
+    complete: bool
+    history_before: int | None = None
+    has_more_history: bool | None = None
+
+
+class BrowserContextDataSource(Protocol):
+    def list_contexts(
+        self,
+        *,
+        subject_id: str,
+        limit: int,
+    ) -> Sequence[BrowserContextSourceSummary]: ...
+
+    def context_exists(self, *, subject_id: str, context_id: str) -> bool: ...
+
+    def read_context(
+        self,
+        *,
+        subject_id: str,
+        context_id: str,
+        from_sequence: int,
+        history: str | None,
+        history_before: int | None,
+        limit: int,
+    ) -> BrowserContextSourcePage | None: ...
+
+
+@dataclass(slots=True)
+class _RouteState:
+    route: BrowserBridgeContextRoute
+    advertised: frozenset[str]
+    subscribed: set[str]
+
+
+RouteAuthorizer = Callable[[BrowserBridgeContextRoute], bool]
+
+
+class BrowserBridgeContextAccess:
+    """Exact-route context advertisement, subscription, and projection seam."""
+
+    def __init__(
+        self,
+        *,
+        data_source: BrowserContextDataSource | None = None,
+        route_authorizer: RouteAuthorizer | None = None,
+        max_advertised_contexts: int = MAX_ADVERTISED_CONTEXTS,
+        max_subscriptions: int = MAX_CONTEXT_SUBSCRIPTIONS,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        if min(max_advertised_contexts, max_subscriptions) < 1:
+            raise ValueError("context authorization bounds must be positive")
+        self._data_source = data_source or AgentContextDataSource()
+        self._route_authorizer = route_authorizer or (lambda _route: False)
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        self._max_advertised_contexts = max_advertised_contexts
+        self._max_subscriptions = max_subscriptions
+        self._routes: dict[tuple[int, str, str], _RouteState] = {}
+        self._lock = threading.RLock()
+
+    @property
+    def transport_profile(self) -> BrowserBridgeTransportProfile:
+        return self._transport_profile
+
+    def advertise_contexts(
+        self,
+        route: BrowserBridgeContextRoute,
+        *,
+        limit: int = MAX_ADVERTISED_CONTEXTS,
+    ) -> tuple[dict[str, Any], ...]:
+        route = _route(route)
+        limit = _bounded_limit(limit, self._max_advertised_contexts, "context list")
+        self._require_current(route, "context.list")
+        try:
+            source_items = self._data_source.list_contexts(
+                subject_id=route.principal.subject_id,
+                limit=limit,
+            )
+        except Exception as error:
+            raise BrowserBridgeContextUnavailable("context source unavailable") from error
+        self._require_current(route, "context.list")
+        if not isinstance(source_items, Sequence) or isinstance(
+            source_items, (str, bytes, bytearray)
+        ):
+            raise BrowserBridgeContextUnavailable("invalid context source")
+        if len(source_items) > limit:
+            raise BrowserBridgeContextUnavailable("context source exceeded limit")
+        projected = tuple(_project_summary(item) for item in source_items)
+        context_ids = [item["context_id"] for item in projected]
+        if len(set(context_ids)) != len(context_ids):
+            raise BrowserBridgeContextUnavailable("duplicate context source identity")
+        self._require_current(route, "context.list")
+        key = _route_key(route)
+        with self._lock:
+            prior = self._routes.get(key)
+            subscriptions = (
+                prior.subscribed & set(context_ids)
+                if prior is not None and _same_route(prior.route, route)
+                else set()
+            )
+            self._routes[key] = _RouteState(
+                route=route,
+                advertised=frozenset(context_ids),
+                subscribed=subscriptions,
+            )
+        self._require_current(route, "context.list")
+        return projected
+
+    def subscribe(
+        self,
+        route: BrowserBridgeContextRoute,
+        *,
+        context_id: Any,
+    ) -> None:
+        route = _route(route)
+        context_id = _identifier(context_id, "context_id")
+        self._require_current(route, "context.read")
+        self._require_advertised(route, context_id)
+        if not self._context_exists(route, context_id, "context.read"):
+            raise BrowserBridgeContextDenied("CONTEXT_NOT_FOUND")
+        self._require_current(route, "context.read")
+        with self._lock:
+            state = self._state_for_route_locked(route)
+            if context_id not in state.advertised:
+                raise BrowserBridgeContextDenied("CONTEXT_NOT_ADVERTISED")
+            if (
+                context_id not in state.subscribed
+                and len(state.subscribed) >= self._max_subscriptions
+            ):
+                raise BrowserBridgeContextDenied("CONTEXT_SUBSCRIPTION_LIMIT")
+            state.subscribed.add(context_id)
+        self._require_current(route, "context.read")
+
+    def unsubscribe(
+        self,
+        route: BrowserBridgeContextRoute,
+        *,
+        context_id: Any,
+    ) -> None:
+        route = _route(route)
+        context_id = _identifier(context_id, "context_id")
+        self._require_current(route, "context.read")
+        with self._lock:
+            state = self._state_for_route_locked(route)
+            if context_id not in state.advertised:
+                raise BrowserBridgeContextDenied("CONTEXT_NOT_ADVERTISED")
+            state.subscribed.discard(context_id)
+
+    def authorize_message_target(
+        self,
+        route: BrowserBridgeContextRoute,
+        *,
+        context_id: Any,
+    ) -> None:
+        route = _route(route)
+        context_id = _identifier(context_id, "context_id")
+        self._require_current(route, "context.message")
+        self._require_advertised(route, context_id)
+        if not self._context_exists(route, context_id, "context.message"):
+            raise BrowserBridgeContextDenied("CONTEXT_NOT_FOUND")
+        self._require_current(route, "context.message")
+        self._require_advertised(route, context_id)
+
+    def project_snapshot(
+        self,
+        route: BrowserBridgeContextRoute,
+        *,
+        context_id: Any,
+        from_sequence: int = 0,
+        history: str | None = None,
+        history_before: int | None = None,
+        limit: int = MAX_CONTEXT_PAGE_EVENTS,
+    ) -> dict[str, Any]:
+        route = _route(route)
+        context_id = _identifier(context_id, "context_id")
+        from_sequence = _cursor(from_sequence, "from_sequence")
+        history = _history_mode(history)
+        if history_before is not None:
+            history_before = _cursor(history_before, "history_before")
+        limit = _bounded_limit(limit, MAX_CONTEXT_PAGE_EVENTS, "context page")
+        self._require_current(route, "context.read")
+        self._require_subscribed(route, context_id)
+        try:
+            page = self._data_source.read_context(
+                subject_id=route.principal.subject_id,
+                context_id=context_id,
+                from_sequence=from_sequence,
+                history=history,
+                history_before=history_before,
+                limit=limit,
+            )
+        except Exception as error:
+            raise BrowserBridgeContextUnavailable("context source unavailable") from error
+        self._require_current(route, "context.read")
+        self._require_subscribed(route, context_id)
+        if page is None:
+            raise BrowserBridgeContextDenied("CONTEXT_NOT_FOUND")
+        projected_page = _project_page(
+            page,
+            context_id,
+            limit,
+            minimum_cursor=(
+                from_sequence
+                if history is None and history_before is None
+                else None
+            ),
+            require_history_pagination=(
+                history == "tail" or history_before is not None
+            ),
+        )
+        self._require_current(route, "context.read")
+        self._require_subscribed(route, context_id)
+        return projected_page
+
+    def project_event(
+        self,
+        route: BrowserBridgeContextRoute,
+        *,
+        context_id: Any,
+        entry: Any,
+    ) -> dict[str, Any] | None:
+        route = _route(route)
+        context_id = _identifier(context_id, "context_id")
+        self._require_current(route, "context.read")
+        self._require_subscribed(route, context_id)
+        projected = _project_log_entry(entry, context_id)
+        self._require_current(route, "context.read")
+        self._require_subscribed(route, context_id)
+        return projected
+
+    def project_completion(
+        self,
+        route: BrowserBridgeContextRoute,
+        *,
+        context_id: Any,
+        status: Any,
+    ) -> dict[str, str]:
+        route = _route(route)
+        context_id = _identifier(context_id, "context_id")
+        if status not in _COMPLETION_STATUSES:
+            raise BrowserBridgeContextError("invalid completion status")
+        self._require_current(route, "context.read")
+        self._require_subscribed(route, context_id)
+        return {"context_id": context_id, "status": status}
+
+    def disconnect(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: Any,
+        load_generation_id: Any,
+    ) -> bool:
+        if not isinstance(principal, WsPrincipal):
+            raise BrowserBridgeContextError("invalid bridge principal")
+        sid = _identifier(connector_sid, "connector_sid")
+        generation = _native_identifier(load_generation_id, "load_generation_id")
+        key = (id(principal), sid, generation)
+        with self._lock:
+            state = self._routes.get(key)
+            if state is None or state.route.principal is not principal:
+                return False
+            self._routes.pop(key, None)
+            return True
+
+    def _context_exists(
+        self,
+        route: BrowserBridgeContextRoute,
+        context_id: str,
+        scope: str,
+    ) -> bool:
+        try:
+            exists = self._data_source.context_exists(
+                subject_id=route.principal.subject_id,
+                context_id=context_id,
+            )
+        except Exception as error:
+            raise BrowserBridgeContextUnavailable("context source unavailable") from error
+        self._require_current(route, scope)
+        return exists is True
+
+    def _require_current(self, route: BrowserBridgeContextRoute, scope: str) -> None:
+        if (
+            route.transport_profile is not self._transport_profile
+            or scope not in route.principal.scopes
+        ):
+            raise BrowserBridgeContextDenied("SCOPE_DENIED")
+        try:
+            current = self._route_authorizer(route)
+        except Exception:
+            current = False
+        if current is not True:
+            self._drop_route(route)
+            raise BrowserBridgeContextDenied("STALE_BRIDGE_ROUTE")
+
+    def _require_advertised(
+        self,
+        route: BrowserBridgeContextRoute,
+        context_id: str,
+    ) -> None:
+        with self._lock:
+            state = self._state_for_route_locked(route)
+            if context_id not in state.advertised:
+                raise BrowserBridgeContextDenied("CONTEXT_NOT_ADVERTISED")
+
+    def _require_subscribed(
+        self,
+        route: BrowserBridgeContextRoute,
+        context_id: str,
+    ) -> None:
+        with self._lock:
+            state = self._state_for_route_locked(route)
+            if context_id not in state.subscribed:
+                raise BrowserBridgeContextDenied("CONTEXT_NOT_SUBSCRIBED")
+
+    def _state_for_route_locked(
+        self,
+        route: BrowserBridgeContextRoute,
+    ) -> _RouteState:
+        state = self._routes.get(_route_key(route))
+        if state is None or not _same_route(state.route, route):
+            raise BrowserBridgeContextDenied("CONTEXTS_NOT_ADVERTISED")
+        return state
+
+    def _drop_route(self, route: BrowserBridgeContextRoute) -> None:
+        key = _route_key(route)
+        with self._lock:
+            state = self._routes.get(key)
+            if state is not None and _same_route(state.route, route):
+                self._routes.pop(key, None)
+
+
+class AgentContextDataSource:
+    """Read-only adapter over the current in-process AgentContext/log contract."""
+
+    def list_contexts(
+        self,
+        *,
+        subject_id: str,
+        limit: int,
+    ) -> Sequence[BrowserContextSourceSummary]:
+        if subject_id != "single_user":
+            return ()
+        from agent import AgentContext
+
+        contexts = [
+            context for context in AgentContext.all() if _is_visible_context(context)
+        ]
+        contexts.sort(
+            key=lambda context: _datetime_to_ms(getattr(context, "last_message", None)),
+            reverse=True,
+        )
+        return tuple(_source_summary(context) for context in contexts[:limit])
+
+    def context_exists(self, *, subject_id: str, context_id: str) -> bool:
+        if subject_id != "single_user":
+            return False
+        from agent import AgentContext
+
+        return _is_visible_context(AgentContext.get(context_id))
+
+    def read_context(
+        self,
+        *,
+        subject_id: str,
+        context_id: str,
+        from_sequence: int,
+        history: str | None,
+        history_before: int | None,
+        limit: int,
+    ) -> BrowserContextSourcePage | None:
+        if subject_id != "single_user":
+            return None
+        from agent import AgentContext
+
+        context = AgentContext.get(context_id)
+        if not _is_visible_context(context):
+            return None
+        log = getattr(context, "log", None)
+        if log is None or not callable(getattr(log, "output", None)):
+            return None
+        lock = getattr(log, "_lock", None)
+        updates = getattr(log, "updates", None)
+        if isinstance(updates, list):
+            if lock is not None:
+                with lock:
+                    total = len(updates)
+            else:
+                total = len(updates)
+        else:
+            total = int(log.output().end)
+
+        page_history_before: int | None = None
+        has_more_history: bool | None = None
+        if history_before is not None:
+            before = min(history_before, total)
+            start = max(before - limit, 0)
+            end = before
+            page_history_before = start
+            has_more_history = bool(start)
+        elif history == "tail":
+            start = max(total - limit, 0)
+            end = total
+            page_history_before = start
+            has_more_history = bool(start)
+        else:
+            start = min(from_sequence, total)
+            end = min(start + limit, total)
+        output = log.output(start=start, end=end)
+        return BrowserContextSourcePage(
+            entries=tuple(output.items),
+            last_sequence=int(output.end),
+            complete=not bool(context.is_running()),
+            history_before=page_history_before,
+            has_more_history=has_more_history,
+        )
+
+
+def _project_summary(value: Any) -> dict[str, Any]:
+    if not isinstance(value, BrowserContextSourceSummary):
+        raise BrowserBridgeContextUnavailable("invalid context summary")
+    context_id = _identifier(value.context_id, "context_id")
+    label = _truncate_text(value.label, MAX_CONTEXT_LABEL_BYTES)
+    if not label:
+        label = "Untitled task"
+    if value.kind not in {"chat", "task"} or value.status not in {
+        "idle",
+        "running",
+        "paused",
+    }:
+        raise BrowserBridgeContextUnavailable("invalid context summary")
+    created = _timestamp(value.created_at_ms)
+    updated = _timestamp(value.updated_at_ms)
+    if updated < created:
+        raise BrowserBridgeContextUnavailable("invalid context summary")
+    return {
+        "context_id": context_id,
+        "label": label,
+        "kind": value.kind,
+        "status": value.status,
+        "created_at_ms": created,
+        "updated_at_ms": updated,
+    }
+
+
+def _project_page(
+    page: Any,
+    context_id: str,
+    limit: int,
+    *,
+    minimum_cursor: int | None,
+    require_history_pagination: bool,
+) -> dict[str, Any]:
+    if (
+        not isinstance(page, BrowserContextSourcePage)
+        or not isinstance(page.entries, tuple)
+        or len(page.entries) > limit
+        or not isinstance(page.complete, bool)
+    ):
+        raise BrowserBridgeContextUnavailable("invalid context page")
+    last_sequence = _cursor(page.last_sequence, "last_sequence")
+    if (
+        page.entries
+        and minimum_cursor is not None
+        and last_sequence <= minimum_cursor
+    ):
+        raise BrowserBridgeContextUnavailable("context page did not advance")
+    if require_history_pagination and (
+        page.history_before is None or not isinstance(page.has_more_history, bool)
+    ):
+        raise BrowserBridgeContextUnavailable("missing context pagination")
+    result: dict[str, Any] = {
+        "context_id": context_id,
+        "events": [
+            projected
+            for entry in page.entries
+            if (projected := _project_log_entry(entry, context_id)) is not None
+        ],
+        "last_sequence": last_sequence,
+        "complete": page.complete,
+    }
+    if page.history_before is not None or page.has_more_history is not None:
+        if page.history_before is None or not isinstance(page.has_more_history, bool):
+            raise BrowserBridgeContextUnavailable("invalid context pagination")
+        history_before = _cursor(page.history_before, "history_before")
+        if history_before > last_sequence:
+            raise BrowserBridgeContextUnavailable("invalid context pagination")
+        if page.entries and last_sequence <= history_before:
+            raise BrowserBridgeContextUnavailable("context page did not advance")
+        result["history_before"] = history_before
+        result["has_more_history"] = page.has_more_history
+    return result
+
+
+def _project_log_entry(entry: Any, context_id: str) -> dict[str, Any] | None:
+    if not isinstance(entry, Mapping):
+        return None
+    item_no = entry.get("no")
+    if (
+        isinstance(item_no, bool)
+        or not isinstance(item_no, int)
+        or not 0 <= item_no < MAX_CONTEXT_CURSOR
+    ):
+        return None
+    entry_type = entry.get("type")
+    if not isinstance(entry_type, str):
+        return None
+    event: str
+    data: dict[str, str]
+    role = _MESSAGE_TYPES.get(entry_type)
+    if role is not None:
+        text = _truncate_text(entry.get("content"), MAX_CONTEXT_TEXT_BYTES)
+        if not text:
+            return None
+        event = "message"
+        data = {"role": role, "text": text}
+    else:
+        activity = _ACTIVITY_TYPES.get(entry_type)
+        if activity is None:
+            return None
+        event = "activity"
+        data = {"activity": activity[0], "status": activity[1]}
+    projected: dict[str, Any] = {
+        "context_id": context_id,
+        "sequence": item_no + 1,
+        "event": event,
+        "data": data,
+    }
+    timestamp_ms = _source_timestamp_ms(entry.get("timestamp"))
+    if timestamp_ms is not None:
+        projected["timestamp_ms"] = timestamp_ms
+    correlation_id = entry.get("id")
+    try:
+        if correlation_id is not None:
+            projected["correlation_id"] = _native_identifier(
+                correlation_id,
+                "correlation_id",
+            )
+    except BrowserBridgeContextError:
+        pass
+    return projected
+
+
+def _source_summary(context: Any) -> BrowserContextSourceSummary:
+    context_type = getattr(getattr(context, "type", None), "value", "user")
+    if bool(getattr(context, "paused", False)):
+        status = "paused"
+    elif bool(context.is_running()):
+        status = "running"
+    else:
+        status = "idle"
+    return BrowserContextSourceSummary(
+        context_id=str(getattr(context, "id", "")),
+        label=str(getattr(context, "name", "") or "Untitled task"),
+        kind="task" if context_type == "task" else "chat",
+        status=status,
+        created_at_ms=_datetime_to_ms(getattr(context, "created_at", None)),
+        updated_at_ms=_datetime_to_ms(getattr(context, "last_message", None)),
+    )
+
+
+def _is_visible_context(context: Any) -> bool:
+    if context is None:
+        return False
+    return getattr(getattr(context, "type", None), "value", None) != "background"
+
+
+def _datetime_to_ms(value: Any) -> int:
+    if not isinstance(value, datetime):
+        return 0
+    try:
+        timestamp = value.timestamp()
+    except (OSError, OverflowError, ValueError):
+        return 0
+    if not math.isfinite(timestamp) or timestamp < 0:
+        return 0
+    return int(timestamp * 1_000)
+
+
+def _source_timestamp_ms(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if not math.isfinite(value) or value < 0:
+        return None
+    timestamp = int(value * 1_000)
+    return timestamp if timestamp <= MAX_CONTEXT_CURSOR else None
+
+
+def _truncate_text(value: Any, max_bytes: int) -> str:
+    if not isinstance(value, str) or not value:
+        return ""
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeError:
+        return ""
+    if len(encoded) <= max_bytes:
+        return value
+    marker = "\n\n[Text truncated]"
+    budget = max_bytes - len(marker.encode("utf-8"))
+    clipped = encoded[: max(budget, 0)]
+    while clipped:
+        try:
+            return clipped.decode("utf-8") + marker
+        except UnicodeDecodeError:
+            clipped = clipped[:-1]
+    return marker if len(marker.encode("utf-8")) <= max_bytes else ""
+
+
+def _route(value: Any) -> BrowserBridgeContextRoute:
+    if not isinstance(value, BrowserBridgeContextRoute):
+        raise BrowserBridgeContextError("invalid bridge context route")
+    return value
+
+
+def _route_key(route: BrowserBridgeContextRoute) -> tuple[int, str, str]:
+    return id(route.principal), route.connector_sid, route.load_generation_id
+
+
+def _same_route(
+    expected: BrowserBridgeContextRoute,
+    candidate: BrowserBridgeContextRoute,
+) -> bool:
+    return (
+        expected.principal is candidate.principal
+        and expected.connector_sid == candidate.connector_sid
+        and expected.load_generation_id == candidate.load_generation_id
+    )
+
+
+def _identifier(value: Any, field_name: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or not value.isprintable()
+    ):
+        raise BrowserBridgeContextError(f"invalid {field_name}")
+    try:
+        size = len(value.encode("utf-8"))
+    except UnicodeError:
+        raise BrowserBridgeContextError(f"invalid {field_name}") from None
+    if size > MAX_CONTEXT_IDENTIFIER_BYTES:
+        raise BrowserBridgeContextError(f"invalid {field_name}")
+    return value
+
+
+def _native_identifier(value: Any, field_name: str) -> str:
+    value = _identifier(value, field_name)
+    if _NATIVE_IDENTIFIER.fullmatch(value) is None:
+        raise BrowserBridgeContextError(f"invalid {field_name}")
+    return value
+
+
+def _timestamp(value: Any) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= MAX_CONTEXT_CURSOR
+    ):
+        raise BrowserBridgeContextUnavailable("invalid context timestamp")
+    return value
+
+
+def _cursor(value: Any, field_name: str) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= MAX_CONTEXT_CURSOR
+    ):
+        raise BrowserBridgeContextError(f"invalid {field_name}")
+    return value
+
+
+def _bounded_limit(value: Any, maximum: int, subject: str) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 1 <= value <= maximum
+    ):
+        raise BrowserBridgeContextError(f"invalid {subject} limit")
+    return value
+
+
+def _history_mode(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    if value != "tail":
+        raise BrowserBridgeContextError("invalid history mode")
+    return "tail"
+
+
+_access: BrowserBridgeContextAccess | None = None
+_access_lock = threading.Lock()
+
+
+def get_browser_bridge_context_access() -> BrowserBridgeContextAccess:
+    global _access
+    if _access is None:
+        with _access_lock:
+            if _access is None:
+                _access = BrowserBridgeContextAccess()
+    return _access

--- a/plugins/_a0_connector/helpers/browser_bridge_context_controller.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_context_controller.py
@@ -1,0 +1,568 @@
+"""Exact-route controller for the Browser bridge context event surface.
+
+This is a presentation transport only.  Its polling tasks read the existing
+AgentContext projection and may be cancelled independently; they never own,
+cancel, reset, remove, or otherwise alter an AgentContext task.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+import re
+from typing import Any, Callable
+
+from helpers.ws_principal import WsPrincipal, restricted_correlation_id
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    MAX_ADVERTISED_CONTEXTS,
+    MAX_CONTEXT_CURSOR,
+    MAX_CONTEXT_PAGE_EVENTS,
+    BrowserBridgeContextAccess,
+    BrowserBridgeContextRoute,
+)
+from plugins._a0_connector.helpers.browser_bridge_messages import (
+    BrowserBridgeMessageDispatcher,
+)
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+)
+
+
+CONTRACT_VERSION = 1
+WS_NAMESPACE = PRODUCTION_BROWSER_BRIDGE_TRANSPORT.namespace
+RESTRICTED_HANDLER_ID = PRODUCTION_BROWSER_BRIDGE_TRANSPORT.handler_id
+CONTEXT_LIST_EVENT = "connector_context_list"
+CONTEXT_SUBSCRIBE_EVENT = "connector_subscribe_context"
+CONTEXT_UNSUBSCRIBE_EVENT = "connector_unsubscribe_context"
+CONTEXT_SEND_MESSAGE_EVENT = "connector_send_message"
+CONTEXT_SNAPSHOT_EVENT = "connector_context_snapshot"
+CONTEXT_EVENT = "connector_context_event"
+CONTEXT_COMPLETE_EVENT = "connector_context_complete"
+CONTEXT_QUEUE_EVENT = "connector_message_queue_updated"
+
+_INBOUND_EVENTS = frozenset(
+    {
+        CONTEXT_LIST_EVENT,
+        CONTEXT_SUBSCRIBE_EVENT,
+        CONTEXT_UNSUBSCRIBE_EVENT,
+        CONTEXT_SEND_MESSAGE_EVENT,
+    }
+)
+_OUTBOUND_EVENTS = frozenset(
+    {CONTEXT_SNAPSHOT_EVENT, CONTEXT_EVENT, CONTEXT_COMPLETE_EVENT, CONTEXT_QUEUE_EVENT}
+)
+_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+
+MAX_PRESENTATION_STREAMS = 32
+MIN_POLL_INTERVAL_SECONDS = 0.01
+MAX_POLL_INTERVAL_SECONDS = 5.0
+DEFAULT_POLL_INTERVAL_SECONDS = 0.25
+MAX_CANCEL_WAIT_SECONDS = 1.0
+MAX_EMIT_TIMEOUT_SECONDS = 10.0
+DEFAULT_EMIT_TIMEOUT_SECONDS = 5.0
+
+
+class BrowserBridgeContextControllerError(ValueError):
+    """A context controller request or dependency is invalid."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+class BrowserBridgeContextControllerDenied(PermissionError):
+    """The exact current route cannot use the context event surface."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(slots=True)
+class _PresentationStream:
+    route: BrowserBridgeContextRoute
+    context_id: str
+    cursor: int
+    completion_reported: bool
+    task: asyncio.Task[None] | None = None
+    queue_signature: str | None = None
+
+
+RouteAuthorizer = Callable[[BrowserBridgeContextRoute], bool]
+
+
+class BrowserBridgeContextController:
+    """Dispatch strict bridge context requests and own bounded live views."""
+
+    def __init__(
+        self,
+        *,
+        access: BrowserBridgeContextAccess,
+        messages: BrowserBridgeMessageDispatcher,
+        manager: Any,
+        route_authorizer: RouteAuthorizer | None = None,
+        queue_projection: Callable | None = None,
+        max_streams: int = MAX_PRESENTATION_STREAMS,
+        poll_interval_seconds: float = DEFAULT_POLL_INTERVAL_SECONDS,
+        cancel_wait_seconds: float = MAX_CANCEL_WAIT_SECONDS,
+        emit_timeout_seconds: float = DEFAULT_EMIT_TIMEOUT_SECONDS,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        if not isinstance(access, BrowserBridgeContextAccess):
+            raise BrowserBridgeContextControllerError("INVALID_CONTEXT_ACCESS")
+        if not isinstance(messages, BrowserBridgeMessageDispatcher):
+            raise BrowserBridgeContextControllerError("INVALID_MESSAGE_DISPATCHER")
+        if getattr(messages, "_access", None) is not access:
+            raise BrowserBridgeContextControllerError("INVALID_MESSAGE_DISPATCHER")
+        if not callable(getattr(manager, "emit_to", None)):
+            raise BrowserBridgeContextControllerError("INVALID_WEBSOCKET_MANAGER")
+        if isinstance(max_streams, bool) or not 1 <= max_streams <= MAX_PRESENTATION_STREAMS:
+            raise BrowserBridgeContextControllerError("INVALID_STREAM_LIMIT")
+        if (
+            isinstance(poll_interval_seconds, bool)
+            or not isinstance(poll_interval_seconds, (int, float))
+            or not MIN_POLL_INTERVAL_SECONDS
+            <= float(poll_interval_seconds)
+            <= MAX_POLL_INTERVAL_SECONDS
+        ):
+            raise BrowserBridgeContextControllerError("INVALID_POLL_INTERVAL")
+        if (
+            isinstance(cancel_wait_seconds, bool)
+            or not isinstance(cancel_wait_seconds, (int, float))
+            or not 0 < float(cancel_wait_seconds) <= MAX_CANCEL_WAIT_SECONDS
+        ):
+            raise BrowserBridgeContextControllerError("INVALID_CANCEL_WAIT")
+        if (
+            isinstance(emit_timeout_seconds, bool)
+            or not isinstance(emit_timeout_seconds, (int, float))
+            or not 0 < float(emit_timeout_seconds) <= MAX_EMIT_TIMEOUT_SECONDS
+        ):
+            raise BrowserBridgeContextControllerError("INVALID_EMIT_TIMEOUT")
+        self._access = access
+        self._messages = messages
+        self._manager = manager
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        if access.transport_profile is not self._transport_profile:
+            raise BrowserBridgeContextControllerError("INVALID_CONTEXT_ACCESS")
+        if messages.transport_profile is not self._transport_profile:
+            raise BrowserBridgeContextControllerError("INVALID_MESSAGE_DISPATCHER")
+        self._route_authorizer = route_authorizer or (lambda _route: False)
+        self._queue_projection = queue_projection
+        self._max_streams = max_streams
+        self._poll_interval_seconds = float(poll_interval_seconds)
+        self._cancel_wait_seconds = float(cancel_wait_seconds)
+        self._emit_timeout_seconds = float(emit_timeout_seconds)
+        self._streams: dict[
+            tuple[int, str, str, str], _PresentationStream
+        ] = {}
+        # Public lifecycle mutations are serialized.  Pollers never acquire
+        # this lock and instead compare their exact retained stream object.
+        self._dispatch_lock = asyncio.Lock()
+
+    @property
+    def stream_count(self) -> int:
+        return len(self._streams)
+
+    async def dispatch(
+        self,
+        event: str,
+        route: BrowserBridgeContextRoute,
+        document: Any,
+    ) -> dict[str, Any]:
+        if event not in _INBOUND_EVENTS:
+            raise BrowserBridgeContextControllerDenied("EVENT_NOT_ALLOWED")
+        route = _route(route)
+        request = _request_document(document)
+        self._require_current(route)
+        if event == CONTEXT_LIST_EVENT:
+            return await self._list(route, request)
+        if event == CONTEXT_SUBSCRIBE_EVENT:
+            return await self._subscribe(route, request)
+        if event == CONTEXT_UNSUBSCRIBE_EVENT:
+            return await self._unsubscribe(route, request)
+        _exact_keys(
+            request,
+            required={"contract_version", "context_id", "client_message_id", "text"},
+            optional={"artifact_ids", "tab_candidates"},
+        )
+        _contract(request)
+        for name in ("artifact_ids", "tab_candidates"):
+            if name in request:
+                value = request.pop(name)
+                if not isinstance(value, list) or value:
+                    raise BrowserBridgeContextControllerDenied(
+                        "ATTACHMENT_AUTHORITY_UNAVAILABLE"
+                    )
+        # The purpose-built dispatcher owns durable idempotency and performs
+        # its own exact-route check immediately before the log/model effect.
+        return self._messages.send(route, request)
+
+    async def disconnect(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: Any,
+        load_generation_id: Any,
+    ) -> bool:
+        sid = _identifier(connector_sid, "connector_sid")
+        generation = _identifier(load_generation_id, "load_generation_id")
+        if not isinstance(principal, WsPrincipal):
+            raise BrowserBridgeContextControllerError("INVALID_ROUTE")
+        prefix = (id(principal), sid, generation)
+        async with self._dispatch_lock:
+            streams = [
+                self._streams.pop(key)
+                for key in tuple(self._streams)
+                if key[:3] == prefix
+            ]
+            await self._cancel_streams(streams)
+            removed = self._access.disconnect(
+                principal=principal,
+                connector_sid=sid,
+                load_generation_id=generation,
+            )
+        return bool(streams) or removed
+
+    async def _list(
+        self,
+        route: BrowserBridgeContextRoute,
+        request: dict[str, Any],
+    ) -> dict[str, Any]:
+        _exact_keys(
+            request,
+            required={"contract_version"},
+            optional={"limit"},
+        )
+        _contract(request)
+        limit = request.get("limit", MAX_ADVERTISED_CONTEXTS)
+        if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= MAX_ADVERTISED_CONTEXTS:
+            raise BrowserBridgeContextControllerError("INVALID_STATE")
+        async with self._dispatch_lock:
+            contexts = self._access.advertise_contexts(route, limit=limit)
+            advertised = {item["context_id"] for item in contexts}
+            stale = [
+                self._streams.pop(key)
+                for key in tuple(self._streams)
+                if key[:3] == _route_prefix(route) and key[3] not in advertised
+            ]
+            await self._cancel_streams(stale)
+        self._require_current(route)
+        return {"contract_version": CONTRACT_VERSION, "contexts": list(contexts)}
+
+    async def _subscribe(
+        self,
+        route: BrowserBridgeContextRoute,
+        request: dict[str, Any],
+    ) -> dict[str, Any]:
+        _exact_keys(
+            request,
+            required={"contract_version", "context_id"},
+            optional={"from", "history", "history_before"},
+        )
+        _contract(request)
+        context_id = _identifier(request["context_id"], "context_id")
+        from_sequence = _cursor(request.get("from", 0), "from")
+        history = request.get("history")
+        if history is not None and history not in {"tail", "all"}:
+            raise BrowserBridgeContextControllerError("INVALID_STATE")
+        history_before = request.get("history_before")
+        if history_before is not None:
+            history_before = _cursor(history_before, "history_before")
+        key = _stream_key(route, context_id)
+        async with self._dispatch_lock:
+            previous = self._streams.pop(key, None)
+            await self._cancel_streams([previous] if previous is not None else [])
+            if len(self._streams) >= self._max_streams:
+                raise BrowserBridgeContextControllerDenied("CONTEXT_STREAM_LIMIT")
+            subscribed = False
+            try:
+                self._access.subscribe(route, context_id=context_id)
+                subscribed = True
+                snapshot = self._access.project_snapshot(
+                    route,
+                    context_id=context_id,
+                    from_sequence=from_sequence,
+                    history=history,
+                    history_before=history_before,
+                    limit=MAX_CONTEXT_PAGE_EVENTS,
+                )
+                stream = _PresentationStream(
+                    route=route,
+                    context_id=context_id,
+                    cursor=snapshot["last_sequence"],
+                    completion_reported=bool(snapshot["complete"]),
+                )
+                # Register before emission so unsubscribe/disconnect can make
+                # an in-flight frame stale.  Shared emit_to independently pins
+                # the exact ConnectionInfo principal at dispatcher delivery.
+                self._streams[key] = stream
+                await self._emit(route, CONTEXT_SNAPSHOT_EVENT, snapshot)
+                await self._queue_update(stream)
+                if snapshot["complete"]:
+                    completion = self._access.project_completion(
+                        route, context_id=context_id, status="completed"
+                    )
+                    await self._emit(route, CONTEXT_COMPLETE_EVENT, completion)
+                task = asyncio.create_task(
+                    self._poll(stream),
+                    name=f"browser-bridge-context:{context_id}",
+                )
+                stream.task = task
+            except Exception:
+                self._streams.pop(key, None)
+                if subscribed:
+                    try:
+                        self._access.unsubscribe(route, context_id=context_id)
+                    except Exception:
+                        pass
+                raise
+        result: dict[str, Any] = {
+            "contract_version": CONTRACT_VERSION,
+            "context_id": context_id,
+            "subscribed": True,
+            "last_sequence": snapshot["last_sequence"],
+        }
+        if "history_before" in snapshot:
+            result["history_before"] = snapshot["history_before"]
+            result["has_more_history"] = snapshot["has_more_history"]
+        return result
+
+    async def _unsubscribe(
+        self,
+        route: BrowserBridgeContextRoute,
+        request: dict[str, Any],
+    ) -> dict[str, Any]:
+        _exact_keys(request, required={"contract_version", "context_id"})
+        _contract(request)
+        context_id = _identifier(request["context_id"], "context_id")
+        key = _stream_key(route, context_id)
+        async with self._dispatch_lock:
+            stream = self._streams.pop(key, None)
+            await self._cancel_streams([stream] if stream is not None else [])
+            self._access.unsubscribe(route, context_id=context_id)
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "context_id": context_id,
+            "unsubscribed": True,
+        }
+
+    async def _poll(self, stream: _PresentationStream) -> None:
+        key = _stream_key(stream.route, stream.context_id)
+        try:
+            while True:
+                if not self._stream_is_current(key, stream):
+                    return
+                await asyncio.sleep(self._poll_interval_seconds)
+                if not self._stream_is_current(key, stream):
+                    return
+                self._require_current(stream.route)
+                await self._queue_update(stream)
+                snapshot = self._access.project_snapshot(
+                    stream.route,
+                    context_id=stream.context_id,
+                    from_sequence=stream.cursor,
+                    limit=MAX_CONTEXT_PAGE_EVENTS,
+                )
+                if not self._stream_is_current(key, stream):
+                    return
+                prior_cursor = stream.cursor
+                page_cursor = snapshot["last_sequence"]
+                stream.cursor = page_cursor
+                events = snapshot["events"]
+                for index, event in enumerate(events):
+                    if not self._stream_is_current(key, stream):
+                        return
+                    # Do not expose the page-end cursor until the last visible
+                    # event has been delivered.  If transport drops mid-page,
+                    # replay starts from the prior source cursor and stable item
+                    # sequences are safely upserted instead of skipping frames.
+                    event_cursor = (
+                        page_cursor if index == len(events) - 1 else prior_cursor
+                    )
+                    await self._emit(
+                        stream.route,
+                        CONTEXT_EVENT,
+                        {**event, "last_sequence": event_cursor},
+                    )
+                complete = bool(snapshot["complete"])
+                if complete and (not stream.completion_reported or bool(events)):
+                    if not self._stream_is_current(key, stream):
+                        return
+                    completion = self._access.project_completion(
+                        stream.route,
+                        context_id=stream.context_id,
+                        status="completed",
+                    )
+                    await self._emit(
+                        stream.route, CONTEXT_COMPLETE_EVENT, completion
+                    )
+                stream.completion_reported = complete
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Source/route/transport loss terminates only this presentation
+            # reader.  Raw source or transport errors are never reflected.
+            return
+        finally:
+            if self._streams.get(key) is stream:
+                self._streams.pop(key, None)
+                try:
+                    self._access.unsubscribe(
+                        stream.route, context_id=stream.context_id
+                    )
+                except Exception:
+                    pass
+
+    async def _queue_update(self, stream: _PresentationStream) -> None:
+        if self._queue_projection is None:
+            return
+        self._require_current(stream.route)
+        payload = self._queue_projection(stream.route, stream.context_id)
+        if not isinstance(payload, dict) or set(payload) != {"contract_version", "context_id", "message_queue"}:
+            raise BrowserBridgeContextControllerError("INVALID_QUEUE_PROJECTION")
+        items = payload["message_queue"]
+        if type(payload["contract_version"]) is not int or payload["contract_version"] != 1 or payload["context_id"] != stream.context_id or not isinstance(items, list) or len(items) > 32:
+            raise BrowserBridgeContextControllerError("INVALID_QUEUE_PROJECTION")
+        identifiers = set()
+        for item in items:
+            if not isinstance(item, dict) or set(item) != {"id", "text", "attachments", "attachment_count"}:
+                raise BrowserBridgeContextControllerError("INVALID_QUEUE_PROJECTION")
+            item_id = _identifier(item["id"], "item_id")
+            if item_id in identifiers or not isinstance(item["text"], str) or len(item["text"]) > 100 or item["attachments"] != [] or type(item["attachment_count"]) is not int or item["attachment_count"] != 0:
+                raise BrowserBridgeContextControllerError("INVALID_QUEUE_PROJECTION")
+            identifiers.add(item_id)
+        signature = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        self._require_current(stream.route)
+        if signature == stream.queue_signature:
+            return
+        await self._emit(stream.route, CONTEXT_QUEUE_EVENT, payload)
+        stream.queue_signature = signature
+
+    async def _emit(
+        self,
+        route: BrowserBridgeContextRoute,
+        event: str,
+        payload: dict[str, Any],
+    ) -> None:
+        if event not in _OUTBOUND_EVENTS:
+            raise BrowserBridgeContextControllerDenied("EVENT_NOT_ALLOWED")
+        self._require_current(route)
+        data = {"contract_version": CONTRACT_VERSION, **payload}
+        await asyncio.wait_for(
+            self._manager.emit_to(
+                self._transport_profile.namespace,
+                route.connector_sid,
+                event,
+                data,
+                handler_id=self._transport_profile.handler_id,
+                correlation_id=restricted_correlation_id(None),
+                expected_principal=route.principal,
+            ),
+            timeout=self._emit_timeout_seconds,
+        )
+        self._require_current(route)
+
+    async def _cancel_streams(
+        self, streams: list[_PresentationStream]
+    ) -> None:
+        tasks = [stream.task for stream in streams if stream.task is not None]
+        for task in tasks:
+            task.cancel()
+        if not tasks:
+            return
+        done, _pending = await asyncio.wait(
+            tasks, timeout=self._cancel_wait_seconds
+        )
+        # Retrieve terminal exceptions without waiting on a cancellation-hostile
+        # dependency.  Removed stream identities prevent any future emission.
+        for task in done:
+            try:
+                task.exception()
+            except asyncio.CancelledError:
+                pass
+
+    def _stream_is_current(
+        self,
+        key: tuple[int, str, str, str],
+        stream: _PresentationStream,
+    ) -> bool:
+        return self._streams.get(key) is stream and self._is_current(stream.route)
+
+    def _require_current(self, route: BrowserBridgeContextRoute) -> None:
+        if not self._is_current(route):
+            raise BrowserBridgeContextControllerDenied("STALE_BRIDGE_ROUTE")
+
+    def _is_current(self, route: BrowserBridgeContextRoute) -> bool:
+        if route.transport_profile is not self._transport_profile:
+            return False
+        try:
+            return self._route_authorizer(route) is True
+        except Exception:
+            return False
+
+
+def _request_document(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise BrowserBridgeContextControllerError("INVALID_STATE")
+    result = dict(value)
+    # WsManager injects this already-sanitized envelope value into handler data;
+    # it is transport metadata and never part of a native method document.
+    result.pop("correlationId", None)
+    return result
+
+
+def _exact_keys(
+    value: dict[str, Any],
+    *,
+    required: set[str],
+    optional: set[str] | None = None,
+) -> None:
+    optional = optional or set()
+    keys = set(value)
+    if not required <= keys or not keys <= required | optional:
+        raise BrowserBridgeContextControllerError("INVALID_STATE")
+
+
+def _contract(value: dict[str, Any]) -> None:
+    version = value.get("contract_version")
+    if isinstance(version, bool) or not isinstance(version, int) or version != CONTRACT_VERSION:
+        raise BrowserBridgeContextControllerError("INVALID_STATE")
+
+
+def _route(value: Any) -> BrowserBridgeContextRoute:
+    if not isinstance(value, BrowserBridgeContextRoute):
+        raise BrowserBridgeContextControllerError("INVALID_ROUTE")
+    return value
+
+
+def _identifier(value: Any, name: str) -> str:
+    if not isinstance(value, str) or _IDENTIFIER.fullmatch(value) is None:
+        raise BrowserBridgeContextControllerError(f"INVALID_{name.upper()}")
+    return value
+
+
+def _cursor(value: Any, name: str) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= MAX_CONTEXT_CURSOR
+    ):
+        raise BrowserBridgeContextControllerError(f"INVALID_{name.upper()}")
+    return value
+
+
+def _route_prefix(route: BrowserBridgeContextRoute) -> tuple[int, str, str]:
+    return (id(route.principal), route.connector_sid, route.load_generation_id)
+
+
+def _stream_key(
+    route: BrowserBridgeContextRoute, context_id: str
+) -> tuple[int, str, str, str]:
+    return (*_route_prefix(route), context_id)

--- a/plugins/_a0_connector/helpers/browser_bridge_credential_control.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_credential_control.py
@@ -1,0 +1,81 @@
+"""Strict, production-only credential controls for the proven current bridge."""
+import asyncio
+
+from plugins._a0_connector.helpers.browser_bridge_context_controller import _request_document, _exact_keys, _contract, _identifier
+from plugins._a0_connector.helpers.browser_bridge_credentials import get_browser_bridge_credential_store
+from plugins._a0_connector.helpers.browser_bridge_runtime import BrowserBridgeRuntimeDenied
+from plugins._a0_connector.helpers.browser_bridge_transport import PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+
+
+class BrowserBridgeCredentialController:
+    def __init__(self, *, manager, current, server_instance_id, retire_bridge, credentials=None):
+        self.manager, self.current = manager, current
+        self.server_instance_id, self.retire_bridge = server_instance_id, retire_bridge
+        self.credentials = credentials or get_browser_bridge_credential_store()
+        self._tasks = set()
+
+    async def dispatch(self, route, document):
+        request = _request_document(document)
+        action = request.get("action")
+        extra = {"rotation_id", "public_key"} if action == "rotate" else {"rotation_id"} if action == "status" else set()
+        _exact_keys(request, required={"contract_version", "action"} | extra)
+        _contract(request)
+        principal = route.principal
+        if (action not in {"rotate", "status", "revoke"}
+            or route.transport_profile is not PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+            or principal.principal_type != "browser_bridge"
+            or "bridge.connect" not in principal.scopes or not self.current(route)):
+            raise BrowserBridgeRuntimeDenied("SCOPE_DENIED")
+        identity = dict(bridge_id=principal.principal_id, server_id=self.server_instance_id(),
+                        subject_id=principal.subject_id, key_generation=principal.key_generation)
+        if action in {"rotate", "status"}:
+            rotation_id = _identifier(request["rotation_id"], "rotation_id")
+            if action == "rotate":
+                result = self.credentials.begin(**identity, rotation_id=rotation_id, public_key=request["public_key"])
+            else:
+                result = self.credentials.status(**identity, rotation_id=rotation_id)
+            if not self.current(route):
+                raise BrowserBridgeRuntimeDenied("RUNTIME_NOT_ADMITTED")
+            return {"action": action, **result}
+        # Durable denial precedes all network awaits. Cancellation may not undo
+        # revocation or cancel process-owned negative session cleanup.
+        revoked = self.credentials.self_revoke(**identity)
+        if revoked is None:
+            raise BrowserBridgeRuntimeDenied("RUNTIME_NOT_ADMITTED")
+        from plugins._a0_connector.helpers.browser_bridge_auth import get_browser_bridge_challenge_store
+        get_browser_bridge_challenge_store().invalidate_bridge(identity["bridge_id"], identity["server_id"])
+        self.retire_bridge(identity["bridge_id"])
+        result = {"contract_version": 1, "action": "revoke", "rotation_id": None,
+                  "key_generation": principal.key_generation, "status": "revoked", "expires_at_ms": None}
+        task = asyncio.create_task(self._notify_and_disconnect(route, result))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        await asyncio.shield(task)
+        return result
+
+    async def _notify_and_disconnect(self, route, result):
+        profile = PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        try:
+            await asyncio.wait_for(self.manager.emit_to(profile.namespace, route.connector_sid,
+                "connector_bridge_credential_status", result, handler_id=profile.handler_id,
+                expected_principal=route.principal), timeout=5)
+        except Exception:
+            pass  # Durable denial already exists; notification is not a success prerequisite.
+        with self.manager.lock:
+            targets = [(namespace, sid, info.principal) for (namespace, sid), info in self.manager.connections.items()
+                       if info.principal is not None and info.principal.principal_type == "browser_bridge"
+                       and info.principal.principal_id == route.principal.principal_id
+                       and info.principal.subject_id == route.principal.subject_id]
+        for namespace, sid, principal in targets:
+            with self.manager.lock:
+                current = self.manager.connections.get((namespace, sid))
+                if current is None or current.principal is not principal:
+                    continue
+            try:
+                await asyncio.wait_for(self.manager.socketio.disconnect(sid, namespace=namespace), timeout=5)
+            except Exception:
+                pass
+
+    async def close(self):
+        if self._tasks:
+            await asyncio.gather(*tuple(self._tasks), return_exceptions=True)

--- a/plugins/_a0_connector/helpers/browser_bridge_credential_control.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_credential_control.py.dox.md
@@ -1,0 +1,15 @@
+# Scoped credential controls
+
+Own the production-only connector_bridge_credential_control dispatch. Exact v1
+requests are rotate (rotation_id plus public_key), status (rotation_id), and
+revoke (no further fields). Derive bridge, generation and subject from the exact
+currently admitted principal. Never accept a caller-selected bridge or scopes.
+Replies contain only contract_version, action, rotation_id, key_generation,
+status and expires_at_ms. They contain no keys or credential material.
+
+Self-revocation durably denies the record and pending generations, invalidates
+outstanding challenges and withdraws route authority before network cleanup.
+One retained task sends a bounded authenticated negative status and disconnects
+only still-identical restricted sessions of that bridge/subject. Cancellation
+cannot resurrect authority or cancel cleanup. Notification loss does not undo
+revocation. No claimed or uncertain Chrome tab is closed by this controller.

--- a/plugins/_a0_connector/helpers/browser_bridge_credentials.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_credentials.py
@@ -1,0 +1,141 @@
+"""Production public-key rotation; the pairing store owns the atomic lock/write."""
+from __future__ import annotations
+
+from typing import Any
+
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    BROWSER_BRIDGE_RECORD_SCHEMA_VERSION, BrowserBridgePairingUnavailable,
+    BrowserBridgePairingStore, _public_key, validate_identifier,
+    get_browser_bridge_pairing_store,
+)
+
+ROTATION_TTL_MS = 600_000
+
+
+def validate_rotation(value: Any, record: dict) -> dict:
+    keys = {"rotation_id", "from_generation", "public_key", "created_at_ms", "expires_at_ms", "status"}
+    if not isinstance(value, dict) or set(value) != keys or record["state"] != "active":
+        raise BrowserBridgePairingUnavailable("invalid credential rotation")
+    if (type(value["from_generation"]) is not int or not 1 <= value["from_generation"] < 2_147_483_647
+        or type(value["created_at_ms"]) is not int or value["created_at_ms"] < 0
+        or type(value["expires_at_ms"]) is not int
+        or value["expires_at_ms"] != value["created_at_ms"] + ROTATION_TTL_MS
+        or value["status"] not in {"pending", "active"}):
+        raise BrowserBridgePairingUnavailable("invalid credential rotation")
+    result = dict(value)
+    result["rotation_id"] = validate_identifier(value["rotation_id"], field_name="rotation_id")
+    result["public_key"] = _public_key(value["public_key"])
+    offset = 1 if value["status"] == "active" else 0
+    if (record["key_generation"] != value["from_generation"] + offset
+        or (result["public_key"] == record["public_key"]) != (offset == 1)):
+        raise BrowserBridgePairingUnavailable("invalid credential rotation")
+    return result
+
+
+class BrowserBridgeCredentialStore:
+    def __init__(self, pairing: BrowserBridgePairingStore):
+        if not isinstance(pairing, BrowserBridgePairingStore):
+            raise TypeError("pairing owner required")
+        self.pairing = pairing
+
+    def _write(self, records: list[dict]) -> None:
+        self.pairing._repository._save({"schema_version": BROWSER_BRIDGE_RECORD_SCHEMA_VERSION, "bridges": records})
+
+    @staticmethod
+    def _match(record, bridge_id, server_id, subject_id=None):
+        return (record["bridge_id"] == bridge_id and record["server_instance_id"] == server_id
+                and record["state"] == "active" and (subject_id is None or record["subject_id"] == subject_id))
+
+    def begin(self, *, bridge_id: str, server_id: str, subject_id: str,
+              key_generation: int, rotation_id: str, public_key: Any) -> dict:
+        rotation_id = validate_identifier(rotation_id, field_name="rotation_id")
+        public_key = _public_key(public_key)
+        with self.pairing._lock:
+            now = self.pairing._clock_ms()
+            records = self.pairing._repository._validated_records()
+            record = next((r for r in records if self._match(r, bridge_id, server_id, subject_id)), None)
+            if record is None or record["key_generation"] != key_generation:
+                raise BrowserBridgePairingUnavailable("credential authority changed")
+            previous = record.get("rotation")
+            if previous and previous["rotation_id"] == rotation_id:
+                if previous["public_key"] != public_key:
+                    raise BrowserBridgePairingUnavailable("rotation conflict")
+                return self._status(record, previous, now)
+            if (record["public_key"] == public_key or key_generation >= 2_147_483_647
+                or (previous and previous["status"] == "pending" and now < previous["expires_at_ms"])):
+                raise BrowserBridgePairingUnavailable("rotation conflict")
+            record["rotation"] = {"rotation_id": rotation_id, "from_generation": key_generation,
+                "public_key": public_key, "created_at_ms": now,
+                "expires_at_ms": now + ROTATION_TTL_MS, "status": "pending"}
+            validate_rotation(record["rotation"], record)
+            self._write(records)
+            return self._status(record, record["rotation"], now)
+
+    def status(self, *, bridge_id, server_id, subject_id, key_generation, rotation_id):
+        with self.pairing._lock:
+            record = self.pairing._repository.active_record(bridge_id=bridge_id, server_instance_id=server_id)
+            if not record or record["subject_id"] != subject_id or record["key_generation"] != key_generation:
+                raise BrowserBridgePairingUnavailable("credential authority changed")
+            rotation = record.get("rotation")
+            if rotation is None or rotation["rotation_id"] != rotation_id:
+                raise BrowserBridgePairingUnavailable("unknown rotation")
+            return self._status(record, rotation, self.pairing._clock_ms())
+
+    @staticmethod
+    def _status(record, rotation, now):
+        status = rotation["status"]
+        if status == "pending" and now >= rotation["expires_at_ms"]:
+            status = "expired"
+        return {"contract_version": 1, "rotation_id": rotation["rotation_id"],
+                "key_generation": record["key_generation"], "status": status,
+                "expires_at_ms": rotation["expires_at_ms"] if status == "pending" else None}
+
+    def self_revoke(self, *, bridge_id, server_id, subject_id, key_generation):
+        with self.pairing._lock:
+            record = self.pairing._repository.active_record(bridge_id=bridge_id, server_instance_id=server_id)
+            if not record or record["subject_id"] != subject_id or record["key_generation"] != key_generation:
+                raise BrowserBridgePairingUnavailable("credential authority changed")
+            return self.pairing._repository.revoke(bridge_id=bridge_id, server_instance_id=server_id,
+                subject_id=subject_id, revoked_at_ms=self.pairing._clock_ms())
+
+    def authentication_records(self, bridge_id: str, server_id: str) -> tuple[dict, ...]:
+        with self.pairing._lock:
+            record = self.pairing._repository.active_record(bridge_id=bridge_id, server_instance_id=server_id)
+            if not record:
+                return ()
+            rotation = record.get("rotation")
+            if rotation and rotation["status"] == "pending" and self.pairing._clock_ms() < rotation["expires_at_ms"]:
+                candidate = dict(record)
+                candidate["key_generation"] += 1
+                candidate["public_key"] = dict(rotation["public_key"])
+                return (record, candidate)
+            return (record,)
+
+    def accept_verified_key(self, verified: dict, authenticated_at_ms: int) -> None:
+        """CAS exact verified public key, not merely generation (pending-key ABA)."""
+        with self.pairing._lock:
+            now = self.pairing._clock_ms()
+            records = self.pairing._repository._validated_records()
+            record = next((r for r in records if self._match(r, verified["bridge_id"],
+                           verified["server_instance_id"], verified["subject_id"])), None)
+            if (record is None or type(authenticated_at_ms) is not int or authenticated_at_ms < 0
+                or any(record[k] != verified[k] for k in ("extension_id", "companion_instance_id", "scopes"))):
+                raise BrowserBridgePairingUnavailable("credential authority changed")
+            if record["key_generation"] == verified["key_generation"] and record["public_key"] == verified["public_key"]:
+                record["last_authenticated_at_ms"] = authenticated_at_ms
+            else:
+                rotation = record.get("rotation")
+                if (not rotation or rotation["status"] != "pending" or now >= rotation["expires_at_ms"]
+                    or verified["key_generation"] != record["key_generation"] + 1
+                    or verified["public_key"] != rotation["public_key"]
+                    or verified.get("rotation", {}).get("rotation_id") != rotation["rotation_id"]):
+                    raise BrowserBridgePairingUnavailable("credential authority changed")
+                record["key_generation"] = verified["key_generation"]
+                record["public_key"] = dict(verified["public_key"])
+                record["last_authenticated_at_ms"] = authenticated_at_ms
+                record["rotation"] = {**rotation, "status": "active"}
+            self._write(records)
+
+
+def get_browser_bridge_credential_store() -> BrowserBridgeCredentialStore:
+    return BrowserBridgeCredentialStore(get_browser_bridge_pairing_store())

--- a/plugins/_a0_connector/helpers/browser_bridge_credentials.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_credentials.py.dox.md
@@ -1,0 +1,21 @@
+# Browser credential rotation
+
+The pairing repository and its existing RLock own every read-modify-write.
+Persist only one optional strict public-key rotation record beside the active
+credential. Requests cannot change subject, extension, bridge, installation or
+scopes. Ten-minute pending generations never replace the active key until a
+fresh one-use challenge has verified the exact new public key. Authentication
+tries at most the active and live pending key; the verified-key commit compares
+public key, rotation ID, generation and immutable identity under the same lock,
+preventing pending-generation ABA. Failed proofs, expiry or persistence retain
+the previous key. A successful commit invalidates old-key admission immediately;
+old work may end uncertain and is never replayed. Revocation clears pending keys.
+Only public records survive restart. This helper never generates private keys.
+
+Existing version-1 records without rotation remain readable. Generations are
+strict positive bounded integers, not booleans. Unknown optional fields fail.
+The extension/native companion still needs its own interruption-safe private-key
+staging and new authenticated session before local old-key deletion.
+
+Verification: tests/test_browser_bridge_credentials.py uses actual Ed25519
+signatures with synthetic records and clock; no live credentials or model calls.

--- a/plugins/_a0_connector/helpers/browser_bridge_cutover.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_cutover.py
@@ -1,0 +1,550 @@
+"""Versioned, read-only legacy Chrome bridge cutover primitives.
+
+This foundation module deliberately detects and describes legacy installations
+without importing their state or performing migration side effects. Runtime
+quarantine, draining, persistence, pairing, and browser actions belong to later
+vertical slices.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Iterable, Mapping
+
+
+CUTOVER_CONTRACT = "a0.browser-bridge.cutover.v1"
+CUTOVER_SCHEMA_VERSION = 1
+LEGACY_PLUGIN_NAME = "chrome_extension"
+LEGACY_PLUGIN_VERSION = "1.0.0"
+MINIMUM_STRUCTURAL_MARKERS = 2
+MAX_FINGERPRINT_FILE_BYTES = 64 * 1024
+
+
+class LegacyDetectionState(str, Enum):
+    """Safe public classification for a possible prototype installation."""
+
+    ABSENT = "absent"
+    PARTIAL = "partial"
+    UNKNOWN = "unknown"
+    CONFIRMED = "confirmed"
+
+
+class CutoverState(str, Enum):
+    """Server/operator states frozen by ``a0.browser-bridge.cutover.v1``."""
+
+    NOT_DETECTED = "not_detected"
+    LEGACY_DETECTED = "legacy_detected"
+    V1_PAIRED_INACTIVE = "v1_paired_inactive"
+    DRAINING_LEGACY = "draining_legacy"
+    LEGACY_DISABLED = "legacy_disabled"
+    LEGACY_LOCAL_PURGE_REQUIRED = "legacy_local_purge_required"
+    READY_TO_ACTIVATE = "ready_to_activate"
+    VERIFYING = "verifying"
+    COMPLETE = "complete"
+    BLOCKED = "blocked"
+    CANCELED = "canceled"
+
+
+_NORMAL_TRANSITIONS: Mapping[CutoverState, frozenset[CutoverState]] = MappingProxyType(
+    {
+        CutoverState.NOT_DETECTED: frozenset({CutoverState.LEGACY_DETECTED}),
+        CutoverState.LEGACY_DETECTED: frozenset({CutoverState.V1_PAIRED_INACTIVE}),
+        CutoverState.V1_PAIRED_INACTIVE: frozenset({CutoverState.DRAINING_LEGACY}),
+        CutoverState.DRAINING_LEGACY: frozenset({CutoverState.LEGACY_DISABLED}),
+        CutoverState.LEGACY_DISABLED: frozenset(
+            {
+                CutoverState.LEGACY_LOCAL_PURGE_REQUIRED,
+                CutoverState.READY_TO_ACTIVATE,
+            }
+        ),
+        CutoverState.LEGACY_LOCAL_PURGE_REQUIRED: frozenset(
+            {CutoverState.READY_TO_ACTIVATE}
+        ),
+        CutoverState.READY_TO_ACTIVATE: frozenset({CutoverState.VERIFYING}),
+        CutoverState.VERIFYING: frozenset({CutoverState.COMPLETE}),
+        CutoverState.COMPLETE: frozenset(),
+        CutoverState.BLOCKED: frozenset(),
+        CutoverState.CANCELED: frozenset(),
+    }
+)
+
+
+@dataclass(frozen=True)
+class LegacyBridgeDetection:
+    """Redacted result of structurally fingerprinting a plugin directory."""
+
+    state: LegacyDetectionState
+    reason_code: str
+    manifest_matched: bool
+    matched_markers: tuple[str, ...] = ()
+    inspected_marker_count: int = 0
+
+    @property
+    def confirmed(self) -> bool:
+        return self.state is LegacyDetectionState.CONFIRMED
+
+    def to_public_dict(self) -> dict[str, Any]:
+        """Return the complete allowlisted public projection.
+
+        No caller-provided path, manifest value, file content, exception, URL,
+        token, or identifier can enter this projection.
+        """
+
+        return {
+            "contract": CUTOVER_CONTRACT,
+            "schema_version": CUTOVER_SCHEMA_VERSION,
+            "state": self.state.value,
+            "reason_code": self.reason_code,
+            "manifest_matched": self.manifest_matched,
+            "matched_marker_count": len(self.matched_markers),
+            "inspected_marker_count": self.inspected_marker_count,
+        }
+
+
+@dataclass(frozen=True)
+class _BoundedFileRead:
+    exists: bool
+    data: bytes = b""
+    unavailable: bool = False
+
+
+@dataclass(frozen=True)
+class _MarkerInspection:
+    matched: bool
+    unavailable: bool = False
+
+
+def can_transition_cutover(current: CutoverState, target: CutoverState) -> bool:
+    """Return whether a normal or safe terminal transition is allowed."""
+
+    if current == target:
+        return True
+    if current in {CutoverState.COMPLETE, CutoverState.BLOCKED, CutoverState.CANCELED}:
+        return False
+    if target in {CutoverState.BLOCKED, CutoverState.CANCELED}:
+        return True
+    return target in _NORMAL_TRANSITIONS[current]
+
+
+def cutover_contract_schema() -> dict[str, Any]:
+    """Return the versioned, mutation-independent public schema descriptor."""
+
+    return {
+        "contract": CUTOVER_CONTRACT,
+        "schema_version": CUTOVER_SCHEMA_VERSION,
+        "legacy_detection_states": [state.value for state in LegacyDetectionState],
+        "cutover_states": [state.value for state in CutoverState],
+        "minimum_structural_markers": MINIMUM_STRUCTURAL_MARKERS,
+        "projection_fields": [
+            "contract",
+            "schema_version",
+            "state",
+            "reason_code",
+            "manifest_matched",
+            "matched_marker_count",
+            "inspected_marker_count",
+        ],
+    }
+
+
+def detect_legacy_browser_bridge(plugin_root: str | Path | None) -> LegacyBridgeDetection:
+    """Fingerprint a possible legacy plugin without returning any raw values.
+
+    Confirmation requires the exact legacy manifest identity plus at least two
+    independent structural markers. Reads are bounded and symlinks are rejected
+    so an untrusted plugin tree cannot redirect fingerprinting outside its root.
+    """
+
+    if plugin_root is None:
+        return _result(LegacyDetectionState.ABSENT, "legacy_bridge_absent", False, (), 0)
+
+    try:
+        raw_root = Path(plugin_root)
+        root_stat = raw_root.lstat()
+    except FileNotFoundError:
+        return _result(LegacyDetectionState.ABSENT, "legacy_bridge_absent", False, (), 0)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return _result(
+            LegacyDetectionState.UNKNOWN,
+            "legacy_bridge_detection_unavailable",
+            False,
+            (),
+            0,
+        )
+    if stat.S_ISLNK(root_stat.st_mode):
+        return _result(
+            LegacyDetectionState.UNKNOWN,
+            "legacy_bridge_root_untrusted",
+            False,
+            (),
+            0,
+        )
+    if not stat.S_ISDIR(root_stat.st_mode):
+        return _result(
+            LegacyDetectionState.PARTIAL,
+            "legacy_bridge_fingerprint_incomplete",
+            False,
+            (),
+            0,
+        )
+
+    root_fd: int | None = None
+    try:
+        root_fd = os.open(
+            raw_root,
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
+        )
+        opened_root_stat = os.fstat(root_fd)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        if root_fd is not None:
+            try:
+                os.close(root_fd)
+            except OSError:
+                pass
+        return _result(
+            LegacyDetectionState.UNKNOWN,
+            "legacy_bridge_detection_unavailable",
+            False,
+            (),
+            0,
+        )
+    if (
+        not stat.S_ISDIR(opened_root_stat.st_mode)
+        or opened_root_stat.st_dev != root_stat.st_dev
+        or opened_root_stat.st_ino != root_stat.st_ino
+    ):
+        os.close(root_fd)
+        return _result(
+            LegacyDetectionState.UNKNOWN,
+            "legacy_bridge_root_changed",
+            False,
+            (),
+            0,
+        )
+
+    try:
+        manifest, manifest_unavailable = _read_yaml_mapping(root_fd, "plugin.yaml")
+        manifest_matched = bool(
+            manifest
+            and manifest.get("name") == LEGACY_PLUGIN_NAME
+            and str(manifest.get("version") or "") == LEGACY_PLUGIN_VERSION
+        )
+
+        marker_inspections = {
+            name: predicate(root_fd) for name, predicate in _STRUCTURAL_MARKERS.items()
+        }
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return _result(
+            LegacyDetectionState.UNKNOWN,
+            "legacy_bridge_detection_unavailable",
+            False,
+            (),
+            0,
+        )
+    finally:
+        os.close(root_fd)
+    markers = tuple(
+        name for name, inspection in marker_inspections.items() if inspection.matched
+    )
+    inspected = sum(
+        not inspection.unavailable for inspection in marker_inspections.values()
+    )
+    if manifest_unavailable or any(
+        inspection.unavailable for inspection in marker_inspections.values()
+    ):
+        return _result(
+            LegacyDetectionState.UNKNOWN,
+            "legacy_bridge_detection_unavailable",
+            manifest_matched,
+            markers,
+            inspected,
+        )
+    if manifest_matched and len(markers) >= MINIMUM_STRUCTURAL_MARKERS:
+        return _result(
+            LegacyDetectionState.CONFIRMED,
+            "legacy_bridge_detected",
+            True,
+            markers,
+            inspected,
+        )
+    return _result(
+        LegacyDetectionState.PARTIAL,
+        "legacy_bridge_fingerprint_incomplete",
+        manifest_matched,
+        markers,
+        inspected,
+    )
+
+
+def detect_legacy_browser_bridge_roots(
+    plugin_roots: Iterable[str | Path],
+) -> LegacyBridgeDetection:
+    """Inspect roots in runtime precedence order and return the first present one."""
+
+    strongest = _result(
+        LegacyDetectionState.ABSENT,
+        "legacy_bridge_absent",
+        False,
+        (),
+        0,
+    )
+    for plugin_root in plugin_roots:
+        candidate = detect_legacy_browser_bridge(plugin_root)
+        if candidate.state is not LegacyDetectionState.ABSENT:
+            return candidate
+    return strongest
+
+
+def detect_installed_legacy_browser_bridge() -> LegacyBridgeDetection:
+    """Inspect canonical Agent Zero roots without changing plugin state."""
+
+    try:
+        return detect_legacy_browser_bridge_roots(_installed_legacy_plugin_roots())
+    except Exception:
+        return _result(
+            LegacyDetectionState.UNKNOWN,
+            "legacy_bridge_detection_unavailable",
+            False,
+            (),
+            0,
+        )
+
+
+def _installed_legacy_plugin_roots() -> Iterable[str | Path]:
+    from helpers import plugins
+
+    return plugins.get_plugin_roots(LEGACY_PLUGIN_NAME)
+
+
+def build_cutover_foundation_status(
+    detection: LegacyBridgeDetection,
+) -> dict[str, Any]:
+    """Describe detection and quarantine truth without claiming side effects."""
+
+    if detection.confirmed:
+        state = CutoverState.LEGACY_DETECTED.value
+        quarantine_reason = "foundation_detection_only"
+    elif detection.state is LegacyDetectionState.ABSENT:
+        state = CutoverState.NOT_DETECTED.value
+        quarantine_reason = detection.reason_code
+    else:
+        state = CutoverState.BLOCKED.value
+        quarantine_reason = detection.reason_code
+    return {
+        "contract": CUTOVER_CONTRACT,
+        "schema_version": CUTOVER_SCHEMA_VERSION,
+        "state": state,
+        "legacy": detection.to_public_dict(),
+        "quarantine": {
+            "state": "not_applied",
+            "reason_code": quarantine_reason,
+        },
+    }
+
+
+def _result(
+    state: LegacyDetectionState,
+    reason_code: str,
+    manifest_matched: bool,
+    markers: tuple[str, ...],
+    inspected: int,
+) -> LegacyBridgeDetection:
+    return LegacyBridgeDetection(
+        state=state,
+        reason_code=reason_code,
+        manifest_matched=manifest_matched,
+        matched_markers=tuple(sorted(markers)),
+        inspected_marker_count=inspected,
+    )
+
+
+def _read_bounded_file(root_fd: int, relative_path: str) -> _BoundedFileRead:
+    """Read one regular file through a no-follow descriptor walk rooted at ``root``."""
+
+    parts = tuple(part for part in relative_path.split("/") if part)
+    if not parts or any(part in {".", ".."} for part in parts):
+        return _BoundedFileRead(exists=False)
+
+    opened_fds: list[int] = []
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    file_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        directory_fd = os.dup(root_fd)
+        opened_fds.append(directory_fd)
+        for part in parts[:-1]:
+            entry_stat = os.stat(part, dir_fd=directory_fd, follow_symlinks=False)
+            if stat.S_ISLNK(entry_stat.st_mode) or not stat.S_ISDIR(entry_stat.st_mode):
+                return _BoundedFileRead(exists=False)
+            directory_fd = os.open(part, directory_flags, dir_fd=directory_fd)
+            opened_fds.append(directory_fd)
+            opened_directory_stat = os.fstat(directory_fd)
+            if (
+                opened_directory_stat.st_dev != entry_stat.st_dev
+                or opened_directory_stat.st_ino != entry_stat.st_ino
+            ):
+                return _BoundedFileRead(exists=False, unavailable=True)
+
+        entry_stat = os.stat(parts[-1], dir_fd=directory_fd, follow_symlinks=False)
+        if stat.S_ISLNK(entry_stat.st_mode) or not stat.S_ISREG(entry_stat.st_mode):
+            return _BoundedFileRead(exists=False)
+        file_fd = os.open(parts[-1], file_flags, dir_fd=directory_fd)
+        opened_fds.append(file_fd)
+        opened_stat = os.fstat(file_fd)
+        if (
+            not stat.S_ISREG(opened_stat.st_mode)
+            or opened_stat.st_dev != entry_stat.st_dev
+            or opened_stat.st_ino != entry_stat.st_ino
+        ):
+            return _BoundedFileRead(exists=False, unavailable=True)
+
+        chunks: list[bytes] = []
+        remaining = MAX_FINGERPRINT_FILE_BYTES + 1
+        while remaining:
+            chunk = os.read(file_fd, remaining)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        data = b"".join(chunks)
+        if len(data) > MAX_FINGERPRINT_FILE_BYTES:
+            return _BoundedFileRead(exists=False)
+        final_stat = os.fstat(file_fd)
+        if (
+            final_stat.st_size != opened_stat.st_size
+            or final_stat.st_mtime_ns != opened_stat.st_mtime_ns
+            or final_stat.st_ctime_ns != opened_stat.st_ctime_ns
+        ):
+            return _BoundedFileRead(exists=False, unavailable=True)
+        return _BoundedFileRead(exists=True, data=data)
+    except FileNotFoundError:
+        return _BoundedFileRead(exists=False)
+    except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+        return _BoundedFileRead(exists=False, unavailable=True)
+    finally:
+        for file_descriptor in reversed(opened_fds):
+            try:
+                os.close(file_descriptor)
+            except OSError:
+                pass
+
+
+def _read_text(root_fd: int, relative_path: str) -> tuple[str, bool]:
+    result = _read_bounded_file(root_fd, relative_path)
+    if not result.exists or result.unavailable:
+        return "", result.unavailable
+    try:
+        return result.data.decode("utf-8"), False
+    except UnicodeError:
+        return "", False
+
+
+def _read_yaml_mapping(root_fd: int, relative_path: str) -> tuple[dict[str, Any], bool]:
+    text, unavailable = _read_text(root_fd, relative_path)
+    if not text:
+        return {}, unavailable
+    # The legacy fingerprints use only top-level scalar keys. A deliberately
+    # small parser avoids constructing arbitrary YAML objects from a third-party
+    # plugin merely to identify those keys.
+    parsed: dict[str, str] = {}
+    for line in text.splitlines():
+        if not line or line[0].isspace() or line.lstrip().startswith("#"):
+            continue
+        key, separator, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if (
+            not separator
+            or not key
+            or any(
+                ch not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+                for ch in key
+            )
+        ):
+            continue
+        if value.startswith(("[", "{", "&", "*", "!", "|", ">")):
+            continue
+        parsed[key] = value.strip("\"'")
+    return parsed, unavailable
+
+
+def _tool_marker(root_fd: int) -> _MarkerInspection:
+    text, unavailable = _read_text(root_fd, "tools/chrome_bridge.py")
+    return _MarkerInspection(
+        matched="class ChromeBridge" in text and "enqueue_command" in text,
+        unavailable=unavailable,
+    )
+
+
+def _route_marker(root_fd: int) -> _MarkerInspection:
+    required = {
+        "api/session_upsert.py",
+        "api/command_pull.py",
+        "api/command_result.py",
+    }
+    results = [_read_bounded_file(root_fd, relative_path) for relative_path in required]
+    return _MarkerInspection(
+        matched=all(result.exists and not result.unavailable for result in results),
+        unavailable=any(result.unavailable for result in results),
+    )
+
+
+def _context_marker(root_fd: int) -> _MarkerInspection:
+    text, unavailable = _read_text(root_fd, "helpers/constants.py")
+    required = {
+        'SOURCE_NAME = "chrome_extension"',
+        'CTX_BROWSER_SESSION_ID = "chrome_browser_session_id"',
+        'CTX_CHROME_CAPABILITIES = "chrome_extension_capabilities"',
+    }
+    return _MarkerInspection(
+        matched=all(value in text for value in required),
+        unavailable=unavailable,
+    )
+
+
+def _config_marker(root_fd: int) -> _MarkerInspection:
+    config, unavailable = _read_yaml_mapping(root_fd, "default_config.yaml")
+    required = {
+        "command_timeout_seconds",
+        "redelivery_seconds",
+        "stale_session_seconds",
+        "max_inspect_nodes",
+        "prompt_guidance",
+    }
+    return _MarkerInspection(
+        matched=required.issubset(config),
+        unavailable=unavailable,
+    )
+
+
+def _prompt_marker(root_fd: int) -> _MarkerInspection:
+    required = {
+        "prompts/agent.system.tool.chrome_bridge.md",
+        "prompts/fw.chrome.system_context.md",
+    }
+    results = [_read_bounded_file(root_fd, relative_path) for relative_path in required]
+    return _MarkerInspection(
+        matched=all(result.exists and not result.unavailable for result in results),
+        unavailable=any(result.unavailable for result in results),
+    )
+
+
+_STRUCTURAL_MARKERS = MappingProxyType(
+    {
+        "legacy_command_routes": _route_marker,
+        "legacy_context_keys": _context_marker,
+        "legacy_polling_config": _config_marker,
+        "legacy_prompt_pair": _prompt_marker,
+        "legacy_tool": _tool_marker,
+    }
+)

--- a/plugins/_a0_connector/helpers/browser_bridge_events.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_events.py
@@ -1,0 +1,1048 @@
+"""Durable, fail-closed receipt of critical Browser bridge events.
+
+Only the critical event forms whose Core effects are defined here are
+accepted.  Durable receipts contain hashes and cursor metadata, never browser
+event data.  A separate generation-qualified acknowledgement is the only
+authority for the extension to prune its write-ahead log.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from dataclasses import dataclass, field
+import hashlib
+import json
+import re
+import threading
+from typing import Any, Callable
+
+from helpers.ws_principal import WsPrincipal, restricted_correlation_id
+from plugins._a0_connector.helpers.browser_bridge_approval import (
+    BrowserActionDataClassification,
+    BrowserBridgeApprovalError,
+    parse_action_data_classification,
+)
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    BrowserBridgeContextRoute,
+)
+from plugins._a0_connector.helpers.browser_bridge_policy import (
+    BrowserBridgePolicyError,
+    normalize_site_origin,
+)
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+)
+
+
+CONTRACT_VERSION = 1
+WS_NAMESPACE = PRODUCTION_BROWSER_BRIDGE_TRANSPORT.namespace
+RESTRICTED_HANDLER_ID = PRODUCTION_BROWSER_BRIDGE_TRANSPORT.handler_id
+BROWSER_EVENT = "connector_browser_event"
+BROWSER_EVENT_ACK = "connector_browser_event_ack"
+
+MAX_SAFE_INTEGER = 2**53 - 1
+MAX_IDENTIFIER_BYTES = 256
+MAX_ROUTES = 64
+MAX_RECEIPTS_PER_ROUTE = 2048
+MAX_TOTAL_RECEIPTS = 8192
+RETAIN_APPLIED_RECEIPTS = 256
+MAX_ACK_EMIT_SECONDS = 10.0
+DEFAULT_ACK_EMIT_SECONDS = 5.0
+MAX_SITE_SUMMARY_BYTES = 512
+MAX_ACTION_SUMMARY_BYTES = 512
+TYPE_CHALLENGE_SUMMARY = "Allow Agent Zero to type into the highlighted field?"
+UPLOAD_CHALLENGE_SUMMARY = "Allow Agent Zero to share the selected attachment with this site? File selection can immediately upload it."
+_ACTION_CLASSES = frozenset(
+    {"sensitive_input", "external_side_effect", "unknown"}
+)
+
+_STORE_KEY = "a0_browser_bridge_critical_events_v1"
+_OPAQUE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+_DIGEST = re.compile(r"[a-f0-9]{64}")
+
+_LEASE_STATES = frozenset(
+    {
+        "active",
+        "finalizing",
+        "closed",
+        "released",
+        "retained",
+        "outcome_unknown",
+        "orphan",
+    }
+)
+_LEASE_OWNERSHIP = frozenset({"created", "claimed"})
+_LEASE_DISPOSITIONS = frozenset({"ephemeral", "deliverable", "handoff"})
+_LEASE_CHANGES = frozenset(
+    {
+        "created",
+        "finalizing",
+        "tab_closed",
+        "user_takeover",
+        "finalized",
+        "orphaned",
+    }
+)
+_LEASE_REASON_CODES = frozenset(
+    {
+        "FINALIZATION_STARTED",
+        "TAB_CLOSED",
+        "USER_TAKEOVER",
+        "LEASE_ORPHANED",
+        "FINALIZED_CLOSED",
+        "FINALIZED_RELEASED",
+        "FINALIZED_RETAINED",
+        "FINALIZATION_OUTCOME_UNKNOWN",
+    }
+)
+
+_persistent_lock = threading.RLock()
+
+
+class BrowserBridgeEventError(RuntimeError):
+    """A critical event cannot be accepted or durably acknowledged."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+class BrowserBridgeEventDenied(PermissionError):
+    """The exact current Browser bridge route lacks event authority."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class LeaseInvalidation:
+    """Negative-only lease cache invalidation; it conveys no grant or state."""
+
+    principal: WsPrincipal
+    connector_sid: str
+    load_generation_id: str
+    context_id: str
+    browser_session_id: str
+    turn_id: str
+    lease_id_digest: str
+    browser_id_digest: str
+    state: str
+    ownership: str
+    disposition: str
+    change: str
+    reason_code: str
+
+
+@dataclass(frozen=True, slots=True)
+class TurnFinalizedNotice:
+    """Informational summary that deliberately omits a usable control ID."""
+
+    principal: WsPrincipal
+    connector_sid: str
+    load_generation_id: str
+    context_id: str
+    browser_session_id: str
+    turn_id: str
+    control_id_digest: str
+    status: str
+    closed_count: int
+    released_count: int
+    retained_count: int
+    already_finalized_count: int
+    error_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class SiteChallengeNotice:
+    """Exact challenge registration input; it grants no site authority."""
+
+    principal: WsPrincipal
+    connector_sid: str
+    load_generation_id: str
+    context_id: str
+    browser_session_id: str
+    turn_id: str
+    action_id: str
+    op_id: str
+    challenge_id: str
+    origin: str
+    canonical_parameter_hash: str
+    target_fingerprint: str
+    lease_id_digest: str
+    browser_id_digest: str
+    document_id: str | None
+    document_epoch: int
+    summary: str = field(repr=False)
+    expires_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class ActionChallengeNotice:
+    """Exact consequential-action challenge input; it grants no authority."""
+
+    principal: WsPrincipal
+    connector_sid: str
+    load_generation_id: str
+    context_id: str
+    browser_session_id: str
+    turn_id: str
+    action_id: str
+    op_id: str
+    challenge_id: str
+    origin: str
+    action_class: str
+    canonical_parameter_hash: str
+    target_fingerprint: str
+    lease_id_digest: str
+    browser_id_digest: str
+    document_id: str
+    document_epoch: int
+    summary: str = field(repr=False)
+    data_classification: BrowserActionDataClassification
+    expires_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationCriticalEventIdentity:
+    """Redacted identity of one fully validated, but unapplied, replay event."""
+
+    load_generation_id: str
+    event_sequence: int
+    event_type: str
+    challenge_kind: str | None
+
+
+RouteVerifier = Callable[[BrowserBridgeContextRoute], bool]
+LeaseInvalidator = Callable[[LeaseInvalidation], None]
+FinalizationObserver = Callable[[TurnFinalizedNotice], None]
+SiteChallengeRegistrar = Callable[[SiteChallengeNotice], None]
+ActionChallengeRegistrar = Callable[[ActionChallengeNotice], None]
+
+
+class BrowserBridgeCriticalEventReceiver:
+    """Validate, reserve, apply, and ACK exact critical event sequences."""
+
+    def __init__(
+        self,
+        *,
+        manager: Any,
+        server_instance_id: Callable[[], str],
+        current_route_verifier: RouteVerifier | None = None,
+        invalidate_lease: LeaseInvalidator | None = None,
+        observe_finalization: FinalizationObserver | None = None,
+        register_site_challenge: SiteChallengeRegistrar | None = None,
+        register_action_challenge: ActionChallengeRegistrar | None = None,
+        load: Callable[[], Any] | None = None,
+        save: Callable[[dict[str, Any]], None] | None = None,
+        ack_emit_seconds: float = DEFAULT_ACK_EMIT_SECONDS,
+        lock: threading.RLock | None = None,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        if not callable(getattr(manager, "emit_to", None)):
+            raise BrowserBridgeEventError("INVALID_WEBSOCKET_MANAGER")
+        if not callable(server_instance_id):
+            raise BrowserBridgeEventError("INVALID_SERVER_INSTANCE")
+        if (
+            isinstance(ack_emit_seconds, bool)
+            or not isinstance(ack_emit_seconds, (int, float))
+            or not 0 < float(ack_emit_seconds) <= MAX_ACK_EMIT_SECONDS
+        ):
+            raise BrowserBridgeEventError("INVALID_ACK_TIMEOUT")
+        self._manager = manager
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        self._server_instance_id = server_instance_id
+        self._current_route_verifier = current_route_verifier or (
+            lambda _route: False
+        )
+        self._invalidate_lease = invalidate_lease or _unavailable_callback
+        self._observe_finalization = (
+            observe_finalization or _unavailable_callback
+        )
+        self._register_site_challenge = (
+            register_site_challenge or _unavailable_callback
+        )
+        self._register_action_challenge = (
+            register_action_challenge or _unavailable_callback
+        )
+        self._load = load or _load_events
+        self._save = save or _save_events
+        self._ack_emit_seconds = float(ack_emit_seconds)
+        self._lock = lock or _persistent_lock
+
+    async def receive(
+        self,
+        route: BrowserBridgeContextRoute,
+        document: Any,
+    ) -> dict[str, Any]:
+        route = _route(route)
+        event, callback_value = _validate_event(
+            route, document, self._transport_profile
+        )
+        server_id = self._current_server(route)
+        owner_hash = _hash_json(
+            {
+                "server_instance_id": server_id,
+                "bridge_id": route.principal.principal_id,
+                "subject_id": route.principal.subject_id,
+            }
+        )
+        binding_hash = _hash_json(
+            {
+                "owner_hash": owner_hash,
+                "key_generation": route.principal.key_generation,
+                "load_generation_id": route.load_generation_id,
+            }
+        )
+        event_id_hash = _hash_text(event["event_id"])
+        event_hash = _hash_json(event)
+
+        with self._lock:
+            self._require_current(route, server_id)
+            state = self._state()
+            routes = state["routes"]
+            record = routes.get(binding_hash)
+            if record is None:
+                # A verified current route establishes replacement.  An event
+                # claim by itself never deletes another generation's cursor.
+                for key in tuple(routes):
+                    if routes[key]["owner_hash"] == owner_hash:
+                        routes.pop(key)
+                if len(routes) >= MAX_ROUTES:
+                    raise BrowserBridgeEventError("EVENT_REGISTRY_FULL")
+                record = {
+                    "owner_hash": owner_hash,
+                    "binding_hash": binding_hash,
+                    "cursor": 0,
+                    "receipts": {},
+                }
+                routes[binding_hash] = record
+
+            initial_cursor = record["cursor"]
+            sequence_key = str(event["event_sequence"])
+            receipt = record["receipts"].get(sequence_key)
+            duplicate_sequence = next(
+                (
+                    sequence
+                    for sequence, candidate in record["receipts"].items()
+                    if candidate["event_id_hash"] == event_id_hash
+                    and sequence != sequence_key
+                ),
+                None,
+            )
+            if duplicate_sequence is not None:
+                raise BrowserBridgeEventError("EVENT_ID_CONFLICT")
+            if receipt is not None and (
+                receipt["event_id_hash"] != event_id_hash
+                or receipt["event_hash"] != event_hash
+            ):
+                raise BrowserBridgeEventError("EVENT_SEQUENCE_CONFLICT")
+
+            should_apply = False
+            if event["event_sequence"] <= initial_cursor:
+                # Old applied receipts may have compacted.  The generation's
+                # durable cursor is sufficient to ACK without replaying any
+                # callback or creating new authority.
+                should_ack = True
+            else:
+                if receipt is None:
+                    self._make_receipt_space(state, record)
+                    receipt = {
+                        "event_id_hash": event_id_hash,
+                        "event_hash": event_hash,
+                        "state": "accepted",
+                    }
+                    record["receipts"][sequence_key] = receipt
+                    self._persist(state)
+                    self._require_current(route, server_id)
+                    should_apply = True
+                elif receipt["state"] == "accepted":
+                    should_apply = True
+
+                if should_apply:
+                    self._run_callback(event["event_type"], callback_value)
+                    self._require_current(route, server_id)
+                    # The first save is the crash-safe reservation.  This save
+                    # records successful callback application and cursor motion.
+                    receipt["state"] = "applied"
+
+                cursor = record["cursor"]
+                while True:
+                    next_receipt = record["receipts"].get(str(cursor + 1))
+                    if next_receipt is None or next_receipt["state"] != "applied":
+                        break
+                    cursor += 1
+                if should_apply or cursor != record["cursor"]:
+                    record["cursor"] = cursor
+                    self._compact_applied(record)
+                    self._persist(state)
+                    self._require_current(route, server_id)
+                should_ack = cursor > initial_cursor
+
+        if should_ack:
+            await self._emit_ack(route, server_id, record["cursor"])
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "event_id": event["event_id"],
+            "status": "accepted",
+        }
+
+    def _state(self) -> dict[str, Any]:
+        try:
+            value = self._load()
+        except Exception:
+            raise BrowserBridgeEventError("EVENT_STORE_UNAVAILABLE") from None
+        if value is None or value == {}:
+            return {"schema_version": 1, "routes": {}}
+        if (
+            not isinstance(value, dict)
+            or set(value) != {"schema_version", "routes"}
+            or type(value["schema_version"]) is not int
+            or value["schema_version"] != 1
+            or not isinstance(value["routes"], dict)
+            or len(value["routes"]) > MAX_ROUTES
+        ):
+            raise BrowserBridgeEventError("EVENT_STORE_UNAVAILABLE")
+        routes: dict[str, dict[str, Any]] = {}
+        total_receipts = 0
+        for key, raw_record in value["routes"].items():
+            if (
+                not isinstance(key, str)
+                or _DIGEST.fullmatch(key) is None
+                or not isinstance(raw_record, dict)
+                or set(raw_record)
+                != {"owner_hash", "binding_hash", "cursor", "receipts"}
+                or raw_record.get("binding_hash") != key
+                or not isinstance(raw_record.get("owner_hash"), str)
+                or _DIGEST.fullmatch(raw_record["owner_hash"]) is None
+                or not _safe_integer(raw_record.get("cursor"))
+                or not isinstance(raw_record.get("receipts"), dict)
+                or len(raw_record["receipts"]) > MAX_RECEIPTS_PER_ROUTE
+            ):
+                raise BrowserBridgeEventError("EVENT_STORE_UNAVAILABLE")
+            receipts: dict[str, dict[str, str]] = {}
+            event_ids: set[str] = set()
+            cursor = raw_record["cursor"]
+            for sequence, raw_receipt in raw_record["receipts"].items():
+                if (
+                    not isinstance(sequence, str)
+                    or not sequence.isascii()
+                    or not sequence.isdigit()
+                    or sequence.startswith("0")
+                    or len(sequence) > 16
+                ):
+                    raise BrowserBridgeEventError("EVENT_STORE_UNAVAILABLE")
+                number = int(sequence)
+                if not 1 <= number <= MAX_SAFE_INTEGER or str(number) != sequence:
+                    raise BrowserBridgeEventError("EVENT_STORE_UNAVAILABLE")
+                if (
+                    not isinstance(raw_receipt, dict)
+                    or set(raw_receipt)
+                    != {"event_id_hash", "event_hash", "state"}
+                    or not isinstance(raw_receipt.get("event_id_hash"), str)
+                    or _DIGEST.fullmatch(raw_receipt["event_id_hash"]) is None
+                    or not isinstance(raw_receipt.get("event_hash"), str)
+                    or _DIGEST.fullmatch(raw_receipt["event_hash"]) is None
+                    or raw_receipt.get("state") not in {"accepted", "applied"}
+                    or (number <= cursor and raw_receipt["state"] != "applied")
+                    or raw_receipt["event_id_hash"] in event_ids
+                ):
+                    raise BrowserBridgeEventError("EVENT_STORE_UNAVAILABLE")
+                event_ids.add(raw_receipt["event_id_hash"])
+                receipts[sequence] = dict(raw_receipt)
+            total_receipts += len(receipts)
+            routes[key] = {
+                "owner_hash": raw_record["owner_hash"],
+                "binding_hash": key,
+                "cursor": cursor,
+                "receipts": receipts,
+            }
+        if total_receipts > MAX_TOTAL_RECEIPTS:
+            raise BrowserBridgeEventError("EVENT_STORE_UNAVAILABLE")
+        return {"schema_version": 1, "routes": routes}
+
+    def _make_receipt_space(
+        self,
+        state: dict[str, Any],
+        record: dict[str, Any],
+    ) -> None:
+        self._compact_applied(record)
+        total = sum(
+            len(candidate["receipts"])
+            for candidate in state["routes"].values()
+        )
+        if (
+            len(record["receipts"]) >= MAX_RECEIPTS_PER_ROUTE
+            or total >= MAX_TOTAL_RECEIPTS
+        ):
+            raise BrowserBridgeEventError("EVENT_REGISTRY_FULL")
+
+    @staticmethod
+    def _compact_applied(record: dict[str, Any]) -> None:
+        cutoff = max(record["cursor"] - RETAIN_APPLIED_RECEIPTS, 0)
+        record["receipts"] = {
+            sequence: receipt
+            for sequence, receipt in record["receipts"].items()
+            if int(sequence) > cutoff
+        }
+
+    def _run_callback(self, event_type: str, value: Any) -> None:
+        if value is None:
+            return
+        if event_type == "challenge.required":
+            callback = (
+                self._register_action_challenge
+                if isinstance(value, ActionChallengeNotice)
+                else self._register_site_challenge
+                if isinstance(value, SiteChallengeNotice)
+                else None
+            )
+        else:
+            callback = {
+                "lease.changed": self._invalidate_lease,
+                "turn.finalized": self._observe_finalization,
+            }.get(event_type)
+        if callback is None:
+            raise BrowserBridgeEventError("EVENT_CALLBACK_FAILED")
+        try:
+            result = callback(value)
+        except Exception:
+            raise BrowserBridgeEventError("EVENT_CALLBACK_FAILED") from None
+        if result is not None:
+            raise BrowserBridgeEventError("EVENT_CALLBACK_FAILED")
+
+    def _persist(self, state: dict[str, Any]) -> None:
+        try:
+            self._save(deepcopy(state))
+        except Exception:
+            raise BrowserBridgeEventError("EVENT_STORE_UNAVAILABLE") from None
+
+    def _current_server(self, route: BrowserBridgeContextRoute) -> str:
+        try:
+            server_id = _identifier(self._server_instance_id(), "server_instance_id")
+        except Exception:
+            raise BrowserBridgeEventDenied("STALE_BRIDGE_ROUTE") from None
+        self._require_current(route, server_id)
+        return server_id
+
+    def _require_current(
+        self, route: BrowserBridgeContextRoute, server_id: str
+    ) -> None:
+        try:
+            current = self._current_route_verifier(route) is True
+            same_server = self._server_instance_id() == server_id
+        except Exception:
+            current = False
+            same_server = False
+        if not current or not same_server:
+            raise BrowserBridgeEventDenied("STALE_BRIDGE_ROUTE")
+        if route.transport_profile is not self._transport_profile:
+            raise BrowserBridgeEventDenied("SCOPE_DENIED")
+
+    async def _emit_ack(
+        self,
+        route: BrowserBridgeContextRoute,
+        server_id: str,
+        cursor: int,
+    ) -> None:
+        self._require_current(route, server_id)
+        try:
+            await asyncio.wait_for(
+                self._manager.emit_to(
+                    self._transport_profile.namespace,
+                    route.connector_sid,
+                    BROWSER_EVENT_ACK,
+                    {
+                        "contract_version": CONTRACT_VERSION,
+                        "bridge_id": route.principal.principal_id,
+                        "load_generation_id": route.load_generation_id,
+                        "highest_contiguous_event_sequence": cursor,
+                    },
+                    handler_id=self._transport_profile.handler_id,
+                    correlation_id=restricted_correlation_id(None),
+                    expected_principal=route.principal,
+                ),
+                timeout=self._ack_emit_seconds,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            raise BrowserBridgeEventError("EVENT_ACK_FAILED") from None
+        self._require_current(route, server_id)
+
+
+def _validate_event(
+    route: BrowserBridgeContextRoute,
+    value: Any,
+    transport_profile: BrowserBridgeTransportProfile,
+) -> tuple[
+    dict[str, Any],
+    LeaseInvalidation
+    | TurnFinalizedNotice
+    | SiteChallengeNotice
+    | ActionChallengeNotice
+    | None,
+]:
+    profile = require_browser_bridge_transport_profile(transport_profile)
+    if (
+        route.transport_profile is not profile
+        or
+        "browser.operate" not in route.principal.scopes
+        or not route.principal.permits_inbound(BROWSER_EVENT, profile.handler_id)
+    ):
+        raise BrowserBridgeEventDenied("SCOPE_DENIED")
+    if not isinstance(value, dict):
+        raise BrowserBridgeEventError("INVALID_EVENT")
+    event = dict(value)
+    # Shared WsManager supplies this sanitized envelope-only value to handlers.
+    event.pop("correlationId", None)
+    if set(event) != {
+        "contract_version",
+        "event_id",
+        "load_generation_id",
+        "event_sequence",
+        "delivery",
+        "event_type",
+        "observed_at_ms",
+        "context_id",
+        "browser_session_id",
+        "turn_id",
+        "op_id",
+        "action_id",
+        "data",
+    }:
+        raise BrowserBridgeEventError("INVALID_EVENT")
+    if (
+        type(event["contract_version"]) is not int
+        or event["contract_version"] != CONTRACT_VERSION
+        or event["load_generation_id"] != route.load_generation_id
+        or event["delivery"] != "critical"
+        or not isinstance(event["event_type"], str)
+        or event["event_type"]
+        not in {"lease.changed", "turn.finalized", "challenge.required"}
+        or not _safe_integer(event["event_sequence"], positive=True)
+        or not _safe_integer(event["observed_at_ms"])
+    ):
+        raise BrowserBridgeEventError("INVALID_EVENT")
+    for name in (
+        "event_id",
+        "load_generation_id",
+        "context_id",
+        "browser_session_id",
+        "turn_id",
+    ):
+        event[name] = _identifier(event[name], name)
+    for name in ("op_id", "action_id"):
+        if event[name] is not None:
+            event[name] = _identifier(event[name], name)
+    if event["event_type"] == "challenge.required":
+        if event["op_id"] is None or event["action_id"] is None:
+            raise BrowserBridgeEventError("INVALID_EVENT")
+        kind = event["data"].get("kind") if isinstance(event["data"], dict) else None
+        if kind == "site":
+            data = _site_challenge_data(event["data"])
+            callback = SiteChallengeNotice(
+                principal=route.principal,
+                connector_sid=route.connector_sid,
+                load_generation_id=route.load_generation_id,
+                context_id=event["context_id"],
+                browser_session_id=event["browser_session_id"],
+                turn_id=event["turn_id"],
+                action_id=event["action_id"],
+                op_id=event["op_id"],
+                challenge_id=data["challenge_id"],
+                origin=data["origin"],
+                canonical_parameter_hash=data["canonical_parameter_hash"],
+                target_fingerprint=data["target_fingerprint"],
+                lease_id_digest=data["lease_id_digest"],
+                browser_id_digest=data["browser_id_digest"],
+                document_id=data["document_id"],
+                document_epoch=data["document_epoch"],
+                summary=data["summary"],
+                expires_at_ms=data["expires_at_ms"],
+            )
+        elif kind == "action":
+            data = _action_challenge_data(event["data"])
+            callback = ActionChallengeNotice(
+                principal=route.principal,
+                connector_sid=route.connector_sid,
+                load_generation_id=route.load_generation_id,
+                context_id=event["context_id"],
+                browser_session_id=event["browser_session_id"],
+                turn_id=event["turn_id"],
+                action_id=event["action_id"],
+                op_id=event["op_id"],
+                challenge_id=data["challenge_id"],
+                origin=data["origin"],
+                action_class=data["action_class"],
+                canonical_parameter_hash=data["canonical_parameter_hash"],
+                target_fingerprint=data["target_fingerprint"],
+                lease_id_digest=data["lease_id_digest"],
+                browser_id_digest=data["browser_id_digest"],
+                document_id=data["document_id"],
+                document_epoch=data["document_epoch"],
+                summary=data["summary"],
+                data_classification=parse_action_data_classification(
+                    data["data_classification"]
+                ),
+                expires_at_ms=data["expires_at_ms"],
+            )
+        else:
+            raise BrowserBridgeEventError("INVALID_EVENT")
+    elif event["event_type"] == "lease.changed":
+        data = _lease_data(event["data"])
+        # Creation is passive evidence and cannot grant Core authority.  It
+        # also must not withdraw a lease recorded from the successful operation
+        # result if the at-least-once event arrives later.
+        callback: LeaseInvalidation | TurnFinalizedNotice | None = None
+        if data["change"] != "created":
+            callback = LeaseInvalidation(
+                principal=route.principal,
+                connector_sid=route.connector_sid,
+                load_generation_id=route.load_generation_id,
+                context_id=event["context_id"],
+                browser_session_id=event["browser_session_id"],
+                turn_id=event["turn_id"],
+                lease_id_digest=data["lease_id_digest"],
+                browser_id_digest=data["browser_id_digest"],
+                state=data["state"],
+                ownership=data["ownership"],
+                disposition=data["disposition"],
+                change=data["change"],
+                reason_code=data["reason_code"],
+            )
+    else:
+        data = _finalization_data(event["data"])
+        callback = TurnFinalizedNotice(
+            principal=route.principal,
+            connector_sid=route.connector_sid,
+            load_generation_id=route.load_generation_id,
+            context_id=event["context_id"],
+            browser_session_id=event["browser_session_id"],
+            turn_id=event["turn_id"],
+            control_id_digest=_hash_text(data["control_id"]),
+            status=data["status"],
+            closed_count=data["closed_count"],
+            released_count=data["released_count"],
+            retained_count=data["retained_count"],
+            already_finalized_count=data["already_finalized_count"],
+            error_count=data["error_count"],
+        )
+    event["data"] = data
+    return event, callback
+
+
+def validate_reconciliation_critical_event(
+    route: BrowserBridgeContextRoute,
+    value: Any,
+    *,
+    transport_profile: BrowserBridgeTransportProfile = (
+        PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    ),
+) -> ReconciliationCriticalEventIdentity:
+    """Validate a replay snapshot without applying or acknowledging it.
+
+    This deliberately returns only routing/cursor metadata.  The full event
+    stays owned by the extension WAL until it is replayed through the normal
+    durable receiver after route promotion.
+    """
+
+    # Embedded reconcile events are native event objects, not WsManager
+    # envelopes.  The live receiver tolerates and strips its sanitized
+    # correlationId wrapper, but accepting that extra key here would diverge
+    # from the extension's exact parseBrowserEventParams schema.
+    if not isinstance(value, dict) or set(value) != {
+        "contract_version",
+        "event_id",
+        "load_generation_id",
+        "event_sequence",
+        "delivery",
+        "event_type",
+        "observed_at_ms",
+        "context_id",
+        "browser_session_id",
+        "turn_id",
+        "op_id",
+        "action_id",
+        "data",
+    }:
+        raise BrowserBridgeEventError("INVALID_EVENT")
+    event, callback = _validate_event(route, value, transport_profile)
+    return ReconciliationCriticalEventIdentity(
+        load_generation_id=event["load_generation_id"],
+        event_sequence=event["event_sequence"],
+        event_type=event["event_type"],
+        challenge_kind=(
+            "site"
+            if isinstance(callback, SiteChallengeNotice)
+            else "action"
+            if isinstance(callback, ActionChallengeNotice)
+            else None
+        ),
+    )
+
+
+def _lease_data(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != {
+        "lease_id_digest",
+        "browser_id_digest",
+        "state",
+        "ownership",
+        "disposition",
+        "change",
+        "reason_code",
+    }:
+        raise BrowserBridgeEventError("INVALID_EVENT")
+    data = dict(value)
+    for name in ("lease_id_digest", "browser_id_digest"):
+        if not isinstance(data[name], str) or _DIGEST.fullmatch(data[name]) is None:
+            raise BrowserBridgeEventError("INVALID_EVENT")
+    if (
+        not isinstance(data["state"], str)
+        or data["state"] not in _LEASE_STATES
+        or not isinstance(data["ownership"], str)
+        or data["ownership"] not in _LEASE_OWNERSHIP
+        or not isinstance(data["disposition"], str)
+        or data["disposition"] not in _LEASE_DISPOSITIONS
+        or not isinstance(data["change"], str)
+        or data["change"] not in _LEASE_CHANGES
+        or (
+            data["reason_code"] is not None
+            and (
+                not isinstance(data["reason_code"], str)
+                or data["reason_code"] not in _LEASE_REASON_CODES
+            )
+        )
+    ):
+        raise BrowserBridgeEventError("INVALID_EVENT")
+    expected = {
+        "created": {("active", None)},
+        "finalizing": {("finalizing", "FINALIZATION_STARTED")},
+        "tab_closed": {("closed", "TAB_CLOSED")},
+        "user_takeover": {("released", "USER_TAKEOVER")},
+        "orphaned": {("orphan", "LEASE_ORPHANED")},
+        "finalized": {
+            ("closed", "FINALIZED_CLOSED"),
+            ("released", "FINALIZED_RELEASED"),
+            ("retained", "FINALIZED_RETAINED"),
+            ("outcome_unknown", "FINALIZATION_OUTCOME_UNKNOWN"),
+        },
+    }
+    if (data["state"], data["reason_code"]) not in expected[data["change"]]:
+        raise BrowserBridgeEventError("INVALID_EVENT")
+    return data
+
+
+def _finalization_data(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != {
+        "control_id",
+        "status",
+        "closed_count",
+        "released_count",
+        "retained_count",
+        "already_finalized_count",
+        "error_count",
+    }:
+        raise BrowserBridgeEventError("INVALID_EVENT")
+    data = dict(value)
+    data["control_id"] = _identifier(data["control_id"], "control_id")
+    if data["status"] != "completed" or any(
+        not _safe_integer(data[name]) or data[name] > 256
+        for name in (
+            "closed_count",
+            "released_count",
+            "retained_count",
+            "already_finalized_count",
+            "error_count",
+        )
+    ):
+        raise BrowserBridgeEventError("INVALID_EVENT")
+    return data
+
+
+def _site_challenge_data(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != {
+        "challenge_id",
+        "kind",
+        "origin",
+        "action_class",
+        "canonical_parameter_hash",
+        "target_fingerprint",
+        "lease_id_digest",
+        "browser_id_digest",
+        "document_id",
+        "document_epoch",
+        "summary",
+        "options",
+        "expires_at_ms",
+    }:
+        raise BrowserBridgeEventError("INVALID_EVENT")
+    data = dict(value)
+    data["challenge_id"] = _identifier(data["challenge_id"], "challenge_id")
+    if data["document_id"] is not None:
+        data["document_id"] = _identifier(data["document_id"], "document_id")
+    for name in (
+        "canonical_parameter_hash",
+        "target_fingerprint",
+        "lease_id_digest",
+        "browser_id_digest",
+    ):
+        if not isinstance(data[name], str) or _DIGEST.fullmatch(data[name]) is None:
+            raise BrowserBridgeEventError("INVALID_EVENT")
+    try:
+        canonical_origin = normalize_site_origin(data["origin"])
+    except BrowserBridgePolicyError:
+        raise BrowserBridgeEventError("INVALID_EVENT") from None
+    summary = data["summary"]
+    try:
+        summary_bytes = summary.encode("utf-8") if isinstance(summary, str) else b""
+    except UnicodeError:
+        raise BrowserBridgeEventError("INVALID_EVENT") from None
+    if (
+        canonical_origin != data["origin"]
+        or data["kind"] != "site"
+        or data["action_class"] != "navigate"
+        or not _safe_integer(data["document_epoch"])
+        or not _safe_integer(data["expires_at_ms"], positive=True)
+        or data["options"] != ["deny", "allow_once", "allow_turn"]
+        or not isinstance(summary, str)
+        or not summary
+        or not summary.isprintable()
+        or len(summary_bytes) > MAX_SITE_SUMMARY_BYTES
+    ):
+        raise BrowserBridgeEventError("INVALID_EVENT")
+    data["origin"] = canonical_origin
+    return data
+
+
+def _action_challenge_data(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != {
+        "challenge_id",
+        "kind",
+        "origin",
+        "action_class",
+        "canonical_parameter_hash",
+        "target_fingerprint",
+        "lease_id_digest",
+        "browser_id_digest",
+        "document_id",
+        "document_epoch",
+        "summary",
+        "options",
+        "data_classification",
+        "expires_at_ms",
+    }:
+        raise BrowserBridgeEventError("INVALID_EVENT")
+    data = dict(value)
+    data["challenge_id"] = _identifier(data["challenge_id"], "challenge_id")
+    data["document_id"] = _identifier(data["document_id"], "document_id")
+    for name in (
+        "canonical_parameter_hash",
+        "target_fingerprint",
+        "lease_id_digest",
+        "browser_id_digest",
+    ):
+        if not isinstance(data[name], str) or _DIGEST.fullmatch(data[name]) is None:
+            raise BrowserBridgeEventError("INVALID_EVENT")
+    try:
+        canonical_origin = normalize_site_origin(data["origin"])
+    except BrowserBridgePolicyError:
+        raise BrowserBridgeEventError("INVALID_EVENT") from None
+    try:
+        classification = parse_action_data_classification(
+            data["data_classification"]
+        )
+    except BrowserBridgeApprovalError:
+        raise BrowserBridgeEventError("INVALID_EVENT") from None
+    summary = data["summary"]
+    try:
+        summary_bytes = summary.encode("utf-8") if isinstance(summary, str) else b""
+    except UnicodeError:
+        raise BrowserBridgeEventError("INVALID_EVENT") from None
+    if (
+        canonical_origin != data["origin"]
+        or data["kind"] != "action"
+        or not isinstance(data["action_class"], str)
+        or data["action_class"] not in _ACTION_CLASSES
+        or (
+            classification.kind == "text"
+            and (
+                data["action_class"] != "sensitive_input"
+                or summary != TYPE_CHALLENGE_SUMMARY
+            )
+        )
+        or not _safe_integer(data["document_epoch"])
+        or not _safe_integer(data["expires_at_ms"], positive=True)
+        or data["options"] != ["decline", "approve_once"]
+        or not isinstance(summary, str)
+        or not summary
+        or not summary.isprintable()
+        or len(summary_bytes) > MAX_ACTION_SUMMARY_BYTES
+    ):
+        raise BrowserBridgeEventError("INVALID_EVENT")
+    data["origin"] = canonical_origin
+    data["data_classification"] = classification.as_wire_value()
+    return data
+
+
+def _safe_integer(value: Any, *, positive: bool = False) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, int)
+        and (1 if positive else 0) <= value <= MAX_SAFE_INTEGER
+    )
+
+
+def _identifier(value: Any, name: str) -> str:
+    if not isinstance(value, str) or _OPAQUE_ID.fullmatch(value) is None:
+        raise BrowserBridgeEventError(f"INVALID_{name.upper()}")
+    try:
+        if len(value.encode("utf-8")) > MAX_IDENTIFIER_BYTES:
+            raise BrowserBridgeEventError(f"INVALID_{name.upper()}")
+    except UnicodeError:
+        raise BrowserBridgeEventError(f"INVALID_{name.upper()}") from None
+    return value
+
+
+def _route(value: Any) -> BrowserBridgeContextRoute:
+    if not isinstance(value, BrowserBridgeContextRoute):
+        raise BrowserBridgeEventError("INVALID_ROUTE")
+    return value
+
+
+def _hash_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _hash_json(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _unavailable_callback(_value: Any) -> None:
+    raise BrowserBridgeEventError("EVENT_CALLBACK_UNAVAILABLE")
+
+
+def _load_events() -> Any:
+    from helpers import kvp
+
+    return kvp.get_persistent(_STORE_KEY, None)
+
+
+def _save_events(value: dict[str, Any]) -> None:
+    from helpers import kvp
+
+    kvp.set_persistent(_STORE_KEY, value)

--- a/plugins/_a0_connector/helpers/browser_bridge_journal.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_journal.py
@@ -1,0 +1,74 @@
+"""Hash-only replay receipts using the existing atomic KVP store.
+
+New receipts are indexed individually. Original v1 records stay a read-only
+fallback; its version marker fences older writers before the first new write.
+Receipts are never evicted or interpreted as permission to retry.
+Callers hold their existing lane lock across reservation, effect and settlement.
+"""
+
+import re
+
+
+_HASH = re.compile(r"[a-f0-9]{64}")
+_MISSING = object()
+
+
+class BrowserBridgeJournal:
+    def __init__(self, store_key, validate_record, error_factory, *, load=None, save=None):
+        from helpers import kvp
+
+        if (load is None) != (save is None):
+            raise ValueError("journal load and save must be supplied together")
+        self.store_key = store_key
+        self.validate_record = validate_record
+        self.error_factory = error_factory
+        self.load = load or kvp.get_persistent
+        self.save = save or kvp.set_persistent
+
+    def get(self, key):
+        if not isinstance(key, str) or not _HASH.fullmatch(key):
+            return None  # Foreign Core queue IDs are not bridge receipts.
+        try:
+            value = self.load(self._key(key), _MISSING)
+            if value is not _MISSING:
+                self._envelope(value, "record")
+                self.validate_record(value["record"])
+                return dict(value["record"])
+            return self._legacy_records().get(key)
+        except Exception:
+            raise self.error_factory() from None
+
+    def put(self, key, record):
+        try:
+            if not isinstance(key, str) or not _HASH.fullmatch(key):
+                raise ValueError()
+            self.validate_record(record)
+            self._legacy_records(fence=True)
+            self.save(self._key(key), {"schema_version": 1, "record": dict(record)})
+        except Exception:
+            raise self.error_factory() from None
+
+    def _key(self, key):
+        return f"{self.store_key}.records.{key}"
+
+    def _legacy_records(self, *, fence=False):
+        value = self.load(self.store_key, None)
+        if value is None:
+            value = {"schema_version": 1, "records": {}}
+        self._envelope(value, "records", versions=(1, 2))
+        records = value["records"]
+        if not isinstance(records, dict) or len(records) > 2048:
+            raise ValueError()
+        for key, record in records.items():
+            if not isinstance(key, str) or not _HASH.fullmatch(key):
+                raise ValueError()
+            self.validate_record(record)
+        if fence and value["schema_version"] == 1:
+            # Older builds must fail closed, not overlook indexed receipts.
+            self.save(self.store_key, {"schema_version": 2, "records": records})
+        return {key: dict(record) for key, record in records.items()}
+
+    @staticmethod
+    def _envelope(value, field, *, versions=(1,)):
+        if not isinstance(value, dict) or set(value) != {"schema_version", field} or type(value["schema_version"]) is not int or value["schema_version"] not in versions:
+            raise ValueError()

--- a/plugins/_a0_connector/helpers/browser_bridge_legacy_quarantine.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_legacy_quarantine.py
@@ -1,0 +1,274 @@
+"""Recoverable, exact-owner legacy context/history quarantine. No v1 authority."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import threading
+
+from plugins._a0_connector.helpers.browser_bridge_legacy_retirement import (
+    LegacyRetirementDenied, get_legacy_retirement,
+)
+
+LOCK = threading.RLock()
+CONTEXT_KEYS = ("source", "chrome_browser_session_id", "chrome_extension_capabilities")
+MAX_BYTES = 32 * 1024 * 1024
+MAX_RECORDS = 10000
+MAX_REMOVALS = 1024
+
+
+def enabled():
+    owner = get_legacy_retirement()
+    try:
+        with owner.lock:
+            return owner._journal() is not None
+    except Exception:
+        return False  # Corrupt state is not permission to mutate unrelated chats.
+
+
+def _encode(value):
+    raw = json.dumps(value, ensure_ascii=False, allow_nan=False, separators=(",", ":")).encode("utf-8")
+    if len(raw) > MAX_BYTES:
+        raise LegacyRetirementDenied("legacy_quarantine_limit")
+    return raw
+
+
+def _unique(pairs):
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise LegacyRetirementDenied("legacy_quarantine_ambiguous")
+        value[key] = item
+    return value
+
+
+def _tool_result(content):
+    return (type(content) is dict and content.get("tool_name") == "chrome_bridge"
+            and type(content.get("tool_result")) is str
+            and type(content.get("browser_session_id")) is str
+            and type(content.get("command_id")) is str
+            and content.get("command_status") in {"completed", "failed"})
+
+
+def _summary_tree(summary):
+    if type(summary) is not str or '"image_data_url"' not in summary:
+        return None
+    if len(summary.encode("utf-8")) > MAX_BYTES:
+        raise LegacyRetirementDenied("legacy_quarantine_limit")
+    try:
+        tree = json.loads(summary, object_pairs_hook=_unique)
+    except (ValueError, TypeError):
+        return None  # Never substring-redact prose or malformed historical text.
+    return tree if _tool_result(tree) and "image_data_url" in tree else None
+
+
+def _walk(node, path, budget, summaries):
+    if type(node) is not dict:
+        return
+    budget[0] += 1
+    if budget[0] > MAX_RECORDS or len(path) > 64:
+        raise LegacyRetirementDenied("legacy_quarantine_limit")
+    kind = node.get("_cls")
+    if kind == "Message":
+        content = node.get("content")
+        if node.get("ai") is False and _tool_result(content):
+            if "image_data_url" in content:
+                yield content, "image_data_url", path + ["content", "image_data_url"]
+            summary = _summary_tree(node.get("summary"))
+            if summary is not None:
+                summaries.append((node, summary))
+                yield summary, "image_data_url", path + ["summary", "image_data_url"]
+        return
+    lists = {"History": ("bulks", "topics"), "Bulk": ("records",), "Topic": ("messages",)}.get(kind, ())
+    for key in lists:
+        children = node.get(key, [])
+        if type(children) is not list:
+            raise LegacyRetirementDenied("legacy_quarantine_ambiguous")
+        for index, child in enumerate(children):
+            yield from _walk(child, path + [key, index], budget, summaries)
+    if kind == "History":
+        yield from _walk(node.get("current"), path + ["current"], budget, summaries)
+
+
+def _context_slots(data):
+    if type(data) is dict and data.get("source") == "chrome_extension":
+        for key in CONTEXT_KEYS:
+            if key in data:
+                yield data, key, ["data", key]
+
+
+def _commit(context_id, slots, store):
+    if not slots:
+        return {"context_keys": 0, "screenshots": 0}
+    if len(slots) > MAX_REMOVALS:
+        raise LegacyRetirementDenied("legacy_quarantine_limit")
+    # Shared Message/content objects can appear more than once in a live
+    # history. Reject ambiguous recovery locations before backup or deletion;
+    # never delete one alias and then fail with KeyError on another.
+    identities = {(id(mapping), key) for mapping, key, _path in slots}
+    if len(identities) != len(slots):
+        raise LegacyRetirementDenied("legacy_quarantine_ambiguous")
+    entries = [{"location": path, "value": mapping[key]} for mapping, key, path in slots]
+    # Preserve precisely the removed values, not entire chats or user artifacts.
+    raw = _encode({"contract": "a0.legacy-quarantine.v1", "context_id": context_id, "entries": entries})
+    originals = [mapping[key] for mapping, key, _path in slots]
+    store(raw)  # Durable private recovery copy must precede the first removal.
+    if any(mapping.get(key) is not old for (mapping, key, _path), old in zip(slots, originals)):
+        raise LegacyRetirementDenied("legacy_quarantine_changed")
+    counts = {"context_keys": 0, "screenshots": 0}
+    for mapping, key, _path in slots:
+        del mapping[key]
+        counts["screenshots" if key == "image_data_url" else "context_keys"] += 1
+    return counts
+
+
+def quarantine_document(document, *, store=None):
+    """Sanitize a serialized context before deserialization; preserve other data."""
+    if type(document) is not dict:
+        raise LegacyRetirementDenied("legacy_quarantine_ambiguous")
+    with LOCK:
+        slots = list(_context_slots(document.get("data")))
+        rewrites, summaries = [], []
+        agents = document.get("agents", [])
+        if type(agents) is not list or len(agents) > 64:
+            raise LegacyRetirementDenied("legacy_quarantine_limit")
+        budget = [0]
+        for index, agent in enumerate(agents):
+            if type(agent) is not dict:
+                continue
+            raw = agent.get("history")
+            if type(raw) is not str or '"image_data_url"' not in raw or '"chrome_bridge"' not in raw:
+                continue
+            if len(raw.encode("utf-8")) > MAX_BYTES:
+                raise LegacyRetirementDenied("legacy_quarantine_limit")
+            tree = json.loads(raw, object_pairs_hook=_unique)
+            history_slots = list(_walk(tree, ["agents", index, "history"], budget, summaries))
+            if history_slots:
+                slots.extend(history_slots)
+                rewrites.append((agent, tree))
+        counts = _commit(document.get("id"), slots, store or retain_private)
+        for node, summary in summaries:
+            node["summary"] = json.dumps(summary, ensure_ascii=False, separators=(",", ":"))
+        for agent, tree in rewrites:
+            agent["history"] = json.dumps(tree, ensure_ascii=False, separators=(",", ":"))
+        return counts
+
+
+def quarantine_context(context, *, store=None):
+    """Remove exact live slots, including subordinate histories, after backup."""
+    from helpers.history import History, Bulk, Topic, Message
+    from agent import Agent
+    with LOCK:
+        slots = list(_context_slots(context.data))
+        agent, seen, budget, changed_messages, summaries = context.agent0, set(), [0], [], []
+        while agent is not None:
+            if id(agent) in seen or len(seen) >= 64:
+                raise LegacyRetirementDenied("legacy_quarantine_limit")
+            index = len(seen)
+            seen.add(id(agent))
+            history = agent.history
+            if type(history) is not History:
+                raise LegacyRetirementDenied("legacy_quarantine_ambiguous")
+            stack = [(history, ["agents", index, "history"])]
+            while stack:
+                record, path = stack.pop()
+                budget[0] += 1
+                if budget[0] > MAX_RECORDS or len(path) > 64:
+                    raise LegacyRetirementDenied("legacy_quarantine_limit")
+                if type(record) is Message:
+                    if record.ai is False and _tool_result(record.content):
+                        if "image_data_url" in record.content:
+                            slots.append((record.content, "image_data_url", path + ["content", "image_data_url"]))
+                            changed_messages.append(record)
+                        summary = _summary_tree(record.summary)
+                        if summary is not None:
+                            slots.append((summary, "image_data_url", path + ["summary", "image_data_url"]))
+                            summaries.append((record, summary))
+                            changed_messages.append(record)
+                    continue
+                keys = ("bulks", "topics", "current") if type(record) is History else ("records",) if type(record) is Bulk else ("messages",) if type(record) is Topic else ()
+                for key in keys:
+                    children = getattr(record, key)
+                    if key == "current":
+                        stack.append((children, path + [key]))
+                    elif type(children) is list:
+                        stack.extend((child, path + [key, index]) for index, child in enumerate(children))
+                    else:
+                        raise LegacyRetirementDenied("legacy_quarantine_ambiguous")
+            agent = agent.data.get(Agent.DATA_NAME_SUBORDINATE)
+        counts = _commit(context.id, slots, store or retain_private)
+        for record, summary in summaries:
+            record.summary = json.dumps(summary, ensure_ascii=False, separators=(",", ":"))
+        for message in changed_messages:
+            message.tokens = 0
+        return counts
+
+
+def retain_private(raw, *, root=None):
+    """Content-addressed private recovery blobs; never returned or auto-restored."""
+    from helpers import files
+    root = root or files.get_abs_path()
+    if not hasattr(os, "O_NOFOLLOW") or len(raw) > MAX_BYTES:
+        raise LegacyRetirementDenied("legacy_quarantine_unavailable")
+    fds = []
+    try:
+        fds.append(os.open(root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW))
+        fds.append(os.open("usr", os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=fds[-1]))
+        name = "browser_bridge_legacy_quarantine"
+        try:
+            os.mkdir(name, 0o700, dir_fd=fds[-1])
+            os.fsync(fds[-1])
+        except FileExistsError:
+            pass
+        fds.append(os.open(name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=fds[-1]))
+        directory = os.fstat(fds[-1])
+        if directory.st_uid != os.getuid() or stat.S_IMODE(directory.st_mode) & 0o077:
+            raise LegacyRetirementDenied("legacy_quarantine_unavailable")
+        name = hashlib.sha256(raw).hexdigest() + ".json"
+        try:
+            fd = os.open(name, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600, dir_fd=fds[-1])
+        except FileExistsError:
+            fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=fds[-1])
+            try:
+                info = os.fstat(fd)
+                if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1 or info.st_uid != os.getuid() or stat.S_IMODE(info.st_mode) & 0o077 or info.st_size != len(raw):
+                    raise LegacyRetirementDenied("legacy_quarantine_unavailable")
+                with os.fdopen(fd, "rb", closefd=False) as reader:
+                    if reader.read(MAX_BYTES + 1) != raw:
+                        raise LegacyRetirementDenied("legacy_quarantine_changed")
+            finally:
+                os.close(fd)
+            return
+        with os.fdopen(fd, "wb") as writer:
+            writer.write(raw)
+            writer.flush()
+            os.fsync(writer.fileno())
+        os.fsync(fds[-1])
+    except Exception:
+        raise LegacyRetirementDenied("legacy_quarantine_unavailable") from None
+    finally:
+        for fd in reversed(fds):
+            os.close(fd)
+
+
+def sweep_loaded(offset=0):
+    """One explicit bounded page; dormant chats use the lazy load hook."""
+    from agent import AgentContext
+    from helpers import persist_chat
+    if not enabled() or type(offset) is not int or not 0 <= offset <= MAX_RECORDS:
+        raise LegacyRetirementDenied()
+    contexts = sorted(AgentContext.all(), key=lambda item: item.id)
+    if len(contexts) > MAX_RECORDS:
+        raise LegacyRetirementDenied("legacy_quarantine_limit")
+    counts = {"context_keys": 0, "screenshots": 0, "processed": 0}
+    for context in contexts[offset:offset + 20]:
+        result = quarantine_context(context)
+        persist_chat.save_tmp_chat(context)
+        for key in ("context_keys", "screenshots"):
+            counts[key] += result[key]
+        counts["processed"] += 1
+    following = offset + counts["processed"]
+    return {"scope": "currently_loaded_contexts", **counts,
+            "next_offset": following if following < len(contexts) else None,
+            "dormant_chats": "quarantined_on_next_load", "activation_ready": False}

--- a/plugins/_a0_connector/helpers/browser_bridge_legacy_quarantine.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_legacy_quarantine.py.dox.md
@@ -1,0 +1,53 @@
+# Recoverable legacy context/history quarantine
+
+This plugin-owned migration runs only after a valid explicit retirement journal
+exists. A missing or corrupt journal grants no mutation permission. It never
+maps old keys or identifiers to browser-v1 authority.
+
+The generic `persist_chat._serialize_context` and `_deserialize_context`
+extension seams invoke the plugin's synchronous start hooks. Save/export
+quarantines live main/subordinate histories before serialization; load/import
+quarantines the serialized document before context creation. Only the exact
+`source == "chrome_extension"` context removes `source`,
+`chrome_browser_session_id`, and `chrome_extension_capabilities`.
+
+History traversal follows only actual History/Bulk/Topic/Message structural
+edges. Only non-AI Message content with exact `tool_name: chrome_bridge`, string
+tool result/session/command IDs and a terminal command status loses its
+`image_data_url` member. Exact JSON tool-result summaries on the same owned
+Message receive the same treatment; prose, unknown structures, user messages,
+metadata, explicit attachments, safe outcome fields and dimensions stay intact.
+Token caches of changed live messages are invalidated. Repeated runs are no-ops.
+
+Before removing anything, retain only removed values and structural locations
+in a content-addressed recovery blob under
+`usr/browser_bridge_legacy_quarantine`. It is outside normal chat loading and
+artifact transport, never returned by the API and never automatically restored.
+The root/usr/quarantine chain is opened with descriptor-relative no-follow
+checks; the quarantine directory is owner-only 0700 and new blobs 0600. Files
+are exclusive-create, flushed and fsynced before mutations. Existing blobs must
+match exact bytes, owner, private mode and single-link regular-file shape. No
+overwrite or automatic purge occurs. An interrupted partial blob fails closed
+for manual operator repair. Recoverability does not authorize re-enabling old
+credentials or browser bindings; any recovery is an explicit operator action.
+
+Bound the recovery object to 32 MiB, 1,024 removed members, 10,000 structural
+records and 64 agents/nesting components. Storage failure, concurrent slot
+changes, ambiguous candidate JSON or exceeded limits abort before mutation.
+Repeated live references to the same dictionary/key are rejected before any
+backup or removal so aliasing cannot produce a partially applied deletion.
+Private backup data is deliberately separate from the redacted retirement
+journal. Do not log it or include it in v1 inventories.
+
+The authenticated, CSRF-protected `quarantine` API action additionally requires
+explicit all-legacy-scopes confirmation and an integer offset. It processes at
+most 20 currently loaded contexts per request using normal atomic chat saves.
+Offsets refer to the current sorted inventory, not a durable snapshot; repeat
+from zero if contexts change. Dormant saved chats are not read or overwritten
+by the sweep and are migrated on their next normal load. The response labels
+that scope and always reports `activation_ready: false`; no whole-installation
+cleanup claim is made. Chrome storage in an old extension ID/profile and its
+tabs are outside Core authority and remain operator-owned cleanup.
+
+Verification uses synthetic histories/private temporary roots and the actual
+decorated persistence path; never run tests against live chats or quarantine.

--- a/plugins/_a0_connector/helpers/browser_bridge_legacy_retirement.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_legacy_retirement.py
@@ -1,0 +1,321 @@
+"""Explicit prototype retirement. Never imports legacy authority into bridge v1."""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import math
+import os
+from pathlib import Path
+import sys
+import threading
+import time
+import types
+import uuid
+
+from plugins._a0_connector.helpers.browser_bridge_cutover import (
+    CUTOVER_CONTRACT, LEGACY_PLUGIN_NAME,
+    detect_legacy_browser_bridge, _read_bounded_file,
+)
+
+STORE_KEY = "a0_browser_bridge_legacy_retirement_v1"
+STORE_DIGEST = "28cd59d3bf1e3c5237d9c62102336f5b6f5fc88d89ec16528b6b03079c44cc43"
+MAX_COMMANDS = 512
+MAX_SESSIONS = 64
+STATES = {"draining_legacy", "legacy_disabled", "blocked"}
+COUNTERS = {"completed", "canceled_not_applied", "outcome_unknown"}
+
+
+class LegacyRetirementDenied(ValueError):
+    def __init__(self, code="migration_incomplete"):
+        self.code = code
+        super().__init__(code)
+
+
+def _deny(*args, **kwargs):
+    raise LegacyRetirementDenied("legacy_bridge_retired")
+
+
+class PrototypeRegistryAdapter:
+    """Only the exact inspected prototype implementation can be drained."""
+    def __init__(self, module: types.ModuleType, root: Path):
+        if type(module) is not types.ModuleType or not detect_legacy_browser_bridge(root).confirmed:
+            raise LegacyRetirementDenied()
+        if not hasattr(os, "O_NOFOLLOW"):
+            raise LegacyRetirementDenied()
+        fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        try:
+            source = _read_bounded_file(fd, "helpers/session_store.py")
+        finally:
+            os.close(fd)
+        expected = str(root / "helpers/session_store.py")
+        if (not source.exists or source.unavailable or hashlib.sha256(source.data).hexdigest() != STORE_DIGEST
+            or getattr(module, "__file__", None) != expected
+            or type(getattr(module, "_lock", None)) is not type(threading.RLock())
+            or type(getattr(module, "_sessions", None)) is not dict):
+            raise LegacyRetirementDenied()
+        for name in ("enqueue_command", "pull_next_command", "upsert_session", "store_command_result"):
+            fn = getattr(module, name, None)
+            if not isinstance(fn, types.FunctionType) or fn.__globals__ is not vars(module) or fn.__code__.co_filename != expected:
+                raise LegacyRetirementDenied()
+        self.module = module
+        self.pending = {}
+        self.counts = dict.fromkeys(COUNTERS, 0)
+        self.started = False
+
+    def begin(self):
+        with self.module._lock:
+            sessions = self.module._sessions
+            if len(sessions) > MAX_SESSIONS:
+                raise LegacyRetirementDenied()
+            commands = []
+            for session_id, session in sessions.items():
+                if (type(session) is not self.module.BrowserSession or session.browser_session_id != session_id
+                    or type(session.commands) is not dict or type(session.queue) is not list):
+                    raise LegacyRetirementDenied()
+                for command_id, command in session.commands.items():
+                    if (type(command) is not self.module.BridgeCommand or command.command_id != command_id
+                        or command.browser_session_id != session_id or command.status not in {"queued", "dispatched", "completed", "failed"}
+                        or type(command.created_at) not in {int, float} or type(command.timeout_seconds) not in {int, float}
+                        or type(command.attempts) is not int or not 0 <= command.attempts <= 2147483647
+                        or not math.isfinite(command.created_at) or not math.isfinite(command.timeout_seconds)
+                        or command.timeout_seconds <= 0):
+                        raise LegacyRetirementDenied()
+                    commands.append((session_id, command_id, command))
+            if len(commands) > MAX_COMMANDS:
+                raise LegacyRetirementDenied()
+            now = time.time()
+            # Existing tools reference this module; stop all producers under its
+            # original queue lock before retaining only exact dispatched receipts.
+            for name in ("enqueue_command", "pull_next_command", "upsert_session", "bind_context_to_session", "get_session", "get_session_or_context", "list_sessions"):
+                setattr(self.module, name, _deny)
+            self.module.store_command_result = self.accept_result
+            self.started = True
+            for session_id, command_id, command in commands:
+                if command.status == "queued" and command.attempts == 0:
+                    self.counts["canceled_not_applied"] += 1
+                    command.status, command.error = "failed", "CANCELED_NOT_APPLIED"
+                    command.completed_at = now
+                elif command.status == "dispatched":
+                    self.pending[(session_id, command_id)] = (command, min(now + 30, command.created_at + command.timeout_seconds))
+                elif command.status in {"completed", "failed"} and command.result is not None:
+                    self.counts["completed"] += 1
+                else:
+                    category = "outcome_unknown" if command.attempts else "canceled_not_applied"
+                    self.counts[category] += 1
+                    command.status, command.error = "failed", category.upper()
+                command.payload, command.result, command.target_tab_id = {}, {}, None
+            for session in sessions.values():
+                session.tabs, session.capabilities, session.active_tab_id = {}, {}, None
+                session.queue.clear()  # No redelivery, even from old queued code.
+            return len(self.pending)
+
+    def accept_result(self, browser_session_id, command_id, *, status, **ignored):
+        with self.module._lock:
+            if status not in {"completed", "failed"}:
+                raise LegacyRetirementDenied("legacy_outcome_unknown")
+            item = self.pending.pop((browser_session_id, command_id), None)
+            if item is None:
+                raise LegacyRetirementDenied("legacy_outcome_unknown")
+            command, deadline = item
+            if time.time() >= deadline:
+                command.status, command.error = "failed", "OUTCOME_UNKNOWN"
+                self.counts["outcome_unknown"] += 1
+                raise LegacyRetirementDenied("legacy_outcome_unknown")
+            command.status, command.error, command.completed_at = status, "", time.time()
+            command.result = {}  # Incoming screenshots, text and tab metadata are discarded.
+            self.counts["completed"] += 1
+            return {"status": status}
+
+    def remaining(self):
+        with self.module._lock:
+            now = time.time()
+            for key, (command, deadline) in tuple(self.pending.items()):
+                if now >= deadline:
+                    command.status, command.error, command.completed_at = "failed", "OUTCOME_UNKNOWN", now
+                    self.counts["outcome_unknown"] += 1
+                    self.pending.pop(key)
+            return bool(self.pending)
+
+    def finish(self):
+        with self.module._lock:
+            for command, _deadline in self.pending.values():
+                command.status, command.error = "failed", "OUTCOME_UNKNOWN"
+                self.counts["outcome_unknown"] += 1
+            self.pending.clear()
+            self.module._sessions.clear()
+            self.module.store_command_result = _deny
+            return dict(self.counts)
+
+
+def _installed_adapter():
+    from helpers import plugins
+    roots = list(plugins.get_plugin_roots(LEGACY_PLUGIN_NAME))
+    root = next((Path(path) for path in roots if os.path.lexists(path)), None)
+    if root is None or not detect_legacy_browser_bridge(root).confirmed:
+        raise LegacyRetirementDenied()
+    modules = [module for name, module in tuple(sys.modules.items()) if name in {
+        "usr.plugins.chrome_extension.helpers.session_store", "plugins.chrome_extension.helpers.session_store"}]
+    if len(modules) > 1:
+        raise LegacyRetirementDenied()
+    # Do not execute an unimported third-party plugin to manufacture drain proof.
+    if not modules:
+        return None
+    return PrototypeRegistryAdapter(modules[0], root)
+
+
+class LegacyRetirement:
+    def __init__(self, *, load=None, save=None, adapter=None, disable=None):
+        self.load = load or _load
+        self.save = save or _save
+        self.adapter = adapter or _installed_adapter
+        self.disable = disable or _disable
+        self.lock = threading.RLock()
+        self.task = None
+        self.failed = False
+        self.guard_installed = False
+        self.active_requests = 0
+
+    def _journal(self):
+        value = self.load()
+        if value is None:
+            return None
+        keys = {"schema_version", "migration_id", "state", "started_at_ms", "completed", "canceled_not_applied", "outcome_unknown"}
+        if (type(value) is not dict or set(value) != keys or type(value["schema_version"]) is not int or value["schema_version"] != 1
+            or value["state"] not in STATES or not isinstance(value["migration_id"], str)
+            or len(value["migration_id"]) != 36 or str(uuid.UUID(value["migration_id"])) != value["migration_id"]
+            or type(value["started_at_ms"]) is not int or value["started_at_ms"] < 0
+            or any(type(value[key]) is not int or not 0 <= value[key] <= MAX_COMMANDS for key in COUNTERS)):
+            raise LegacyRetirementDenied()
+        return dict(value)
+
+    def blocked(self):
+        try:
+            with self.lock:
+                return self.failed or self._journal() is not None
+        except Exception:
+            return True
+
+    def status(self):
+        try:
+            with self.lock:
+                journal = self._journal()
+            state = journal["state"] if journal else "not_started"
+            if self.failed or (state == "draining_legacy" and self.task is None):
+                state = "blocked"
+            return {"contract": CUTOVER_CONTRACT, "schema_version": 1, "state": state,
+                    "counts": {key: journal[key] if journal else 0 for key in sorted(COUNTERS)},
+                    "local_browser_cleanup": "operator_required", "browser_tabs_changed": False,
+                    "activation_ready": False}
+        except Exception:
+            return {"contract": CUTOVER_CONTRACT, "schema_version": 1, "state": "blocked",
+                    "reason_code": "migration_incomplete", "activation_ready": False}
+
+    def _write(self, value):
+        self.save(value)
+        if self._journal() != value:
+            raise LegacyRetirementDenied("storage_write_failed")
+
+    async def retire(self):
+        with self.lock:
+            if not self.guard_installed or self.active_requests:
+                raise LegacyRetirementDenied()
+            previous = self._journal()
+            if previous is not None:
+                return self.status()  # Never replay an interrupted drain.
+            adapter = self.adapter()
+            journal = {"schema_version": 1, "migration_id": str(uuid.uuid4()), "state": "draining_legacy",
+                       "started_at_ms": time.time_ns() // 1_000_000, **dict.fromkeys(COUNTERS, 0)}
+            try:
+                self._write(journal)
+                pending = adapter.begin() if adapter is not None else 0
+                # Crash recovery conservatively retains all dispatched work as
+                # unknown. No raw command/session identifier enters the journal.
+                if adapter is not None:
+                    journal.update(adapter.counts)
+                    journal["outcome_unknown"] += pending
+                    self._write(journal)
+            except Exception:
+                self.failed = True
+                if adapter is not None and adapter.started:
+                    adapter.finish()
+                raise LegacyRetirementDenied() from None
+            self.task = asyncio.create_task(self._finish(adapter, journal))
+        await asyncio.shield(self.task)
+        return self.status()
+
+    async def _finish(self, adapter, journal):
+        try:
+            while adapter is not None and adapter.remaining():
+                await asyncio.sleep(0.05)
+            if adapter is not None:
+                journal.update(adapter.finish())
+            self.disable()  # Existing plugin toggle runs only after bounded drain.
+            journal["state"] = "legacy_disabled"
+            with self.lock:
+                self._write(journal)
+        except BaseException:
+            if adapter is not None:
+                journal.update(adapter.finish())
+            journal["state"] = "blocked"
+            self.failed = True
+            try:
+                with self.lock:
+                    self._write(journal)
+            except Exception:
+                pass
+
+
+def _load():
+    from helpers import kvp
+    return kvp.get_persistent(STORE_KEY, None)
+
+
+def _save(value):
+    from helpers import kvp
+    kvp.set_persistent(STORE_KEY, value)
+
+
+def _disable():
+    from helpers import plugins
+    plugins.toggle_plugin(LEGACY_PLUGIN_NAME, False, clear_overrides=True)
+    if plugins.get_toggle_state(LEGACY_PLUGIN_NAME) != "disabled":
+        raise LegacyRetirementDenied()
+
+
+_owner = LegacyRetirement()
+
+
+def get_legacy_retirement():
+    return _owner
+
+
+def install_legacy_retirement_guard(app):
+    """Install once at normal Flask startup; unrelated APIs remain untouched."""
+    if app.extensions.get("a0_legacy_retirement_guard"):
+        return
+    from flask import Response, request, g
+    import json
+
+    @app.before_request
+    def legacy_guard():
+        prefix = next((value for value in ("/api/plugins/chrome_extension/", "/plugins/chrome_extension/") if request.path.startswith(value)), None)
+        if prefix is None:
+            return None
+        with _owner.lock:
+            if not _owner.blocked() or (request.path == prefix + "command_result" and _owner.task is not None and not _owner.task.done() and not _owner.failed):
+                _owner.active_requests += 1
+                g.a0_legacy_retirement_active = True
+                return None  # Existing route still verifies its API credential.
+            state = _owner.status()["state"]
+        code = "LEGACY_CUTOVER_IN_PROGRESS" if state == "draining_legacy" else "LEGACY_BRIDGE_RETIRED"
+        return Response(json.dumps({"error": code}), status=409 if state == "draining_legacy" else 410, mimetype="application/json")
+
+    @app.teardown_request
+    def legacy_request_finished(_error):
+        if getattr(g, "a0_legacy_retirement_active", False):
+            with _owner.lock:
+                _owner.active_requests -= 1
+            g.a0_legacy_retirement_active = False
+
+    app.extensions["a0_legacy_retirement_guard"] = True
+    _owner.guard_installed = True

--- a/plugins/_a0_connector/helpers/browser_bridge_legacy_retirement.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_legacy_retirement.py.dox.md
@@ -1,0 +1,40 @@
+# Explicit legacy retirement
+
+`LegacyRetirement` is an opt-in local retirement adapter, not a bridge-v1
+activation or migration-readiness authority. Normal startup only installs the
+Flask request guard; no journal means no retirement effects. A corrupt or
+interrupted journal blocks only legacy Chrome bridge requests/tools, never
+unrelated WebUI APIs. Both the canonical `/api/plugins/chrome_extension/`
+routes and defensive `/plugins/chrome_extension/` alias are covered. Existing
+in-flight legacy requests prevent starting retirement.
+
+The authenticated, CSRF-protected retirement endpoint requires explicit
+confirmation covering all legacy plugin scopes. It accepts only an inspected,
+structurally confirmed prototype root and, if loaded, the exact bounded source
+digest and known process-registry shape. It never imports an unloaded legacy
+plugin to create proof. Ambiguous roots, multiple registries, unsafe filesystem
+inspection, malformed commands, or storage failures fail closed.
+
+Under the original registry lock, producers and redelivery stop before queued
+commands become `CANCELED_NOT_APPLIED`. Only already-dispatched exact
+session/command receipts may complete once, until the earlier original deadline
+or thirty seconds. Unresolved commands become `OUTCOME_UNKNOWN` and are never
+replayed. Incoming payloads, screenshots and tab metadata are discarded. The
+process registry is scrubbed before the existing global plugin toggle disables
+the prototype and clears its scope overrides. No token rotation, old-authority
+transfer, browser automation, tab closure, plugin-file deletion, or v1 selection
+occurs. The persisted journal contains only a migration UUID, timestamps, state
+and bounded counters. An interrupted journal never silently resumes.
+
+The `Agent.get_tool` extension rejects only `chrome_bridge` after retirement
+begins. `browser_bridge_legacy_quarantine.py` owns the recoverable, exact-owner
+context/history lazy persistence hooks and bounded loaded-context sweep.
+Browser-local storage cleanup, cross-extension-ID cleanup attestation, dormant
+chat loading, and full production cutover remain separate requirements.
+Status therefore always reports `activation_ready: false` and
+operator-required local browser cleanup. The read-only cutover detector and
+runtime owner's existing legacy admission checks are not bypassed.
+
+Focused tests use an exact, inert prototype source fixture and temporary
+registries. They must not touch live plugin credentials, contexts, or browser
+tabs.

--- a/plugins/_a0_connector/helpers/browser_bridge_local_approval.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_local_approval.py
@@ -1,0 +1,32 @@
+"""Exact authenticated route adapter for explicit companion-local decisions."""
+
+from plugins._a0_connector.helpers.browser_bridge_context_controller import (
+    _request_document, _exact_keys, _contract, _identifier,
+)
+from plugins._a0_connector.helpers.browser_bridge_runtime import BrowserBridgeRuntimeDenied
+
+
+class BrowserBridgeLocalApprovalController:
+    def __init__(self, *, actions, sites, current):
+        self.actions, self.sites, self.current = actions, sites, current
+
+    async def dispatch(self, route, document):
+        request = _request_document(document)
+        _exact_keys(request, required={"contract_version", "challenge_id", "kind", "decision"})
+        _contract(request)
+        challenge_id = _identifier(request["challenge_id"], "challenge_id")
+        if not self.current(route) or "browser.approval" not in route.principal.scopes:
+            raise BrowserBridgeRuntimeDenied("SCOPE_DENIED")
+        kind, decision = request["kind"], request["decision"]
+        if kind == "site" and decision in ("deny", "allow_once", "allow_turn"):
+            receipt = await self.sites.decide(subject_id=route.principal.subject_id,
+                                              challenge_id=challenge_id, decision=decision,
+                                              expected_route=route)
+        elif kind == "action" and decision in ("decline", "approve_once"):
+            receipt = await self.actions.decide(subject_id=route.principal.subject_id,
+                                                challenge_id=challenge_id, choice=decision,
+                                                expected_route=route)
+        else:
+            raise BrowserBridgeRuntimeDenied("INVALID_STATE")
+        # Public projection says accepted, never that Chrome applied the action.
+        return {"contract_version": 1, **receipt.as_public_dict()}

--- a/plugins/_a0_connector/helpers/browser_bridge_local_approval.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_local_approval.py.dox.md
@@ -1,0 +1,23 @@
+# Browser bridge local approval adapter
+
+## Contract
+
+- Accept only integer `contract_version: 1`, `challenge_id`, `kind`, and
+  `decision` from an admitted principal with `browser.approval`.
+- `kind: site` accepts `deny`, `allow_once`, `allow_turn`; `kind: action`
+  accepts `decline`, `approve_once`. Inputs cannot supply subject, context,
+  bridge, browser, operation, receipt or grant bindings.
+- Existing site/action repositories compare the caller's immutable principal
+  object, SID, load generation and fixed transport profile to their retained
+  challenge under the repository lock, including same-choice replay. Shared
+  subject identity alone cannot decide another bridge's challenge.
+- Reuse repository receipt and correlated-control lifecycles; return only
+  their public accepted projection. Accepted never means browser-applied.
+- The companion must expose this event only from explicit local user action,
+  not a page script or model/tool call. Server adapter construction alone
+  does not attest that companion boundary or activate production.
+
+## Verification
+
+- Run `tests/test_browser_bridge_local_approval.py` for exact-principal,
+  socket/generation isolation and existing site/action decision composition.

--- a/plugins/_a0_connector/helpers/browser_bridge_messages.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_messages.py
@@ -1,0 +1,180 @@
+"""Once-only, authorized text delivery to an existing Agent Zero context.
+
+The durable reservation precedes any log/model effect. A crash in that window
+is uncertain, never permission to replay a message. No attachment paths, model
+configuration, project creation, or legacy connector authority cross this lane.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import threading
+import time
+from typing import Any, Callable
+
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    BrowserBridgeContextAccess, BrowserBridgeContextRoute,
+)
+from plugins._a0_connector.helpers.browser_bridge_journal import BrowserBridgeJournal
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+)
+
+
+_STORE_KEY = "a0_browser_bridge_messages_v1"
+_MAX_TEXT_BYTES = 32768
+_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+_HASH = re.compile(r"[a-f0-9]{64}")
+_persistent_lock = threading.RLock()
+
+
+class BrowserBridgeMessageError(RuntimeError):
+    def __init__(self, code: str, *, outcome: str = "not_applied") -> None:
+        super().__init__(code)
+        self.code = code
+        self.outcome = outcome
+
+
+class BrowserBridgeMessageDispatcher:
+    def __init__(
+        self,
+        *,
+        access: BrowserBridgeContextAccess,
+        server_instance_id: Callable[[], str],
+        load: Callable[[str, Any], Any] | None = None,
+        save: Callable[[str, dict[str, Any]], None] | None = None,
+        deliver: Callable[[str, str, str], None] | None = None,
+        clock_ms: Callable[[], int] | None = None,
+        lock=None,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        self._access = access
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        access_profile = getattr(access, "transport_profile", None)
+        if (
+            access_profile is not None
+            and access_profile is not self._transport_profile
+        ):
+            raise BrowserBridgeMessageError("INVALID_STATE")
+        self._server_instance_id = server_instance_id
+        self._journal = BrowserBridgeJournal(
+            _STORE_KEY, _validate_record,
+            lambda: BrowserBridgeMessageError("MESSAGE_STORE_UNAVAILABLE"),
+            load=load, save=save,
+        )
+        self._deliver = deliver or _deliver_existing_context
+        self._clock_ms = clock_ms or (lambda: time.time_ns() // 1_000_000)
+        self._lock = lock or _persistent_lock
+
+    @property
+    def transport_profile(self) -> BrowserBridgeTransportProfile:
+        return self._transport_profile
+
+    def send(self, route: BrowserBridgeContextRoute, document: dict[str, Any]) -> dict[str, Any]:
+        if not isinstance(document, dict) or set(document) != {"contract_version", "context_id", "client_message_id", "text"} or type(document.get("contract_version")) is not int or document["contract_version"] != 1:
+            raise BrowserBridgeMessageError("INVALID_STATE")
+        context_id = _identifier(document["context_id"])
+        message_id = _identifier(document["client_message_id"])
+        text = document["text"]
+        if not isinstance(text, str) or not text.strip():
+            raise BrowserBridgeMessageError("INVALID_STATE")
+        try:
+            if len(text.encode("utf-8")) > _MAX_TEXT_BYTES:
+                raise BrowserBridgeMessageError("INVALID_STATE")
+        except UnicodeError:
+            raise BrowserBridgeMessageError("INVALID_STATE") from None
+        self._authorize(route, context_id)
+        try:
+            server_id = _identifier(self._server_instance_id())
+        except Exception:
+            raise BrowserBridgeMessageError("SCOPE_DENIED") from None
+        binding = {
+            "server_instance_id": server_id,
+            "bridge_id": route.principal.principal_id,
+            "subject_id": route.principal.subject_id,
+            "context_id": context_id,
+            "client_message_id": message_id,
+        }
+        key = _digest(binding)
+        content_hash = _digest({"binding": binding, "text": text})
+        with self._lock:
+            prior = self._journal.get(key)
+            if prior is not None:
+                if prior["content_hash"] != content_hash:
+                    raise BrowserBridgeMessageError("IDEMPOTENCY_CONFLICT")
+                if prior["state"] != "accepted":
+                    raise BrowserBridgeMessageError("OUTCOME_UNKNOWN", outcome="unknown")
+                self._authorize(route, context_id)
+                return _accepted(context_id, message_id)
+            now = self._clock_ms()
+            if type(now) is not int or now < 0:
+                raise BrowserBridgeMessageError("INVALID_STATE")
+            record = {"content_hash": content_hash, "state": "reserved", "created_at_ms": now}
+            self._journal.put(key, record)
+            # No await or queued closure separates this final current-route
+            # check from the actual model/log effect.
+            self._authorize(route, context_id)
+            try:
+                still_same_server = self._server_instance_id() == server_id
+            except Exception:
+                still_same_server = False
+            if not still_same_server:
+                raise BrowserBridgeMessageError("SCOPE_DENIED")
+            try:
+                self._deliver(context_id, text, message_id)
+            except Exception:
+                # Keep the reservation even if only the log effect happened.
+                raise BrowserBridgeMessageError("OUTCOME_UNKNOWN", outcome="unknown") from None
+            record["state"] = "accepted"
+            try:
+                self._journal.put(key, record)
+            except BrowserBridgeMessageError:
+                raise BrowserBridgeMessageError("OUTCOME_UNKNOWN", outcome="unknown") from None
+        return _accepted(context_id, message_id)
+
+    def _authorize(self, route: BrowserBridgeContextRoute, context_id: str) -> None:
+        if route.transport_profile is not self._transport_profile:
+            raise BrowserBridgeMessageError("SCOPE_DENIED")
+        try:
+            self._access.authorize_message_target(route, context_id=context_id)
+        except Exception:
+            raise BrowserBridgeMessageError("SCOPE_DENIED") from None
+
+
+def _validate_record(record):
+    if not isinstance(record, dict) or set(record) != {"content_hash", "state", "created_at_ms"} or not isinstance(record["content_hash"], str) or not _HASH.fullmatch(record["content_hash"]) or record["state"] not in {"reserved", "accepted"} or type(record["created_at_ms"]) is not int or record["created_at_ms"] < 0:
+        raise ValueError()
+
+
+def _identifier(value: Any) -> str:
+    if not isinstance(value, str) or _ID.fullmatch(value) is None:
+        raise BrowserBridgeMessageError("INVALID_STATE")
+    return value
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def _accepted(context_id: str, message_id: str) -> dict[str, Any]:
+    return {"contract_version": 1, "context_id": context_id, "client_message_id": message_id, "status": "accepted"}
+
+
+def _deliver_existing_context(context_id: str, text: str, message_id: str) -> None:
+    from agent import AgentContext, AgentContextType, UserMessage
+
+    context = AgentContext.get(context_id)
+    if context is None or context.type == AgentContextType.BACKGROUND:
+        raise BrowserBridgeMessageError("CONTEXT_NOT_FOUND")
+    context.log.log(type="user", heading="", content=text, kvps={}, id=message_id)
+    # AgentContext owns this task independently of the WebSocket/side panel.
+    # Do not switch global current context or inherit caller paths/profiles.
+    context.communicate(UserMessage(message=text, attachments=[]))

--- a/plugins/_a0_connector/helpers/browser_bridge_operations.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_operations.py
@@ -1,0 +1,1863 @@
+"""Bounded, process-only browser operation and control dispatch foundation.
+
+This module deliberately has no dependency on the connector's legacy runtime
+registry.  Callers must inject both current authorization and a restricted
+sender.  It is an internal seam; importing it does not activate or advertise
+the browser bridge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from dataclasses import dataclass, field
+import json
+import hashlib
+import math
+import re
+import threading
+import time
+from typing import Any, Awaitable, Callable, Mapping
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+    require_runtime_transport_principal,
+    require_transport_principal_identity,
+    transport_profile_for_principal_identity,
+)
+
+
+CONTRACT_VERSION = 1
+OPERATION_EVENT = "connector_browser_op"
+CONTROL_EVENT = "connector_browser_control"
+MAX_TIMEOUT_MS = 120_000
+MAX_NON_ARTIFACT_BYTES = 512 * 1024
+MAX_IDENTIFIER_BYTES = 256
+MAX_REASON_BYTES = 2_048
+MAX_CAPABILITIES = 64
+MAX_CAPABILITY_BYTES = 128
+MAX_DISPOSITIONS = 256
+MAX_JSON_DEPTH = 32
+MAX_JSON_NODES = 20_000
+
+_ACTIONS = frozenset(
+    {
+        "open", "list", "state", "set_active", "navigate", "back",
+        "forward", "reload", "content", "detail", "evaluate", "click",
+        "type", "submit", "type_submit", "scroll", "hover",
+        "double_click", "right_click", "drag", "wheel", "mouse",
+        "keyboard", "key_chord", "clipboard", "set_viewport",
+        "select_option", "set_checked", "upload_file", "screenshot",
+        "close", "close_all", "multi", "ensure", "status", "claim",
+    }
+)
+_READ_ONLY_ACTIONS = frozenset(
+    {"list", "state", "content", "detail", "screenshot", "status"}
+)
+_CONTROL_METHODS = frozenset(
+    {
+        "browser.cancel",
+        "browser.finalize_turn",
+        "browser.resolve_challenge",
+        "browser.reconcile",
+    }
+)
+_OUTCOMES = frozenset({"not_applied", "applied", "unknown"})
+_DISPOSITIONS = frozenset({"ephemeral", "deliverable", "handoff"})
+_ACTION_CHALLENGE_CLASSES = frozenset(
+    {"sensitive_input", "external_side_effect", "unknown"}
+)
+_ERROR_CODE = re.compile(r"[A-Z][A-Z0-9_]{0,63}")
+_CORE_CORRELATION_ID = re.compile(r"[A-Za-z0-9_-]{1,128}")
+_NATIVE_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]*")
+
+
+class BrowserBridgeBrokerError(RuntimeError):
+    """A local operation was rejected before it crossed the bridge."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        outcome: str = "not_applied",
+        retryable: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.outcome = outcome
+        self.retryable = retryable
+
+
+@dataclass(frozen=True, slots=True)
+class BridgeAuthorization:
+    """Current server-derived authority and negotiated capability snapshot."""
+
+    principal: WsPrincipal
+    connector_sid: str
+    load_generation_id: str
+    contract_version: int
+    outer_features: frozenset[str]
+    actions: frozenset[str]
+    features: frozenset[str]
+
+    def __post_init__(self) -> None:
+        for name in ("outer_features", "actions", "features"):
+            object.__setattr__(self, name, frozenset(getattr(self, name)))
+
+
+@dataclass(frozen=True, slots=True)
+class OperationBinding:
+    principal: WsPrincipal
+    connector_sid: str
+    load_generation_id: str
+    context_id: str
+    browser_session_id: str
+    turn_id: str
+    action_id: str
+    op_id: str
+
+    @property
+    def bridge_id(self) -> str:
+        return self.principal.principal_id
+
+
+@dataclass(frozen=True, slots=True)
+class TurnBinding:
+    principal: WsPrincipal
+    connector_sid: str
+    load_generation_id: str
+    context_id: str
+    browser_session_id: str
+    turn_id: str
+
+    @property
+    def bridge_id(self) -> str:
+        return self.principal.principal_id
+
+
+@dataclass(frozen=True, slots=True)
+class ControlBinding:
+    principal: WsPrincipal
+    connector_sid: str
+    load_generation_id: str
+    context_id: str
+    browser_session_id: str
+    turn_id: str
+    control_id: str
+    method: str
+    op_id: str | None = None
+    action_id: str | None = None
+
+    @property
+    def bridge_id(self) -> str:
+        return self.principal.principal_id
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationBinding:
+    """Process-owned provisional route identity for one reconcile control."""
+
+    principal: WsPrincipal
+    connector_sid: str
+    load_generation_id: str
+    control_id: str
+    transport_profile: BrowserBridgeTransportProfile
+
+    @property
+    def bridge_id(self) -> str:
+        return self.principal.principal_id
+
+    @property
+    def method(self) -> str:
+        return "browser.reconcile"
+
+
+@dataclass(frozen=True, slots=True)
+class BrokerCompletion:
+    ok: bool
+    code: str | None = None
+    error: str | None = None
+    outcome: str | None = None
+    retryable: bool = False
+    result: dict[str, Any] | None = field(default=None, repr=False)
+    receipts: tuple[Any, ...] = field(default=(), repr=False)
+    artifacts: tuple[Any, ...] = field(default=(), repr=False)
+    details: dict[str, Any] | None = field(default=None, repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class OperationTicket:
+    binding: OperationBinding
+    deadline_ms: int
+    effect: str
+    _future: asyncio.Future[BrokerCompletion] = field(
+        repr=False, compare=False, hash=False
+    )
+    action: str = ""
+    target_tab_handle: str | None = None
+    target_ref: str | None = field(default=None, repr=False)
+    expected_action_class: str | None = field(default=None, repr=False)
+    text_sha256: str | None = field(default=None, repr=False)
+    canonical_parameter_hash: str | None = field(default=None, repr=False)
+    destination_origin: str | None = field(default=None, repr=False)
+    _dispatch_future: asyncio.Future[BrokerCompletion] | None = field(default=None, repr=False, compare=False, hash=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ControlTicket:
+    binding: ControlBinding | ReconciliationBinding
+    deadline_ms: int
+    _future: asyncio.Future[BrokerCompletion] = field(
+        repr=False, compare=False, hash=False
+    )
+    _settlement_acceptor: Callable[
+        [BrokerCompletion], BrokerCompletion | None
+    ] | None = field(default=None, repr=False, compare=False, hash=False)
+
+
+@dataclass(frozen=True, slots=True)
+class DisconnectSummary:
+    operations: int
+    controls: int
+
+
+class SettlementStatus:
+    SETTLED = "settled"
+    NOT_FOUND = "not_found"
+    MISMATCH = "mismatch"
+    DUPLICATE = "duplicate"
+
+
+Authorizer = Callable[
+    [OperationBinding | TurnBinding | ControlBinding | ReconciliationBinding],
+    BridgeAuthorization | None,
+]
+Sender = Callable[
+    [str, str, dict[str, Any], str, WsPrincipal], Awaitable[None]
+]
+
+
+class BrowserBridgeOperationBroker:
+    """Bounded pending registry and exact operation/control correlator."""
+
+    def __init__(
+        self,
+        *,
+        sender: Sender,
+        authorizer: Authorizer,
+        clock_ms: Callable[[], int] | None = None,
+        max_pending_operations: int = 128,
+        max_pending_controls: int = 128,
+        max_completed_ids: int = 2_048,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        if min(max_pending_operations, max_pending_controls, max_completed_ids) < 1:
+            raise ValueError("Broker bounds must be positive")
+        self._sender = sender
+        self._authorizer = authorizer
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        self._clock_ms = clock_ms or (lambda: time.monotonic_ns() // 1_000_000)
+        self._max_pending_operations = max_pending_operations
+        self._max_pending_controls = max_pending_controls
+        self._max_completed_ids = max_completed_ids
+        self._operations: dict[str, OperationTicket] = {}
+        self._action_identities: set[tuple[str, str, str, str]] = set()
+        self._controls: dict[str, ControlTicket] = {}
+        self._completed_operations: deque[str] = deque()
+        self._completed_operation_set: set[str] = set()
+        self._completed_controls: deque[str] = deque()
+        self._completed_control_set: set[str] = set()
+        # A reply can settle before an injected sender returns. Bound and retain
+        # transport tasks separately from pending replies so fast settlements
+        # cannot create an unbounded backlog of still-running sends.
+        self._send_tasks: set[asyncio.Task[None]] = set()
+        self._max_send_tasks = max_pending_operations + max_pending_controls
+        self._lock = threading.RLock()
+
+    @property
+    def pending_operation_count(self) -> int:
+        with self._lock:
+            return len(self._operations)
+
+    @property
+    def transport_profile(self) -> BrowserBridgeTransportProfile:
+        return self._transport_profile
+
+    @property
+    def pending_control_count(self) -> int:
+        with self._lock:
+            return len(self._controls)
+
+    def current_operation(self, *, principal: WsPrincipal, connector_sid: str,
+                          load_generation_id: str, op_id: str) -> OperationTicket | None:
+        """Return retained intent only for an exact still-authorized pending op."""
+        with self._lock:
+            ticket = self._operations.get(op_id)
+            if ticket is None or not self._source_matches(ticket.binding, principal, connector_sid, load_generation_id):
+                return None
+            if self._clock_ms() >= ticket.deadline_ms:
+                return None
+            try:
+                self._authorize(ticket.binding, scope="browser.operate", event=OPERATION_EVENT,
+                                outer_feature="browser_extension_bridge_v1")
+            except BrowserBridgeBrokerError:
+                return None
+            return ticket if self._operations.get(op_id) is ticket else None
+
+    def remaining_operation_ms(self, ticket: OperationTicket) -> int:
+        binding = ticket.binding
+        current = self.current_operation(principal=binding.principal, connector_sid=binding.connector_sid,
+                                         load_generation_id=binding.load_generation_id, op_id=binding.op_id)
+        return max(0, ticket.deadline_ms - self._clock_ms()) if current is ticket else 0
+
+    def pending_operations_for_turn(self, turn: TurnBinding) -> tuple[OperationTicket, ...]:
+        """Snapshot only this exact live route's turn for process-owned cleanup."""
+        self._validate_turn_binding(turn)
+        with self._lock:
+            return tuple(
+                ticket for ticket in self._operations.values()
+                if self._source_matches(ticket.binding, turn.principal, turn.connector_sid, turn.load_generation_id)
+                and ticket.binding.context_id == turn.context_id
+                and ticket.binding.browser_session_id == turn.browser_session_id
+                and ticket.binding.turn_id == turn.turn_id
+            )
+
+    async def begin_operation(
+        self,
+        binding: OperationBinding,
+        *,
+        action: str,
+        target: Mapping[str, Any] | None,
+        args: Mapping[str, Any],
+        timeout_ms: int,
+        required_capabilities: tuple[str, ...] | list[str],
+        policy: Mapping[str, Any] | None = None,
+        display: Mapping[str, Any] | None = None,
+        dispatch_preflight: Callable[[], bool] | None = None,
+    ) -> OperationTicket:
+        self._validate_operation_binding(binding)
+        if action not in _ACTIONS:
+            raise _rejected("UNSUPPORTED_CAPABILITY", "Unsupported browser action")
+        timeout_ms = _timeout(timeout_ms)
+        required = _capabilities(required_capabilities)
+        canonical_target = _target(target)
+        canonical_args = _mapping_copy(args, "args")
+        canonical_policy = _policy(policy)
+        canonical_display = _display(display)
+        authorization = self._authorize(
+            binding,
+            scope="browser.operate",
+            event=OPERATION_EVENT,
+            outer_feature="browser_extension_bridge_v1",
+        )
+        available = authorization.actions | authorization.features
+        if action not in authorization.actions or any(
+            capability not in available for capability in required
+        ):
+            raise _rejected(
+                "UNSUPPORTED_CAPABILITY",
+                "The bridge does not support all required capabilities",
+            )
+        payload = {
+            "contract_version": CONTRACT_VERSION,
+            "bridge_id": binding.bridge_id,
+            "load_generation_id": binding.load_generation_id,
+            "op_id": binding.op_id,
+            "action_id": binding.action_id,
+            "context_id": binding.context_id,
+            "browser_session_id": binding.browser_session_id,
+            "turn_id": binding.turn_id,
+            "action": action,
+            "target": canonical_target,
+            "args": canonical_args,
+            "timeout_ms": timeout_ms,
+            "required_capabilities": list(required),
+            "policy": canonical_policy,
+            "display": canonical_display,
+        }
+        payload = _bounded_json_copy(payload)
+        loop = asyncio.get_running_loop()
+        parameter_hash = _operation_parameter_hash(
+            binding,
+            action,
+            canonical_target,
+            canonical_args,
+            canonical_display,
+        )
+        if action in {"navigate", "click", "type", "upload_file"} and parameter_hash is None:
+            raise _rejected("INVALID_STATE", "Invalid challenge-bound browser action")
+        text_sha256 = (
+            _type_text_digest(canonical_args) if action == "type" else None
+        )
+        ticket = OperationTicket(
+            binding=binding,
+            deadline_ms=self._clock_ms() + timeout_ms,
+            effect="read_only" if action in _READ_ONLY_ACTIONS else "mutating",
+            _future=loop.create_future(),
+            action=action,
+            target_tab_handle=canonical_target.get("tab_handle") if canonical_target else None,
+            target_ref=(
+                canonical_args.get("ref")
+                if action in {"click", "type", "upload_file"}
+                else None
+            ),
+            expected_action_class=(
+                canonical_args.get("expected_action_class")
+                if action in {"click", "type", "upload_file"}
+                else None
+            ),
+            text_sha256=text_sha256,
+            canonical_parameter_hash=parameter_hash,
+            destination_origin=_navigation_origin(action, canonical_args),
+            _dispatch_future=loop.create_future(),
+        )
+        action_identity = self._action_identity(binding)
+        with self._lock:
+            self._check_send_capacity_locked()
+            if len(self._operations) >= self._max_pending_operations:
+                raise _rejected("INVALID_STATE", "Operation registry is full")
+            if (
+                binding.op_id in self._operations
+                or binding.op_id in self._completed_operation_set
+            ):
+                raise _rejected("IDEMPOTENCY_CONFLICT", "Operation ID is not fresh")
+            if action_identity in self._action_identities:
+                raise _rejected("IDEMPOTENCY_CONFLICT", "Action is already pending")
+            self._operations[binding.op_id] = ticket
+            self._action_identities.add(action_identity)
+            self._launch_send(ticket, OPERATION_EVENT, payload, binding.op_id, dispatch_preflight)
+        return ticket
+
+    async def perform(self, binding: OperationBinding, **kwargs: Any) -> BrokerCompletion:
+        ticket = await self.begin_operation(binding, **kwargs)
+        return await self.wait_operation(ticket)
+
+    async def begin_cancel(
+        self,
+        operation: OperationTicket,
+        *,
+        control_id: str,
+        reason: str,
+        timeout_ms: int,
+    ) -> ControlTicket:
+        _core_correlation_id(control_id, "control_id")
+        timeout_ms = _timeout(timeout_ms)
+        reason = _reason(reason)
+        with self._lock:
+            if self._operations.get(operation.binding.op_id) is not operation:
+                raise _rejected("INVALID_STATE", "Only the exact pending operation can be canceled")
+        binding = ControlBinding(
+            principal=operation.binding.principal,
+            connector_sid=operation.binding.connector_sid,
+            load_generation_id=operation.binding.load_generation_id,
+            context_id=operation.binding.context_id,
+            browser_session_id=operation.binding.browser_session_id,
+            turn_id=operation.binding.turn_id,
+            control_id=control_id,
+            method="browser.cancel",
+            op_id=operation.binding.op_id,
+            action_id=operation.binding.action_id,
+        )
+        payload = {
+            "method": binding.method,
+            "contract_version": CONTRACT_VERSION,
+            "bridge_id": binding.bridge_id,
+            "load_generation_id": binding.load_generation_id,
+            "control_id": binding.control_id,
+            "op_id": binding.op_id,
+            "action_id": binding.action_id,
+            "context_id": binding.context_id,
+            "browser_session_id": binding.browser_session_id,
+            "turn_id": binding.turn_id,
+            "reason": reason,
+        }
+        return await self._begin_control(binding, payload, timeout_ms)
+
+    async def begin_finalize(
+        self,
+        turn: TurnBinding,
+        *,
+        control_id: str,
+        dispositions: Mapping[str, str],
+        reason: str,
+        timeout_ms: int,
+    ) -> ControlTicket:
+        self._validate_turn_binding(turn)
+        _core_correlation_id(control_id, "control_id")
+        timeout_ms = _timeout(timeout_ms)
+        reason = _reason(reason)
+        canonical_dispositions = _dispositions(dispositions)
+        binding = ControlBinding(
+            principal=turn.principal,
+            connector_sid=turn.connector_sid,
+            load_generation_id=turn.load_generation_id,
+            context_id=turn.context_id,
+            browser_session_id=turn.browser_session_id,
+            turn_id=turn.turn_id,
+            control_id=control_id,
+            method="browser.finalize_turn",
+        )
+        payload = {
+            "method": binding.method,
+            "contract_version": CONTRACT_VERSION,
+            "bridge_id": binding.bridge_id,
+            "load_generation_id": binding.load_generation_id,
+            "control_id": binding.control_id,
+            "context_id": binding.context_id,
+            "browser_session_id": binding.browser_session_id,
+            "turn_id": binding.turn_id,
+            "dispositions": canonical_dispositions,
+            "reason": reason,
+        }
+        return await self._begin_control(binding, payload, timeout_ms)
+
+    async def begin_reconcile(
+        self,
+        binding: ReconciliationBinding,
+        *,
+        expected_contexts: list[Mapping[str, Any]]
+        | tuple[Mapping[str, Any], ...],
+        event_cursors: list[Mapping[str, Any]]
+        | tuple[Mapping[str, Any], ...],
+        known_control_ids: list[str] | tuple[str, ...],
+        timeout_ms: int,
+        dispatch_preflight: Callable[[], bool],
+        settlement_acceptor: Callable[
+            [BrokerCompletion], BrokerCompletion | None
+        ],
+    ) -> ControlTicket:
+        """Queue one provisional-route reconciliation control.
+
+        The synchronous settlement acceptor is the security barrier between a
+        verified reconcile result and route promotion.  It runs before the
+        result future is delivered, so a following critical event cannot rely
+        on transport FIFO alone for authority.
+        """
+
+        self._validate_reconciliation_binding(binding)
+        if binding.transport_profile is not self._transport_profile:
+            raise _rejected("SCOPE_DENIED", "Reconciliation transport is unavailable")
+        timeout_ms = _timeout(timeout_ms)
+        if not callable(dispatch_preflight) or not callable(settlement_acceptor):
+            raise _rejected("INVALID_STATE", "Reconciliation authority is unavailable")
+        payload = {
+            "method": "browser.reconcile",
+            "contract_version": CONTRACT_VERSION,
+            "bridge_id": binding.bridge_id,
+            "load_generation_id": binding.load_generation_id,
+            "control_id": binding.control_id,
+            "expected_contexts": _reconciliation_expected_contexts(
+                expected_contexts
+            ),
+            "event_cursors": _reconciliation_event_cursors(event_cursors),
+            "known_control_ids": _reconciliation_control_ids(
+                known_control_ids
+            ),
+        }
+        return await self._begin_control(
+            binding,
+            payload,
+            timeout_ms,
+            dispatch_preflight,
+            settlement_acceptor,
+        )
+
+    async def _begin_control(
+        self,
+        binding: ControlBinding | ReconciliationBinding,
+        payload: dict[str, Any],
+        timeout_ms: int,
+        dispatch_preflight: Callable[[], bool] | None = None,
+        settlement_acceptor: Callable[
+            [BrokerCompletion], BrokerCompletion | None
+        ] | None = None,
+    ) -> ControlTicket:
+        if binding.method not in _CONTROL_METHODS:
+            raise _rejected("INVALID_STATE", "Unsupported browser control")
+        if (binding.method == "browser.reconcile") is not isinstance(
+            binding, ReconciliationBinding
+        ):
+            raise _rejected("INVALID_STATE", "Invalid browser control binding")
+        self._authorize(
+            binding,
+            scope="browser.control",
+            event=CONTROL_EVENT,
+            outer_feature="connector_browser_control",
+        )
+        payload = _bounded_json_copy(payload)
+        loop = asyncio.get_running_loop()
+        ticket = ControlTicket(
+            binding=binding,
+            deadline_ms=self._clock_ms() + timeout_ms,
+            _future=loop.create_future(),
+            _settlement_acceptor=settlement_acceptor,
+        )
+        with self._lock:
+            self._check_send_capacity_locked()
+            if len(self._controls) >= self._max_pending_controls:
+                raise _rejected("INVALID_STATE", "Control registry is full")
+            if (
+                binding.control_id in self._controls
+                or binding.control_id in self._completed_control_set
+            ):
+                raise _rejected("IDEMPOTENCY_CONFLICT", "Control ID is not fresh")
+            self._controls[binding.control_id] = ticket
+            self._launch_send(ticket, CONTROL_EVENT, payload, binding.control_id, dispatch_preflight)
+        return ticket
+
+    async def begin_site_resolution(self, operation: OperationTicket, *, control_id: str,
+                                    resolution: Mapping[str, Any], authorization_current: Callable[[], bool],
+                                    timeout_ms: int = 10_000) -> ControlTicket:
+        """Only server-owned site decisions may supply this control preflight."""
+        _core_correlation_id(control_id, "control_id")
+        if not callable(authorization_current) or authorization_current() is not True:
+            raise _rejected("SCOPE_DENIED", "Site decision is not current")
+        remaining = self.remaining_operation_ms(operation)
+        if remaining <= 0 or operation.action != "navigate" or not operation.canonical_parameter_hash or not operation.destination_origin or not operation.target_tab_handle:
+            raise _rejected("INVALID_STATE", "Navigation is no longer pending")
+        data = _mapping_copy(resolution, "resolution")
+        required = {"challenge_id", "tab_handle", "document_id", "document_epoch",
+                    "canonical_parameter_hash", "target_fingerprint", "origin", "action_class", "decision", "grant"}
+        if set(data) != required or data["action_class"] != "navigate":
+            raise _rejected("INVALID_STATE", "Invalid site resolution")
+        _identifier(data["challenge_id"], "challenge_id")
+        if data["document_id"] is not None:
+            _identifier(data["document_id"], "document_id")
+        if (
+            data["tab_handle"] != operation.target_tab_handle
+            or data["canonical_parameter_hash"] != operation.canonical_parameter_hash
+            or data["origin"] != operation.destination_origin
+            or type(data["document_epoch"]) is not int or not 0 <= data["document_epoch"] <= 2**53 - 1
+            or not isinstance(data["target_fingerprint"], str)
+            or re.fullmatch(r"[a-f0-9]{64}", data["target_fingerprint"]) is None
+            or not isinstance(data["decision"], str) or data["decision"] not in {"deny", "allow_once", "allow_turn"}
+        ):
+            raise _rejected("SCOPE_DENIED", "Site resolution binding mismatch")
+        grant = data["grant"]
+        if data["decision"] == "deny":
+            if grant is not None:
+                raise _rejected("INVALID_STATE", "A denial cannot grant access")
+        elif (
+            not isinstance(grant, dict) or set(grant) != {"origin_grant_id", "scope", "origin", "expires_at_ms"}
+            or grant["scope"] != ("operation" if data["decision"] == "allow_once" else "turn")
+            or grant["origin"] != data["origin"] or type(grant["expires_at_ms"]) is not int
+            or not 0 < grant["expires_at_ms"] <= 2**53 - 1
+        ):
+            raise _rejected("INVALID_STATE", "Invalid site grant")
+        else:
+            _identifier(grant["origin_grant_id"], "origin_grant_id")
+        source = operation.binding
+        binding = ControlBinding(source.principal, source.connector_sid, source.load_generation_id,
+                                 source.context_id, source.browser_session_id, source.turn_id,
+                                 control_id, "browser.resolve_challenge", source.op_id, source.action_id)
+        payload = {"method": binding.method, "contract_version": 1, "bridge_id": binding.bridge_id,
+                   "load_generation_id": binding.load_generation_id, "control_id": control_id,
+                   "context_id": binding.context_id, "browser_session_id": binding.browser_session_id,
+                   "turn_id": binding.turn_id, "op_id": binding.op_id, "action_id": binding.action_id, **data}
+
+        def still_current() -> bool:
+            return self.remaining_operation_ms(operation) > 0 and authorization_current() is True
+
+        return await self._begin_control(binding, payload, min(_timeout(timeout_ms), remaining), still_current)
+
+    async def begin_action_resolution(
+        self,
+        operation: OperationTicket,
+        *,
+        control_id: str,
+        resolution: Mapping[str, Any],
+        authorization_current: Callable[[], bool],
+        timeout_ms: int = 10_000,
+    ) -> ControlTicket:
+        """Queue one exact, server-owned consequential-action decision."""
+
+        _core_correlation_id(control_id, "control_id")
+        if not callable(authorization_current) or authorization_current() is not True:
+            raise _rejected("SCOPE_DENIED", "Action decision is not current")
+        remaining = self.remaining_operation_ms(operation)
+        if (
+            remaining <= 0
+            or operation.action not in {"click", "type", "upload_file"}
+            or not operation.canonical_parameter_hash
+            or not operation.target_tab_handle
+            or not operation.target_ref
+            or operation.expected_action_class not in _ACTION_CHALLENGE_CLASSES
+            or (
+                operation.action == "type"
+                and (
+                    operation.expected_action_class != "sensitive_input"
+                    or not isinstance(operation.text_sha256, str)
+                    or re.fullmatch(r"[a-f0-9]{64}", operation.text_sha256)
+                    is None
+                )
+            )
+            or (operation.action in {"click", "upload_file"} and operation.text_sha256 is not None)
+            or (operation.action == "upload_file" and operation.expected_action_class != "external_side_effect")
+        ):
+            raise _rejected("INVALID_STATE", "Action is no longer pending")
+        data = _mapping_copy(resolution, "resolution")
+        required = {
+            "challenge_id",
+            "tab_handle",
+            "document_id",
+            "document_epoch",
+            "canonical_parameter_hash",
+            "target_fingerprint",
+            "origin",
+            "action_class",
+            "data_classification",
+            "decision",
+            "grant",
+        }
+        if set(data) != required:
+            raise _rejected("INVALID_STATE", "Invalid action resolution")
+        _identifier(data["challenge_id"], "challenge_id")
+        _identifier(data["document_id"], "document_id")
+        try:
+            from plugins._a0_connector.helpers.browser_bridge_policy import (
+                normalize_site_origin,
+            )
+            from plugins._a0_connector.helpers.browser_bridge_approval import (
+                BrowserActionDataClassification,
+                NO_ACTION_DATA_CLASSIFICATION,
+                parse_action_data_classification,
+            )
+
+            canonical_origin = normalize_site_origin(data["origin"])
+            classification = parse_action_data_classification(
+                data["data_classification"]
+            )
+        except Exception:
+            raise _rejected("SCOPE_DENIED", "Action resolution origin is invalid") from None
+        expected_classification = (
+            NO_ACTION_DATA_CLASSIFICATION
+            if operation.action in {"click", "upload_file"}
+            else BrowserActionDataClassification(
+                "text", "sensitive", operation.text_sha256
+            )
+        )
+        if (
+            data["tab_handle"] != operation.target_tab_handle
+            or data["canonical_parameter_hash"]
+            != operation.canonical_parameter_hash
+            or type(data["document_epoch"]) is not int
+            or not 0 <= data["document_epoch"] <= 2**53 - 1
+            or not isinstance(data["target_fingerprint"], str)
+            or re.fullmatch(r"[a-f0-9]{64}", data["target_fingerprint"])
+            is None
+            or not isinstance(data["action_class"], str)
+            or data["action_class"] not in _ACTION_CHALLENGE_CLASSES
+            or data["action_class"] != operation.expected_action_class
+            or classification != expected_classification
+            or not isinstance(data["decision"], str)
+            or data["decision"] not in {"decline", "approve_once"}
+            or canonical_origin != data["origin"]
+        ):
+            raise _rejected("SCOPE_DENIED", "Action resolution binding mismatch")
+        grant = data["grant"]
+        if data["decision"] == "decline":
+            if grant is not None:
+                raise _rejected("INVALID_STATE", "A decline cannot grant access")
+        elif (
+            not isinstance(grant, dict)
+            or set(grant)
+            != {
+                "action_grant_id",
+                "scope",
+                "origin",
+                "action_class",
+                "canonical_parameter_hash",
+                "target_fingerprint",
+                "data_classification",
+                "expires_at_ms",
+            }
+            or grant["scope"] != "operation"
+            or grant["origin"] != data["origin"]
+            or grant["action_class"] != data["action_class"]
+            or grant["canonical_parameter_hash"]
+            != data["canonical_parameter_hash"]
+            or grant["target_fingerprint"] != data["target_fingerprint"]
+            or type(grant["expires_at_ms"]) is not int
+            or not 0 < grant["expires_at_ms"] <= 2**53 - 1
+        ):
+            raise _rejected("INVALID_STATE", "Invalid action grant")
+        else:
+            _identifier(grant["action_grant_id"], "action_grant_id")
+            try:
+                grant_classification = parse_action_data_classification(
+                    grant["data_classification"]
+                )
+            except Exception:
+                raise _rejected("INVALID_STATE", "Invalid action grant") from None
+            if grant_classification != classification:
+                raise _rejected("INVALID_STATE", "Invalid action grant")
+        data["data_classification"] = classification.as_wire_value()
+        if isinstance(grant, dict):
+            grant["data_classification"] = classification.as_wire_value()
+        source = operation.binding
+        binding = ControlBinding(
+            source.principal,
+            source.connector_sid,
+            source.load_generation_id,
+            source.context_id,
+            source.browser_session_id,
+            source.turn_id,
+            control_id,
+            "browser.resolve_challenge",
+            source.op_id,
+            source.action_id,
+        )
+        payload = {
+            "method": binding.method,
+            "contract_version": CONTRACT_VERSION,
+            "bridge_id": binding.bridge_id,
+            "load_generation_id": binding.load_generation_id,
+            "control_id": control_id,
+            "context_id": binding.context_id,
+            "browser_session_id": binding.browser_session_id,
+            "turn_id": binding.turn_id,
+            "op_id": binding.op_id,
+            "action_id": binding.action_id,
+            **data,
+        }
+
+        def still_current() -> bool:
+            return (
+                self.remaining_operation_ms(operation) > 0
+                and authorization_current() is True
+            )
+
+        return await self._begin_control(
+            binding,
+            payload,
+            min(_timeout(timeout_ms), remaining),
+            still_current,
+        )
+
+    async def wait_operation(self, ticket: OperationTicket) -> BrokerCompletion:
+        return await self._wait(ticket, operation=True)
+
+    async def wait_dispatched(self, ticket: OperationTicket) -> None:
+        """Wait for this exact operation's transport send before input frames.
+
+        Successful dispatch is ordering evidence, never effect completion. A
+        canceled caller cannot cancel the process-owned dispatch or its receipt.
+        """
+        with self._lock:
+            if self._operations.get(ticket.binding.op_id) is not ticket or ticket._dispatch_future is None:
+                raise _rejected("INVALID_STATE", "Operation dispatch is no longer pending")
+        remaining = max(0, ticket.deadline_ms - self._clock_ms()) / 1_000
+        try:
+            completion = await asyncio.wait_for(asyncio.shield(ticket._dispatch_future), remaining)
+        except asyncio.TimeoutError:
+            self._expire_ticket(ticket)
+            raise _rejected("DEADLINE_EXCEEDED", "Operation dispatch deadline expired") from None
+        with self._lock:
+            if not completion.ok:
+                raise _rejected(completion.code or "CONNECTION_LOST", "Operation transport dispatch failed")
+            if self._operations.get(ticket.binding.op_id) is not ticket or self._clock_ms() >= ticket.deadline_ms:
+                raise _rejected("INVALID_STATE", "Operation retired before input transfer")
+
+    async def wait_control(self, ticket: ControlTicket) -> BrokerCompletion:
+        return await self._wait(ticket, operation=False)
+
+    async def _wait(
+        self,
+        ticket: OperationTicket | ControlTicket,
+        *,
+        operation: bool,
+    ) -> BrokerCompletion:
+        remaining = max(0, ticket.deadline_ms - self._clock_ms()) / 1_000
+        try:
+            return await asyncio.wait_for(asyncio.shield(ticket._future), remaining)
+        except asyncio.TimeoutError:
+            self.expire(self._clock_ms())
+            # A custom clock may be fixed in tests. Ensure this exact ticket is
+            # terminal even when the real asyncio timeout won the race first.
+            if not ticket._future.done():
+                completion = self._deadline_completion(ticket, operation=operation)
+                if operation:
+                    self._finish_operation(ticket, completion)
+                else:
+                    self._finish_control(ticket, completion)
+            return await asyncio.shield(ticket._future)
+
+    def settle_operation(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: str,
+        load_generation_id: str,
+        payload: Mapping[str, Any],
+    ) -> str:
+        candidate = _incoming_mapping(payload)
+        op_id = candidate.get("op_id") if candidate is not None else None
+        if not isinstance(op_id, str):
+            return SettlementStatus.NOT_FOUND
+        with self._lock:
+            ticket = self._operations.get(op_id)
+            if ticket is None:
+                return (
+                    SettlementStatus.DUPLICATE
+                    if op_id in self._completed_operation_set
+                    else SettlementStatus.NOT_FOUND
+                )
+            if candidate is None or not self._operation_result_matches(
+                ticket.binding, principal, connector_sid, load_generation_id, candidate
+            ):
+                return SettlementStatus.MISMATCH
+            completion = _parse_operation_completion(candidate)
+            if completion is None:
+                return SettlementStatus.MISMATCH
+            if ticket.deadline_ms <= self._clock_ms():
+                completion = self._deadline_completion(ticket, operation=True)
+            self._remove_operation_locked(ticket)
+        self._deliver(ticket._future, completion)
+        return SettlementStatus.SETTLED
+
+    def settle_control(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: str,
+        load_generation_id: str,
+        payload: Mapping[str, Any],
+    ) -> str:
+        candidate = _incoming_mapping(payload)
+        control_id = candidate.get("control_id") if candidate is not None else None
+        if not isinstance(control_id, str):
+            return SettlementStatus.NOT_FOUND
+        with self._lock:
+            ticket = self._controls.get(control_id)
+            if ticket is None:
+                return (
+                    SettlementStatus.DUPLICATE
+                    if control_id in self._completed_control_set
+                    else SettlementStatus.NOT_FOUND
+                )
+            if candidate is None or not self._control_result_matches(
+                ticket.binding, principal, connector_sid, load_generation_id, candidate
+            ):
+                return SettlementStatus.MISMATCH
+            completion = _parse_control_completion(candidate)
+            if completion is None:
+                return SettlementStatus.MISMATCH
+            if ticket.deadline_ms <= self._clock_ms():
+                completion = self._deadline_completion(ticket, operation=False)
+            elif ticket._settlement_acceptor is not None:
+                try:
+                    completion = ticket._settlement_acceptor(completion)
+                except Exception:
+                    completion = None
+                if completion is None:
+                    return SettlementStatus.MISMATCH
+            self._remove_control_locked(ticket)
+        self._deliver(ticket._future, completion)
+        return SettlementStatus.SETTLED
+
+    def disconnect(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: str,
+        load_generation_id: str,
+    ) -> DisconnectSummary:
+        operations: list[OperationTicket] = []
+        controls: list[ControlTicket] = []
+        with self._lock:
+            for ticket in tuple(self._operations.values()):
+                if self._source_matches(ticket.binding, principal, connector_sid, load_generation_id):
+                    self._remove_operation_locked(ticket)
+                    operations.append(ticket)
+            for ticket in tuple(self._controls.values()):
+                if self._source_matches(ticket.binding, principal, connector_sid, load_generation_id):
+                    self._remove_control_locked(ticket)
+                    controls.append(ticket)
+        for ticket in operations:
+            if ticket.effect == "mutating":
+                completion = _error("OUTCOME_UNKNOWN", "Browser operation outcome is unknown", "unknown")
+            else:
+                completion = _error(
+                    "CONNECTION_LOST", "Browser bridge connection was lost",
+                    "not_applied", retryable=True,
+                )
+            self._deliver(ticket._future, completion)
+        for ticket in controls:
+            completion = (
+                _error(
+                    "CONNECTION_LOST",
+                    "Browser reconciliation connection was lost",
+                    "not_applied",
+                    retryable=True,
+                )
+                if isinstance(ticket.binding, ReconciliationBinding)
+                else _error(
+                    "OUTCOME_UNKNOWN",
+                    "Browser control outcome is unknown",
+                    "unknown",
+                )
+            )
+            self._deliver(ticket._future, completion)
+        return DisconnectSummary(len(operations), len(controls))
+
+    def expire(self, now_ms: int | None = None) -> DisconnectSummary:
+        now = self._clock_ms() if now_ms is None else now_ms
+        operations: list[OperationTicket] = []
+        controls: list[ControlTicket] = []
+        with self._lock:
+            for ticket in tuple(self._operations.values()):
+                if ticket.deadline_ms <= now:
+                    self._remove_operation_locked(ticket)
+                    operations.append(ticket)
+            for ticket in tuple(self._controls.values()):
+                if ticket.deadline_ms <= now:
+                    self._remove_control_locked(ticket)
+                    controls.append(ticket)
+        for ticket in operations:
+            self._deliver(ticket._future, self._deadline_completion(ticket, operation=True))
+        for ticket in controls:
+            self._deliver(ticket._future, self._deadline_completion(ticket, operation=False))
+        return DisconnectSummary(len(operations), len(controls))
+
+    def _deadline_completion(
+        self, ticket: OperationTicket | ControlTicket, *, operation: bool
+    ) -> BrokerCompletion:
+        if operation and isinstance(ticket, OperationTicket) and ticket.effect == "read_only":
+            return _error(
+                "DEADLINE_EXCEEDED", "Browser operation deadline expired",
+                "not_applied", retryable=True,
+            )
+        if (
+            isinstance(ticket, ControlTicket)
+            and isinstance(ticket.binding, ReconciliationBinding)
+        ):
+            return _error(
+                "DEADLINE_EXCEEDED",
+                "Browser reconciliation deadline expired",
+                "not_applied",
+                retryable=True,
+            )
+        subject = "control" if isinstance(ticket, ControlTicket) else "operation"
+        return _error("OUTCOME_UNKNOWN", f"Browser {subject} outcome is unknown", "unknown")
+
+    def _launch_send(
+        self,
+        ticket: OperationTicket | ControlTicket,
+        event: str,
+        payload: dict[str, Any],
+        correlation_id: str,
+        dispatch_preflight: Callable[[], bool] | None = None,
+    ) -> None:
+        async def send_if_current() -> None:
+            operation = isinstance(ticket, OperationTicket)
+            with self._lock:
+                pending = (
+                    self._operations.get(correlation_id)
+                    if operation else self._controls.get(correlation_id)
+                )
+                if pending is not ticket:
+                    return
+                authorization = self._authorize(
+                    ticket.binding,
+                    scope="browser.operate" if operation else "browser.control",
+                    event=event,
+                    outer_feature=(
+                        "browser_extension_bridge_v1" if operation
+                        else "connector_browser_control"
+                    ),
+                )
+                if operation and (
+                    payload["action"] not in authorization.actions
+                    or any(capability not in authorization.actions | authorization.features
+                           for capability in payload["required_capabilities"])
+                ):
+                    raise _rejected("UNSUPPORTED_CAPABILITY", "Browser capabilities changed before dispatch")
+                if operation and not _operation_intent_matches(ticket, payload):
+                    raise _rejected(
+                        "INVALID_STATE",
+                        "Browser operation intent changed before dispatch",
+                    )
+                if dispatch_preflight is not None:
+                    try:
+                        permitted = dispatch_preflight() is True
+                    except Exception:
+                        permitted = False
+                    if not permitted:
+                        raise _rejected("ORIGIN_BLOCKED", "Browser policy changed before dispatch")
+            # The restricted sender must still revalidate the exact principal
+            # at its own final transport boundary. No caller metadata can grant
+            # authority across an await inside that sender.
+            await self._sender(
+                ticket.binding.connector_sid, event, payload, correlation_id,
+                ticket.binding.principal,
+            )
+
+        async def dispatch() -> None:
+            try:
+                remaining = max(0, ticket.deadline_ms - self._clock_ms()) / 1_000
+                if remaining <= 0:
+                    self.expire()
+                    return
+                await asyncio.wait_for(send_if_current(), timeout=remaining)
+                if isinstance(ticket, OperationTicket) and ticket._dispatch_future is not None:
+                    with self._lock:
+                        if self._operations.get(ticket.binding.op_id) is ticket:
+                            self._deliver(ticket._dispatch_future, BrokerCompletion(ok=True))
+            except BrowserBridgeBrokerError as exc:
+                completion = _error(exc.code, "Browser dispatch authorization is unavailable", "not_applied")
+                if isinstance(ticket, OperationTicket):
+                    self._finish_operation(ticket, completion)
+                else:
+                    self._finish_control(ticket, completion)
+            except asyncio.CancelledError:
+                self._transport_failed(ticket)
+                raise
+            except Exception:
+                self._transport_failed(ticket)
+
+        loop = asyncio.get_running_loop()
+        # Expiration survives cancellation of every caller waiting for a reply.
+        # Successful send is not completion and must not leave a pending slot
+        # occupied forever when the remote peer never returns a result.
+        deadline = loop.call_later(
+            max(0, ticket.deadline_ms - self._clock_ms()) / 1_000,
+            self._expire_ticket, ticket,
+        )
+        ticket._future.add_done_callback(lambda _future: deadline.cancel())
+        task = loop.create_task(dispatch())
+        self._send_tasks.add(task)
+        task.add_done_callback(self._send_finished)
+
+    def _check_send_capacity_locked(self) -> None:
+        if len(self._send_tasks) >= self._max_send_tasks:
+            raise _rejected("INVALID_STATE", "Browser transport queue is full")
+
+    def _send_finished(self, task: asyncio.Task[None]) -> None:
+        with self._lock:
+            self._send_tasks.discard(task)
+
+    def _expire_ticket(self, ticket: OperationTicket | ControlTicket) -> None:
+        completion = self._deadline_completion(ticket, operation=isinstance(ticket, OperationTicket))
+        if isinstance(ticket, OperationTicket):
+            self._finish_operation(ticket, completion)
+        else:
+            self._finish_control(ticket, completion)
+
+    def _transport_failed(self, ticket: OperationTicket | ControlTicket) -> None:
+        if isinstance(ticket, OperationTicket):
+            completion = (
+                _error(
+                    "CONNECTION_LOST", "Browser bridge send failed",
+                    "not_applied", retryable=True,
+                )
+                if ticket.effect == "read_only"
+                else _error("OUTCOME_UNKNOWN", "Browser operation outcome is unknown", "unknown")
+            )
+            self._finish_operation(ticket, completion)
+        else:
+            self._finish_control(
+                ticket,
+                (
+                    _error(
+                        "CONNECTION_LOST",
+                        "Browser reconciliation send failed",
+                        "not_applied",
+                        retryable=True,
+                    )
+                    if isinstance(ticket.binding, ReconciliationBinding)
+                    else _error(
+                        "OUTCOME_UNKNOWN",
+                        "Browser control outcome is unknown",
+                        "unknown",
+                    )
+                ),
+            )
+
+    def _finish_operation(
+        self, ticket: OperationTicket, completion: BrokerCompletion
+    ) -> bool:
+        with self._lock:
+            if self._operations.get(ticket.binding.op_id) is not ticket:
+                return False
+            self._remove_operation_locked(ticket)
+        self._deliver(ticket._future, completion)
+        return True
+
+    def _finish_control(
+        self, ticket: ControlTicket, completion: BrokerCompletion
+    ) -> bool:
+        with self._lock:
+            if self._controls.get(ticket.binding.control_id) is not ticket:
+                return False
+            self._remove_control_locked(ticket)
+        self._deliver(ticket._future, completion)
+        return True
+
+    def _remove_operation_locked(self, ticket: OperationTicket) -> None:
+        if ticket._dispatch_future is not None:
+            self._deliver(ticket._dispatch_future, _error("CONNECTION_LOST", "Operation retired before dispatch", "not_applied"))
+        self._operations.pop(ticket.binding.op_id, None)
+        self._action_identities.discard(self._action_identity(ticket.binding))
+        self._remember(
+            ticket.binding.op_id,
+            self._completed_operations,
+            self._completed_operation_set,
+        )
+
+    def _remove_control_locked(self, ticket: ControlTicket) -> None:
+        self._controls.pop(ticket.binding.control_id, None)
+        self._remember(
+            ticket.binding.control_id,
+            self._completed_controls,
+            self._completed_control_set,
+        )
+
+    def _remember(self, value: str, queue: deque[str], values: set[str]) -> None:
+        queue.append(value)
+        values.add(value)
+        while len(queue) > self._max_completed_ids:
+            values.discard(queue.popleft())
+
+    @staticmethod
+    def _deliver(
+        future: asyncio.Future[BrokerCompletion], completion: BrokerCompletion
+    ) -> None:
+        def set_result() -> None:
+            if not future.done():
+                future.set_result(completion)
+
+        try:
+            future.get_loop().call_soon_threadsafe(set_result)
+        except RuntimeError:
+            # Process shutdown can close the owning loop after the pending item
+            # was removed. Never let that escape through an inbound handler.
+            return
+
+    def _authorize(
+        self,
+        binding: OperationBinding
+        | TurnBinding
+        | ControlBinding
+        | ReconciliationBinding,
+        *,
+        scope: str,
+        event: str,
+        outer_feature: str,
+    ) -> BridgeAuthorization:
+        principal = binding.principal
+        try:
+            require_transport_principal_identity(
+                principal, self._transport_profile
+            )
+        except ValueError:
+            raise _rejected("SCOPE_DENIED", "Browser bridge scope is unavailable") from None
+        if scope not in principal.scopes or not principal.permits_outbound(
+            event, self._transport_profile.handler_id
+        ):
+            raise _rejected("SCOPE_DENIED", "Browser bridge scope is unavailable")
+        try:
+            authorization = self._authorizer(binding)
+        except Exception:
+            raise _rejected("SCOPE_DENIED", "Browser bridge authorization is unavailable") from None
+        if (
+            authorization is None
+            or not isinstance(authorization, BridgeAuthorization)
+            or authorization.principal is not principal
+            or authorization.connector_sid != binding.connector_sid
+            or authorization.load_generation_id != binding.load_generation_id
+            or authorization.contract_version != CONTRACT_VERSION
+            or outer_feature not in authorization.outer_features
+        ):
+            raise _rejected("SCOPE_DENIED", "Browser bridge authorization is stale")
+        return authorization
+
+    @staticmethod
+    def _source_matches(
+        binding: OperationBinding | ControlBinding | ReconciliationBinding,
+        principal: WsPrincipal,
+        connector_sid: str,
+        load_generation_id: str,
+    ) -> bool:
+        return (
+            binding.principal is principal
+            and binding.connector_sid == connector_sid
+            and binding.load_generation_id == load_generation_id
+        )
+
+    def _operation_result_matches(
+        self,
+        binding: OperationBinding,
+        principal: WsPrincipal,
+        connector_sid: str,
+        load_generation_id: str,
+        payload: dict[str, Any],
+    ) -> bool:
+        return self._source_matches(binding, principal, connector_sid, load_generation_id) and all(
+            payload.get(key) == value
+            for key, value in {
+                "contract_version": CONTRACT_VERSION,
+                "bridge_id": binding.bridge_id,
+                "load_generation_id": binding.load_generation_id,
+                "context_id": binding.context_id,
+                "browser_session_id": binding.browser_session_id,
+                "turn_id": binding.turn_id,
+                "op_id": binding.op_id,
+                "action_id": binding.action_id,
+            }.items()
+        )
+
+    def _control_result_matches(
+        self,
+        binding: ControlBinding | ReconciliationBinding,
+        principal: WsPrincipal,
+        connector_sid: str,
+        load_generation_id: str,
+        payload: dict[str, Any],
+    ) -> bool:
+        if type(payload.get("contract_version")) is not int:
+            return False
+        expected: dict[str, Any] = {
+            "contract_version": CONTRACT_VERSION,
+            "method": (
+                "browser.reconcile"
+                if isinstance(binding, ReconciliationBinding)
+                else binding.method
+            ),
+            "bridge_id": binding.bridge_id,
+            "load_generation_id": binding.load_generation_id,
+            "control_id": binding.control_id,
+        }
+        if isinstance(binding, ControlBinding):
+            expected.update(
+                context_id=binding.context_id,
+                browser_session_id=binding.browser_session_id,
+                turn_id=binding.turn_id,
+            )
+        if isinstance(binding, ControlBinding) and binding.method in {
+            "browser.cancel",
+            "browser.resolve_challenge",
+        }:
+            expected.update(op_id=binding.op_id, action_id=binding.action_id)
+        return self._source_matches(binding, principal, connector_sid, load_generation_id) and all(
+            payload.get(key) == value for key, value in expected.items()
+        )
+
+    @staticmethod
+    def _action_identity(binding: OperationBinding) -> tuple[str, str, str, str]:
+        return (
+            binding.bridge_id,
+            binding.context_id,
+            binding.browser_session_id,
+            binding.action_id,
+        )
+
+    @staticmethod
+    def _validate_operation_binding(binding: OperationBinding) -> None:
+        for name in (
+            "connector_sid", "load_generation_id", "context_id",
+            "browser_session_id", "turn_id", "action_id", "op_id",
+        ):
+            _identifier(getattr(binding, name), name)
+        _native_identifier(binding.load_generation_id, "load_generation_id")
+        _core_correlation_id(binding.op_id, "op_id")
+        _validate_principal(binding.principal)
+
+    @staticmethod
+    def _validate_turn_binding(binding: TurnBinding) -> None:
+        for name in (
+            "connector_sid", "load_generation_id", "context_id",
+            "browser_session_id", "turn_id",
+        ):
+            _identifier(getattr(binding, name), name)
+        _native_identifier(binding.load_generation_id, "load_generation_id")
+        _validate_principal(binding.principal)
+
+    @staticmethod
+    def _validate_reconciliation_binding(
+        binding: ReconciliationBinding,
+    ) -> None:
+        for name in ("connector_sid", "load_generation_id", "control_id"):
+            _identifier(getattr(binding, name), name)
+        _native_identifier(binding.load_generation_id, "load_generation_id")
+        _core_correlation_id(binding.control_id, "control_id")
+        _validate_principal(binding.principal)
+
+
+def _validate_principal(principal: WsPrincipal) -> None:
+    try:
+        transport_profile_for_principal_identity(principal)
+    except ValueError:
+        raise _rejected("SCOPE_DENIED", "A restricted bridge principal is required")
+    _identifier(principal.principal_id, "bridge_id")
+
+
+def _identifier(value: Any, name: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value.encode("utf-8")) > MAX_IDENTIFIER_BYTES
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+    ):
+        raise _rejected("INVALID_STATE", f"Invalid {name}")
+    return value
+
+
+def _timeout(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value <= MAX_TIMEOUT_MS:
+        raise _rejected("INVALID_STATE", "Invalid browser operation timeout")
+    return value
+
+
+def _core_correlation_id(value: Any, name: str) -> str:
+    value = _identifier(value, name)
+    if _CORE_CORRELATION_ID.fullmatch(value) is None:
+        raise _rejected("INVALID_STATE", f"Invalid {name}")
+    return value
+
+
+def _native_identifier(value: Any, name: str) -> str:
+    value = _identifier(value, name)
+    if _NATIVE_IDENTIFIER.fullmatch(value) is None:
+        raise _rejected("INVALID_STATE", f"Invalid {name}")
+    return value
+
+
+def _reason(value: Any) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value.encode("utf-8")) > MAX_REASON_BYTES
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+    ):
+        raise _rejected("INVALID_STATE", "Invalid browser control reason")
+    return value
+
+
+def _capabilities(values: Any) -> tuple[str, ...]:
+    if not isinstance(values, (tuple, list)) or len(values) > MAX_CAPABILITIES:
+        raise _rejected("INVALID_STATE", "Invalid required capabilities")
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if (
+            not isinstance(value, str)
+            or not value
+            or len(value.encode("utf-8")) > MAX_CAPABILITY_BYTES
+            or value in seen
+        ):
+            raise _rejected("INVALID_STATE", "Invalid required capabilities")
+        seen.add(value)
+        result.append(value)
+    return tuple(result)
+
+
+def _target(value: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping) or set(value) != {"tab_handle"}:
+        raise _rejected("INVALID_STATE", "Invalid browser target")
+    return {"tab_handle": _identifier(value["tab_handle"], "tab_handle")}
+
+
+def _policy(value: Mapping[str, Any] | None) -> dict[str, str | None]:
+    value = {} if value is None else value
+    if not isinstance(value, Mapping) or not set(value) <= {"origin_grant_id", "action_grant_id"}:
+        raise _rejected("INVALID_STATE", "Invalid browser policy")
+    result: dict[str, str | None] = {}
+    for key in ("origin_grant_id", "action_grant_id"):
+        item = value.get(key)
+        result[key] = None if item is None else _identifier(item, key)
+    return result
+
+
+def _display(value: Mapping[str, Any] | None) -> dict[str, bool]:
+    value = {} if value is None else value
+    if not isinstance(value, Mapping) or not set(value) <= {"cursor", "foreground"}:
+        raise _rejected("INVALID_STATE", "Invalid browser display options")
+    cursor = value.get("cursor", False)
+    foreground = value.get("foreground", False)
+    if not isinstance(cursor, bool) or not isinstance(foreground, bool):
+        raise _rejected("INVALID_STATE", "Invalid browser display options")
+    return {"cursor": cursor, "foreground": foreground}
+
+
+def _dispositions(value: Mapping[str, str]) -> dict[str, str]:
+    if not isinstance(value, Mapping) or len(value) > MAX_DISPOSITIONS:
+        raise _rejected("INVALID_STATE", "Invalid browser lease dispositions")
+    result: dict[str, str] = {}
+    for lease_id, disposition in value.items():
+        lease_id = _identifier(lease_id, "lease_id")
+        if disposition not in _DISPOSITIONS:
+            raise _rejected("INVALID_STATE", "Invalid browser lease disposition")
+        result[lease_id] = disposition
+    return result
+
+
+def _reconciliation_expected_contexts(values: Any) -> list[dict[str, Any]]:
+    if not isinstance(values, (tuple, list)) or len(values) > 128:
+        raise _rejected("INVALID_STATE", "Invalid reconciliation contexts")
+    result: list[dict[str, Any]] = []
+    context_ids: set[str] = set()
+    for value in values:
+        if not isinstance(value, Mapping) or set(value) != {
+            "context_id",
+            "browser_session_id",
+            "active_turn_ids",
+        }:
+            raise _rejected("INVALID_STATE", "Invalid reconciliation context")
+        context_id = _identifier(value["context_id"], "context_id")
+        browser_session_id = _identifier(
+            value["browser_session_id"], "browser_session_id"
+        )
+        turns = value["active_turn_ids"]
+        if not isinstance(turns, (tuple, list)) or len(turns) > 32:
+            raise _rejected("INVALID_STATE", "Invalid reconciliation turns")
+        active_turn_ids = [
+            _identifier(turn, "turn_id") for turn in turns
+        ]
+        if (
+            context_id in context_ids
+            or len(set(active_turn_ids)) != len(active_turn_ids)
+        ):
+            raise _rejected("INVALID_STATE", "Duplicate reconciliation identity")
+        context_ids.add(context_id)
+        result.append(
+            {
+                "context_id": context_id,
+                "browser_session_id": browser_session_id,
+                "active_turn_ids": active_turn_ids,
+            }
+        )
+    return result
+
+
+def _reconciliation_event_cursors(values: Any) -> list[dict[str, Any]]:
+    if not isinstance(values, (tuple, list)) or len(values) > 16:
+        raise _rejected("INVALID_STATE", "Invalid reconciliation cursors")
+    result: list[dict[str, Any]] = []
+    generations: set[str] = set()
+    for value in values:
+        if not isinstance(value, Mapping) or set(value) != {
+            "load_generation_id",
+            "last_acked_event_sequence",
+        }:
+            raise _rejected("INVALID_STATE", "Invalid reconciliation cursor")
+        generation = _native_identifier(
+            value["load_generation_id"], "load_generation_id"
+        )
+        sequence = value["last_acked_event_sequence"]
+        if (
+            generation in generations
+            or isinstance(sequence, bool)
+            or not isinstance(sequence, int)
+            or not 0 <= sequence <= 2**53 - 1
+        ):
+            raise _rejected("INVALID_STATE", "Invalid reconciliation cursor")
+        generations.add(generation)
+        result.append(
+            {
+                "load_generation_id": generation,
+                "last_acked_event_sequence": sequence,
+            }
+        )
+    return result
+
+
+def _reconciliation_control_ids(values: Any) -> list[str]:
+    if not isinstance(values, (tuple, list)) or len(values) > 2_048:
+        raise _rejected("INVALID_STATE", "Invalid reconciliation controls")
+    result = [_identifier(value, "control_id") for value in values]
+    if len(set(result)) != len(result):
+        raise _rejected("INVALID_STATE", "Duplicate reconciliation control")
+    return result
+
+
+def _mapping_copy(value: Mapping[str, Any], name: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise _rejected("INVALID_STATE", f"Invalid browser {name}")
+    return _bounded_json_copy(dict(value))
+
+
+def _bounded_json_copy(value: Any) -> Any:
+    try:
+        _validate_json_tree(value)
+        encoded = json.dumps(
+            value, ensure_ascii=False, allow_nan=False, separators=(",", ":")
+        ).encode("utf-8")
+    except (TypeError, ValueError, OverflowError, RecursionError):
+        raise _rejected("INVALID_STATE", "Browser payload is not canonical JSON") from None
+    if len(encoded) > MAX_NON_ARTIFACT_BYTES:
+        raise _rejected("INVALID_STATE", "Browser payload exceeds the bounded frame")
+    return json.loads(encoded)
+
+
+def _validate_json_tree(value: Any) -> None:
+    nodes = 0
+
+    def visit(item: Any, depth: int) -> None:
+        nonlocal nodes
+        nodes += 1
+        if nodes > MAX_JSON_NODES or depth > MAX_JSON_DEPTH:
+            raise ValueError("JSON tree exceeds broker bounds")
+        if item is None or isinstance(item, (bool, str, int)):
+            return
+        if isinstance(item, float):
+            if not math.isfinite(item):
+                raise ValueError("JSON number must be finite")
+            return
+        if isinstance(item, dict):
+            for key, child in item.items():
+                if (
+                    not isinstance(key, str)
+                    or not key
+                    or len(key.encode("utf-8")) > MAX_IDENTIFIER_BYTES
+                    or any(ord(character) < 0x20 or ord(character) == 0x7F for character in key)
+                ):
+                    raise ValueError("JSON object key is invalid")
+                visit(child, depth + 1)
+            return
+        if isinstance(item, list):
+            for child in item:
+                visit(child, depth + 1)
+            return
+        raise TypeError("Value is not JSON")
+
+    visit(value, 0)
+
+
+def _incoming_mapping(value: Mapping[str, Any]) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    try:
+        return _bounded_json_copy(dict(value))
+    except BrowserBridgeBrokerError:
+        return None
+
+
+def _parse_operation_completion(payload: dict[str, Any]) -> BrokerCompletion | None:
+    common = {
+        "contract_version", "bridge_id", "load_generation_id", "context_id",
+        "browser_session_id", "turn_id", "op_id", "action_id", "ok",
+    }
+    if payload.get("ok") is True:
+        if set(payload) != common | {"result", "receipts", "artifacts"}:
+            return None
+        if not isinstance(payload.get("result"), dict):
+            return None
+        receipts = payload.get("receipts")
+        artifacts = payload.get("artifacts")
+        if not isinstance(receipts, list) or not isinstance(artifacts, list):
+            return None
+        return BrokerCompletion(
+            ok=True,
+            result=_bounded_json_copy(payload["result"]),
+            receipts=tuple(_bounded_json_copy(receipts)),
+            artifacts=tuple(_bounded_json_copy(artifacts)),
+        )
+    if payload.get("ok") is False and set(payload) == common | {"code", "error", "error_data"}:
+        return _parse_error(payload)
+    return None
+
+
+def _parse_control_completion(payload: dict[str, Any]) -> BrokerCompletion | None:
+    common = {
+        "contract_version",
+        "method",
+        "bridge_id",
+        "load_generation_id",
+        "control_id",
+        "ok",
+    }
+    if payload.get("method") != "browser.reconcile":
+        common |= {"context_id", "browser_session_id", "turn_id"}
+    if payload.get("method") in {"browser.cancel", "browser.resolve_challenge"}:
+        common |= {"op_id", "action_id"}
+    if payload.get("ok") is True and set(payload) == common | {"result"}:
+        if not isinstance(payload.get("result"), dict):
+            return None
+        return BrokerCompletion(ok=True, result=_bounded_json_copy(payload["result"]))
+    if payload.get("ok") is False and set(payload) == common | {"code", "error", "error_data"}:
+        return _parse_error(payload)
+    return None
+
+
+def _parse_error(payload: dict[str, Any]) -> BrokerCompletion | None:
+    code = payload.get("code")
+    error = payload.get("error")
+    data = payload.get("error_data")
+    if (
+        not isinstance(code, str)
+        or _ERROR_CODE.fullmatch(code) is None
+        or not isinstance(error, str)
+        or not error
+        or len(error.encode("utf-8")) > 2_048
+        or not isinstance(data, dict)
+        or data.get("outcome") not in _OUTCOMES
+        or not isinstance(data.get("retryable"), bool)
+        or not isinstance(data.get("details", {}), dict)
+    ):
+        return None
+    return BrokerCompletion(
+        ok=False,
+        code=code,
+        error=error,
+        outcome=data["outcome"],
+        retryable=data["retryable"],
+        details=_bounded_json_copy(data.get("details", {})),
+    )
+
+
+def _error(
+    code: str, message: str, outcome: str, *, retryable: bool = False
+) -> BrokerCompletion:
+    return BrokerCompletion(
+        ok=False, code=code, error=message, outcome=outcome, retryable=retryable
+    )
+
+
+def _rejected(code: str, message: str) -> BrowserBridgeBrokerError:
+    return BrowserBridgeBrokerError(code, message)
+
+
+def _operation_parameter_hash(binding, action, target, args, display) -> str | None:
+    if not target or set(target) != {"tab_handle"}:
+        return None
+    if action == "navigate":
+        valid_args = set(args) == {"url"} and isinstance(args["url"], str)
+    elif action == "click":
+        valid_args = (
+            set(args) == {"ref", "expected_action_class"}
+            and _valid_click_ref(args["ref"])
+            and isinstance(args["expected_action_class"], str)
+            and args["expected_action_class"] in _ACTION_CHALLENGE_CLASSES
+        )
+    elif action == "type":
+        valid_args = _type_text_digest(args) is not None
+    elif action == "upload_file":
+        valid_args = _valid_upload_args(args)
+    else:
+        return None
+    if not valid_args:
+        return None
+    # Matches the extension's parsed (camelCase target) stable JSON, not the
+    # transport-only bridge/load fields or policy receipt identifiers.
+    value = {"action": action, "target": {"tabHandle": target["tab_handle"]},
+             "context_id": binding.context_id, "browser_session_id": binding.browser_session_id,
+             "turn_id": binding.turn_id, "args": args, "display": display}
+    encoded = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _operation_intent_matches(
+    ticket: OperationTicket, payload: dict[str, Any]
+) -> bool:
+    if ticket.action not in {"navigate", "click", "type", "upload_file"}:
+        return True
+    target = payload.get("target")
+    if (
+        payload.get("action") != ticket.action
+        or not isinstance(target, dict)
+        or target != {"tab_handle": ticket.target_tab_handle}
+    ):
+        return False
+    try:
+        parameter_hash = _operation_parameter_hash(
+            ticket.binding,
+            ticket.action,
+            target,
+            payload.get("args"),
+            payload.get("display"),
+        )
+    except Exception:
+        return False
+    if parameter_hash != ticket.canonical_parameter_hash:
+        return False
+    args = payload.get("args")
+    if not isinstance(args, dict):
+        return False
+    if ticket.action == "navigate":
+        return True
+    if (
+        args.get("ref") != ticket.target_ref
+        or args.get("expected_action_class") != ticket.expected_action_class
+    ):
+        return False
+    if ticket.action in {"click", "upload_file"}:
+        return ticket.text_sha256 is None
+    return _type_text_digest(args) == ticket.text_sha256
+
+
+def _valid_upload_args(args: Any) -> bool:
+    return (
+        isinstance(args, dict)
+        and set(args) == {"ref", "expected_action_class", "artifact_id", "mime_type", "byte_count", "sha256"}
+        and _valid_click_ref(args["ref"])
+        and args["expected_action_class"] == "external_side_effect"
+        and isinstance(args["artifact_id"], str)
+        and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}", args["artifact_id"]) is not None
+        and isinstance(args["mime_type"], str) and len(args["mime_type"]) <= 255
+        and re.fullmatch(r"[a-z0-9!#$&^_.+-]+/[a-z0-9!#$&^_.+-]+", args["mime_type"]) is not None
+        and type(args["byte_count"]) is int and 1 <= args["byte_count"] <= 25 * 1024 * 1024
+        and isinstance(args["sha256"], str)
+        and re.fullmatch(r"sha256:[a-f0-9]{64}", args["sha256"]) is not None
+    )
+
+
+def _type_text_digest(args: Any) -> str | None:
+    if not isinstance(args, dict) or set(args) != {
+        "ref",
+        "text",
+        "text_sha256",
+        "expected_action_class",
+    }:
+        return None
+    if (
+        not _valid_click_ref(args["ref"])
+        or args["expected_action_class"] != "sensitive_input"
+        or not isinstance(args["text_sha256"], str)
+        or re.fullmatch(r"[a-f0-9]{64}", args["text_sha256"]) is None
+        or not isinstance(args["text"], str)
+        or "\x00" in args["text"]
+        or "\r" in args["text"]
+    ):
+        return None
+    try:
+        encoded = args["text"].encode("utf-8")
+    except UnicodeError:
+        return None
+    if not 1 <= len(encoded) <= 32_768:
+        return None
+    digest = hashlib.sha256(encoded).hexdigest()
+    return digest if digest == args["text_sha256"] else None
+
+
+def _valid_click_ref(value: Any) -> bool:
+    try:
+        return bool(
+            isinstance(value, str)
+            and value
+            and len(value.encode("utf-8")) <= 128
+            and _NATIVE_IDENTIFIER.fullmatch(value) is not None
+        )
+    except UnicodeError:
+        return False
+
+
+def _navigation_origin(action, args) -> str | None:
+    if action != "navigate" or not isinstance(args.get("url"), str):
+        return None
+    from urllib.parse import urlsplit, urlunsplit
+    from plugins._a0_connector.helpers.browser_bridge_policy import normalize_site_origin
+    try:
+        url = urlsplit(args["url"])
+        return normalize_site_origin(urlunsplit((url.scheme, url.netloc, "", "", "")))
+    except Exception:
+        return None

--- a/plugins/_a0_connector/helpers/browser_bridge_pairing.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_pairing.py
@@ -1,0 +1,1208 @@
+"""Bounded, fail-closed Browser bridge pairing foundation.
+
+Pending pairing secrets and source-rate state are process memory only. Durable
+state contains only the companion public-key record required by trust v1.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import ipaddress
+import json
+import os
+import re
+import secrets
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable, Mapping, MutableMapping
+from urllib.parse import urlsplit
+
+if TYPE_CHECKING:
+    from plugins._browser.helpers.bridge_foundation import BrowserBridgeGate
+
+
+BROWSER_BRIDGE_TRUST_CONTRACT = "a0.browser-bridge.trust.v1"
+BROWSER_BRIDGE_TRUST_VERSION = 1
+BROWSER_BRIDGE_PAIRING_FEATURE = "browser_bridge_pairing_v1"
+BROWSER_BRIDGE_EXTENSION_ID_ENV = "A0_BROWSER_BRIDGE_EXTENSION_ID"
+BROWSER_BRIDGE_SERVER_BASE_URL_ENV = "A0_BROWSER_BRIDGE_SERVER_BASE_URL"
+BROWSER_BRIDGE_RECORD_STORE_KEY = "a0_browser_bridge_credentials_v1"
+BROWSER_BRIDGE_RECORD_SCHEMA_VERSION = 1
+BROWSER_BRIDGE_INVENTORY_CONTRACT = "a0.browser-bridge.bridges.v1"
+
+PAIRING_TTL_MS = 5 * 60 * 1000
+PAIRING_MAX_FAILED_EXCHANGES = 5
+PAIRING_SECRET_BYTES = 20
+MAX_PENDING_PAIRINGS = 128
+MAX_BRIDGE_RECORDS = 64
+MAX_REQUEST_BYTES = 8 * 1024
+MAX_DISPLAY_NAME_BYTES = 192
+MAX_IDENTIFIER_BYTES = 512
+SOURCE_RATE_WINDOW_MS = 60 * 1000
+SOURCE_RATE_MAX_EXCHANGES = 20
+MAX_SOURCE_BUCKETS = 256
+
+SUBJECT_ID = "single_user"
+CONNECTOR_PROTOCOL = "a0-connector.v1"
+BROWSER_PROTOCOL = "a0.browser-bridge.v1"
+CORE_ADAPTER_CONTRACT = "a0.browser-bridge.adapter.v1"
+MV3_RUNTIME_CONTRACT = "a0.browser-bridge.mv3-runtime.v1"
+
+FIXED_BROWSER_BRIDGE_SCOPES = (
+    "bridge.connect",
+    "context.list",
+    "context.read",
+    "context.message",
+    "browser.operate",
+    "browser.control",
+    "browser.artifact",
+    "browser.approval",
+)
+
+_CROCKFORD_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_PAIRING_CODE_RE = re.compile(
+    r"^A0B1-([0-9A-F]{8})-([0-9A-HJKMNP-TV-Z]{32})$"
+)
+_EXTENSION_ID_RE = re.compile(r"^[a-p]{32}$")
+_PUBLIC_KEY_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
+_SAFE_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._~-]+$")
+_DNS_LABEL_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+
+
+class BrowserBridgePairingError(ValueError):
+    """Internal typed pairing error; callers must return allowlisted messages."""
+
+
+class BrowserBridgePairingUnavailable(BrowserBridgePairingError):
+    pass
+
+
+class BrowserBridgePairingExchangeFailed(BrowserBridgePairingError):
+    pass
+
+
+class _DuplicateJsonKey(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class PairingCreation:
+    pairing_id: str
+    pairing_code: str = field(repr=False)
+    server_base_url: str = ""
+    server_instance_fingerprint: str = ""
+    extension_id: str = ""
+    display_name: str = ""
+    created_at_ms: int = 0
+    expires_at_ms: int = 0
+
+    def as_public_dict(self) -> dict[str, Any]:
+        return {
+            "contract": BROWSER_BRIDGE_TRUST_CONTRACT,
+            "trust_version": BROWSER_BRIDGE_TRUST_VERSION,
+            "state": "pairing_pending",
+            "pairing_id": self.pairing_id,
+            "pairing_code": self.pairing_code,
+            "server": {
+                "base_url": self.server_base_url,
+                "instance_fingerprint": self.server_instance_fingerprint,
+            },
+            "extension_id": self.extension_id,
+            "display_name": self.display_name,
+            "created_at_ms": self.created_at_ms,
+            "expires_at_ms": self.expires_at_ms,
+            "expires_in_seconds": PAIRING_TTL_MS // 1000,
+            "native_runtime_location": "user_browser_host",
+            "docker_install_target": False,
+            "connector_session_ready": False,
+            "browser_control_ready": False,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PairingExchangeSuccess:
+    bridge_id: str
+    server_instance_id: str
+    server_base_url: str
+    extension_id: str
+    display_name: str
+    created_at_ms: int
+
+    def as_public_dict(self) -> dict[str, Any]:
+        return {
+            "contract": BROWSER_BRIDGE_TRUST_CONTRACT,
+            "trust_version": BROWSER_BRIDGE_TRUST_VERSION,
+            "state": "paired",
+            "bridge_id": self.bridge_id,
+            "server_instance_id": self.server_instance_id,
+            "server_base_url": self.server_base_url,
+            "subject_id": SUBJECT_ID,
+            "extension_id": self.extension_id,
+            "display_name": self.display_name,
+            "key_generation": 1,
+            "scopes": list(FIXED_BROWSER_BRIDGE_SCOPES),
+            "protocols": {
+                "connector": CONNECTOR_PROTOCOL,
+                "browser": BROWSER_PROTOCOL,
+                "adapter": CORE_ADAPTER_CONTRACT,
+                "mv3_runtime": MV3_RUNTIME_CONTRACT,
+            },
+            "policy": {"site_mode": "ask_per_site"},
+            "created_at_ms": self.created_at_ms,
+            "native_runtime_location": "user_browser_host",
+            "docker_install_target": False,
+            "connector_session_ready": False,
+            "browser_control_ready": False,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserBridgePublicRecord:
+    """Allowlisted WebUI projection of one durable bridge record."""
+
+    bridge_id: str
+    display_name: str
+    state: str
+    key_generation: int
+    created_at_ms: int
+    last_authenticated_at_ms: int | None
+    revoked_at_ms: int | None
+
+    def as_public_dict(self) -> dict[str, Any]:
+        return {
+            "bridge_id": self.bridge_id,
+            "display_name": self.display_name,
+            "state": self.state,
+            "key_generation": self.key_generation,
+            "created_at_ms": self.created_at_ms,
+            "last_authenticated_at_ms": self.last_authenticated_at_ms,
+            "revoked_at_ms": self.revoked_at_ms,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserBridgeRevocation:
+    bridge: BrowserBridgePublicRecord
+    already_revoked: bool
+
+
+@dataclass(slots=True)
+class _PendingPairing:
+    pairing_id: str
+    pairing_prefix: str
+    owner_id: str
+    secret_digest: bytes = field(repr=False)
+    server_instance_id: str = field(repr=False)
+    server_base_url: str
+    extension_id: str
+    display_name: str
+    created_at_ms: int
+    expires_at_ms: int
+    failed_exchanges: int = 0
+
+
+@dataclass(slots=True)
+class _SourceRate:
+    window_started_at_ms: int
+    attempts: int
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _random_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _bounded_string(value: Any, *, field_name: str, max_bytes: int) -> str:
+    if not isinstance(value, str) or not value:
+        raise BrowserBridgePairingError(f"invalid {field_name}")
+    if value != value.strip() or not value.isprintable():
+        raise BrowserBridgePairingError(f"invalid {field_name}")
+    try:
+        size = len(value.encode("utf-8"))
+    except UnicodeError as error:
+        raise BrowserBridgePairingError(f"invalid {field_name}") from error
+    if size > max_bytes:
+        raise BrowserBridgePairingError(f"invalid {field_name}")
+    return value
+
+
+def validate_identifier(value: Any, *, field_name: str) -> str:
+    return _bounded_string(
+        value,
+        field_name=field_name,
+        max_bytes=MAX_IDENTIFIER_BYTES,
+    )
+
+
+def validate_display_name(value: Any) -> str:
+    return _bounded_string(
+        value,
+        field_name="display_name",
+        max_bytes=MAX_DISPLAY_NAME_BYTES,
+    )
+
+
+def parse_unique_json_object(raw_data: bytes) -> dict[str, Any] | None:
+    """Decode one JSON object while rejecting duplicate keys at every depth."""
+
+    def unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise _DuplicateJsonKey("duplicate JSON object key")
+            result[key] = value
+        return result
+
+    try:
+        document = json.loads(raw_data, object_pairs_hook=unique_object)
+    except (TypeError, ValueError, UnicodeError, RecursionError):
+        return None
+    return document if isinstance(document, dict) else None
+
+
+def validate_extension_id(value: Any) -> str:
+    if not isinstance(value, str) or not _EXTENSION_ID_RE.fullmatch(value):
+        raise BrowserBridgePairingError("invalid extension_id")
+    return value
+
+
+def configured_extension_id(
+    *, environ: Mapping[str, str] | None = None
+) -> str | None:
+    source = os.environ if environ is None else environ
+    try:
+        return validate_extension_id(source.get(BROWSER_BRIDGE_EXTENSION_ID_ENV))
+    except BrowserBridgePairingError:
+        return None
+
+
+def normalize_server_base_url(value: Any) -> str:
+    raw = _bounded_string(value, field_name="server_base_url", max_bytes=2048)
+    if any(character in raw for character in ("\\", "\r", "\n", "\t")):
+        raise BrowserBridgePairingError("invalid server_base_url")
+    try:
+        parsed = urlsplit(raw)
+        port = parsed.port
+    except ValueError as error:
+        raise BrowserBridgePairingError("invalid server_base_url") from error
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise BrowserBridgePairingError("invalid server_base_url")
+
+    hostname = parsed.hostname.rstrip(".").lower()
+    try:
+        ascii_hostname = hostname.encode("idna").decode("ascii")
+    except UnicodeError as error:
+        raise BrowserBridgePairingError("invalid server_base_url") from error
+    try:
+        parsed_address = ipaddress.ip_address(ascii_hostname)
+    except ValueError:
+        parsed_address = None
+    if not ascii_hostname or (
+        parsed_address is None
+        and any(
+            not _DNS_LABEL_RE.fullmatch(label)
+            for label in ascii_hostname.split(".")
+        )
+    ):
+        raise BrowserBridgePairingError("invalid server_base_url")
+
+    path = parsed.path or ""
+    if "%" in path or "//" in path:
+        raise BrowserBridgePairingError("invalid server_base_url")
+    segments = [segment for segment in path.split("/") if segment]
+    if any(
+        segment in {".", ".."} or not _SAFE_PATH_SEGMENT_RE.fullmatch(segment)
+        for segment in segments
+    ):
+        raise BrowserBridgePairingError("invalid server_base_url")
+    normalized_path = "/" + "/".join(segments) if segments else ""
+
+    is_loopback = _is_loopback_hostname(ascii_hostname)
+    if parsed.scheme == "http" and not is_loopback:
+        raise BrowserBridgePairingError("invalid server_base_url")
+    if port is not None and port < 1:
+        raise BrowserBridgePairingError("invalid server_base_url")
+
+    host = f"[{ascii_hostname}]" if ":" in ascii_hostname else ascii_hostname
+    default_port = 80 if parsed.scheme == "http" else 443
+    port_suffix = f":{port}" if port is not None and port != default_port else ""
+    return f"{parsed.scheme}://{host}{port_suffix}{normalized_path}"
+
+
+def _is_loopback_hostname(hostname: str) -> bool:
+    if hostname == "localhost" or hostname.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def server_base_url_for_request(
+    request: Any,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    source = os.environ if environ is None else environ
+    configured = source.get(BROWSER_BRIDGE_SERVER_BASE_URL_ENV)
+    if configured:
+        return normalize_server_base_url(configured)
+
+    headers = getattr(request, "headers", {}) or {}
+    origin = headers.get("Origin") if hasattr(headers, "get") else None
+    if origin:
+        script_root = str(getattr(request, "script_root", "") or "")
+        origin_url = normalize_server_base_url(f"{origin.rstrip('/')}{script_root}")
+        request_root = getattr(request, "url_root", None)
+        if request_root and normalize_server_base_url(request_root) != origin_url:
+            raise BrowserBridgePairingUnavailable("request origin does not match host")
+        return origin_url
+    request_root = getattr(request, "url_root", None)
+    if request_root:
+        return normalize_server_base_url(request_root)
+    raise BrowserBridgePairingUnavailable("server base URL is unavailable")
+
+
+def server_instance_fingerprint(server_instance_id: str) -> str:
+    digest = hashlib.sha256(server_instance_id.encode("utf-8")).hexdigest()
+    return f"sha256:{digest[:20]}"
+
+
+def _encode_crockford(data: bytes) -> str:
+    if len(data) != PAIRING_SECRET_BYTES:
+        raise BrowserBridgePairingError("invalid pairing entropy")
+    number = int.from_bytes(data, "big")
+    characters = ["0"] * 32
+    for index in range(31, -1, -1):
+        number, remainder = divmod(number, 32)
+        characters[index] = _CROCKFORD_ALPHABET[remainder]
+    return "".join(characters)
+
+
+def _normalize_pairing_code(value: Any) -> tuple[str, str]:
+    if not isinstance(value, str) or len(value) != 46:
+        raise BrowserBridgePairingExchangeFailed("pairing exchange failed")
+    normalized = value.upper()
+    match = _PAIRING_CODE_RE.fullmatch(normalized)
+    if match is None:
+        raise BrowserBridgePairingExchangeFailed("pairing exchange failed")
+    return normalized, match.group(1)
+
+
+def _public_key(value: Any) -> dict[str, str]:
+    if not isinstance(value, Mapping) or set(value) != {
+        "algorithm",
+        "encoding",
+        "value",
+    }:
+        raise BrowserBridgePairingExchangeFailed("pairing exchange failed")
+    if value.get("algorithm") != "Ed25519" or value.get("encoding") != "raw-base64url":
+        raise BrowserBridgePairingExchangeFailed("pairing exchange failed")
+    encoded = value.get("value")
+    if not isinstance(encoded, str) or not _PUBLIC_KEY_RE.fullmatch(encoded):
+        raise BrowserBridgePairingExchangeFailed("pairing exchange failed")
+    try:
+        decoded = base64.b64decode(encoded + "=", altchars=b"-_", validate=True)
+    except (binascii.Error, ValueError) as error:
+        raise BrowserBridgePairingExchangeFailed("pairing exchange failed") from error
+    if len(decoded) != 32:
+        raise BrowserBridgePairingExchangeFailed("pairing exchange failed")
+    return {
+        "algorithm": "Ed25519",
+        "encoding": "raw-base64url",
+        "value": encoded,
+    }
+
+
+def coarse_source_key(remote_address: Any) -> str:
+    raw = str(remote_address or "").strip()
+    try:
+        address = ipaddress.ip_address(raw)
+    except ValueError:
+        source_class = "unknown"
+    else:
+        if address.is_loopback:
+            source_class = "loopback"
+        else:
+            prefix = 24 if address.version == 4 else 64
+            source_class = str(ipaddress.ip_network(f"{address}/{prefix}", strict=False))
+    return hashlib.sha256(source_class.encode("ascii")).hexdigest()
+
+
+class BrowserBridgeRecordRepository:
+    """Atomic, bounded repository for public bridge credential records."""
+
+    def __init__(
+        self,
+        *,
+        load: Callable[[], Any] | None = None,
+        save: Callable[[dict[str, Any]], None] | None = None,
+    ) -> None:
+        self._load = load or _load_default_records
+        self._save = save or _save_default_records
+
+    def active_record_present(self, *, server_instance_id: str | None = None) -> bool:
+        records = self._validated_records()
+        safe_server_id = (
+            validate_identifier(server_instance_id, field_name="server_instance_id")
+            if server_instance_id is not None
+            else None
+        )
+        return any(
+            record["state"] == "active"
+            and (
+                safe_server_id is None
+                or record["server_instance_id"] == safe_server_id
+            )
+            for record in records
+        )
+
+    def active_record(
+        self,
+        *,
+        bridge_id: Any,
+        server_instance_id: Any,
+    ) -> dict[str, Any] | None:
+        safe_bridge_id = validate_identifier(bridge_id, field_name="bridge_id")
+        safe_server_id = validate_identifier(
+            server_instance_id,
+            field_name="server_instance_id",
+        )
+        for record in self._validated_records():
+            if (
+                record["bridge_id"] == safe_bridge_id
+                and record["server_instance_id"] == safe_server_id
+                and record["state"] == "active"
+            ):
+                return record
+        return None
+
+    def list_public_records(
+        self,
+        *,
+        server_instance_id: Any,
+        subject_id: Any,
+    ) -> list[BrowserBridgePublicRecord]:
+        safe_server_id = validate_identifier(
+            server_instance_id,
+            field_name="server_instance_id",
+        )
+        safe_subject_id = validate_identifier(subject_id, field_name="subject_id")
+        return sorted(
+            (
+                _public_bridge_record(record)
+                for record in self._validated_records()
+                if record["server_instance_id"] == safe_server_id
+                and record["subject_id"] == safe_subject_id
+            ),
+            key=lambda record: (-record.created_at_ms, record.bridge_id),
+        )
+
+    def public_record(
+        self,
+        *,
+        bridge_id: Any,
+        server_instance_id: Any,
+        subject_id: Any,
+    ) -> BrowserBridgePublicRecord | None:
+        safe_bridge_id = validate_identifier(bridge_id, field_name="bridge_id")
+        for record in self.list_public_records(
+            server_instance_id=server_instance_id,
+            subject_id=subject_id,
+        ):
+            if record.bridge_id == safe_bridge_id:
+                return record
+        return None
+
+    def revoke(
+        self,
+        *,
+        bridge_id: Any,
+        server_instance_id: Any,
+        subject_id: Any,
+        revoked_at_ms: Any,
+    ) -> BrowserBridgeRevocation | None:
+        safe_bridge_id = validate_identifier(bridge_id, field_name="bridge_id")
+        safe_server_id = validate_identifier(
+            server_instance_id,
+            field_name="server_instance_id",
+        )
+        safe_subject_id = validate_identifier(subject_id, field_name="subject_id")
+        if type(revoked_at_ms) is not int or revoked_at_ms < 0:
+            raise BrowserBridgePairingUnavailable("invalid revocation time")
+
+        records = self._validated_records()
+        matched: dict[str, Any] | None = None
+        already_revoked = False
+        updated: list[dict[str, Any]] = []
+        for record in records:
+            candidate = dict(record)
+            if (
+                candidate["bridge_id"] == safe_bridge_id
+                and candidate["server_instance_id"] == safe_server_id
+                and candidate["subject_id"] == safe_subject_id
+            ):
+                already_revoked = candidate["state"] == "revoked"
+                if not already_revoked:
+                    candidate["state"] = "revoked"
+                    candidate["revoked_at_ms"] = revoked_at_ms
+                    candidate.pop("rotation", None)
+                matched = candidate
+            updated.append(candidate)
+        if matched is None:
+            return None
+        if not already_revoked:
+            self._save(
+                {
+                    "schema_version": BROWSER_BRIDGE_RECORD_SCHEMA_VERSION,
+                    "bridges": updated,
+                }
+            )
+        return BrowserBridgeRevocation(
+            bridge=_public_bridge_record(matched),
+            already_revoked=already_revoked,
+        )
+
+    def mark_authenticated(
+        self,
+        *,
+        bridge_id: Any,
+        key_generation: Any,
+        authenticated_at_ms: Any,
+    ) -> None:
+        safe_bridge_id = validate_identifier(bridge_id, field_name="bridge_id")
+        if type(key_generation) is not int or key_generation < 1:
+            raise BrowserBridgePairingUnavailable("invalid key generation")
+        if type(authenticated_at_ms) is not int or authenticated_at_ms < 0:
+            raise BrowserBridgePairingUnavailable("invalid authentication time")
+
+        records = self._validated_records()
+        matched = False
+        updated: list[dict[str, Any]] = []
+        for record in records:
+            candidate = dict(record)
+            if (
+                candidate["bridge_id"] == safe_bridge_id
+                and candidate["key_generation"] == key_generation
+                and candidate["state"] == "active"
+            ):
+                candidate["last_authenticated_at_ms"] = authenticated_at_ms
+                matched = True
+            updated.append(candidate)
+        if not matched:
+            raise BrowserBridgePairingUnavailable("active bridge record unavailable")
+        self._save(
+            {
+                "schema_version": BROWSER_BRIDGE_RECORD_SCHEMA_VERSION,
+                "bridges": updated,
+            }
+        )
+
+    def add(self, record: dict[str, Any]) -> None:
+        records = self._validated_records()
+        if len(records) >= MAX_BRIDGE_RECORDS:
+            raise BrowserBridgePairingUnavailable("bridge record limit reached")
+        validated = _validated_bridge_record(record)
+        if any(
+            existing["bridge_id"] == validated["bridge_id"]
+            for existing in records
+        ):
+            raise BrowserBridgePairingUnavailable("bridge identity collision")
+        records.append(validated)
+        self._save(
+            {
+                "schema_version": BROWSER_BRIDGE_RECORD_SCHEMA_VERSION,
+                "bridges": records,
+            }
+        )
+
+    def _validated_records(self) -> list[dict[str, Any]]:
+        document = self._load()
+        if document in (None, {}):
+            return []
+        if (
+            not isinstance(document, Mapping)
+            or set(document) != {"schema_version", "bridges"}
+            or document.get("schema_version") != BROWSER_BRIDGE_RECORD_SCHEMA_VERSION
+            or not isinstance(document.get("bridges"), list)
+            or len(document["bridges"]) > MAX_BRIDGE_RECORDS
+        ):
+            raise BrowserBridgePairingUnavailable("invalid bridge record store")
+        records = [_validated_bridge_record(record) for record in document["bridges"]]
+        bridge_ids = [record["bridge_id"] for record in records]
+        if len(set(bridge_ids)) != len(bridge_ids):
+            raise BrowserBridgePairingUnavailable("invalid bridge record store")
+        return records
+
+
+def _validated_bridge_record(value: Any) -> dict[str, Any]:
+    required = {
+        "trust_version",
+        "bridge_id",
+        "server_instance_id",
+        "subject_id",
+        "display_name",
+        "companion_instance_id",
+        "extension_id",
+        "public_key",
+        "key_generation",
+        "scopes",
+        "state",
+        "created_at_ms",
+        "last_authenticated_at_ms",
+        "revoked_at_ms",
+    }
+    if not isinstance(value, Mapping) or set(value) not in (required, required | {"rotation"}):
+        raise BrowserBridgePairingUnavailable("invalid bridge record")
+    if (
+        value.get("trust_version") != BROWSER_BRIDGE_TRUST_VERSION
+        or value.get("subject_id") != SUBJECT_ID
+        or type(value.get("key_generation")) is not int
+        or not 1 <= value["key_generation"] <= 2_147_483_647
+        or value.get("state") not in {"active", "revoked"}
+        or value.get("scopes") != list(FIXED_BROWSER_BRIDGE_SCOPES)
+        or type(value.get("created_at_ms")) is not int
+        or value.get("created_at_ms", -1) < 0
+        or (
+            value.get("last_authenticated_at_ms") is not None
+            and (
+                type(value.get("last_authenticated_at_ms")) is not int
+                or value.get("last_authenticated_at_ms") < 0
+            )
+        )
+        or (
+            value.get("revoked_at_ms") is not None
+            and (
+                type(value.get("revoked_at_ms")) is not int
+                or value.get("revoked_at_ms") < 0
+            )
+        )
+        or (value.get("state") == "active" and value.get("revoked_at_ms") is not None)
+        or (value.get("state") == "revoked" and value.get("revoked_at_ms") is None)
+    ):
+        raise BrowserBridgePairingUnavailable("invalid bridge record")
+    try:
+        result = {
+            "trust_version": BROWSER_BRIDGE_TRUST_VERSION,
+            "bridge_id": validate_identifier(value.get("bridge_id"), field_name="bridge_id"),
+            "server_instance_id": validate_identifier(
+                value.get("server_instance_id"),
+                field_name="server_instance_id",
+            ),
+            "subject_id": SUBJECT_ID,
+            "display_name": validate_display_name(value.get("display_name")),
+            "companion_instance_id": validate_identifier(
+                value.get("companion_instance_id"),
+                field_name="companion_instance_id",
+            ),
+            "extension_id": validate_extension_id(value.get("extension_id")),
+            "public_key": _public_key(value.get("public_key")),
+            "key_generation": value["key_generation"],
+            "scopes": list(FIXED_BROWSER_BRIDGE_SCOPES),
+            "state": value["state"],
+            "created_at_ms": value["created_at_ms"],
+            "last_authenticated_at_ms": value["last_authenticated_at_ms"],
+            "revoked_at_ms": value["revoked_at_ms"],
+        }
+    except BrowserBridgePairingError as error:
+        raise BrowserBridgePairingUnavailable("invalid bridge record") from error
+    if "rotation" in value:
+        from plugins._a0_connector.helpers.browser_bridge_credentials import validate_rotation
+        result["rotation"] = validate_rotation(value["rotation"], result)
+    return result
+
+
+def _public_bridge_record(record: Mapping[str, Any]) -> BrowserBridgePublicRecord:
+    """Project only already-validated, non-authorizing presentation fields."""
+    return BrowserBridgePublicRecord(
+        bridge_id=record["bridge_id"],
+        display_name=record["display_name"],
+        state=record["state"],
+        key_generation=record["key_generation"],
+        created_at_ms=record["created_at_ms"],
+        last_authenticated_at_ms=record["last_authenticated_at_ms"],
+        revoked_at_ms=record["revoked_at_ms"],
+    )
+
+
+def _load_default_records() -> Any:
+    from helpers import kvp
+
+    return kvp.get_persistent(BROWSER_BRIDGE_RECORD_STORE_KEY, None)
+
+
+def _save_default_records(value: dict[str, Any]) -> None:
+    from helpers import kvp
+
+    kvp.set_persistent(BROWSER_BRIDGE_RECORD_STORE_KEY, value)
+
+
+class BrowserBridgePairingStore:
+    """Thread-safe pending-pairing and single-use exchange store."""
+
+    def __init__(
+        self,
+        *,
+        repository: BrowserBridgeRecordRepository | None = None,
+        clock_ms: Callable[[], int] = _now_ms,
+        random_bytes: Callable[[int], bytes] = secrets.token_bytes,
+        id_factory: Callable[[], str] = _random_uuid,
+    ) -> None:
+        self._repository = repository or BrowserBridgeRecordRepository()
+        self._clock_ms = clock_ms
+        self._random_bytes = random_bytes
+        self._id_factory = id_factory
+        self._pending: dict[str, _PendingPairing] = {}
+        self._owner_pairing: dict[str, str] = {}
+        self._source_rates: dict[str, _SourceRate] = {}
+        self._lock = threading.RLock()
+
+    def create(
+        self,
+        *,
+        owner_id: str,
+        server_instance_id: str,
+        server_base_url: str,
+        extension_id: str,
+        display_name: str,
+    ) -> PairingCreation:
+        safe_owner = validate_identifier(owner_id, field_name="owner_id")
+        safe_server_id = validate_identifier(
+            server_instance_id,
+            field_name="server_instance_id",
+        )
+        safe_base_url = normalize_server_base_url(server_base_url)
+        safe_extension_id = validate_extension_id(extension_id)
+        safe_display_name = validate_display_name(display_name)
+        now = self._clock_ms()
+        with self._lock:
+            self._expire_locked(now)
+            previous = self._owner_pairing.pop(safe_owner, None)
+            if previous:
+                self._pending.pop(previous, None)
+            while len(self._pending) >= MAX_PENDING_PAIRINGS:
+                oldest = min(
+                    self._pending.values(),
+                    key=lambda pending: (pending.created_at_ms, pending.pairing_id),
+                )
+                self._remove_pending_locked(oldest)
+
+            pairing_id = self._new_unique_pairing_id_locked()
+            prefix = pairing_id.replace("-", "")[:8].upper()
+            entropy = self._random_bytes(PAIRING_SECRET_BYTES)
+            if not isinstance(entropy, bytes) or len(entropy) != PAIRING_SECRET_BYTES:
+                raise BrowserBridgePairingUnavailable("secure entropy unavailable")
+            code = f"A0B1-{prefix}-{_encode_crockford(entropy)}"
+            pending = _PendingPairing(
+                pairing_id=pairing_id,
+                pairing_prefix=prefix,
+                owner_id=safe_owner,
+                secret_digest=hashlib.sha256(code.encode("ascii")).digest(),
+                server_instance_id=safe_server_id,
+                server_base_url=safe_base_url,
+                extension_id=safe_extension_id,
+                display_name=safe_display_name,
+                created_at_ms=now,
+                expires_at_ms=now + PAIRING_TTL_MS,
+            )
+            self._pending[pairing_id] = pending
+            self._owner_pairing[safe_owner] = pairing_id
+
+        return PairingCreation(
+            pairing_id=pairing_id,
+            pairing_code=code,
+            server_base_url=safe_base_url,
+            server_instance_fingerprint=server_instance_fingerprint(safe_server_id),
+            extension_id=safe_extension_id,
+            display_name=safe_display_name,
+            created_at_ms=now,
+            expires_at_ms=now + PAIRING_TTL_MS,
+        )
+
+    def status(
+        self,
+        *,
+        owner_id: str | None,
+        server_instance_id: str | None = None,
+    ) -> dict[str, Any]:
+        now = self._clock_ms()
+        with self._lock:
+            self._expire_locked(now)
+            pending = self._pending_for_owner_locked(owner_id)
+            try:
+                paired = self._repository.active_record_present(
+                    server_instance_id=server_instance_id
+                )
+            except BrowserBridgePairingUnavailable:
+                return _pairing_status(
+                    state="repair_required",
+                    reason_code="bridge_record_store_invalid",
+                )
+            if pending is not None:
+                return _pairing_status(
+                    state="pairing_pending",
+                    reason_code="pairing_intent_active",
+                    pairing_id=pending.pairing_id,
+                    expires_at_ms=pending.expires_at_ms,
+                    server_base_url=pending.server_base_url,
+                    extension_id=pending.extension_id,
+                    display_name=pending.display_name,
+                )
+            return _pairing_status(
+                state="paired" if paired else "unpaired",
+                reason_code=(
+                    "active_bridge_record_present"
+                    if paired
+                    else "no_active_bridge_record"
+                ),
+            )
+
+    def cancel(self, *, owner_id: str | None, pairing_id: Any) -> bool:
+        if owner_id is None:
+            return False
+        try:
+            safe_owner = validate_identifier(owner_id, field_name="owner_id")
+            safe_pairing_id = validate_identifier(
+                pairing_id,
+                field_name="pairing_id",
+            )
+        except BrowserBridgePairingError:
+            return False
+        now = self._clock_ms()
+        with self._lock:
+            self._expire_locked(now)
+            pending = self._pending.get(safe_pairing_id)
+            if pending is None or pending.owner_id != safe_owner:
+                return False
+            self._remove_pending_locked(pending)
+            return True
+
+    def active_bridge_record(
+        self,
+        *,
+        bridge_id: Any,
+        server_instance_id: Any,
+    ) -> dict[str, Any] | None:
+        with self._lock:
+            return self._repository.active_record(
+                bridge_id=bridge_id,
+                server_instance_id=server_instance_id,
+            )
+
+    def list_bridge_records(
+        self,
+        *,
+        server_instance_id: Any,
+        subject_id: Any,
+    ) -> list[BrowserBridgePublicRecord]:
+        with self._lock:
+            return self._repository.list_public_records(
+                server_instance_id=server_instance_id,
+                subject_id=subject_id,
+            )
+
+    def bridge_record(
+        self,
+        *,
+        bridge_id: Any,
+        server_instance_id: Any,
+        subject_id: Any,
+    ) -> BrowserBridgePublicRecord | None:
+        with self._lock:
+            return self._repository.public_record(
+                bridge_id=bridge_id,
+                server_instance_id=server_instance_id,
+                subject_id=subject_id,
+            )
+
+    def revoke_bridge(
+        self,
+        *,
+        bridge_id: Any,
+        server_instance_id: Any,
+        subject_id: Any,
+    ) -> BrowserBridgeRevocation | None:
+        # This is intentionally the same lock used by exchange and
+        # mark_bridge_authenticated. Once this call returns, neither a stale
+        # proof nor an overlapping record write can restore active state.
+        with self._lock:
+            return self._repository.revoke(
+                bridge_id=bridge_id,
+                server_instance_id=server_instance_id,
+                subject_id=subject_id,
+                revoked_at_ms=self._clock_ms(),
+            )
+
+    def mark_bridge_authenticated(
+        self,
+        *,
+        bridge_id: Any,
+        key_generation: Any,
+        authenticated_at_ms: Any,
+    ) -> None:
+        with self._lock:
+            self._repository.mark_authenticated(
+                bridge_id=bridge_id,
+                key_generation=key_generation,
+                authenticated_at_ms=authenticated_at_ms,
+            )
+
+    def exchange(
+        self,
+        request: Any,
+        *,
+        source_key: str,
+    ) -> PairingExchangeSuccess:
+        now = self._clock_ms()
+        with self._lock:
+            self._expire_locked(now)
+            if not self._allow_source_locked(source_key, now):
+                raise BrowserBridgePairingExchangeFailed("pairing exchange failed")
+            try:
+                data = request if isinstance(request, Mapping) else {}
+                code, prefix = _normalize_pairing_code(data.get("pairing_code"))
+            except BrowserBridgePairingExchangeFailed:
+                raise
+
+            pending = next(
+                (
+                    candidate
+                    for candidate in self._pending.values()
+                    if candidate.pairing_prefix == prefix
+                ),
+                None,
+            )
+            if pending is None:
+                raise BrowserBridgePairingExchangeFailed("pairing exchange failed")
+
+            try:
+                success = self._matches_exchange_locked(pending, data, code)
+            except BrowserBridgePairingError:
+                success = False
+            if not success:
+                pending.failed_exchanges += 1
+                if pending.failed_exchanges >= PAIRING_MAX_FAILED_EXCHANGES:
+                    self._remove_pending_locked(pending)
+                raise BrowserBridgePairingExchangeFailed("pairing exchange failed")
+
+            public_key = _public_key(data.get("public_key"))
+            companion_instance_id = validate_identifier(
+                data.get("companion_instance_id"),
+                field_name="companion_instance_id",
+            )
+            bridge_id = validate_identifier(
+                self._id_factory(),
+                field_name="bridge_id",
+            )
+            record = {
+                "trust_version": BROWSER_BRIDGE_TRUST_VERSION,
+                "bridge_id": bridge_id,
+                "server_instance_id": pending.server_instance_id,
+                "subject_id": SUBJECT_ID,
+                "display_name": pending.display_name,
+                "companion_instance_id": companion_instance_id,
+                "extension_id": pending.extension_id,
+                "public_key": public_key,
+                "key_generation": 1,
+                "scopes": list(FIXED_BROWSER_BRIDGE_SCOPES),
+                "state": "active",
+                "created_at_ms": now,
+                "last_authenticated_at_ms": None,
+                "revoked_at_ms": None,
+            }
+            self._repository.add(record)
+            self._remove_pending_locked(pending)
+            return PairingExchangeSuccess(
+                bridge_id=bridge_id,
+                server_instance_id=pending.server_instance_id,
+                server_base_url=pending.server_base_url,
+                extension_id=pending.extension_id,
+                display_name=pending.display_name,
+                created_at_ms=now,
+            )
+
+    def _matches_exchange_locked(
+        self,
+        pending: _PendingPairing,
+        data: Mapping[str, Any],
+        code: str,
+    ) -> bool:
+        if set(data) != {
+            "trust_version",
+            "pairing_code",
+            "server_base_url",
+            "extension_id",
+            "companion_instance_id",
+            "public_key",
+        }:
+            return False
+        if type(data.get("trust_version")) is not int or data.get("trust_version") != 1:
+            return False
+        supplied_digest = hashlib.sha256(code.encode("ascii")).digest()
+        if not hmac.compare_digest(supplied_digest, pending.secret_digest):
+            return False
+        if normalize_server_base_url(data.get("server_base_url")) != pending.server_base_url:
+            return False
+        if validate_extension_id(data.get("extension_id")) != pending.extension_id:
+            return False
+        validate_identifier(
+            data.get("companion_instance_id"),
+            field_name="companion_instance_id",
+        )
+        _public_key(data.get("public_key"))
+        return True
+
+    def _new_unique_pairing_id_locked(self) -> str:
+        for _ in range(16):
+            pairing_id = validate_identifier(
+                self._id_factory(),
+                field_name="pairing_id",
+            )
+            prefix = pairing_id.replace("-", "")[:8].upper()
+            if len(prefix) == 8 and re.fullmatch(r"[0-9A-F]{8}", prefix) and all(
+                candidate.pairing_prefix != prefix
+                for candidate in self._pending.values()
+            ):
+                return pairing_id
+        raise BrowserBridgePairingUnavailable("pairing identity unavailable")
+
+    def _pending_for_owner_locked(
+        self,
+        owner_id: str | None,
+    ) -> _PendingPairing | None:
+        if not owner_id:
+            return None
+        pairing_id = self._owner_pairing.get(owner_id)
+        return self._pending.get(pairing_id) if pairing_id else None
+
+    def _remove_pending_locked(self, pending: _PendingPairing) -> None:
+        self._pending.pop(pending.pairing_id, None)
+        if self._owner_pairing.get(pending.owner_id) == pending.pairing_id:
+            self._owner_pairing.pop(pending.owner_id, None)
+
+    def _expire_locked(self, now: int) -> None:
+        for pending in tuple(self._pending.values()):
+            if pending.expires_at_ms <= now:
+                self._remove_pending_locked(pending)
+        for key, rate in tuple(self._source_rates.items()):
+            if rate.window_started_at_ms + SOURCE_RATE_WINDOW_MS <= now:
+                self._source_rates.pop(key, None)
+
+    def _allow_source_locked(self, source_key: str, now: int) -> bool:
+        safe_key = validate_identifier(source_key, field_name="source_key")
+        rate = self._source_rates.get(safe_key)
+        if rate is None or rate.window_started_at_ms + SOURCE_RATE_WINDOW_MS <= now:
+            if len(self._source_rates) >= MAX_SOURCE_BUCKETS:
+                oldest_key = min(
+                    self._source_rates,
+                    key=lambda key: self._source_rates[key].window_started_at_ms,
+                )
+                self._source_rates.pop(oldest_key, None)
+            self._source_rates[safe_key] = _SourceRate(now, 1)
+            return True
+        rate.attempts += 1
+        return rate.attempts <= SOURCE_RATE_MAX_EXCHANGES
+
+
+def _pairing_status(
+    *,
+    state: str,
+    reason_code: str,
+    pairing_id: str | None = None,
+    expires_at_ms: int | None = None,
+    server_base_url: str | None = None,
+    extension_id: str | None = None,
+    display_name: str | None = None,
+) -> dict[str, Any]:
+    pending = state == "pairing_pending"
+    return {
+        "contract": BROWSER_BRIDGE_TRUST_CONTRACT,
+        "trust_version": BROWSER_BRIDGE_TRUST_VERSION,
+        "state": state,
+        "reason_code": reason_code,
+        "pairing_id": pairing_id if pending else None,
+        "server_base_url": server_base_url if pending else None,
+        "extension_id": extension_id if pending else None,
+        "display_name": display_name if pending else None,
+        "expires_at_ms": expires_at_ms if pending else None,
+        "pairing_code_present": False,
+        "native_runtime_location": "user_browser_host",
+        "docker_install_target": False,
+        "connector_session_ready": False,
+        "browser_control_ready": False,
+    }
+
+
+def build_browser_bridge_pairing_foundation_status(
+    gate: BrowserBridgeGate,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    extension_configured = configured_extension_id(environ=environ) is not None
+    create_enabled = gate.state in {"preview", "available"} and extension_configured
+    if gate.state == "disabled":
+        reason_code = "rollout_disabled"
+    elif not extension_configured:
+        reason_code = "expected_extension_id_not_configured"
+    else:
+        reason_code = "pairing_endpoint_available"
+    return {
+        "contract": BROWSER_BRIDGE_TRUST_CONTRACT,
+        "trust_version": BROWSER_BRIDGE_TRUST_VERSION,
+        "state": "available" if create_enabled else "disabled",
+        "reason_code": reason_code,
+        "pairing_create_enabled": create_enabled,
+        "pairing_exchange_enabled": create_enabled,
+        "connector_session_ready": False,
+        "browser_control_ready": False,
+        "native_runtime_location": "user_browser_host",
+        "docker_install_target": False,
+    }
+
+
+_store: BrowserBridgePairingStore | None = None
+_store_lock = threading.Lock()
+
+
+def get_browser_bridge_pairing_store() -> BrowserBridgePairingStore:
+    global _store
+    with _store_lock:
+        if _store is None:
+            _store = BrowserBridgePairingStore()
+        return _store
+
+
+PAIRING_OWNER_SESSION_KEY = "browser_bridge_pairing_owner_v1"
+
+
+def pairing_owner_id(
+    session_state: MutableMapping[str, Any],
+    *,
+    create: bool,
+) -> str | None:
+    current = session_state.get(PAIRING_OWNER_SESSION_KEY)
+    try:
+        if current is not None:
+            return validate_identifier(current, field_name="pairing owner")
+    except BrowserBridgePairingError:
+        session_state.pop(PAIRING_OWNER_SESSION_KEY, None)
+    if not create:
+        return None
+    owner = secrets.token_urlsafe(24)
+    session_state[PAIRING_OWNER_SESSION_KEY] = owner
+    return owner

--- a/plugins/_a0_connector/helpers/browser_bridge_policy.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_policy.py
@@ -1,0 +1,485 @@
+"""Durable browsing policy with exact-origin grants for paired Browser bridges.
+
+This module persists site decisions only.  It does not mint operation approval
+receipts, advertise Browser runtime readiness, or dispatch connector events.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import ipaddress
+import re
+import threading
+import time
+from typing import Any, Callable, ContextManager, Mapping
+from urllib.parse import urlsplit
+import uuid
+
+from plugins._a0_connector.helpers.browser_bridge_pairing import validate_identifier
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+)
+
+
+BROWSER_BRIDGE_POLICY_CONTRACT = "a0.browser-bridge.site-policy.v1"
+BROWSER_BRIDGE_POLICY_VERSION = 1
+BROWSER_BRIDGE_POLICY_STORE_KEY = "a0_browser_bridge_site_policy_v1"
+DEFAULT_SITE_MODE = "ask_per_site"
+ALL_WEBSITES_MODE = "allow_all_websites"
+MAX_POLICY_REQUEST_BYTES = 8 * 1024
+MAX_POLICY_GRANTS = 512
+MAX_ORIGIN_BYTES = 2_048
+
+_ASCII_LABEL = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
+_persistent_policy_lock = threading.RLock()
+
+
+class BrowserBridgePolicyError(ValueError):
+    """A caller supplied an invalid policy identity or origin."""
+
+
+class BrowserBridgePolicyUnavailable(BrowserBridgePolicyError):
+    """The durable policy cannot be read or updated safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserBridgeOriginGrant:
+    grant_id: str
+    server_instance_id: str
+    bridge_id: str
+    subject_id: str
+    origin: str
+    created_at_ms: int
+    updated_at_ms: int
+
+    def as_public_dict(self) -> dict[str, Any]:
+        return {
+            "grant_id": self.grant_id,
+            "origin": self.origin,
+            "created_at_ms": self.created_at_ms,
+            "updated_at_ms": self.updated_at_ms,
+        }
+
+
+def normalize_site_origin(value: Any) -> str:
+    """Return the exact canonical HTTP(S) origin or reject it."""
+
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise BrowserBridgePolicyError("invalid site origin")
+    try:
+        encoded_size = len(value.encode("utf-8"))
+    except UnicodeError:
+        raise BrowserBridgePolicyError("invalid site origin") from None
+    if (
+        encoded_size > MAX_ORIGIN_BYTES
+        or "\\" in value
+        or "*" in value
+        or "?" in value
+        or "#" in value
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+    ):
+        raise BrowserBridgePolicyError("invalid site origin")
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except (TypeError, ValueError):
+        raise BrowserBridgePolicyError("invalid site origin") from None
+    scheme = parsed.scheme.lower()
+    if (
+        scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+        or parsed.netloc.endswith(":")
+    ):
+        raise BrowserBridgePolicyError("invalid site origin")
+    hostname = parsed.hostname
+    if not hostname or any(character.isspace() for character in hostname):
+        raise BrowserBridgePolicyError("invalid site origin")
+
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        try:
+            ascii_host = hostname.encode("idna").decode("ascii").lower()
+        except UnicodeError:
+            raise BrowserBridgePolicyError("invalid site origin") from None
+        labels = ascii_host.split(".")
+        if (
+            len(ascii_host) > 253
+            or any(not _ASCII_LABEL.fullmatch(label) for label in labels)
+            or _is_browser_ipv4_number(labels[-1])
+        ):
+            raise BrowserBridgePolicyError("invalid site origin")
+        canonical_host = ascii_host
+    else:
+        if getattr(address, "scope_id", None) is not None:
+            raise BrowserBridgePolicyError("invalid site origin")
+        canonical_host = f"[{address.compressed}]" if address.version == 6 else address.compressed
+
+    if port is not None and not 1 <= port <= 65_535:
+        raise BrowserBridgePolicyError("invalid site origin")
+    canonical_port = None if (scheme, port) in {("http", 80), ("https", 443)} else port
+    return f"{scheme}://{canonical_host}{f':{canonical_port}' if canonical_port else ''}"
+
+
+def _is_browser_ipv4_number(label: str) -> bool:
+    """Reject DNS spellings browsers would reinterpret as legacy IPv4."""
+
+    if label.startswith("0x"):
+        return len(label) > 2 and all(character in "0123456789abcdef" for character in label[2:])
+    if len(label) > 1 and label.startswith("0"):
+        return all(character in "01234567" for character in label[1:])
+    return label.isdecimal()
+
+
+class BrowserBridgePolicyRepository:
+    """Bounded saved sites and explicit production all-websites preference."""
+
+    def __init__(
+        self,
+        *,
+        load: Callable[[], Any] | None = None,
+        save: Callable[[dict[str, Any]], None] | None = None,
+        clock_ms: Callable[[], int] | None = None,
+        id_factory: Callable[[], str] | None = None,
+        lock: ContextManager[Any] | None = None,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        self._load = load or _load_default_policy
+        self._save = save or _save_default_policy
+        self._clock_ms = clock_ms or (lambda: time.time_ns() // 1_000_000)
+        self._id_factory = id_factory or (lambda: str(uuid.uuid4()))
+        self._lock = lock or _persistent_policy_lock
+
+    @property
+    def transport_profile(self) -> BrowserBridgeTransportProfile:
+        return self._transport_profile
+
+    def list_grants(
+        self,
+        *,
+        server_instance_id: Any,
+        bridge_id: Any,
+        subject_id: Any,
+    ) -> tuple[BrowserBridgeOriginGrant, ...]:
+        key = _policy_key(server_instance_id, bridge_id, subject_id)
+        with self._lock:
+            grants = self._validated_grants_locked()
+            return tuple(
+                grant
+                for grant in grants
+                if _grant_key(grant) == key
+            )
+
+    def active_grant(
+        self,
+        *,
+        server_instance_id: Any,
+        bridge_id: Any,
+        subject_id: Any,
+        origin: Any,
+    ) -> BrowserBridgeOriginGrant | None:
+        canonical_origin = normalize_site_origin(origin)
+        exact = next(
+            (
+                grant
+                for grant in self.list_grants(
+                    server_instance_id=server_instance_id,
+                    bridge_id=bridge_id,
+                    subject_id=subject_id,
+                )
+                if grant.origin == canonical_origin
+            ),
+            None,
+        )
+        if exact is not None:
+            return exact
+        key = _policy_key(server_instance_id, bridge_id, subject_id)
+        with self._lock:
+            self._validated_grants_locked()
+            mode = next((item for item in self._modes_locked() if _mode_key(item) == key), None)
+            if mode is None:
+                return None
+            # A bounded exact-origin projection, not a wildcard wire grant or
+            # a permanent grant surviving withdrawal of this saved preference.
+            digest = hashlib.sha256((mode["grant_id"] + "\0" + canonical_origin).encode()).hexdigest()
+            return BrowserBridgeOriginGrant("all-sites-" + digest, *key, canonical_origin,
+                                            mode["created_at_ms"], mode["updated_at_ms"])
+
+    def site_mode(self, *, server_instance_id, bridge_id, subject_id) -> str:
+        key = _policy_key(server_instance_id, bridge_id, subject_id)
+        with self._lock:
+            self._validated_grants_locked()
+            return ALL_WEBSITES_MODE if any(_mode_key(item) == key for item in self._modes_locked()) else DEFAULT_SITE_MODE
+
+    def set_site_mode(self, *, server_instance_id, bridge_id, subject_id, site_mode) -> None:
+        if self._transport_profile is not PRODUCTION_BROWSER_BRIDGE_TRANSPORT or not isinstance(site_mode, str) or site_mode not in {DEFAULT_SITE_MODE, ALL_WEBSITES_MODE}:
+            raise BrowserBridgePolicyError("invalid site mode")
+        key = _policy_key(server_instance_id, bridge_id, subject_id)
+        with self._lock:
+            grants = self._validated_grants_locked()
+            modes = self._modes_locked()
+            existing = next((item for item in modes if _mode_key(item) == key), None)
+            if (existing is not None) == (site_mode == ALL_WEBSITES_MODE):
+                return
+            modes = [item for item in modes if _mode_key(item) != key]
+            if site_mode == ALL_WEBSITES_MODE:
+                if len(modes) >= 128:
+                    raise BrowserBridgePolicyUnavailable("site mode capacity")
+                now = self._now()
+                mode = dict(zip(("server_instance_id", "bridge_id", "subject_id"), key))
+                try:
+                    grant_id = validate_identifier(self._id_factory(), field_name="grant_id")
+                except Exception as error:
+                    raise BrowserBridgePolicyUnavailable("site mode identity unavailable") from error
+                mode.update(grant_id=grant_id, created_at_ms=now, updated_at_ms=now)
+                if any(item["grant_id"] == mode["grant_id"] for item in modes):
+                    raise BrowserBridgePolicyUnavailable("site mode identity collision")
+                modes.append(mode)
+            self._save_grants_locked(grants, modes=modes)
+            if self.site_mode(server_instance_id=key[0], bridge_id=key[1], subject_id=key[2]) != site_mode:
+                raise BrowserBridgePolicyUnavailable("site mode readback failed")
+
+    def allow(
+        self,
+        *,
+        server_instance_id: Any,
+        bridge_id: Any,
+        subject_id: Any,
+        origin: Any,
+    ) -> BrowserBridgeOriginGrant:
+        server_id, safe_bridge_id, safe_subject_id = _policy_key(
+            server_instance_id, bridge_id, subject_id
+        )
+        canonical_origin = normalize_site_origin(origin)
+        with self._lock:
+            grants = self._validated_grants_locked()
+            for grant in grants:
+                if (
+                    _grant_key(grant) == (server_id, safe_bridge_id, safe_subject_id)
+                    and grant.origin == canonical_origin
+                ):
+                    return grant
+            if len(grants) >= MAX_POLICY_GRANTS:
+                raise BrowserBridgePolicyUnavailable("site policy grant limit reached")
+            now = self._now()
+            try:
+                grant_id = validate_identifier(self._id_factory(), field_name="grant_id")
+            except Exception as error:
+                raise BrowserBridgePolicyUnavailable("site policy identity unavailable") from error
+            if any(grant.grant_id == grant_id for grant in grants):
+                raise BrowserBridgePolicyUnavailable("site policy identity collision")
+            grant = BrowserBridgeOriginGrant(
+                grant_id=grant_id,
+                server_instance_id=server_id,
+                bridge_id=safe_bridge_id,
+                subject_id=safe_subject_id,
+                origin=canonical_origin,
+                created_at_ms=now,
+                updated_at_ms=now,
+            )
+            grants.append(grant)
+            self._save_grants_locked(grants)
+            return grant
+
+    def revoke(
+        self,
+        *,
+        server_instance_id: Any,
+        bridge_id: Any,
+        subject_id: Any,
+        origin: Any,
+    ) -> bool:
+        key = _policy_key(server_instance_id, bridge_id, subject_id)
+        canonical_origin = normalize_site_origin(origin)
+        with self._lock:
+            grants = self._validated_grants_locked()
+            retained = [
+                grant
+                for grant in grants
+                if not (_grant_key(grant) == key and grant.origin == canonical_origin)
+            ]
+            if len(retained) == len(grants):
+                return False
+            self._save_grants_locked(retained)
+            return True
+
+    def _validated_grants_locked(self) -> list[BrowserBridgeOriginGrant]:
+        try:
+            document = self._load()
+        except Exception as error:
+            raise BrowserBridgePolicyUnavailable("site policy store unavailable") from error
+        if document in (None, {}):
+            return []
+        if (
+            not isinstance(document, Mapping)
+            or type(document.get("schema_version")) is not int
+            or (document.get("schema_version"), frozenset(document)) not in {
+                (1, frozenset({"schema_version", "grants"})),
+                (2, frozenset({"schema_version", "grants", "all_websites"})),
+            }
+            or not isinstance(document.get("grants"), list)
+            or len(document["grants"]) > MAX_POLICY_GRANTS
+        ):
+            raise BrowserBridgePolicyUnavailable("invalid site policy store")
+        try:
+            grants = [_validated_grant(value) for value in document["grants"]]
+        except BrowserBridgePolicyError as error:
+            raise BrowserBridgePolicyUnavailable("invalid site policy store") from error
+        keys = [(*_grant_key(grant), grant.origin) for grant in grants]
+        grant_ids = [grant.grant_id for grant in grants]
+        if len(set(keys)) != len(keys) or len(set(grant_ids)) != len(grant_ids):
+            raise BrowserBridgePolicyUnavailable("invalid site policy store")
+        try:
+            self._validate_modes(document.get("all_websites", []))
+        except Exception as error:
+            raise BrowserBridgePolicyUnavailable("invalid site mode store") from error
+        return grants
+
+    def _modes_locked(self):
+        try:
+            document = self._load()
+            return self._validate_modes(document.get("all_websites", []) if document else [])
+        except Exception as error:
+            raise BrowserBridgePolicyUnavailable("invalid site mode store") from error
+
+    def _validate_modes(self, values):
+        if not isinstance(values, list) or len(values) > 128 or (values and self._transport_profile is not PRODUCTION_BROWSER_BRIDGE_TRANSPORT):
+            raise BrowserBridgePolicyUnavailable("invalid site mode store")
+        keys, ids = set(), set()
+        for item in values:
+            if not isinstance(item, dict) or set(item) != {"server_instance_id", "bridge_id", "subject_id", "grant_id", "created_at_ms", "updated_at_ms"}:
+                raise BrowserBridgePolicyUnavailable("invalid site mode store")
+            key = _policy_key(item["server_instance_id"], item["bridge_id"], item["subject_id"])
+            token = validate_identifier(item["grant_id"], field_name="grant_id")
+            if (key in keys or token in ids or type(item["created_at_ms"]) is not int
+                or type(item["updated_at_ms"]) is not int or not 0 <= item["created_at_ms"] <= item["updated_at_ms"]):
+                raise BrowserBridgePolicyUnavailable("invalid site mode store")
+            keys.add(key); ids.add(token)
+        return [dict(item) for item in values]
+
+    def _save_grants_locked(self, grants: list[BrowserBridgeOriginGrant], *, modes=None) -> None:
+        modes = self._modes_locked() if modes is None else self._validate_modes(modes)
+        document = {
+            "schema_version": 2 if modes else BROWSER_BRIDGE_POLICY_VERSION,
+            "grants": [_grant_as_stored_dict(grant) for grant in grants],
+            **({"all_websites": modes} if modes else {}),
+        }
+        try:
+            self._save(document)
+        except Exception as error:
+            raise BrowserBridgePolicyUnavailable("site policy store unavailable") from error
+
+    def _now(self) -> int:
+        now = self._clock_ms()
+        if isinstance(now, bool) or not isinstance(now, int) or now < 0:
+            raise BrowserBridgePolicyUnavailable("site policy clock unavailable")
+        return now
+
+
+def _policy_key(
+    server_instance_id: Any,
+    bridge_id: Any,
+    subject_id: Any,
+) -> tuple[str, str, str]:
+    try:
+        return (
+            validate_identifier(server_instance_id, field_name="server_instance_id"),
+            validate_identifier(bridge_id, field_name="bridge_id"),
+            validate_identifier(subject_id, field_name="subject_id"),
+        )
+    except Exception as error:
+        raise BrowserBridgePolicyError("invalid site policy identity") from error
+
+
+def _grant_key(grant: BrowserBridgeOriginGrant) -> tuple[str, str, str]:
+    return grant.server_instance_id, grant.bridge_id, grant.subject_id
+
+
+def _mode_key(value):
+    return value["server_instance_id"], value["bridge_id"], value["subject_id"]
+
+
+def _validated_grant(value: Any) -> BrowserBridgeOriginGrant:
+    required = {
+        "grant_id", "server_instance_id", "bridge_id", "subject_id", "origin",
+        "created_at_ms", "updated_at_ms",
+    }
+    if not isinstance(value, Mapping) or set(value) != required:
+        raise BrowserBridgePolicyError("invalid site policy grant")
+    created = value.get("created_at_ms")
+    updated = value.get("updated_at_ms")
+    if (
+        isinstance(created, bool)
+        or not isinstance(created, int)
+        or created < 0
+        or isinstance(updated, bool)
+        or not isinstance(updated, int)
+        or updated < created
+    ):
+        raise BrowserBridgePolicyError("invalid site policy grant")
+    server_id, bridge_id, subject_id = _policy_key(
+        value.get("server_instance_id"), value.get("bridge_id"), value.get("subject_id")
+    )
+    try:
+        grant_id = validate_identifier(value.get("grant_id"), field_name="grant_id")
+    except Exception as error:
+        raise BrowserBridgePolicyError("invalid site policy grant") from error
+    return BrowserBridgeOriginGrant(
+        grant_id=grant_id,
+        server_instance_id=server_id,
+        bridge_id=bridge_id,
+        subject_id=subject_id,
+        origin=normalize_site_origin(value.get("origin")),
+        created_at_ms=created,
+        updated_at_ms=updated,
+    )
+
+
+def _grant_as_stored_dict(grant: BrowserBridgeOriginGrant) -> dict[str, Any]:
+    return {
+        "grant_id": grant.grant_id,
+        "server_instance_id": grant.server_instance_id,
+        "bridge_id": grant.bridge_id,
+        "subject_id": grant.subject_id,
+        "origin": grant.origin,
+        "created_at_ms": grant.created_at_ms,
+        "updated_at_ms": grant.updated_at_ms,
+    }
+
+
+def _load_default_policy() -> Any:
+    from helpers import kvp
+
+    return kvp.get_persistent(BROWSER_BRIDGE_POLICY_STORE_KEY, None)
+
+
+def _save_default_policy(value: dict[str, Any]) -> None:
+    from helpers import kvp
+
+    kvp.set_persistent(BROWSER_BRIDGE_POLICY_STORE_KEY, value)
+
+
+_repository: BrowserBridgePolicyRepository | None = None
+_repository_lock = threading.Lock()
+
+
+def get_browser_bridge_policy_repository() -> BrowserBridgePolicyRepository:
+    global _repository
+    if _repository is None:
+        with _repository_lock:
+            if _repository is None:
+                _repository = BrowserBridgePolicyRepository()
+    return _repository

--- a/plugins/_a0_connector/helpers/browser_bridge_queue.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_queue.py
@@ -1,0 +1,227 @@
+"""Restricted text-only access to bridge-owned Core message queue items.
+
+Queue data stays in the existing AgentContext. The separate durable journal
+contains hashes only and prevents replay from enqueueing or sending twice.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+import threading
+
+from helpers.ws_principal import restricted_correlation_id
+from plugins._a0_connector.helpers.browser_bridge_journal import BrowserBridgeJournal
+
+QUEUE_EVENTS = frozenset({"connector_message_queue_add", "connector_message_queue_remove", "connector_message_queue_send"})
+_STORE_KEY = "a0_browser_bridge_queue_v1"
+_LOCK = threading.RLock()
+_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+_HASH = re.compile(r"[a-f0-9]{64}")
+_MAX_ITEMS = 32
+
+
+class BrowserBridgeQueueError(RuntimeError):
+    def __init__(self, code: str, *, outcome: str = "not_applied") -> None:
+        super().__init__(code)
+        self.code = code
+        self.outcome = outcome
+
+
+class BrowserBridgeQueueController:
+    def __init__(self, *, access, messages, manager, server_instance_id,
+                 context_get=None, queue_service=None, load=None, save=None,
+                 mark_dirty=None):
+        self.access, self.messages, self.manager = access, messages, manager
+        self.profile = access.transport_profile
+        self.server_instance_id = server_instance_id
+        self.context_get = context_get or _context_get
+        self.queue_service = queue_service
+        self.journal = BrowserBridgeJournal(
+            _STORE_KEY, _validate_record,
+            lambda: BrowserBridgeQueueError("QUEUE_STORE_UNAVAILABLE"),
+            load=load, save=save,
+        )
+        self.mark_dirty = mark_dirty or _mark_dirty
+
+    async def dispatch(self, event, route, document):
+        if not isinstance(document, dict):
+            raise BrowserBridgeQueueError("INVALID_STATE")
+        request = dict(document)
+        request.pop("correlationId", None)
+        required = {"contract_version", "context_id"}
+        if event == "connector_message_queue_add":
+            required |= {"client_message_id", "text"}
+        elif event in QUEUE_EVENTS:
+            required |= {"item_id"}
+        else:
+            raise BrowserBridgeQueueError("EVENT_NOT_ALLOWED")
+        if set(request) != required or type(request.get("contract_version")) is not int or request["contract_version"] != 1:
+            raise BrowserBridgeQueueError("INVALID_STATE")
+        context_id = _identifier(request["context_id"])
+        self._authorize(route, context_id, event)
+        context = self.context_get(context_id)
+        if context is None:
+            raise BrowserBridgeQueueError("CONTEXT_NOT_FOUND")
+        scope = _digest([self.server_instance_id(), route.principal.principal_id, route.principal.subject_id, context_id])
+        queue = self.queue_service
+        if queue is None:
+            from helpers import message_queue as queue
+        with _LOCK:
+            self._authorize(route, context_id, event)
+            if event == "connector_message_queue_add":
+                message_id = _identifier(request["client_message_id"])
+                text = request["text"]
+                try:
+                    valid_text = isinstance(text, str) and bool(text.strip()) and len(text.encode("utf-8")) <= 32768
+                except UnicodeError:
+                    valid_text = False
+                if not valid_text:
+                    raise BrowserBridgeQueueError("INVALID_STATE")
+                item_id = _digest([scope, message_id])
+                content_hash = _digest(text)
+                prior = self.journal.get(item_id)
+                if prior is not None:
+                    if prior["content_hash"] != content_hash:
+                        raise BrowserBridgeQueueError("IDEMPOTENCY_CONFLICT")
+                    if prior["state"] == "reserved":
+                        raise BrowserBridgeQueueError("OUTCOME_UNKNOWN", outcome="unknown")
+                    # A consumed/deleted item is not recreated by an old add.
+                    status = prior["state"]
+                else:
+                    if len(queue.get_queue(context)) >= _MAX_ITEMS:
+                        raise BrowserBridgeQueueError("QUEUE_LIMIT")
+                    record = {"scope": scope, "content_hash": content_hash, "state": "reserved"}
+                    self.journal.put(item_id, record)
+                    self._authorize(route, context_id, event)
+                    try:
+                        queue.add(context, text, [], item_id=item_id)
+                        record["state"] = "queued"
+                        self.journal.put(item_id, record)
+                    except Exception:
+                        raise BrowserBridgeQueueError("OUTCOME_UNKNOWN", outcome="unknown") from None
+                    status = "queued"
+            else:
+                item_id = _identifier(request["item_id"])
+                prior = self.journal.get(item_id)
+                if prior is None or prior["scope"] != scope:
+                    raise BrowserBridgeQueueError("QUEUE_ITEM_NOT_FOUND")
+                target_state = "removed" if event.endswith("_remove") else "sent"
+                if prior["state"] == target_state:
+                    status = target_state
+                elif prior["state"] != "queued":
+                    raise BrowserBridgeQueueError("OUTCOME_UNKNOWN" if prior["state"] == "reserved" else "QUEUE_ITEM_NOT_FOUND",
+                                                 outcome="unknown" if prior["state"] == "reserved" else "not_applied")
+                else:
+                    found = next((item for item in queue.get_queue(context) if item.get("id") == item_id), None)
+                    if found is None:
+                        # Core may already have consumed the ordinary queue.
+                        prior["state"] = "removed"
+                        self.journal.put(item_id, prior)
+                        status = "removed"
+                    else:
+                        if found.get("attachments") or _digest(found.get("text")) != prior["content_hash"]:
+                            raise BrowserBridgeQueueError("QUEUE_ITEM_CHANGED")
+                        prior["state"] = "reserved"
+                        self.journal.put(item_id, prior)
+                        self._authorize(route, context_id, event)
+                        try:
+                            if target_state == "sent":
+                                # Pop before the effect so Core's normal queue
+                                # consumer cannot subsequently send this item.
+                                item = queue.pop_item(context, item_id)
+                                if item is None or item.get("attachments") or _digest(item.get("text")) != prior["content_hash"]:
+                                    raise BrowserBridgeQueueError("QUEUE_ITEM_CHANGED")
+                                self.messages.send(route, {"contract_version": 1, "context_id": context_id,
+                                                          "client_message_id": "queue:" + item_id, "text": item["text"]})
+                            else:
+                                queue.remove(context, item_id)
+                            prior["state"] = target_state
+                            self.journal.put(item_id, prior)
+                        except Exception:
+                            # Never retry an uncertain model/log or queue effect.
+                            raise BrowserBridgeQueueError("OUTCOME_UNKNOWN", outcome="unknown") from None
+                        status = target_state
+            self.mark_dirty(context_id)
+            self._authorize(route, context_id, event)
+            try:
+                items = self._items(queue, context, scope)
+            except BrowserBridgeQueueError:
+                # A projection read failure cannot undo the persisted effect.
+                raise BrowserBridgeQueueError("OUTCOME_UNKNOWN", outcome="unknown") from None
+        payload = {"contract_version": 1, "context_id": context_id, "message_queue": items}
+        try:
+            await asyncio.wait_for(self.manager.emit_to(
+                self.profile.namespace, route.connector_sid, "connector_message_queue_updated", payload,
+                handler_id=self.profile.handler_id, correlation_id=restricted_correlation_id(None),
+                expected_principal=route.principal), timeout=5)
+        except Exception:
+            # A presentation failure cannot convert a persisted effect to a
+            # not-applied response that encourages an unsafe retry.
+            raise BrowserBridgeQueueError("OUTCOME_UNKNOWN", outcome="unknown") from None
+        self._authorize(route, context_id, event)
+        return {**payload, "item_id": item_id, "status": status}
+
+    def _authorize(self, route, context_id, event):
+        if route.transport_profile is not self.profile or not route.principal.permits_inbound(event, self.profile.handler_id):
+            raise BrowserBridgeQueueError("SCOPE_DENIED")
+        try:
+            self.access.authorize_message_target(route, context_id=context_id)
+        except Exception:
+            raise BrowserBridgeQueueError("SCOPE_DENIED") from None
+
+    def project(self, route, context_id):
+        """Current owned queue for the existing subscribed-context poller."""
+        self._authorize(route, context_id, "connector_message_queue_add")
+        context = self.context_get(context_id)
+        if context is None:
+            raise BrowserBridgeQueueError("CONTEXT_NOT_FOUND")
+        queue = self.queue_service
+        if queue is None:
+            from helpers import message_queue as queue
+        scope = _digest([self.server_instance_id(), route.principal.principal_id, route.principal.subject_id, context_id])
+        with _LOCK:
+            items = self._items(queue, context, scope)
+        self._authorize(route, context_id, "connector_message_queue_add")
+        return {"contract_version": 1, "context_id": context_id, "message_queue": items}
+
+    def _items(self, queue, context, scope):
+        items = []
+        for item in queue.get_queue(context):
+            record = self.journal.get(item.get("id"))
+            if record is None or record["scope"] != scope or record["state"] != "queued":
+                continue
+            if item.get("attachments") or _digest(item.get("text")) != record["content_hash"]:
+                continue
+            items.append({"id": item["id"], "text": item["text"][:100], "attachments": [], "attachment_count": 0})
+            if len(items) == _MAX_ITEMS:
+                break
+        return items
+
+def _validate_record(record):
+    if not isinstance(record, dict) or set(record) != {"scope", "content_hash", "state"}:
+        raise ValueError()
+    if any(not isinstance(record[name], str) or not _HASH.fullmatch(record[name]) for name in ("scope", "content_hash")) or record["state"] not in {"reserved", "queued", "removed", "sent"}:
+        raise ValueError()
+
+
+def _identifier(value):
+    if not isinstance(value, str) or not _ID.fullmatch(value):
+        raise BrowserBridgeQueueError("INVALID_STATE")
+    return value
+
+
+def _digest(value):
+    return hashlib.sha256(json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def _context_get(context_id):
+    from agent import AgentContext
+    return AgentContext.get(context_id)
+
+
+def _mark_dirty(context_id):
+    from helpers.state_monitor_integration import mark_dirty_for_context
+    mark_dirty_for_context(context_id, reason="browser_bridge_queue")

--- a/plugins/_a0_connector/helpers/browser_bridge_queue.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_queue.py.dox.md
@@ -1,0 +1,46 @@
+# Browser bridge queue controller
+
+## Ownership
+
+- Own strict `connector_message_queue_add`, `remove`, and `send` dispatch.
+- Reuse the Core `helpers.message_queue` for AgentContext queue storage, and
+  the bridge message dispatcher for once-only explicit text delivery.
+
+## Inputs and effects
+
+- All requests require integer `contract_version: 1` and `context_id`.
+- Add additionally requires `client_message_id` and nonblank UTF-8 `text`
+  bounded to 32 KiB. Remove and send require one exact `item_id` returned by
+  add. Batch/global clears, paths, attachments, caller subjects and raw route
+  bindings are not accepted by this lane.
+- Recheck current immutable principal/SID/load and advertise-before-message
+  access before every effect. Only queue items created by the same server,
+  bridge, subject and context are visible or actionable; foreign Core queue
+  entries remain untouched and are not projected.
+- The normal Core queue consumer may consume an accepted item independently
+  of presentation. An old add never recreates an item once accepted.
+- Persist hash-only reservations before effects and final states afterwards.
+  Duplicate content conflicts; uncertain effects are never automatically
+  repeated. Explicit send removes the queue entry before model/log delivery
+  and retains an uncertain tombstone on failure. Hash receipts use the shared
+  plugin journal's individually indexed atomic KVP records; historical v1
+  receipts remain a read-only fallback and are never evicted. A schema-v2 marker
+  is persisted before the first indexed write so older builds fail closed on
+  downgrade. Lifetime usage
+  does not exhaust a fixed record quota; disk use grows with distinct IDs.
+  The Core queue remains bounded to 32 entries for this producer.
+- Responses contain version, context, opaque item ID, status and at most 32
+  owned previews of 100 characters, never attachment references. Send the
+  same bounded queue projection through exact-principal restricted emission.
+  A failed presentation after an effect reports unknown, not not-applied.
+- The existing subscribed-context poller calls `project` on subscribe and on
+  its normal tick, sending only changed owned projections. Reopening a panel
+  restores current queue state and ordinary Core consumption clears its item;
+  no second polling task or reconnect resend is created.
+
+## Verification
+
+- `tests/test_browser_bridge_queue.py` exercises the real Core queue with a
+  synthetic context, durable in-memory stores and no model/network effects.
+- Full native codecs, runtime admission, release trust and publication are
+  separate; this helper does not assert readiness.

--- a/plugins/_a0_connector/helpers/browser_bridge_reconciliation.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_reconciliation.py
@@ -1,0 +1,875 @@
+"""Strict, nonactivating Browser bridge reconciliation prerequisite.
+
+This controller can prove that an exact provisional transport returned one
+bounded reconciliation snapshot.  It does not create a runtime principal,
+admit a route, select a browser, persist peer lease claims, or apply/ACK events.
+The injected promoter is the only composition seam and must atomically compare
+and promote the exact current route.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import re
+import threading
+from typing import Any, Callable, Mapping
+
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    BrowserBridgeContextRoute,
+)
+from plugins._a0_connector.helpers.browser_bridge_events import (
+    validate_reconciliation_critical_event,
+)
+from plugins._a0_connector.helpers.browser_bridge_operations import (
+    BrokerCompletion,
+    BrowserBridgeBrokerError,
+    BrowserBridgeOperationBroker,
+    ReconciliationBinding,
+)
+from plugins._a0_connector.helpers.browser_bridge_policy import (
+    BrowserBridgePolicyError,
+    normalize_site_origin,
+)
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+    require_transport_principal_identity,
+)
+
+
+CONTRACT_VERSION = 1
+NEGOTIATED_MAX_JSON_FRAME_BYTES = 786_432
+ACTUAL_NON_ARTIFACT_PACKET_BYTES = 512 * 1024
+DEFAULT_TIMEOUT_MS = 10_000
+MAX_ACTIVE_RECONCILIATIONS = 32
+
+_OPAQUE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+_DIGEST = re.compile(r"[a-f0-9]{64}")
+_ERROR_CODE = re.compile(r"[A-Z][A-Z0-9_]{0,63}")
+_LEASE_ORIGINS = frozenset({"created", "claimed"})
+_LEASE_DISPOSITIONS = frozenset({"ephemeral", "deliverable", "handoff"})
+_LEASE_STATES = frozenset(
+    {
+        "active",
+        "finalizing",
+        "closed",
+        "released",
+        "retained",
+        "outcome_unknown",
+        "orphan",
+    }
+)
+_TAKEOVER_REASONS = frozenset(
+    {
+        "moved",
+        "pinned",
+        "unpinned",
+        "ungrouped",
+        "regrouped",
+        "shared_group",
+        "window_changed",
+        "other",
+    }
+)
+_RETENTION_REASONS = frozenset(
+    {
+        "user_takeover",
+        "claimed_tab",
+        "non_ephemeral",
+        "generation_mismatch",
+        "handle_mismatch",
+        "context_mismatch",
+        "browser_session_mismatch",
+        "turn_mismatch",
+        "control_mismatch",
+        "identity_mismatch",
+        "tab_missing",
+        "protected",
+        "ambiguous",
+        "unresolved_reconciliation",
+        "not_active",
+        "outcome_unknown",
+    }
+)
+_NONTERMINAL_STAGES = frozenset(
+    {"prepared", "waiting_approval", "effect_started"}
+)
+_TERMINAL_STAGES = frozenset(
+    {"succeeded", "failed", "canceled", "outcome_unknown"}
+)
+_MUTATION_OUTCOMES = frozenset({"not_applied", "applied", "unknown"})
+
+
+class BrowserBridgeReconciliationError(RuntimeError):
+    """A reconciliation attempt was rejected without exposing peer data."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class ExpectedReconciliationContext:
+    context_id: str
+    browser_session_id: str
+    active_turn_ids: tuple[str, ...]
+
+    def as_wire_dict(self) -> dict[str, Any]:
+        if not isinstance(self.active_turn_ids, tuple):
+            raise BrowserBridgeReconciliationError("RECONCILE_REQUEST_INVALID")
+        turns = tuple(_identifier(item) for item in self.active_turn_ids)
+        if len(turns) > 32 or len(set(turns)) != len(turns):
+            raise BrowserBridgeReconciliationError("RECONCILE_REQUEST_INVALID")
+        return {
+            "context_id": _identifier(self.context_id),
+            "browser_session_id": _identifier(self.browser_session_id),
+            "active_turn_ids": list(turns),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationEventCursor:
+    load_generation_id: str
+    last_acked_event_sequence: int
+
+    def as_wire_dict(self) -> dict[str, Any]:
+        return {
+            "load_generation_id": _identifier(self.load_generation_id),
+            "last_acked_event_sequence": _safe_integer(
+                self.last_acked_event_sequence
+            ),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationSnapshot:
+    expected_contexts: tuple[ExpectedReconciliationContext, ...] = ()
+    event_cursors: tuple[ReconciliationEventCursor, ...] = ()
+    known_control_ids: tuple[str, ...] = ()
+
+    def as_wire_parts(
+        self,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str]]:
+        if (
+            not isinstance(self.expected_contexts, tuple)
+            or not isinstance(self.event_cursors, tuple)
+            or not isinstance(self.known_control_ids, tuple)
+            or
+            len(self.expected_contexts) > 128
+            or len(self.event_cursors) > 16
+            or len(self.known_control_ids) > 2_048
+            or not all(
+                isinstance(value, ExpectedReconciliationContext)
+                for value in self.expected_contexts
+            )
+            or not all(
+                isinstance(value, ReconciliationEventCursor)
+                for value in self.event_cursors
+            )
+        ):
+            raise BrowserBridgeReconciliationError("RECONCILE_REQUEST_INVALID")
+        contexts = [value.as_wire_dict() for value in self.expected_contexts]
+        cursors = [value.as_wire_dict() for value in self.event_cursors]
+        controls = [_identifier(value) for value in self.known_control_ids]
+        if (
+            len({value["context_id"] for value in contexts}) != len(contexts)
+            or len({value["load_generation_id"] for value in cursors})
+            != len(cursors)
+            or len(set(controls)) != len(controls)
+        ):
+            raise BrowserBridgeReconciliationError("RECONCILE_REQUEST_INVALID")
+        return contexts, cursors, controls
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserBridgeReconciliationSummary:
+    """Only non-authoritative counts retained from the peer snapshot."""
+
+    lease_count: int
+    inflight_operation_count: int
+    terminal_receipt_count: int
+    pending_critical_event_count: int
+    prior_generation_orphan_count: int
+
+    def as_wire_dict(self) -> dict[str, int]:
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "lease_count": self.lease_count,
+            "inflight_operation_count": self.inflight_operation_count,
+            "terminal_receipt_count": self.terminal_receipt_count,
+            "pending_critical_event_count": self.pending_critical_event_count,
+            "prior_generation_orphan_count": self.prior_generation_orphan_count,
+        }
+
+
+SnapshotSource = Callable[[ReconciliationBinding], ReconciliationSnapshot]
+RouteCurrent = Callable[[ReconciliationBinding], bool]
+RoutePromoter = Callable[
+    [ReconciliationBinding, BrowserBridgeReconciliationSummary], bool
+]
+
+
+class BrowserBridgeReconciliationController:
+    """Own bounded reconcile tasks for exact provisional transport routes.
+
+    ``route_current`` means the exact binding is live in either provisional or
+    promoted state.  ``promote`` must synchronously compare-and-promote that
+    route without blocking or awaiting.  Composition must use a consistent lock
+    order because promotion runs while the broker holds its settlement lock.
+    Route retirement remains an owner responsibility and must also disconnect
+    the broker ticket; this helper never invents lifecycle authority.
+    """
+
+    def __init__(
+        self,
+        *,
+        broker: BrowserBridgeOperationBroker,
+        snapshot_source: SnapshotSource,
+        route_current: RouteCurrent,
+        promote: RoutePromoter,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+        timeout_ms: int = DEFAULT_TIMEOUT_MS,
+        max_active: int = MAX_ACTIVE_RECONCILIATIONS,
+    ) -> None:
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        if broker.transport_profile is not self._transport_profile:
+            raise BrowserBridgeReconciliationError("TRANSPORT_PROFILE_MISMATCH")
+        if not callable(snapshot_source) or not callable(route_current) or not callable(promote):
+            raise BrowserBridgeReconciliationError("RECONCILIATION_UNAVAILABLE")
+        if (
+            isinstance(timeout_ms, bool)
+            or not isinstance(timeout_ms, int)
+            or not 1 <= timeout_ms <= 120_000
+            or isinstance(max_active, bool)
+            or not isinstance(max_active, int)
+            or not 1 <= max_active <= MAX_ACTIVE_RECONCILIATIONS
+        ):
+            raise BrowserBridgeReconciliationError("RECONCILIATION_INVALID")
+        self._broker = broker
+        self._snapshot_source = snapshot_source
+        self._route_current = route_current
+        self._promote = promote
+        self._timeout_ms = timeout_ms
+        self._max_active = max_active
+        self._active: dict[
+            tuple[int, str, str], asyncio.Task[BrowserBridgeReconciliationSummary]
+        ] = {}
+        self._lock = threading.RLock()
+
+    def start(
+        self,
+        binding: ReconciliationBinding,
+        *,
+        expected_install_instance_id: str,
+    ) -> asyncio.Task[BrowserBridgeReconciliationSummary]:
+        """Start a controller-owned task that survives caller cancellation."""
+
+        self._validate_binding(binding)
+        expected_install_instance_id = _identifier(expected_install_instance_id)
+        self._require_current(binding)
+        key = self._route_key(binding)
+        with self._lock:
+            if key in self._active:
+                raise BrowserBridgeReconciliationError(
+                    "RECONCILIATION_IN_PROGRESS"
+                )
+            if len(self._active) >= self._max_active:
+                raise BrowserBridgeReconciliationError(
+                    "RECONCILIATION_CAPACITY"
+                )
+            task = asyncio.get_running_loop().create_task(
+                self._run(binding, expected_install_instance_id)
+            )
+            self._active[key] = task
+            task.add_done_callback(
+                lambda completed, route_key=key: self._finished(
+                    route_key, completed
+                )
+            )
+            return task
+
+    async def reconcile(
+        self,
+        binding: ReconciliationBinding,
+        *,
+        expected_install_instance_id: str,
+    ) -> BrowserBridgeReconciliationSummary:
+        return await asyncio.shield(
+            self.start(
+                binding,
+                expected_install_instance_id=expected_install_instance_id,
+            )
+        )
+
+    async def _run(
+        self,
+        binding: ReconciliationBinding,
+        expected_install_instance_id: str,
+    ) -> BrowserBridgeReconciliationSummary:
+        self._require_current(binding, "RECONCILIATION_START_SCOPE_LOST")
+        try:
+            snapshot = self._snapshot_source(binding)
+        except BrowserBridgeReconciliationError:
+            raise
+        except Exception:
+            raise BrowserBridgeReconciliationError(
+                "RECONCILIATION_UNAVAILABLE"
+            ) from None
+        if not isinstance(snapshot, ReconciliationSnapshot):
+            raise BrowserBridgeReconciliationError("RECONCILE_REQUEST_INVALID")
+        contexts, cursors, controls = snapshot.as_wire_parts()
+        self._require_current(binding, "RECONCILIATION_SNAPSHOT_SCOPE_LOST")
+
+        def accept(
+            completion: BrokerCompletion,
+        ) -> BrokerCompletion | None:
+            if not completion.ok:
+                return completion
+            if not self._is_current(binding):
+                return _denied_completion()
+            try:
+                summary = parse_browser_reconcile_result(
+                    completion.result,
+                    binding=binding,
+                    expected_install_instance_id=expected_install_instance_id,
+                    transport_profile=self._transport_profile,
+                )
+            except BrowserBridgeReconciliationError:
+                return None
+            if not self._is_current(binding):
+                return _denied_completion()
+            # This callback must atomically compare and promote the exact route.
+            # It is intentionally synchronous and runs in broker settlement
+            # before the future is resolved or the next FIFO event can rely on
+            # the route.
+            try:
+                promoted = self._promote(binding, summary) is True
+            except Exception:
+                promoted = False
+            if not promoted or not self._is_current(binding):
+                return _denied_completion()
+            return BrokerCompletion(ok=True, result=summary.as_wire_dict())
+
+        try:
+            ticket = await self._broker.begin_reconcile(
+                binding,
+                expected_contexts=contexts,
+                event_cursors=cursors,
+                known_control_ids=controls,
+                timeout_ms=self._timeout_ms,
+                dispatch_preflight=lambda: self._is_current(binding),
+                settlement_acceptor=accept,
+            )
+        except BrowserBridgeBrokerError as exc:
+            if exc.code == "SCOPE_DENIED":
+                from plugins._a0_connector.helpers.browser_bridge_application import record_production_browser_stage
+                record_production_browser_stage("RECONCILIATION_BROKER_SCOPE_LOST")
+            raise BrowserBridgeReconciliationError(exc.code) from None
+        self._require_current(binding, "RECONCILIATION_PENDING_SCOPE_LOST")
+        completion = await self._broker.wait_control(ticket)
+        if not completion.ok:
+            # Disconnect removes route authority before resolving this future.
+            # Preserve its typed failure instead of masking it as scope loss;
+            # a negative completion cannot promote or replay anything.
+            raise BrowserBridgeReconciliationError(
+                completion.code or "RECONCILIATION_FAILED"
+            )
+        self._require_current(binding, "RECONCILIATION_SETTLEMENT_SCOPE_LOST")
+        return _summary_from_wire(completion.result)
+
+    def _validate_binding(self, binding: ReconciliationBinding) -> None:
+        if not isinstance(binding, ReconciliationBinding):
+            raise BrowserBridgeReconciliationError("RECONCILIATION_INVALID")
+        try:
+            if binding.transport_profile is not self._transport_profile:
+                raise ValueError("transport profile mismatch")
+            require_transport_principal_identity(
+                binding.principal, self._transport_profile
+            )
+            _identifier(binding.principal.principal_id)
+            _identifier(binding.principal.subject_id)
+            if (
+                type(binding.principal.key_generation) is not int
+                or binding.principal.key_generation < 1
+            ):
+                raise ValueError("invalid key generation")
+            _identifier(binding.connector_sid)
+            _identifier(binding.load_generation_id)
+            _identifier(binding.control_id)
+        except (ValueError, BrowserBridgeReconciliationError):
+            raise BrowserBridgeReconciliationError("SCOPE_DENIED") from None
+
+    def _is_current(self, binding: ReconciliationBinding) -> bool:
+        try:
+            return self._route_current(binding) is True
+        except Exception:
+            return False
+
+    def _require_current(self, binding: ReconciliationBinding, stage=None) -> None:
+        if not self._is_current(binding):
+            if stage is not None:
+                from plugins._a0_connector.helpers.browser_bridge_application import record_production_browser_stage
+                record_production_browser_stage(stage)
+            raise BrowserBridgeReconciliationError("SCOPE_DENIED")
+
+    @staticmethod
+    def _route_key(binding: ReconciliationBinding) -> tuple[int, str, str]:
+        return (
+            id(binding.principal),
+            binding.connector_sid,
+            binding.load_generation_id,
+        )
+
+    def _finished(
+        self,
+        key: tuple[int, str, str],
+        task: asyncio.Task[BrowserBridgeReconciliationSummary],
+    ) -> None:
+        with self._lock:
+            if self._active.get(key) is task:
+                self._active.pop(key, None)
+        # A shielded caller may be canceled while this process-owned task keeps
+        # running.  Retrieve its terminal exception so asyncio never reports an
+        # unobserved background failure; later awaits still receive it.
+        try:
+            task.exception()
+        except asyncio.CancelledError:
+            pass
+
+
+def parse_browser_reconcile_result(
+    value: Any,
+    *,
+    binding: ReconciliationBinding,
+    expected_install_instance_id: str,
+    transport_profile: BrowserBridgeTransportProfile = (
+        PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    ),
+) -> BrowserBridgeReconciliationSummary:
+    """Strictly validate the full extension result, retaining counts only."""
+
+    profile = require_browser_bridge_transport_profile(transport_profile)
+    try:
+        if binding.transport_profile is not profile:
+            raise ValueError("transport profile mismatch")
+        require_transport_principal_identity(binding.principal, profile)
+        _identifier(binding.principal.principal_id)
+        _identifier(binding.principal.subject_id)
+        _identifier(binding.connector_sid)
+        _identifier(binding.load_generation_id)
+        _identifier(binding.control_id)
+        if (
+            type(binding.principal.key_generation) is not int
+            or binding.principal.key_generation < 1
+        ):
+            raise ValueError("invalid key generation")
+    except (ValueError, BrowserBridgeReconciliationError):
+        raise BrowserBridgeReconciliationError("SCOPE_DENIED") from None
+    result = _record(
+        value,
+        {
+            "contract_version",
+            "control_id",
+            "install_instance_id",
+            "load_generation_id",
+            "leases",
+            "inflight_operations",
+            "terminal_action_receipts",
+            "pending_critical_events",
+            "prior_generation_orphans",
+        },
+    )
+    if (
+        type(result["contract_version"]) is not int
+        or result["contract_version"] != CONTRACT_VERSION
+        or _identifier(result["control_id"]) != binding.control_id
+        or _identifier(result["install_instance_id"])
+        != _identifier(expected_install_instance_id)
+        or _identifier(result["load_generation_id"])
+        != binding.load_generation_id
+    ):
+        raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+
+    leases = _array(result["leases"], 512)
+    inflight = _array(result["inflight_operations"], 256)
+    receipts = _array(result["terminal_action_receipts"], 2_048)
+    pending_events = _array(result["pending_critical_events"], 1_024)
+    orphans = _array(result["prior_generation_orphans"], 512)
+
+    lease_ids: set[str] = set()
+    tab_handles: set[str] = set()
+    for item in leases:
+        lease_id, tab_handle, generation = _validate_lease(item)
+        if (
+            generation != binding.load_generation_id
+            or lease_id in lease_ids
+            or tab_handle in tab_handles
+        ):
+            raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+        lease_ids.add(lease_id)
+        tab_handles.add(tab_handle)
+
+    inflight_ids: set[str] = set()
+    for item in inflight:
+        action_id = _validate_inflight(item)
+        if action_id in inflight_ids:
+            raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+        inflight_ids.add(action_id)
+
+    receipt_ids: set[str] = set()
+    for item in receipts:
+        action_id = _validate_receipt(item)
+        if action_id in receipt_ids:
+            raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+        receipt_ids.add(action_id)
+
+    event_identities: set[tuple[str, int]] = set()
+    for item in pending_events:
+        try:
+            event_generation = _identifier(
+                item.get("load_generation_id")
+                if isinstance(item, Mapping)
+                else None
+            )
+            route = BrowserBridgeContextRoute(
+                binding.principal,
+                binding.connector_sid,
+                event_generation,
+                transport_profile=profile,
+            )
+            identity = validate_reconciliation_critical_event(
+                route, item, transport_profile=profile
+            )
+        except Exception:
+            raise BrowserBridgeReconciliationError(
+                "RECONCILE_RESULT_INVALID"
+            ) from None
+        key = (identity.load_generation_id, identity.event_sequence)
+        if key in event_identities:
+            raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+        event_identities.add(key)
+
+    orphan_digests: set[str] = set()
+    for item in orphans:
+        generation, digest = _validate_orphan(item)
+        if generation == binding.load_generation_id or digest in orphan_digests:
+            raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+        orphan_digests.add(digest)
+
+    return BrowserBridgeReconciliationSummary(
+        lease_count=len(leases),
+        inflight_operation_count=len(inflight),
+        terminal_receipt_count=len(receipts),
+        pending_critical_event_count=len(pending_events),
+        prior_generation_orphan_count=len(orphans),
+    )
+
+
+def _validate_lease(value: Any) -> tuple[str, str, str]:
+    item = _record(
+        value,
+        {
+            "lease_id",
+            "tab_handle",
+            "load_generation_id",
+            "context_id",
+            "browser_session_id",
+            "turn_id",
+            "origin",
+            "disposition",
+            "state",
+            "site_origin",
+            "identity",
+            "group_intent_id",
+            "provider_group_id",
+            "finalization_control_id",
+            "user_intervened",
+            "user_takeover_reason",
+            "is_protected",
+            "is_ambiguous",
+            "unresolved_reconciliation",
+            "overlay_attached",
+            "debugger_attached",
+            "retention_reason",
+            "revision",
+        },
+    )
+    lease_id = _identifier(item["lease_id"])
+    tab_handle = _identifier(item["tab_handle"])
+    generation = _identifier(item["load_generation_id"])
+    for name in ("context_id", "browser_session_id", "turn_id"):
+        _identifier(item[name])
+    _enum(item["origin"], _LEASE_ORIGINS)
+    _enum(item["disposition"], _LEASE_DISPOSITIONS)
+    _enum(item["state"], _LEASE_STATES)
+    _origin(item["site_origin"])
+    identity = _record(
+        item["identity"],
+        {
+            "browser_instance_id",
+            "provider_tab_id",
+            "provider_window_id",
+            "document_id",
+            "document_epoch",
+        },
+    )
+    _identifier(identity["browser_instance_id"])
+    _safe_integer(identity["provider_tab_id"])
+    _safe_integer(identity["provider_window_id"])
+    _nullable_identifier(identity["document_id"])
+    _safe_integer(identity["document_epoch"])
+    _nullable_identifier(item["group_intent_id"])
+    _nullable_safe_integer(item["provider_group_id"])
+    _nullable_identifier(item["finalization_control_id"])
+    _boolean(item["user_intervened"])
+    _nullable_enum(item["user_takeover_reason"], _TAKEOVER_REASONS)
+    for name in (
+        "is_protected",
+        "is_ambiguous",
+        "unresolved_reconciliation",
+        "overlay_attached",
+        "debugger_attached",
+    ):
+        _boolean(item[name])
+    _nullable_enum(item["retention_reason"], _RETENTION_REASONS)
+    _safe_integer(item["revision"])
+    return lease_id, tab_handle, generation
+
+
+def _validate_inflight(value: Any) -> str:
+    item = _record(
+        value,
+        {
+            "load_generation_id",
+            "action_id",
+            "kind",
+            "canonical_parameter_hash",
+            "stage",
+            "created_at_ms",
+            "updated_at_ms",
+        },
+    )
+    _identifier(item["load_generation_id"])
+    action_id = _identifier(item["action_id"])
+    _bounded_text(item["kind"], 128)
+    _digest(item["canonical_parameter_hash"])
+    _enum(item["stage"], _NONTERMINAL_STAGES)
+    _safe_integer(item["created_at_ms"])
+    _safe_integer(item["updated_at_ms"])
+    return action_id
+
+
+def _validate_receipt(value: Any) -> str:
+    item = _record(
+        value,
+        {
+            "load_generation_id",
+            "action_id",
+            "kind",
+            "canonical_parameter_hash",
+            "stage",
+            "safe_receipt",
+            "created_at_ms",
+            "updated_at_ms",
+            "acknowledged_at_ms",
+        },
+    )
+    _identifier(item["load_generation_id"])
+    action_id = _identifier(item["action_id"])
+    _bounded_text(item["kind"], 128)
+    _digest(item["canonical_parameter_hash"])
+    _enum(item["stage"], _TERMINAL_STAGES)
+    receipt = _record(
+        item["safe_receipt"],
+        {"outcome", "code", "lease_handle_digest"},
+    )
+    _enum(receipt["outcome"], _MUTATION_OUTCOMES)
+    if receipt["code"] is not None and (
+        not isinstance(receipt["code"], str)
+        or _ERROR_CODE.fullmatch(receipt["code"]) is None
+    ):
+        raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+    if receipt["lease_handle_digest"] is not None:
+        _digest(receipt["lease_handle_digest"])
+    _safe_integer(item["created_at_ms"])
+    _safe_integer(item["updated_at_ms"])
+    _nullable_safe_integer(item["acknowledged_at_ms"])
+    return action_id
+
+
+def _validate_orphan(value: Any) -> tuple[str, str]:
+    item = _record(
+        value,
+        {
+            "load_generation_id",
+            "lease_handle_digest",
+            "exact_identity_digest",
+            "browser_instance_id",
+            "provider_tab_id",
+            "provider_window_id",
+            "provider_group_id",
+            "context_id",
+            "browser_session_id",
+            "turn_id",
+            "origin",
+            "disposition",
+            "state",
+            "url_identity",
+            "user_intervened",
+            "finalization_control_id",
+            "retention_reason",
+            "updated_at_ms",
+        },
+    )
+    generation = _identifier(item["load_generation_id"])
+    digest = _digest(item["lease_handle_digest"])
+    _digest(item["exact_identity_digest"])
+    _identifier(item["browser_instance_id"])
+    _safe_integer(item["provider_tab_id"])
+    _safe_integer(item["provider_window_id"])
+    _nullable_safe_integer(item["provider_group_id"])
+    for name in ("context_id", "browser_session_id", "turn_id"):
+        _identifier(item[name])
+    _enum(item["origin"], _LEASE_ORIGINS)
+    _enum(item["disposition"], _LEASE_DISPOSITIONS)
+    if item["state"] != "orphan":
+        raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+    url_identity = _record(item["url_identity"], {"origin", "path_digest"})
+    _origin(url_identity["origin"])
+    _digest(url_identity["path_digest"])
+    _boolean(item["user_intervened"])
+    _nullable_identifier(item["finalization_control_id"])
+    _nullable_enum(item["retention_reason"], _RETENTION_REASONS)
+    _safe_integer(item["updated_at_ms"])
+    return generation, digest
+
+
+def _summary_from_wire(value: Any) -> BrowserBridgeReconciliationSummary:
+    item = _record(
+        value,
+        {
+            "contract_version",
+            "lease_count",
+            "inflight_operation_count",
+            "terminal_receipt_count",
+            "pending_critical_event_count",
+            "prior_generation_orphan_count",
+        },
+    )
+    if (
+        type(item["contract_version"]) is not int
+        or item["contract_version"] != CONTRACT_VERSION
+    ):
+        raise BrowserBridgeReconciliationError("RECONCILIATION_FAILED")
+    return BrowserBridgeReconciliationSummary(
+        lease_count=_safe_integer(item["lease_count"], maximum=512),
+        inflight_operation_count=_safe_integer(
+            item["inflight_operation_count"], maximum=256
+        ),
+        terminal_receipt_count=_safe_integer(
+            item["terminal_receipt_count"], maximum=2_048
+        ),
+        pending_critical_event_count=_safe_integer(
+            item["pending_critical_event_count"], maximum=1_024
+        ),
+        prior_generation_orphan_count=_safe_integer(
+            item["prior_generation_orphan_count"], maximum=512
+        ),
+    )
+
+
+def _record(value: Any, keys: set[str]) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != keys:
+        raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+    return dict(value)
+
+
+def _array(value: Any, maximum: int) -> list[Any]:
+    if not isinstance(value, list) or len(value) > maximum:
+        raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+    return value
+
+
+def _identifier(value: Any) -> str:
+    if not isinstance(value, str) or _OPAQUE_ID.fullmatch(value) is None:
+        raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+    return value
+
+
+def _safe_integer(value: Any, *, maximum: int = 2**53 - 1) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= maximum
+    ):
+        raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+    return value
+
+
+def _nullable_safe_integer(value: Any) -> int | None:
+    return None if value is None else _safe_integer(value)
+
+
+def _boolean(value: Any) -> bool:
+    if not isinstance(value, bool):
+        raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+    return value
+
+
+def _enum(value: Any, allowed: frozenset[str]) -> str:
+    if not isinstance(value, str) or value not in allowed:
+        raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+    return value
+
+
+def _nullable_enum(value: Any, allowed: frozenset[str]) -> str | None:
+    return None if value is None else _enum(value, allowed)
+
+
+def _nullable_identifier(value: Any) -> str | None:
+    return None if value is None else _identifier(value)
+
+
+def _digest(value: Any) -> str:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+    return value
+
+
+def _bounded_text(value: Any, maximum: int) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > maximum
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+    ):
+        raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+    return value
+
+
+def _origin(value: Any) -> str:
+    try:
+        normalized = normalize_site_origin(value)
+    except (BrowserBridgePolicyError, TypeError):
+        raise BrowserBridgeReconciliationError(
+            "RECONCILE_RESULT_INVALID"
+        ) from None
+    if normalized != value:
+        raise BrowserBridgeReconciliationError("RECONCILE_RESULT_INVALID")
+    return normalized
+
+
+def _denied_completion() -> BrokerCompletion:
+    return BrokerCompletion(
+        ok=False,
+        code="SCOPE_DENIED",
+        error="Browser reconciliation authority is unavailable",
+        outcome="not_applied",
+        retryable=False,
+    )

--- a/plugins/_a0_connector/helpers/browser_bridge_reconciliation.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_reconciliation.py.dox.md
@@ -1,0 +1,63 @@
+# Browser bridge reconciliation DOX
+
+## Purpose
+
+- Produce one exact `browser.reconcile` control for a process-owned provisional
+  Browser transport route.
+- Strictly validate the complete native/extension snapshot before allowing a
+  future owner to atomically promote that exact route.
+- Retain only redacted counts; lease, provider, operation, receipt, orphan and
+  event records remain non-authoritative peer claims.
+
+## Local Contracts
+
+- `ReconciliationBinding` binds the exact principal object, fixed transport
+  profile, connector SID, load generation and control ID. The broker requires
+  `browser.control`, the selected profile handler and
+  `connector_browser_control` at initial authorization and queued dispatch.
+- Requests preserve the frozen bounded arrays: at most 128 expected contexts,
+  32 active turns per context, 16 generation cursors and 2,048 known controls.
+  Identifiers and duplicates fail closed.
+- Result acceptance checks the exact outer bridge/load/control binding and the
+  complete lease, inflight operation, terminal receipt, pending critical-event
+  and old-generation orphan schema. The actual non-artifact packet remains
+  limited to 524,288 bytes even though hello negotiates a 786,432-byte maximum
+  JSON frame.
+- The settlement acceptor validates and synchronously calls the injected atomic
+  compare-and-promote callback before the broker resolves its future. Transport
+  FIFO is not treated as handler-completion ordering. The callback must not
+  await or block, and composition must preserve a consistent broker/owner lock
+  order.
+- `route_current` means the exact binding is live in either provisional or
+  promoted state. Current authority is rechecked before snapshot construction,
+  after broker begin, during synchronous settlement, after promotion and after
+  the result wait.
+- Pending critical events are schema-checked only. This helper never invokes
+  event callbacks, writes event receipts, advances cursors or emits ACKs. The
+  normal durable receiver owns replay after promotion.
+- Reconciliation tasks are bounded and process-owned so caller cancellation
+  does not interrupt a sent control. The future route owner must retire stale
+  provisional routes and disconnect their broker tickets on loss or shutdown.
+- Timeout, disconnect, stale authority, malformed snapshots and failed atomic
+  promotion never grant route authority. No runtime principal, admission,
+  owner, browser selection, Browser factory or production activation is created
+  here.
+- Fixed private diagnostics distinguish lost scope before the run/snapshot,
+  broker authorization, pending wait or settlement. Use only the application's
+  allowlisted five-per-symbol logger; never record a binding, payload, exception
+  text or peer-supplied code. Diagnostic classification does not alter denial.
+- After waiting for a broker completion, preserve a typed negative outcome
+  before checking current authority: disconnect intentionally withdraws the
+  route before delivering `CONNECTION_LOST`. Otherwise that real failure is
+  obscured by a secondary scope error. Successful completion still requires
+  the exact post-wait route check; no negative outcome promotes or replays work.
+
+## Verification
+
+- Run `pytest tests/test_browser_bridge_reconciliation.py`.
+- Run the existing operation-broker and critical-event test files after broker
+  or event-schema changes.
+
+## Child DOX Index
+
+No child DOX files.

--- a/plugins/_a0_connector/helpers/browser_bridge_release_policy.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_release_policy.py
@@ -1,0 +1,128 @@
+"""Offline verification of the server-owned signed Browser release allowlist."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+import stat
+import time
+from types import MappingProxyType
+
+
+POLICY_ENV = "A0_BROWSER_BRIDGE_RELEASE_POLICY_FILE"
+POLICY_CONTRACT = "a0.browser-bridge.server-release-policy.v1"
+MAX_POLICY_BYTES = 64 * 1024
+MAX_POLICY_LIFETIME_MS = 90 * 24 * 60 * 60 * 1000
+# Release engineering pins reviewed public roots here. Never load a root from
+# the policy being verified, an HTTP request, the extension, or a pairing code.
+TRUSTED_RELEASE_KEYS = MappingProxyType({
+    "publisher-2026": "GEOygP0rBYlVYZEx+bgDhUZ3sVpfVyedoI9Jo+bcYII=",
+})
+_VERSION = re.compile(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)")
+_ENTRY_FIELDS = frozenset({
+    "extension_id", "extension_version", "companion_version", "companion_platform", "companion_arch",
+})
+
+
+def _unique(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate policy key")
+        result[key] = value
+    return result
+
+
+def _base64(value, size):
+    if not isinstance(value, str):
+        raise ValueError("invalid policy signature")
+    decoded = base64.b64decode(value, validate=True)
+    if len(decoded) != size or base64.b64encode(decoded).decode("ascii") != value:
+        raise ValueError("invalid policy signature")
+    return decoded
+
+
+def verify_policy_document(raw: bytes, *, now_ms: int) -> tuple[dict, ...]:
+    """Verify exact bounded bytes against pinned keys; no network or effects."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    if not isinstance(raw, bytes) or not 0 < len(raw) <= MAX_POLICY_BYTES:
+        raise ValueError("invalid release policy")
+    document = json.loads(raw, object_pairs_hook=_unique)
+    if not isinstance(document, dict) or set(document) != {"key_id", "policy", "signature"}:
+        raise ValueError("invalid release policy")
+    key_id = document["key_id"]
+    if not isinstance(key_id, str) or key_id not in TRUSTED_RELEASE_KEYS:
+        raise ValueError("untrusted release policy")
+    policy = document["policy"]
+    if not isinstance(policy, dict) or set(policy) != {"contract", "issued_at_ms", "expires_at_ms", "releases"}:
+        raise ValueError("invalid release policy")
+    issued, expires = policy["issued_at_ms"], policy["expires_at_ms"]
+    if (
+        policy["contract"] != POLICY_CONTRACT
+        or type(issued) is not int or type(expires) is not int
+        or type(now_ms) is not int
+        or not 0 < issued <= now_ms < expires <= 2**53 - 1
+        or expires - issued > MAX_POLICY_LIFETIME_MS
+        or not isinstance(policy["releases"], list)
+        or not 1 <= len(policy["releases"]) <= 64
+    ):
+        raise ValueError("invalid release policy")
+    releases = []
+    for entry in policy["releases"]:
+        if not isinstance(entry, dict) or set(entry) != _ENTRY_FIELDS:
+            raise ValueError("invalid release policy")
+        if (
+            not all(isinstance(value, str) and len(value) <= 64 for value in entry.values())
+            or re.fullmatch(r"[a-p]{32}", entry["extension_id"]) is None
+            or _VERSION.fullmatch(entry["extension_version"]) is None
+            or _VERSION.fullmatch(entry["companion_version"]) is None
+            or tuple(map(int, entry["companion_version"].split("."))) < (2, 12, 0)
+            or entry["companion_platform"] not in {"darwin", "linux", "windows"}
+            or entry["companion_arch"] not in {"aarch64", "arm64", "universal2", "x86_64"}
+            or entry in releases
+        ):
+            raise ValueError("invalid release policy")
+        releases.append(entry)
+    canonical = json.dumps(policy, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")
+    public_key = _base64(TRUSTED_RELEASE_KEYS[key_id], 32)
+    Ed25519PublicKey.from_public_bytes(public_key).verify(_base64(document["signature"], 64), canonical)
+    return tuple(releases)
+
+
+def _read_owned_policy() -> bytes:
+    path = os.environ.get(POLICY_ENV)
+    if not path or not os.path.isabs(path):
+        raise ValueError("release policy is not configured")
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or not 0 < before.st_size <= MAX_POLICY_BYTES:
+            raise ValueError("invalid release policy file")
+        raw = os.read(descriptor, MAX_POLICY_BYTES + 1)
+        after = os.fstat(descriptor)
+        if len(raw) != before.st_size or (before.st_size, before.st_mtime_ns) != (after.st_size, after.st_mtime_ns):
+            raise ValueError("release policy changed while reading")
+        return raw
+    finally:
+        os.close(descriptor)
+
+
+def verify_configured_browser_release(active, sid, hello):
+    """Reverify policy signature/time and exact admitted version tuple per call."""
+    from plugins._a0_connector.helpers.browser_bridge_runtime_owner import VerifiedBrowserRelease
+
+    try:
+        releases = verify_policy_document(_read_owned_policy(), now_ms=time.time_ns() // 1_000_000)
+        expected = {field: getattr(hello, field) for field in _ENTRY_FIELDS}
+        if expected not in releases or hello.extension_id != active.extension_id:
+            return None
+        return VerifiedBrowserRelease(
+            principal=active.principal, server_instance_id=active.server_instance_id,
+            connector_sid=sid, load_generation_id=hello.load_generation_id,
+            install_instance_id=hello.install_instance_id, **expected,
+        )
+    except Exception:
+        return None

--- a/plugins/_a0_connector/helpers/browser_bridge_release_policy.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_release_policy.py.dox.md
@@ -1,0 +1,34 @@
+# Signed server Browser release policy
+
+Reads only the absolute operator-configured `A0_BROWSER_BRIDGE_RELEASE_POLICY_FILE`
+as a bounded no-follow regular file. It never downloads code or reads native
+credentials. Requests and extension metadata cannot choose its path or keys.
+
+Envelope keys are exactly `key_id`, `policy`, `signature`; signature is canonical
+standard-base64 Ed25519 over sorted compact UTF-8 JSON of `policy`. Duplicate
+keys at every depth are denied. Policy keys are exactly `contract`,
+`issued_at_ms`, `expires_at_ms`, `releases`. Contract is
+`a0.browser-bridge.server-release-policy.v1`; issue/expiry are safe integers,
+valid at verification and at most 90 days apart. There are 1–64 unique exact
+release tuples: `extension_id`, `extension_version`, `companion_version`,
+`companion_platform`, `companion_arch`. Stable semantic versions and the
+independent native 2.12.0 floor are mandatory.
+
+`TRUSTED_RELEASE_KEYS` contains only reviewed public Ed25519 roots, keyed by ID
+with canonical base64 32-byte public keys. The reviewed `publisher-2026` root is
+pinned in source; development and fixture roots are not accepted. This pin is
+not a signed release approval: a genuine, currently valid policy must still be
+supplied independently. Policy contents never supply their own root.
+Missing/expired/invalid signatures or unmatched tuples fail closed on
+every admission lookup. Public presentation catalog metadata is not evidence.
+
+A universal2 Mac release uses two exact runtime tuples, `darwin/aarch64` and
+`darwin/x86_64`, because each executing slice reports its runtime architecture.
+This does not change the native catalog's `macos/universal2` artifact identity.
+Each tuple retains the exact approved extension/native versions and production
+extension ID. No platform-group, origin, URL, digest or Docker field is added to
+this policy schema. Loopback server URL and rollout remain separate settings.
+
+This server allowlist does not inspect or attest host executable bytes; the
+native host independently enforces its signed installer/release chain. It
+does not replace pairing, selection, heartbeat, cutover, or transport checks.

--- a/plugins/_a0_connector/helpers/browser_bridge_runtime.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_runtime.py
@@ -1,0 +1,1286 @@
+"""Inactive, principal-bound composition for the Browser bridge runtime.
+
+Hello metadata is parsed as an untrusted capability claim.  A route exists only
+while an injected verifier confirms the current server-owned principal and an
+independent evaluator supplies a complete typed runtime admission.  This module
+does not register WebSocket events, alter the hello-only authentication surface,
+or consult the legacy connector runtime registry.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+import threading
+import time
+from typing import Any, Awaitable, Callable, Mapping
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_approval import (
+    BrowserApprovalRoute,
+)
+from plugins._a0_connector.helpers.browser_bridge_artifacts import ArtifactBinding
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    BrowserBridgeContextAccess,
+    BrowserBridgeContextRoute,
+)
+from plugins._a0_connector.helpers.browser_bridge_operations import (
+    BridgeAuthorization,
+    BrowserBridgeOperationBroker,
+    ControlBinding,
+    OperationBinding,
+    ReconciliationBinding,
+    SettlementStatus,
+    TurnBinding,
+)
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    RUNTIME_REQUIRED_INBOUND_EVENTS,
+    RUNTIME_REQUIRED_OUTBOUND_EVENTS,
+    RUNTIME_REQUIRED_SCOPES,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+    require_runtime_transport_principal,
+    runtime_transport_profile_for_principal,
+)
+from plugins._browser.helpers.extension_sessions import ValidatedExtensionRoute
+
+
+CONNECTOR_PROTOCOL = "a0-connector.v1"
+CONTRACT_VERSION = 1
+RESTRICTED_HANDLER_ID = PRODUCTION_BROWSER_BRIDGE_TRANSPORT.handler_id
+RESTRICTED_HANDLER_PATH = PRODUCTION_BROWSER_BRIDGE_TRANSPORT.handler_path
+WS_NAMESPACE = PRODUCTION_BROWSER_BRIDGE_TRANSPORT.namespace
+
+OPERATION_EVENT = "connector_browser_op"
+CONTROL_EVENT = "connector_browser_control"
+_BROKER_OUTBOUND_EVENTS = frozenset({OPERATION_EVENT, CONTROL_EVENT})
+
+REQUIRED_OUTER_FEATURES = frozenset(
+    {
+        "browser_extension_bridge_v1",
+        "connector_browser_control",
+        "connector_browser_event",
+        "connector_browser_artifact_chunks",
+    }
+)
+REQUIRED_SCOPES = RUNTIME_REQUIRED_SCOPES
+REQUIRED_INBOUND_EVENTS = RUNTIME_REQUIRED_INBOUND_EVENTS
+REQUIRED_OUTBOUND_EVENTS = RUNTIME_REQUIRED_OUTBOUND_EVENTS
+
+PROVEN_ACTIONS = frozenset(
+    {"open", "list", "state", "navigate", "content", "scroll", "hover", "click", "type", "upload_file", "status", "ensure", "screenshot"}
+)
+PROVEN_FEATURES = frozenset(
+    {"tab_leases_v1", "tab_groups_v1", "semantic_dom_v1", "cursor_v1", "trusted_input_v1", "screenshots_v1", "artifacts_v1"}
+)
+MINIMUM_SECURE_COMPANION = (2, 12, 0)
+EXPECTED_LIMITS = (
+    ("artifact_chunk_bytes", 192 * 1024),
+    ("max_artifact_bytes", 25 * 1024 * 1024),
+    ("max_json_frame_bytes", 768 * 1024),
+)
+
+MAX_RUNTIME_SESSIONS = 32
+MAX_CAPABILITIES = 64
+MAX_IDENTIFIER_BYTES = 256
+MAX_LABEL_BYTES = 192
+
+_NATIVE_IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+_EXTENSION_ID = re.compile(r"[a-p]{32}")
+_VERSION = re.compile(r"[0-9A-Za-z][0-9A-Za-z.+_-]{0,63}")
+_PLATFORMS = frozenset({"darwin", "linux", "windows"})
+_ARCHITECTURES = frozenset({"aarch64", "arm64", "universal2", "x86_64"})
+
+
+class BrowserBridgeRuntimeError(ValueError):
+    """A runtime route or hello claim is malformed."""
+
+
+class BrowserBridgeRuntimeDenied(PermissionError):
+    """Current server authority or complete runtime admission is unavailable."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedActivePrincipal:
+    """Server-owned identity returned by the injected active-record verifier."""
+
+    principal: WsPrincipal
+    server_instance_id: str
+    extension_id: str
+    companion_instance_id: str
+
+    def __post_init__(self) -> None:
+        _validate_known_runtime_principal(self.principal)
+        _identifier(self.server_instance_id, "server_instance_id")
+        _extension_id(self.extension_id)
+        _native_identifier(self.companion_instance_id, "companion_instance_id")
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedBridgeHello:
+    """Bounded non-authoritative projection of protocol section 4.3."""
+
+    bridge_id: str
+    browser_id: str
+    browser_label: str
+    load_generation_id: str
+    install_instance_id: str
+    extension_id: str
+    extension_version: str
+    companion_instance_id: str
+    companion_version: str
+    companion_platform: str
+    companion_arch: str
+    contract_version: int
+    outer_features: frozenset[str]
+    actions: frozenset[str]
+    features: frozenset[str]
+    limits: tuple[tuple[str, int], ...]
+
+    def __post_init__(self) -> None:
+        for name in ("outer_features", "actions", "features"):
+            object.__setattr__(self, name, frozenset(getattr(self, name)))
+        object.__setattr__(self, "limits", tuple(self.limits))
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeActivationAttestation:
+    """Short-lived server-owned selection/heartbeat/profile/cutover evidence.
+
+    No production constructor derives this from hello claims or ready flags.
+    The evaluator must repeat each underlying check on every route lookup.
+    """
+
+    principal: WsPrincipal
+    server_instance_id: str
+    connector_sid: str
+    load_generation_id: str
+    extension_id: str
+    install_instance_id: str
+    server_features: frozenset[str]
+    rollout: str
+    selected_bridge: bool
+    heartbeat_fresh: bool
+    subject_profile_bound: bool
+    legacy_control_plane_inactive: bool
+    issued_at_ms: int
+    expires_at_ms: int
+
+    def __post_init__(self) -> None:
+        _validate_runtime_principal(
+            self.principal, PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        )
+        object.__setattr__(self, "server_features", frozenset(self.server_features))
+
+    def as_wire_dict(self) -> dict[str, Any]:
+        _validate_runtime_principal(
+            self.principal, PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        )
+        now = time.time_ns() // 1_000_000
+        if not _activation_fresh(self, now):
+            raise BrowserBridgeRuntimeDenied("ACTIVATION_EXPIRED")
+        return {
+            "principal": "browser_bridge", "bridge_id": self.principal.principal_id,
+            "key_generation": self.principal.key_generation, "extension_id": self.extension_id,
+            "install_instance_id": self.install_instance_id, "server_features": sorted(self.server_features),
+            "rollout": self.rollout, "selected_bridge": self.selected_bridge,
+            "heartbeat_fresh": self.heartbeat_fresh, "subject_profile_bound": self.subject_profile_bound,
+            "legacy_control_plane_inactive": self.legacy_control_plane_inactive,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CompleteRuntimeAdmission:
+    """Independent, exact attestation that every runtime boundary is present."""
+
+    principal: WsPrincipal
+    server_instance_id: str
+    connector_sid: str
+    load_generation_id: str
+    install_instance_id: str
+    contract_version: int
+    outer_features: frozenset[str]
+    actions: frozenset[str]
+    features: frozenset[str]
+    release_trust_ready: bool
+    activation_attested: bool
+    legacy_control_plane_inactive: bool
+    operation_transport_ready: bool
+    control_transport_ready: bool
+    context_transport_ready: bool
+    event_transport_ready: bool
+    artifact_transport_ready: bool
+    approval_transport_ready: bool
+    session_lifecycle_ready: bool
+    policy_enforcement_ready: bool
+    activation: RuntimeActivationAttestation | None = None
+
+    def __post_init__(self) -> None:
+        _validate_runtime_principal(
+            self.principal, PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        )
+        for name in ("outer_features", "actions", "features"):
+            object.__setattr__(self, name, frozenset(getattr(self, name)))
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserBridgeRuntimeRoute:
+    """One admitted process-only route scoped to the current server instance."""
+
+    server_instance_id: str
+    principal: WsPrincipal
+    connector_sid: str
+    hello: NormalizedBridgeHello
+    activation: RuntimeActivationAttestation
+    transport_profile: BrowserBridgeTransportProfile = (
+        PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    )
+
+    def __post_init__(self) -> None:
+        profile = require_browser_bridge_transport_profile(self.transport_profile)
+        _validate_runtime_principal(self.principal, profile)
+        if profile is not PRODUCTION_BROWSER_BRIDGE_TRANSPORT:
+            raise BrowserBridgeRuntimeDenied("RUNTIME_NOT_ADMITTED")
+        if (
+            not isinstance(self.activation, RuntimeActivationAttestation)
+            or self.activation.principal is not self.principal
+        ):
+            raise BrowserBridgeRuntimeDenied("RUNTIME_NOT_ADMITTED")
+
+    @property
+    def bridge_id(self) -> str:
+        return self.principal.principal_id
+
+    @property
+    def browser_id(self) -> str:
+        return self.hello.browser_id
+
+    @property
+    def load_generation_id(self) -> str:
+        return self.hello.load_generation_id
+
+    def as_extension_route(self) -> ValidatedExtensionRoute:
+        return ValidatedExtensionRoute(
+            bridge_id=self.bridge_id,
+            browser_id=self.browser_id,
+            principal=self.principal,
+            connector_sid=self.connector_sid,
+            load_generation_id=self.load_generation_id,
+            transport_profile=self.transport_profile,
+        )
+
+
+ActivePrincipalVerifier = Callable[[WsPrincipal], VerifiedActivePrincipal | None]
+AdmissionEvaluator = Callable[
+    [VerifiedActivePrincipal, str, NormalizedBridgeHello],
+    CompleteRuntimeAdmission | None,
+]
+ContextAuthorizer = Callable[[BrowserBridgeRuntimeRoute, str], bool]
+RouteCleanup = Callable[[WsPrincipal, str, str], None]
+BrokerSender = Callable[
+    [str, str, dict[str, Any], str, WsPrincipal], Awaitable[None]
+]
+
+
+class BrowserBridgeRuntimeRegistry:
+    """Bounded current-route registry and restricted broker composition."""
+
+    def __init__(
+        self,
+        *,
+        sender: BrokerSender | None = None,
+        active_principal_verifier: ActivePrincipalVerifier | None = None,
+        admission_evaluator: AdmissionEvaluator | None = None,
+        context_authorizer: ContextAuthorizer | None = None,
+        cleanup_callbacks: tuple[RouteCleanup, ...] = (),
+        max_sessions: int = MAX_RUNTIME_SESSIONS,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        if isinstance(max_sessions, bool) or not 1 <= max_sessions <= 1_024:
+            raise ValueError("runtime session bound must be positive")
+        if not isinstance(cleanup_callbacks, tuple) or any(
+            not callable(callback) for callback in cleanup_callbacks
+        ):
+            raise ValueError("invalid runtime cleanup callbacks")
+        self._active_principal_verifier = (
+            active_principal_verifier or (lambda _principal: None)
+        )
+        self._admission_evaluator = (
+            admission_evaluator or (lambda _active, _sid, _hello: None)
+        )
+        self._context_authorizer = (
+            context_authorizer or (lambda _route, _context_id: False)
+        )
+        self._cleanup_callbacks = cleanup_callbacks
+        self._max_sessions = max_sessions
+        self._by_sid: dict[str, BrowserBridgeRuntimeRoute] = {}
+        self._sid_by_bridge: dict[str, str] = {}
+        self._reconciling: dict[str, ReconciliationBinding] = {}
+        self._reconciled: set[str] = set()
+        self._lock = threading.RLock()
+        self._broker = BrowserBridgeOperationBroker(
+            sender=sender or _unavailable_sender,
+            authorizer=self.authorize_broker,
+            transport_profile=self._transport_profile,
+        )
+
+    @property
+    def broker(self) -> BrowserBridgeOperationBroker:
+        return self._broker
+
+    @property
+    def session_count(self) -> int:
+        with self._lock:
+            return len(self._by_sid)
+
+    def current_sid_route(self, principal: WsPrincipal, connector_sid: str) -> BrowserBridgeRuntimeRoute | None:
+        """Resolve only server-retained generation; callers cannot pick one."""
+        with self._lock:
+            route = self._by_sid.get(connector_sid)
+        if route is None or route.principal is not principal:
+            return None
+        return self._current_exact_route(principal, connector_sid, route.load_generation_id)
+
+    def retire_bridge(self, bridge_id: str) -> BrowserBridgeRuntimeRoute | None:
+        """Withdraw one exact bridge before a server selection/config changes."""
+        with self._lock:
+            sid = self._sid_by_bridge.get(bridge_id)
+            route = self._by_sid.get(sid) if sid is not None else None
+            if route is None:
+                return None
+            self._remove_locked(route)
+        self._cleanup(route)
+        return route
+
+    def retire_all(self) -> tuple[BrowserBridgeRuntimeRoute, ...]:
+        """Withdraw only this owner's routes before shutdown cleanup."""
+        with self._lock:
+            routes = tuple(self._by_sid.values())
+            for route in routes:
+                self._remove_locked(route)
+        for route in routes:
+            self._cleanup(route)
+        return routes
+
+    def retire_sid(self, principal: WsPrincipal, connector_sid: str) -> BrowserBridgeRuntimeRoute | None:
+        """Cleanup remains possible after revocation makes current checks fail."""
+        with self._lock:
+            route = self._by_sid.get(connector_sid)
+            if route is None or route.principal is not principal:
+                return None
+            self._remove_locked(route)
+        self._cleanup(route)
+        return route
+
+    def register_hello(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: Any,
+        data: Any,
+    ) -> BrowserBridgeRuntimeRoute:
+        sid = _identifier(connector_sid, "connector_sid")
+        active = self._verify_active(principal)
+        hello = normalize_bridge_hello(
+            principal, active, data, transport_profile=self._transport_profile
+        )
+        self._require_admission(active, sid, hello)
+        self._prune_stale_routes()
+
+        for _attempt in range(4):
+            with self._lock:
+                conflicts = self._conflicts_locked(sid, principal.principal_id)
+            stale_or_equivalent: list[BrowserBridgeRuntimeRoute] = []
+            active_conflict = False
+            for route in conflicts:
+                if _equivalent_principal(route.principal, principal):
+                    stale_or_equivalent.append(route)
+                elif self._route_is_current(route):
+                    active_conflict = True
+                else:
+                    stale_or_equivalent.append(route)
+            if active_conflict:
+                raise BrowserBridgeRuntimeDenied("ROUTE_CONFLICT")
+
+            active = self._verify_active(principal)
+            hello = normalize_bridge_hello(
+                principal,
+                active,
+                data,
+                transport_profile=self._transport_profile,
+            )
+            admission = self._require_admission(active, sid, hello)
+            route = BrowserBridgeRuntimeRoute(
+                server_instance_id=active.server_instance_id,
+                principal=principal,
+                connector_sid=sid,
+                hello=hello,
+                activation=admission.activation,
+                transport_profile=self._transport_profile,
+            )
+            with self._lock:
+                if not _same_route_objects(
+                    self._conflicts_locked(sid, principal.principal_id), conflicts
+                ):
+                    continue
+                exact_replay = bool(
+                    len(conflicts) == 1
+                    and conflicts[0].principal is principal
+                    and conflicts[0].connector_sid == sid
+                    and conflicts[0].server_instance_id == active.server_instance_id
+                    and conflicts[0].hello == hello
+                )
+                if exact_replay:
+                    # Refresh the short-lived server attestation without
+                    # treating the same authenticated hello as a disconnect.
+                    self._by_sid[sid] = route
+                    self._sid_by_bridge[route.bridge_id] = sid
+                    replacing = ()
+                else:
+                    replacing = tuple(stale_or_equivalent)
+                    if len(self._by_sid) - len(replacing) >= self._max_sessions:
+                        raise BrowserBridgeRuntimeDenied("SESSION_LIMIT")
+                    for previous in replacing:
+                        self._remove_locked(previous)
+                    self._by_sid[sid] = route
+                    self._sid_by_bridge[route.bridge_id] = sid
+            for previous in replacing:
+                self._cleanup(previous)
+            if not self._route_is_current(route):
+                self._retire(route)
+                raise BrowserBridgeRuntimeDenied("RUNTIME_NOT_ADMITTED")
+            return route
+        raise BrowserBridgeRuntimeDenied("ROUTE_BUSY")
+
+    def resolve_extension_route(
+        self,
+        context_id: Any,
+        bridge_id: Any,
+    ) -> ValidatedExtensionRoute | None:
+        try:
+            context = _identifier(context_id, "context_id")
+            bridge = _identifier(bridge_id, "bridge_id")
+            route = self._current_bridge_route(bridge)
+            if route is None or route.browser_id != f"extension:{bridge}":
+                return None
+            if not self._context_is_authorized(route, context):
+                return None
+            return route.as_extension_route()
+        except Exception:
+            return None
+
+    def authorize_broker(
+        self,
+        binding: OperationBinding | TurnBinding | ControlBinding,
+    ) -> BridgeAuthorization | None:
+        if not isinstance(binding, (OperationBinding, TurnBinding, ControlBinding, ReconciliationBinding)):
+            return None
+        route = self._current_exact_route(
+            binding.principal,
+            binding.connector_sid,
+            binding.load_generation_id,
+        )
+        if route is None:
+            return None
+        if isinstance(binding, ReconciliationBinding):
+            if not self.route_current_for_reconciliation(binding):
+                return None
+        elif not self._context_is_authorized(route, binding.context_id):
+            return None
+        return BridgeAuthorization(
+            principal=route.principal,
+            connector_sid=route.connector_sid,
+            load_generation_id=route.load_generation_id,
+            contract_version=route.hello.contract_version,
+            outer_features=route.hello.outer_features,
+            actions=route.hello.actions,
+            features=route.hello.features,
+        )
+
+    def authorize_context_route(self, route: BrowserBridgeContextRoute) -> bool:
+        if (
+            not isinstance(route, BrowserBridgeContextRoute)
+            or route.transport_profile is not self._transport_profile
+        ):
+            return False
+        current = self._current_exact_route(
+            route.principal,
+            route.connector_sid,
+            route.load_generation_id,
+        )
+        return current is not None and self._is_reconciled(current)
+
+    def authorize_approval_route(self, route: BrowserApprovalRoute) -> bool:
+        if (
+            not isinstance(route, BrowserApprovalRoute)
+            or route.transport_profile is not self._transport_profile
+        ):
+            return False
+        current = self._current_exact_route(
+            route.principal,
+            route.connector_sid,
+            route.load_generation_id,
+        )
+        return bool(
+            current is not None
+            and current.server_instance_id == route.server_instance_id
+            and self._context_is_authorized(current, route.context_id)
+        )
+
+    def authorize_artifact_route(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: Any,
+        load_generation_id: Any,
+        context_id: Any,
+    ) -> bool:
+        try:
+            sid = _identifier(connector_sid, "connector_sid")
+            generation = _native_identifier(
+                load_generation_id, "load_generation_id"
+            )
+            context = _identifier(context_id, "context_id")
+        except BrowserBridgeRuntimeError:
+            return False
+        route = self._current_exact_route(principal, sid, generation)
+        return bool(route is not None and self._context_is_authorized(route, context))
+
+    def authorize_artifact_binding(self, binding: ArtifactBinding) -> bool:
+        if (
+            not isinstance(binding, ArtifactBinding)
+            or binding.transport_profile is not self._transport_profile
+        ):
+            return False
+        if binding.bridge_id != binding.principal.principal_id:
+            return False
+        return self.authorize_artifact_route(
+            principal=binding.principal,
+            connector_sid=binding.connector_sid,
+            load_generation_id=binding.load_generation_id,
+            context_id=binding.context_id,
+        )
+
+    def settle_operation(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: Any,
+        load_generation_id: Any,
+        payload: Mapping[str, Any],
+    ) -> str:
+        if self._settlement_route(principal, connector_sid, load_generation_id) is None:
+            return SettlementStatus.MISMATCH
+        return self._broker.settle_operation(
+            principal=principal,
+            connector_sid=connector_sid,
+            load_generation_id=load_generation_id,
+            payload=payload,
+        )
+
+    def settle_control(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: Any,
+        load_generation_id: Any,
+        payload: Mapping[str, Any],
+    ) -> str:
+        if self._settlement_route(principal, connector_sid, load_generation_id) is None:
+            return SettlementStatus.MISMATCH
+        return self._broker.settle_control(
+            principal=principal,
+            connector_sid=connector_sid,
+            load_generation_id=load_generation_id,
+            payload=payload,
+        )
+
+    def disconnect(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: Any,
+        load_generation_id: Any,
+    ) -> bool:
+        try:
+            sid = _identifier(connector_sid, "connector_sid")
+            generation = _native_identifier(
+                load_generation_id, "load_generation_id"
+            )
+        except BrowserBridgeRuntimeError:
+            return False
+        with self._lock:
+            route = self._by_sid.get(sid)
+            if (
+                route is None
+                or route.principal is not principal
+                or route.load_generation_id != generation
+            ):
+                return False
+            self._remove_locked(route)
+        self._cleanup(route)
+        return True
+
+    def _settlement_route(
+        self,
+        principal: WsPrincipal,
+        connector_sid: Any,
+        load_generation_id: Any,
+    ) -> BrowserBridgeRuntimeRoute | None:
+        try:
+            sid = _identifier(connector_sid, "connector_sid")
+            generation = _native_identifier(
+                load_generation_id, "load_generation_id"
+            )
+        except BrowserBridgeRuntimeError:
+            return None
+        return self._current_exact_route(principal, sid, generation)
+
+    def current_bridge_ready(self, bridge_id: str) -> bool:
+        """Redacted readiness only; never authorizes a context or operation."""
+        route = self._current_bridge_route(bridge_id)
+        return route is not None and self._is_reconciled(route)
+
+    def begin_reconciliation(self, binding: ReconciliationBinding) -> bool:
+        if not isinstance(binding, ReconciliationBinding) or binding.transport_profile is not self._transport_profile:
+            return False
+        route = self._current_exact_route(binding.principal, binding.connector_sid, binding.load_generation_id)
+        with self._lock:
+            if route is None or self._by_sid.get(binding.connector_sid) is not route or binding.connector_sid in self._reconciling:
+                return False
+            self._reconciling[binding.connector_sid] = binding
+            return True
+
+    def route_current_for_reconciliation(self, binding: ReconciliationBinding) -> bool:
+        if not isinstance(binding, ReconciliationBinding) or binding.transport_profile is not self._transport_profile:
+            return False
+        route = self._current_exact_route(binding.principal, binding.connector_sid, binding.load_generation_id)
+        with self._lock:
+            return route is not None and self._by_sid.get(binding.connector_sid) is route and self._reconciling.get(binding.connector_sid) is binding
+
+    def promote_reconciled(self, binding, summary) -> bool:
+        from plugins._a0_connector.helpers.browser_bridge_reconciliation import BrowserBridgeReconciliationSummary
+        if not isinstance(summary, BrowserBridgeReconciliationSummary) or not self.route_current_for_reconciliation(binding):
+            return False
+        with self._lock:
+            route = self._by_sid.get(binding.connector_sid)
+            if (route is None or route.principal is not binding.principal
+                    or route.load_generation_id != binding.load_generation_id
+                    or self._reconciling.get(binding.connector_sid) is not binding):
+                return False
+            self._reconciled.add(binding.connector_sid)
+            return True
+
+    def _is_reconciled(self, route) -> bool:
+        with self._lock:
+            return self._by_sid.get(route.connector_sid) is route and route.connector_sid in self._reconciled
+
+    def _current_bridge_route(
+        self, bridge_id: str
+    ) -> BrowserBridgeRuntimeRoute | None:
+        with self._lock:
+            sid = self._sid_by_bridge.get(bridge_id)
+            route = self._by_sid.get(sid) if sid is not None else None
+        if route is None or route.bridge_id != bridge_id:
+            return None
+        if not self._route_is_current(route):
+            self._retire(route)
+            return None
+        return route
+
+    def _current_exact_route(
+        self,
+        principal: WsPrincipal,
+        connector_sid: str,
+        load_generation_id: str,
+    ) -> BrowserBridgeRuntimeRoute | None:
+        with self._lock:
+            route = self._by_sid.get(connector_sid)
+        if (
+            route is None
+            or route.principal is not principal
+            or route.load_generation_id != load_generation_id
+        ):
+            return None
+        if not self._route_is_current(route):
+            self._retire(route)
+            return None
+        return route
+
+    def _context_is_authorized(
+        self,
+        route: BrowserBridgeRuntimeRoute,
+        context_id: str,
+    ) -> bool:
+        if not self._is_reconciled(route):
+            return False
+        try:
+            authorized = self._context_authorizer(route, context_id) is True
+        except Exception:
+            authorized = False
+        if not authorized:
+            return False
+        if not self._route_is_current(route):
+            self._retire(route)
+            return False
+        return True
+
+    def _route_is_current(self, route: BrowserBridgeRuntimeRoute) -> bool:
+        try:
+            active = self._verify_active(route.principal)
+            if active.server_instance_id != route.server_instance_id:
+                return False
+            normalize_bridge_hello(
+                route.principal,
+                active,
+                _hello_mapping(route.hello),
+                transport_profile=self._transport_profile,
+            )
+            self._require_admission(active, route.connector_sid, route.hello)
+            return True
+        except Exception:
+            return False
+
+    def _verify_active(self, principal: WsPrincipal) -> VerifiedActivePrincipal:
+        _validate_runtime_principal(principal, self._transport_profile)
+        try:
+            active = self._active_principal_verifier(principal)
+        except Exception:
+            active = None
+        if not isinstance(active, VerifiedActivePrincipal) or active.principal is not principal:
+            raise BrowserBridgeRuntimeDenied("PRINCIPAL_NOT_ACTIVE")
+        return active
+
+    def _require_admission(
+        self,
+        active: VerifiedActivePrincipal,
+        connector_sid: str,
+        hello: NormalizedBridgeHello,
+    ) -> CompleteRuntimeAdmission:
+        if self._transport_profile is not PRODUCTION_BROWSER_BRIDGE_TRANSPORT:
+            raise BrowserBridgeRuntimeDenied("RUNTIME_NOT_ADMITTED")
+        try:
+            admission = self._admission_evaluator(active, connector_sid, hello)
+        except Exception:
+            admission = None
+        if not _admission_matches(admission, active, connector_sid, hello):
+            raise BrowserBridgeRuntimeDenied("RUNTIME_NOT_ADMITTED")
+        return admission
+
+    def _conflicts_locked(
+        self,
+        connector_sid: str,
+        bridge_id: str,
+    ) -> tuple[BrowserBridgeRuntimeRoute, ...]:
+        values: list[BrowserBridgeRuntimeRoute] = []
+        by_sid = self._by_sid.get(connector_sid)
+        if by_sid is not None:
+            values.append(by_sid)
+        prior_sid = self._sid_by_bridge.get(bridge_id)
+        by_bridge = self._by_sid.get(prior_sid) if prior_sid is not None else None
+        if by_bridge is not None and all(by_bridge is not item for item in values):
+            values.append(by_bridge)
+        return tuple(values)
+
+    def _prune_stale_routes(self) -> None:
+        with self._lock:
+            routes = tuple(self._by_sid.values())
+        for route in routes:
+            if not self._route_is_current(route):
+                self._retire(route)
+
+    def _remove_locked(self, route: BrowserBridgeRuntimeRoute) -> bool:
+        if self._by_sid.get(route.connector_sid) is not route:
+            return False
+        self._by_sid.pop(route.connector_sid, None)
+        self._reconciling.pop(route.connector_sid, None)
+        self._reconciled.discard(route.connector_sid)
+        if self._sid_by_bridge.get(route.bridge_id) == route.connector_sid:
+            self._sid_by_bridge.pop(route.bridge_id, None)
+        return True
+
+    def _retire(self, route: BrowserBridgeRuntimeRoute) -> None:
+        with self._lock:
+            removed = self._remove_locked(route)
+        if removed:
+            self._cleanup(route)
+
+    def _cleanup(self, route: BrowserBridgeRuntimeRoute) -> None:
+        callbacks: tuple[RouteCleanup, ...] = (
+            lambda principal, sid, generation: self._broker.disconnect(
+                principal=principal,
+                connector_sid=sid,
+                load_generation_id=generation,
+            ),
+            *self._cleanup_callbacks,
+        )
+        for callback in callbacks:
+            try:
+                callback(
+                    route.principal,
+                    route.connector_sid,
+                    route.load_generation_id,
+                )
+            except Exception:
+                continue
+
+
+def normalize_bridge_hello(
+    principal: WsPrincipal,
+    active: VerifiedActivePrincipal,
+    data: Any,
+    *,
+    transport_profile: BrowserBridgeTransportProfile = (
+        PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    ),
+) -> NormalizedBridgeHello:
+    """Strictly project one section-4.3 hello without granting authority."""
+    profile = require_browser_bridge_transport_profile(transport_profile)
+    _validate_runtime_principal(principal, profile)
+    if not isinstance(active, VerifiedActivePrincipal) or active.principal is not principal:
+        raise BrowserBridgeRuntimeError("active principal mismatch")
+    root = _exact_mapping(data, {"protocol", "features", "host_browser"}, "hello")
+    if root["protocol"] != CONNECTOR_PROTOCOL:
+        raise BrowserBridgeRuntimeError("invalid connector protocol")
+    outer_features = _capability_set(
+        root["features"], REQUIRED_OUTER_FEATURES, "outer features"
+    )
+    if outer_features != REQUIRED_OUTER_FEATURES:
+        raise BrowserBridgeRuntimeError("incomplete outer features")
+
+    host = _exact_mapping(
+        root["host_browser"],
+        {
+            "supported",
+            "enabled",
+            "status",
+            "backend_id",
+            "browser_id",
+            "browser_label",
+            "contract_version",
+            "features",
+            "capabilities",
+            "extension",
+            "companion",
+        },
+        "host browser",
+    )
+    bridge_id = principal.principal_id
+    browser_id = f"extension:{bridge_id}"
+    if (
+        host["supported"] is not True
+        or host["enabled"] is not True
+        or host["status"] != "ready"
+        or host["backend_id"] != "chrome_extension"
+        or host["browser_id"] != browser_id
+        or type(host["contract_version"]) is not int
+        or host["contract_version"] != CONTRACT_VERSION
+    ):
+        raise BrowserBridgeRuntimeError("invalid extension backend")
+    browser_label = _bounded_text(host["browser_label"], MAX_LABEL_BYTES, "browser label")
+    host_features = _capability_set(
+        host["features"], {"browser_extension_bridge_v1"}, "host features"
+    )
+    if host_features != frozenset({"browser_extension_bridge_v1"}):
+        raise BrowserBridgeRuntimeError("invalid host features")
+
+    capabilities = _exact_mapping(
+        host["capabilities"], {"actions", "features", "limits"}, "capabilities"
+    )
+    actions = _capability_set(capabilities["actions"], PROVEN_ACTIONS, "actions")
+    features = _capability_set(
+        capabilities["features"], PROVEN_FEATURES, "features"
+    )
+    if len(actions) + len(features) > MAX_CAPABILITIES:
+        raise BrowserBridgeRuntimeError("capability limit exceeded")
+    limits = _limits(capabilities["limits"])
+
+    extension = _exact_mapping(
+        host["extension"],
+        {
+            "id",
+            "version",
+            "manifest_version",
+            "install_instance_id",
+            "load_generation_id",
+        },
+        "extension",
+    )
+    extension_id = _extension_id(extension["id"])
+    if extension_id != active.extension_id or extension["manifest_version"] != 3:
+        raise BrowserBridgeRuntimeError("extension identity mismatch")
+    extension_version = _version(extension["version"], "extension version")
+    install_instance_id = _native_identifier(
+        extension["install_instance_id"], "install_instance_id"
+    )
+    load_generation_id = _native_identifier(
+        extension["load_generation_id"], "load_generation_id"
+    )
+
+    companion = _exact_mapping(
+        host["companion"],
+        {"instance_id", "version", "platform", "arch"},
+        "companion",
+    )
+    companion_instance_id = _native_identifier(
+        companion["instance_id"], "companion_instance_id"
+    )
+    if companion_instance_id != active.companion_instance_id:
+        raise BrowserBridgeRuntimeError("companion identity mismatch")
+    companion_version = _version(companion["version"], "companion version")
+    if (re.fullmatch(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)", companion_version) is None
+            or tuple(map(int, companion_version.split("."))) < MINIMUM_SECURE_COMPANION):
+        raise BrowserBridgeRuntimeError("incompatible companion version")
+    if companion["platform"] not in _PLATFORMS or companion["arch"] not in _ARCHITECTURES:
+        raise BrowserBridgeRuntimeError("invalid companion target")
+
+    return NormalizedBridgeHello(
+        bridge_id=bridge_id,
+        browser_id=browser_id,
+        browser_label=browser_label,
+        load_generation_id=load_generation_id,
+        install_instance_id=install_instance_id,
+        extension_id=extension_id,
+        extension_version=extension_version,
+        companion_instance_id=companion_instance_id,
+        companion_version=companion_version,
+        companion_platform=companion["platform"],
+        companion_arch=companion["arch"],
+        contract_version=CONTRACT_VERSION,
+        outer_features=outer_features,
+        actions=actions,
+        features=features,
+        limits=limits,
+    )
+
+
+def restricted_browser_sender(
+    manager: Any,
+    *,
+    transport_profile: BrowserBridgeTransportProfile = (
+        PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    ),
+) -> BrokerSender:
+    """Build the only allowed broker transport over the shared WS manager."""
+    profile = require_browser_bridge_transport_profile(transport_profile)
+    if not callable(getattr(manager, "emit_to", None)):
+        raise BrowserBridgeRuntimeError("invalid WebSocket manager")
+
+    async def send(
+        connector_sid: str,
+        event: str,
+        payload: dict[str, Any],
+        correlation_id: str,
+        principal: WsPrincipal,
+    ) -> None:
+        if event not in _BROKER_OUTBOUND_EVENTS:
+            raise BrowserBridgeRuntimeDenied("EVENT_NOT_ALLOWED")
+        _validate_runtime_principal(principal, profile)
+        await manager.emit_to(
+            profile.namespace,
+            connector_sid,
+            event,
+            payload,
+            handler_id=profile.handler_id,
+            correlation_id=correlation_id,
+            expected_principal=principal,
+        )
+
+    return send
+
+
+def context_access_authorizer(
+    access: BrowserBridgeContextAccess,
+) -> ContextAuthorizer:
+    """Adapt the purpose-built advertised-context boundary for route selection."""
+    if not isinstance(access, BrowserBridgeContextAccess):
+        raise BrowserBridgeRuntimeError("invalid context access")
+
+    def authorize(route: BrowserBridgeRuntimeRoute, context_id: str) -> bool:
+        try:
+            access.authorize_message_target(
+                BrowserBridgeContextRoute(
+                    principal=route.principal,
+                    connector_sid=route.connector_sid,
+                    load_generation_id=route.load_generation_id,
+                    transport_profile=route.transport_profile,
+                ),
+                context_id=context_id,
+            )
+            return True
+        except Exception:
+            return False
+
+    return authorize
+
+
+def exact_route_cleanup(target: Any) -> RouteCleanup:
+    """Adapt a context, approval, or artifact disconnect boundary exactly."""
+    disconnect = getattr(target, "disconnect", None)
+    if not callable(disconnect):
+        raise BrowserBridgeRuntimeError("invalid route cleanup target")
+
+    def cleanup(
+        principal: WsPrincipal,
+        connector_sid: str,
+        load_generation_id: str,
+    ) -> None:
+        disconnect(
+            principal=principal,
+            connector_sid=connector_sid,
+            load_generation_id=load_generation_id,
+        )
+
+    return cleanup
+
+
+async def _unavailable_sender(
+    _connector_sid: str,
+    _event: str,
+    _payload: dict[str, Any],
+    _correlation_id: str,
+    _principal: WsPrincipal,
+) -> None:
+    raise BrowserBridgeRuntimeDenied("TRANSPORT_NOT_CONFIGURED")
+
+
+def _admission_matches(
+    value: CompleteRuntimeAdmission | None,
+    active: VerifiedActivePrincipal,
+    connector_sid: str,
+    hello: NormalizedBridgeHello,
+) -> bool:
+    if not isinstance(value, CompleteRuntimeAdmission):
+        return False
+    try:
+        _validate_runtime_principal(
+            active.principal, PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        )
+        _validate_runtime_principal(
+            value.principal, PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        )
+    except BrowserBridgeRuntimeDenied:
+        return False
+    readiness = (
+        value.release_trust_ready,
+        value.activation_attested,
+        value.legacy_control_plane_inactive,
+        value.operation_transport_ready,
+        value.control_transport_ready,
+        value.context_transport_ready,
+        value.event_transport_ready,
+        value.artifact_transport_ready,
+        value.approval_transport_ready,
+        value.session_lifecycle_ready,
+        value.policy_enforcement_ready,
+    )
+    return bool(
+        value.principal is active.principal
+        and value.server_instance_id == active.server_instance_id
+        and value.connector_sid == connector_sid
+        and value.load_generation_id == hello.load_generation_id
+        and value.install_instance_id == hello.install_instance_id
+        and value.contract_version == hello.contract_version
+        and value.outer_features == hello.outer_features
+        and value.actions == hello.actions
+        and value.features == hello.features
+        and all(type(item) is bool and item is True for item in readiness)
+        and _activation_matches(value.activation, active, connector_sid, hello)
+    )
+
+
+def _activation_fresh(value: RuntimeActivationAttestation, now: int) -> bool:
+    return bool(
+        type(value.issued_at_ms) is int and type(value.expires_at_ms) is int
+        and 0 < value.issued_at_ms <= now < value.expires_at_ms <= 2**53 - 1
+        and value.expires_at_ms - value.issued_at_ms <= 30_000
+        and isinstance(value.rollout, str) and value.rollout in {"available", "preview_authorized"}
+        and all(type(flag) is bool and flag is True for flag in (
+            value.selected_bridge, value.heartbeat_fresh, value.subject_profile_bound,
+            value.legacy_control_plane_inactive,
+        ))
+    )
+
+
+def _activation_matches(value, active, sid, hello) -> bool:
+    try:
+        _validate_runtime_principal(
+            active.principal, PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        )
+        if isinstance(value, RuntimeActivationAttestation):
+            _validate_runtime_principal(
+                value.principal, PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+            )
+    except BrowserBridgeRuntimeDenied:
+        return False
+    return bool(
+        isinstance(value, RuntimeActivationAttestation)
+        and value.principal is active.principal and value.server_instance_id == active.server_instance_id
+        and value.connector_sid == sid and value.load_generation_id == hello.load_generation_id
+        and value.extension_id == active.extension_id == hello.extension_id
+        and value.install_instance_id == hello.install_instance_id
+        and value.server_features == hello.outer_features
+        and _activation_fresh(value, time.time_ns() // 1_000_000)
+    )
+
+
+def _hello_mapping(hello: NormalizedBridgeHello) -> dict[str, Any]:
+    return {
+        "protocol": CONNECTOR_PROTOCOL,
+        "features": sorted(hello.outer_features),
+        "host_browser": {
+            "supported": True,
+            "enabled": True,
+            "status": "ready",
+            "backend_id": "chrome_extension",
+            "browser_id": hello.browser_id,
+            "browser_label": hello.browser_label,
+            "contract_version": hello.contract_version,
+            "features": ["browser_extension_bridge_v1"],
+            "capabilities": {
+                "actions": sorted(hello.actions),
+                "features": sorted(hello.features),
+                "limits": dict(hello.limits),
+            },
+            "extension": {
+                "id": hello.extension_id,
+                "version": hello.extension_version,
+                "manifest_version": 3,
+                "install_instance_id": hello.install_instance_id,
+                "load_generation_id": hello.load_generation_id,
+            },
+            "companion": {
+                "instance_id": hello.companion_instance_id,
+                "version": hello.companion_version,
+                "platform": hello.companion_platform,
+                "arch": hello.companion_arch,
+            },
+        },
+    }
+
+
+def _equivalent_principal(expected: WsPrincipal, candidate: WsPrincipal) -> bool:
+    return expected == candidate
+
+
+def _same_route_objects(
+    left: tuple[BrowserBridgeRuntimeRoute, ...],
+    right: tuple[BrowserBridgeRuntimeRoute, ...],
+) -> bool:
+    return len(left) == len(right) and all(
+        candidate is expected for candidate, expected in zip(left, right)
+    )
+
+
+def _validate_known_runtime_principal(principal: Any) -> WsPrincipal:
+    try:
+        runtime_transport_profile_for_principal(principal)
+    except ValueError:
+        raise BrowserBridgeRuntimeDenied("INVALID_PRINCIPAL") from None
+    _identifier(principal.principal_id, "bridge_id")
+    _identifier(principal.subject_id, "subject_id")
+    return principal
+
+
+def _validate_runtime_principal(
+    principal: Any,
+    transport_profile: BrowserBridgeTransportProfile = (
+        PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    ),
+) -> WsPrincipal:
+    try:
+        profile = require_browser_bridge_transport_profile(transport_profile)
+        require_runtime_transport_principal(principal, profile)
+    except ValueError:
+        raise BrowserBridgeRuntimeDenied("INVALID_PRINCIPAL") from None
+    if (
+        not isinstance(principal, WsPrincipal)
+        or principal.principal_type != profile.principal_type
+        or principal.handler_id != profile.handler_id
+        or principal.handler_path != profile.handler_path
+    ):
+        raise BrowserBridgeRuntimeDenied("INVALID_PRINCIPAL")
+    _identifier(principal.principal_id, "bridge_id")
+    _identifier(principal.subject_id, "subject_id")
+    return principal
+
+
+def _exact_mapping(value: Any, fields: set[str], subject: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != fields:
+        raise BrowserBridgeRuntimeError(f"invalid {subject}")
+    return value
+
+
+def _capability_set(value: Any, allowed: set[str] | frozenset[str], subject: str) -> frozenset[str]:
+    if not isinstance(value, list) or len(value) > MAX_CAPABILITIES:
+        raise BrowserBridgeRuntimeError(f"invalid {subject}")
+    result: list[str] = []
+    for item in value:
+        if (
+            not isinstance(item, str)
+            or item not in allowed
+            or len(item.encode("utf-8")) > MAX_IDENTIFIER_BYTES
+        ):
+            raise BrowserBridgeRuntimeError(f"invalid {subject}")
+        result.append(item)
+    if len(set(result)) != len(result):
+        raise BrowserBridgeRuntimeError(f"duplicate {subject}")
+    return frozenset(result)
+
+
+def _limits(value: Any) -> tuple[tuple[str, int], ...]:
+    mapping = _exact_mapping(value, set(dict(EXPECTED_LIMITS)), "limits")
+    if any(
+        type(mapping[key]) is not int or mapping[key] != expected
+        for key, expected in EXPECTED_LIMITS
+    ):
+        raise BrowserBridgeRuntimeError("invalid limits")
+    return EXPECTED_LIMITS
+
+
+def _bounded_text(value: Any, maximum: int, subject: str) -> str:
+    try:
+        encoded_size = len(value.encode("utf-8")) if isinstance(value, str) else -1
+    except UnicodeError:
+        encoded_size = -1
+    if (
+        not isinstance(value, str)
+        or not value
+        or not 0 <= encoded_size <= maximum
+        or not value.isprintable()
+    ):
+        raise BrowserBridgeRuntimeError(f"invalid {subject}")
+    return value
+
+
+def _identifier(value: Any, subject: str) -> str:
+    return _bounded_text(value, MAX_IDENTIFIER_BYTES, subject)
+
+
+def _native_identifier(value: Any, subject: str) -> str:
+    value = _identifier(value, subject)
+    if _NATIVE_IDENTIFIER.fullmatch(value) is None:
+        raise BrowserBridgeRuntimeError(f"invalid {subject}")
+    return value
+
+
+def _extension_id(value: Any) -> str:
+    if not isinstance(value, str) or _EXTENSION_ID.fullmatch(value) is None:
+        raise BrowserBridgeRuntimeError("invalid extension_id")
+    return value
+
+
+def _version(value: Any, subject: str) -> str:
+    if not isinstance(value, str) or _VERSION.fullmatch(value) is None:
+        raise BrowserBridgeRuntimeError(f"invalid {subject}")
+    return value

--- a/plugins/_a0_connector/helpers/browser_bridge_runtime_owner.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_runtime_owner.py
@@ -1,0 +1,299 @@
+"""Production composition with independently rechecked server authority.
+
+The release verifier is supplied by the server's verified-release owner, never
+by a request, hello, environment readiness switch, or presentation catalog.
+An absent verifier cannot install this owner.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+import threading
+from typing import Callable
+
+from plugins._a0_connector.helpers.browser_bridge_bootstrap import (
+    bind_browser_bridge_application, retire_browser_bridge_application,
+)
+from plugins._a0_connector.helpers.browser_bridge_cutover import (
+    LegacyDetectionState, detect_installed_legacy_browser_bridge,
+)
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    SUBJECT_ID, configured_extension_id, get_browser_bridge_pairing_store,
+)
+from plugins._a0_connector.helpers.browser_bridge_runtime import (
+    CompleteRuntimeAdmission, NormalizedBridgeHello, RuntimeActivationAttestation,
+    VerifiedActivePrincipal,
+)
+from plugins._a0_connector.helpers.browser_bridge_selection import default_selected_bridge, selection_current
+from plugins._a0_connector.helpers.browser_bridge_session import is_active
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT as PROFILE,
+)
+from plugins._browser.helpers.bridge_foundation import get_browser_bridge_gate
+
+
+HEARTBEAT_MAX_AGE_MS = 30_000
+REQUIRED_BOUNDARIES = frozenset({
+    "operation", "control", "context", "event", "artifact", "approval",
+    "lifecycle", "policy",
+})
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedBrowserRelease:
+    """Exact release-verifier result; construction alone grants no admission.
+
+    Only the independently configured verifier is consulted. The server owner
+    compares every field against the authenticated route on every lookup.
+    Public release metadata is intentionally not accepted by this interface.
+    """
+
+    principal: object
+    server_instance_id: str
+    connector_sid: str
+    load_generation_id: str
+    install_instance_id: str
+    extension_id: str
+    extension_version: str
+    companion_version: str
+    companion_platform: str
+    companion_arch: str
+
+
+ReleaseVerifier = Callable[
+    [VerifiedActivePrincipal, str, NormalizedBridgeHello], VerifiedBrowserRelease | None
+]
+
+
+def _admission_denied(code):
+    from plugins._a0_connector.helpers.browser_bridge_application import record_production_browser_stage
+    record_production_browser_stage(code)
+    return None
+
+
+def _server_instance_id() -> str:
+    from helpers import runtime
+
+    return runtime.get_persistent_id()
+
+
+class BrowserBridgeRuntimeOwner:
+    """Own production factory acquisition, admission, readback and withdrawal."""
+
+    def __init__(self, *, manager, release_verifier: ReleaseVerifier) -> None:
+        if not callable(release_verifier):
+            raise TypeError("a verified Browser release owner is required")
+        if not callable(getattr(manager, "principal_for_sid", None)):
+            raise TypeError("the server WebSocket manager is required")
+        from plugins._a0_connector.helpers.browser_bridge_application import BrowserBridgeApplication
+        from plugins._browser.helpers.extension_sessions import (
+            get_extension_session_lifecycle,
+        )
+
+        self.manager = manager
+        self._release_verifier = release_verifier
+        self._closed = False
+        self.application = BrowserBridgeApplication(
+            manager=manager,
+            server_instance_id=_server_instance_id,
+            lifecycle=get_extension_session_lifecycle(),
+            active_principal_verifier=self.verify_principal,
+            admission_evaluator=self.evaluate_admission,
+            context_authorizer=self.authorize_context,
+            selection_current=selection_current,
+        )
+
+    def install(self) -> bool:
+        if self._closed:
+            raise RuntimeError("Browser runtime owner is closed")
+        if self.application.installed:
+            return False
+        self.application.install()
+        try:
+            bind_browser_bridge_application(self.application)
+        except Exception:
+            # Construction has acquired factory ownership, so a failed bind
+            # must not leave that factory reachable by normal Browser calls.
+            self.application.browser.uninstall()
+            raise
+        return True
+
+    async def close(self) -> bool:
+        if self._closed:
+            return False
+        self._closed = True
+        retired = await retire_browser_bridge_application(self.application)
+        if not retired:
+            await self.application.close()
+        return True
+
+    def verify_principal(self, principal) -> VerifiedActivePrincipal | None:
+        try:
+            if self._closed or not is_active(principal):
+                return None
+            record = get_browser_bridge_pairing_store().active_bridge_record(
+                bridge_id=principal.principal_id,
+                server_instance_id=_server_instance_id(),
+            )
+            if record is None or principal.subject_id != SUBJECT_ID:
+                return None
+            return VerifiedActivePrincipal(
+                principal=principal,
+                server_instance_id=_server_instance_id(),
+                extension_id=record["extension_id"],
+                companion_instance_id=record["companion_instance_id"],
+            )
+        except Exception:
+            return None
+
+
+    def authorize_context(self, route, context_id: str) -> bool:
+        return bool(
+            route.principal.subject_id == SUBJECT_ID
+            and selection_current(context_id, route.bridge_id)
+        )
+
+    def _selected(self, bridge_id: str) -> bool:
+        from agent import AgentContext
+
+        return default_selected_bridge() == bridge_id or any(
+            selection_current(context.id, bridge_id) for context in AgentContext.all()
+        )
+
+    def _heartbeat_fresh(self, principal, sid: str) -> bool:
+        # A connected socket is insufficient. Require recent server-observed
+        # authenticated traffic. Native sends same-generation hello refreshes
+        # during idle; callers cannot supply a heartbeat timestamp.
+        with self.manager.lock:
+            connection = self.manager.connections.get((PROFILE.namespace, sid))
+            if connection is None or connection.principal is not principal:
+                return False
+            observed = int(connection.last_activity.timestamp() * 1000)
+            # A concurrent authenticated receive may have advanced activity
+            # since admission began. Sample now after the activity snapshot,
+            # under its owning lock, rather than rejecting that fresh traffic
+            # as a future timestamp and retiring an otherwise current route.
+            now = time.time_ns() // 1_000_000
+        return 0 <= now - observed < HEARTBEAT_MAX_AGE_MS
+
+    def evaluate_admission(self, active, sid, hello) -> CompleteRuntimeAdmission | None:
+        try:
+            now = time.time_ns() // 1_000_000
+            checks = (
+                ("ADMISSION_OWNER_UNAVAILABLE", lambda: not self._closed and self.application.installed),
+                ("ADMISSION_SOCKET_MISMATCH", lambda: self.manager.principal_for_sid(PROFILE.namespace, sid) is active.principal),
+                ("ADMISSION_PRINCIPAL_REJECTED", lambda: self.verify_principal(active.principal) == active),
+                ("ADMISSION_EXTENSION_MISMATCH", lambda: active.extension_id == configured_extension_id()),
+                ("ADMISSION_ROLLOUT_DISABLED", lambda: get_browser_bridge_gate().state == "available"),
+                ("ADMISSION_SELECTION_MISSING", lambda: self._selected(active.principal.principal_id)),
+                ("ADMISSION_HEARTBEAT_REJECTED", lambda: self._heartbeat_fresh(active.principal, sid)),
+                ("ADMISSION_LEGACY_PRESENT", lambda: detect_installed_legacy_browser_bridge().state is LegacyDetectionState.ABSENT),
+            )
+            for code, permitted in checks:
+                if not permitted():
+                    return _admission_denied(code)
+            boundaries = getattr(self.application, "runtime_boundaries", lambda: frozenset())()
+            if type(boundaries) is not frozenset or not REQUIRED_BOUNDARIES <= boundaries:
+                return _admission_denied("ADMISSION_BOUNDARY_MISSING")
+            evidence = self._release_verifier(active, sid, hello)
+            if type(evidence) is not VerifiedBrowserRelease or evidence.principal is not active.principal:
+                return _admission_denied("ADMISSION_RELEASE_UNVERIFIED")
+            if (
+                evidence.server_instance_id != active.server_instance_id
+                or evidence.connector_sid != sid
+                or any(getattr(evidence, field) != getattr(hello, field) for field in (
+                    "load_generation_id", "install_instance_id", "extension_id",
+                    "extension_version", "companion_version", "companion_platform", "companion_arch",
+                ))
+            ):
+                return _admission_denied("ADMISSION_RELEASE_MISMATCH")
+            activation = RuntimeActivationAttestation(
+                principal=active.principal, server_instance_id=active.server_instance_id,
+                connector_sid=sid, load_generation_id=hello.load_generation_id,
+                extension_id=active.extension_id, install_instance_id=hello.install_instance_id,
+                server_features=hello.outer_features, rollout="available", selected_bridge=True,
+                heartbeat_fresh=True, subject_profile_bound=True, legacy_control_plane_inactive=True,
+                issued_at_ms=now, expires_at_ms=now + HEARTBEAT_MAX_AGE_MS,
+            )
+            return CompleteRuntimeAdmission(
+                principal=active.principal, server_instance_id=active.server_instance_id,
+                connector_sid=sid, load_generation_id=hello.load_generation_id,
+                install_instance_id=hello.install_instance_id, contract_version=hello.contract_version,
+                outer_features=hello.outer_features, actions=hello.actions, features=hello.features,
+                release_trust_ready=True, activation_attested=True, legacy_control_plane_inactive=True,
+                operation_transport_ready="operation" in boundaries,
+                control_transport_ready="control" in boundaries,
+                context_transport_ready="context" in boundaries,
+                event_transport_ready="event" in boundaries,
+                artifact_transport_ready="artifact" in boundaries,
+                approval_transport_ready="approval" in boundaries,
+                session_lifecycle_ready="lifecycle" in boundaries,
+                policy_enforcement_ready="policy" in boundaries,
+                activation=activation,
+            )
+        except Exception:
+            return _admission_denied("ADMISSION_CHECK_EXCEPTION")
+
+
+_owner: BrowserBridgeRuntimeOwner | None = None
+_owner_lock = threading.RLock()
+_release_verifier: ReleaseVerifier | None = None
+_retiring = False
+
+
+def configure_verified_browser_releases(verifier: ReleaseVerifier) -> None:
+    """Configure server-owned release verification before startup, never via HTTP."""
+    if not callable(verifier):
+        raise TypeError("invalid Browser release verifier")
+    global _release_verifier
+    with _owner_lock:
+        if _owner is not None or _retiring:
+            raise RuntimeError("retire the Browser runtime before changing release trust")
+        _release_verifier = verifier
+
+
+def install_configured_browser_runtime(manager) -> bool:
+    """Normal startup; admission stays closed without independently verified trust."""
+    global _owner
+    if get_browser_bridge_gate().state != "available" or configured_extension_id() is None:
+        return False
+    with _owner_lock:
+        if _retiring:
+            raise RuntimeError("Browser runtime is retiring")
+        if _owner is not None:
+            if _owner.manager is not manager or not _owner.application.installed:
+                raise RuntimeError("Browser runtime owner conflict")
+            return False
+        from plugins._a0_connector.helpers.browser_bridge_release_policy import verify_configured_browser_release
+
+        candidate = BrowserBridgeRuntimeOwner(
+            manager=manager,
+            release_verifier=_release_verifier or verify_configured_browser_release,
+        )
+        candidate.install()
+        _owner = candidate
+        return True
+
+
+async def retire_configured_browser_runtime(*, manager=None) -> bool:
+    global _owner, _retiring
+    with _owner_lock:
+        if _owner is None or _retiring:
+            return False
+        if manager is not None and _owner.manager is not manager:
+            return False
+        owner = _owner
+        _owner = None
+        _retiring = True
+    try:
+        return await owner.close()
+    finally:
+        with _owner_lock:
+            _retiring = False
+
+
+async def reload_configured_browser_runtime(manager) -> bool:
+    """Explicit reload withdraws and awaits the former owner before installation."""
+    await retire_configured_browser_runtime()
+    return install_configured_browser_runtime(manager)

--- a/plugins/_a0_connector/helpers/browser_bridge_runtime_owner.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_runtime_owner.py.dox.md
@@ -1,0 +1,71 @@
+# Production Browser runtime owner
+
+`install_configured_browser_runtime` is reached from the enabled connector's
+`webui_server_start` hook inside each ASGI lifespan, before serving requests, for
+the `available` rollout and a configured production extension pin. It acquires
+the real application/factory/lifecycle; missing release approval or transports
+still prevents route admission. Shutdown and explicit reload await exact owner
+retirement before replacement; constructors/imports do not install anything.
+Successful installation registers awaited cleanup on that lifespan's
+`shutdown` stack. Each startup retry installs afresh after prior cleanup, without
+reconstructing the shared server or reusing a closed owner. Its manager check cannot
+retire another server's replacement owner, and cleanup still runs if the plugin
+is subsequently disabled. A separate Core create-end hook retains the read-only
+legacy HTTP retirement guard even when the connector is disabled; it never
+initiates retirement or grants activation. A disabled connector installs no
+production runtime owner.
+Production composition must acquire `get_extension_session_lifecycle()`, the
+same KVP-backed singleton used by monologue hooks. A separately constructed
+lifecycle misses those hooks and wrongly finalizes every Browser call as a
+synthetic turn. Exact service-owner configuration/unconfiguration protects the
+shared production singleton.
+
+Admission rereads active paired credentials and explicit global-default or
+current context selection. A saved global default permits handshake with no
+loaded chats; context authorization still resolves that exact chat's effective
+project/profile selection and preserves internal/other-host overrides. Admission
+requires the same manager-owned principal/SID with authenticated traffic less
+than 30 seconds old, and requires an absent legacy control plane. Native must
+renew same-generation hello at most every 20 seconds; ordinary Engine.IO
+connected state alone does not constitute this application heartbeat.
+Read the exact connection activity and sample the comparison wall clock under
+the same manager lock, in that order. An admission-start timestamp may precede
+concurrent authenticated traffic and must not be used for that comparison.
+Keep genuine future timestamps and ages of 30 seconds or more denied; never
+clamp the age or broaden the freshness window to conceal a race.
+
+The application reports genuinely composed runtime boundaries. An omitted
+artifact or other required lane cannot be covered by a release approval or
+client feature flag. The independently signature-verified release policy must
+approve the exact extension/native tuple; its result is bound to the exact
+principal/server/SID/load/install before constructing a fresh activation.
+
+The new protected selection API may write production Browser configuration only
+after active credential checks, then requires exact project-scoped or explicit
+global-default readback.
+Selection remains distinct from ready activation. No live-instance credentials,
+release roots, policy file, rollout, or browser selection are generated here.
+
+Production transport admission is provisional for browser operation/status
+purposes until one exact reconciliation result promotes it. The first hello
+emits no browser controls or finalization replay. The first same-principal/SID/
+generation repeated hello proves the native transport consumed the initial ACK
+and starts one process-owned reconciliation; no timing sleeps are used. Its
+hello projection is unchanged, so native renewal equality remains exact.
+Replacement resets reconciliation; timeout/mismatch retires the exact route.
+Context, artifact, approval and operation authority remain denied until
+promotion. Reconciliation validates peer inventory but adopts no lease authority.
+
+Private stage diagnostics distinguish initial admission, renewal, reconciliation
+start/result/success and a fixed allowlist of failures. Settled negative replies
+may classify invalid state, unsupported capability, internal error or unknown
+outcome without exposing remote error text. Unknown codes map to OTHER_FAILURE;
+each symbol is logged at most five times per process, so an absent recent log
+does not prove that no retry occurred. Diagnostic symbols never grant readiness.
+Admission rejection symbols identify only the failed predicate: owner, socket,
+principal, extension pin, rollout, selection, heartbeat, legacy isolation,
+required boundaries, release proof or its exact binding. Exceptions report
+only `ADMISSION_CHECK_EXCEPTION`, never values or exception text. Checks retain
+their original order and all remain required.
+
+Verify with `tests/test_browser_bridge_runtime_owner.py` and runtime registry tests.

--- a/plugins/_a0_connector/helpers/browser_bridge_selection.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_selection.py
@@ -1,0 +1,190 @@
+"""Fail-closed server selection for the extension Browser runtime.
+
+The WebUI may identify the chat whose Browser panel is open, but it does not
+select a bridge. Selection is derived from that live AgentContext's agent0
+project/profile configuration and is valid only for the host-required backend.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+from typing import Any, Mapping
+
+
+_CONTEXT_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+_BRIDGE_ID = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9._-]{0,126}[A-Za-z0-9])?"
+)
+_write_lock = threading.RLock()
+
+
+def default_selected_bridge() -> str | None:
+    """Read the explicit global default, independently of any loaded chat."""
+    from helpers import plugins
+    from plugins._browser.helpers.config import parse_extension_browser_selection
+
+    config = plugins.get_plugin_config("_browser", project_name="", agent_profile="")
+    if not isinstance(config, Mapping):
+        raise RuntimeError("browser defaults are unavailable")
+    if config.get("runtime_backend") != "host_required":
+        return None
+    selection = parse_extension_browser_selection(config.get("host_browser_selection"))
+    return selection.bridge_id if selection is not None else None
+
+
+def select_default_bridge(bridge_id: str | None, *, expected_bridge_id: str | None) -> str | None:
+    """Explicit global-only CAS; scoped settings and consent are unchanged."""
+    from helpers import plugins, runtime
+    from plugins._a0_connector.helpers.browser_bridge_bootstrap import get_browser_bridge_application
+    from plugins._a0_connector.helpers.browser_bridge_pairing import (
+        SUBJECT_ID, configured_extension_id, get_browser_bridge_pairing_store,
+    )
+    from plugins._browser.helpers.config import protected_production_selection_write
+    from plugins._browser.helpers.bridge_foundation import get_browser_bridge_gate
+
+    for value in (bridge_id, expected_bridge_id):
+        if value is not None and (not isinstance(value, str) or _BRIDGE_ID.fullmatch(value) is None):
+            raise ValueError("invalid browser selection")
+    if bridge_id is None and expected_bridge_id is None:
+        raise ValueError("missing previous browser selection")
+    with _write_lock:
+        previous = default_selected_bridge()
+        if previous != expected_bridge_id:
+            raise RuntimeError("browser default changed")
+        application = get_browser_bridge_application()
+
+        def check_pair():
+            if application is None or get_browser_bridge_gate().state != "available":
+                raise RuntimeError("browser runtime is not configured")
+            record = get_browser_bridge_pairing_store().active_bridge_record(
+                bridge_id=bridge_id, server_instance_id=runtime.get_persistent_id(),
+            )
+            if (not isinstance(record, Mapping) or record.get("subject_id") != SUBJECT_ID
+                    or record.get("extension_id") != configured_extension_id()):
+                raise RuntimeError("paired browser is unavailable")
+
+        if bridge_id is not None:
+            check_pair()
+        config = dict(plugins.get_plugin_config("_browser", project_name="", agent_profile=""))
+        config.update(runtime_backend="host_required" if bridge_id else "container",
+                      host_browser_selection=f"extension:{bridge_id}" if bridge_id else "")
+        if application is not None and previous is not None and previous != bridge_id:
+            application.registry.retire_bridge(previous)
+        with protected_production_selection_write():
+            plugins.save_plugin_config("_browser", "", "", config, caller="api")
+        if default_selected_bridge() != bridge_id:
+            raise RuntimeError("browser default readback failed")
+        if bridge_id is not None:
+            check_pair()
+        return bridge_id
+
+
+def selected_bridge(context_id: Any) -> str | None:
+    """Return the bridge selected by current server-owned context config."""
+
+    if not isinstance(context_id, str) or _CONTEXT_ID.fullmatch(context_id) is None:
+        return None
+    try:
+        from agent import AgentContext
+        from plugins._browser.helpers.config import (
+            HOST_BROWSER_SELECTION_KEY,
+            RUNTIME_BACKEND_KEY,
+            get_browser_config,
+            parse_extension_browser_selection,
+        )
+
+        context = AgentContext.get(context_id)
+        if context is None or getattr(context, "id", None) != context_id:
+            return None
+        agent = getattr(context, "agent0", None)
+        if agent is None or getattr(agent, "context", None) is not context:
+            return None
+        config = get_browser_config(agent=agent)
+        if (
+            not isinstance(config, Mapping)
+            or config.get(RUNTIME_BACKEND_KEY) != "host_required"
+        ):
+            return None
+        selection = parse_extension_browser_selection(
+            config.get(HOST_BROWSER_SELECTION_KEY)
+        )
+        if selection is None or _BRIDGE_ID.fullmatch(selection.bridge_id) is None:
+            return None
+        return selection.bridge_id
+    except Exception:
+        return None
+
+
+def selection_current(context_id: Any, bridge_id: Any) -> bool:
+    """Check one claimed bridge against the context's current server selection."""
+
+    if not isinstance(bridge_id, str) or _BRIDGE_ID.fullmatch(bridge_id) is None:
+        return False
+    return selected_bridge(context_id) == bridge_id
+
+
+def select_bridge_for_context(context_id: str, bridge_id: str | None, *, expected_bridge_id: str | None = None) -> str | None:
+    """Protected API mutation with active-record validation and exact readback.
+
+    Browser's configuration is project-scoped, never profile-scoped. Selection
+    remains separate from readiness; a newly selected native must authenticate
+    and supply a currently admitted hello before any operation can execute.
+    """
+    from agent import AgentContext
+    from helpers import plugins, projects, runtime
+    from plugins._a0_connector.helpers.browser_bridge_bootstrap import get_browser_bridge_application
+    from plugins._a0_connector.helpers.browser_bridge_pairing import (
+        SUBJECT_ID, configured_extension_id, get_browser_bridge_pairing_store,
+    )
+    from plugins._browser.helpers.config import (
+        get_browser_config, protected_production_selection_write,
+    )
+    from plugins._browser.helpers.bridge_foundation import get_browser_bridge_gate
+
+    if not isinstance(context_id, str) or _CONTEXT_ID.fullmatch(context_id) is None:
+        raise ValueError("invalid browser context")
+    if bridge_id is not None and (
+        not isinstance(bridge_id, str) or _BRIDGE_ID.fullmatch(bridge_id) is None
+    ):
+        raise ValueError("invalid browser selection")
+    with _write_lock:
+        if bridge_id is None and (
+            not isinstance(expected_bridge_id, str)
+            or _BRIDGE_ID.fullmatch(expected_bridge_id) is None
+            or selected_bridge(context_id) != expected_bridge_id
+        ):
+            raise RuntimeError("browser selection changed")
+        context = AgentContext.get(context_id)
+        if context is None or getattr(getattr(context, "agent0", None), "context", None) is not context:
+            raise ValueError("invalid browser context")
+        application = get_browser_bridge_application()
+        if bridge_id is not None:
+            if application is None or get_browser_bridge_gate().state != "available":
+                raise RuntimeError("browser runtime is not configured")
+            record = get_browser_bridge_pairing_store().active_bridge_record(
+                bridge_id=bridge_id, server_instance_id=runtime.get_persistent_id(),
+            )
+            if (
+                not isinstance(record, Mapping) or record.get("subject_id") != SUBJECT_ID
+                or record.get("extension_id") != configured_extension_id()
+            ):
+                raise RuntimeError("paired browser is unavailable")
+        config = dict(get_browser_config(agent=context.agent0))
+        config.update(
+            runtime_backend="host_required" if bridge_id is not None else "container",
+            host_browser_selection=f"extension:{bridge_id}" if bridge_id is not None else "",
+        )
+        # Retire before a shared scope changes. Even if persistence subsequently
+        # fails, old pending operations cannot race a newly selected browser.
+        previous_bridge = selected_bridge(context_id)
+        if application is not None and previous_bridge is not None and previous_bridge != bridge_id:
+            application.registry.retire_bridge(previous_bridge)
+        with protected_production_selection_write():
+            plugins.save_plugin_config(
+                "_browser", projects.get_context_project_name(context) or "", "",
+                config, caller="api",
+            )
+        if selected_bridge(context_id) != bridge_id:
+            raise RuntimeError("browser selection readback failed")
+        return bridge_id

--- a/plugins/_a0_connector/helpers/browser_bridge_selection.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_selection.py.dox.md
@@ -1,0 +1,43 @@
+# browser_bridge_selection.py DOX
+
+## Purpose
+
+- Resolve the extension bridge selected for one live Agent Zero context without
+  treating a WebUI Browser ID or request value as authority.
+
+## Local Contracts
+
+- Load the exact `AgentContext`, require its own `agent0`, and read that agent's
+  project/profile `_browser` configuration through `get_browser_config`.
+- Return a bridge only when `runtime_backend` is exactly `host_required` and
+  `host_browser_selection` is a valid `extension:<bridge_id>` selection.
+- Fail closed on missing contexts, malformed configuration, invalid identifiers,
+  import/load failures, or agent/context mismatch.
+- Callers must recheck `selection_current(context_id, bridge_id)` at challenge
+  registration, decision, and queued-control authorization boundaries.
+
+## Non-Goals
+
+- Read-only selection resolution does not resolve container Browser tab IDs,
+  choose a bridge, test route liveness, or grant runtime/operation authority.
+
+## Protected selection mutation
+
+`select_bridge_for_context` is the protected API's explicit mutation path. It
+requires the real current context, active server/subject paired record, pinned
+extension and installed available production owner. Writes hold a lexical
+config capability unavailable to generic settings requests, target Browser's
+project scope with empty agent profile, and must pass exact readback. The former
+bridge route is retired first; failure cannot route old operations to a new
+browser. Clearing remains possible without an available owner. This helper does
+not grant readiness: hello must independently pass release/runtime admission.
+
+`select_default_bridge` is an explicit global-only mutation with an exact
+previous-bridge precondition, including null for the first default. It loads and
+writes only global Browser config (empty project/profile), preserves its other
+settings, checks active pairing before and after persistence, and retires the
+former route before replacement. Clearing remains available without a runtime
+owner. Existing project/profile configuration is never rewritten or merged;
+framework whole-file precedence preserves those overrides. `default_selected_bridge`
+reads this default without a loaded chat and supplies selection evidence only,
+not credential validity or context/action authority.

--- a/plugins/_a0_connector/helpers/browser_bridge_session.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_session.py
@@ -1,0 +1,88 @@
+"""Hello-only scoped session foundation; no browser/context runtime activation."""
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_auth import (
+    BRIDGE_CONNECTOR_HANDLER,
+    get_browser_bridge_challenge_store,
+)
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    configured_extension_id,
+    get_browser_bridge_pairing_store,
+    server_base_url_for_request,
+)
+from plugins._browser.helpers.bridge_foundation import get_browser_bridge_gate
+
+
+def authenticate(auth: dict, *, handler_id: str) -> WsPrincipal | None:
+    # The shared namespace has already validated Origin before invoking us.
+    from flask import request
+    from helpers import runtime
+
+    if (
+        set(auth) != {"handlers", "principal"}
+        or auth.get("handlers") != [BRIDGE_CONNECTOR_HANDLER]
+        or not isinstance(auth.get("principal"), dict)
+        or set(auth["principal"]) != {"type", "proof", "signature"}
+        or auth["principal"].get("type") != "browser_bridge"
+        or get_browser_bridge_gate().state not in {"preview", "available"}
+    ):
+        return None
+    envelope = auth["principal"]
+    verified = get_browser_bridge_challenge_store().verify(
+        proof=envelope["proof"], signature=envelope["signature"],
+    )
+    if (
+        verified.server_instance_id != runtime.get_persistent_id()
+        or envelope["proof"]["server_base_url"] != server_base_url_for_request(request)
+        or verified.extension_id != configured_extension_id()
+        or "bridge.connect" not in verified.scopes
+    ):
+        return None
+    from plugins._a0_connector.helpers.browser_bridge_bootstrap import (
+        browser_bridge_principal_events,
+    )
+
+    inbound_events, outbound_events = browser_bridge_principal_events()
+    return WsPrincipal(
+        principal_type="browser_bridge", principal_id=verified.bridge_id,
+        subject_id=verified.subject_id, scopes=frozenset(verified.scopes),
+        handler_path=BRIDGE_CONNECTOR_HANDLER, handler_id=handler_id,
+        # Operational event authority exists only for an explicitly installed
+        # server application and never routes through legacy CLI code.
+        inbound_events=inbound_events,
+        outbound_events=outbound_events,
+        key_generation=verified.key_generation,
+    )
+
+
+def is_active(principal: WsPrincipal) -> bool:
+    from helpers import runtime
+
+    try:
+        if get_browser_bridge_gate().state not in {"preview", "available"}:
+            return False
+        record = get_browser_bridge_pairing_store().active_bridge_record(
+            bridge_id=principal.principal_id,
+            server_instance_id=runtime.get_persistent_id(),
+        )
+        return bool(
+            record
+            and record["key_generation"] == principal.key_generation
+            and record["subject_id"] == principal.subject_id
+            and record["extension_id"] == configured_extension_id()
+            and frozenset(record["scopes"]) == principal.scopes
+        )
+    except Exception:
+        return False
+
+
+def hello(data: dict) -> dict:
+    """Return no exec configuration, contexts, host metadata, or runtime feature."""
+    return {
+        "protocol": "a0-connector.v1",
+        "features": [],
+        "principal_type": "browser_bridge",
+        "connector_session_ready": False,
+        "browser_control_ready": False,
+        "reason_code": "scoped_runtime_not_available",
+    }

--- a/plugins/_a0_connector/helpers/browser_bridge_session.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_session.py.dox.md
@@ -1,0 +1,33 @@
+# Browser bridge scoped-session foundation
+
+`authenticate` verifies the exact singleton-handler proof envelope after shared
+Origin checks, rechecks the current server URL/instance and pinned extension,
+and returns a server-derived `WsPrincipal`. `is_active` rechecks rollout,
+credential state, subject, extension, key generation and scopes on requests.
+The namespace supplies neither ambient cookies nor API/CSRF tokens.
+
+Without an explicitly installed server-owned Browser bridge application, only
+`connector_hello` is accepted. Its input is not stored or interpreted as CLI
+remote-tool metadata, and the response contains no runtime features and reports
+session/browser runtime readiness false. Installing the optional application
+freezes the full bridge-only event allowlists into newly authenticated
+principals. Exact hello admission then returns only negotiated metadata, typed
+activation evidence, and the authenticated transport binding. All operational
+events dispatch exclusively to that application and never to legacy connector
+branches; a missing application or unadmitted SID fails closed. Existing
+hello-only principals must reconnect and prove again before they can acquire
+the larger immutable event sets.
+
+The transport-only connector binding may include server instance, bridge, SID,
+key generation, and load generation inside the already proof-authenticated
+Socket.IO acknowledgement. Never reuse those values in Browser status/WebUI.
+Normal WebUI startup composes the production owner only with available rollout
+and a production extension pin; the admission evaluator independently verifies
+signed release approval, complete boundaries, exact selection and fresh activity.
+Removing an installed owner requires the
+bootstrap's async retirement path, which hides it from new routing, awaits its
+route/controller cleanup, and only then clears the site-authority API binding.
+
+No persistence except the existing proof verifier's last-authenticated update.
+Verify with restricted WebSocket, Browser bridge session, and optional
+bootstrap handler regression tests.

--- a/plugins/_a0_connector/helpers/browser_bridge_setup.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_setup.py
@@ -1,0 +1,29 @@
+"""Public setup links; never installation, pairing or runtime authority."""
+from __future__ import annotations
+
+from typing import Mapping
+
+from plugins._a0_connector.helpers.browser_bridge_pairing import configured_extension_id
+from plugins._a0_connector.helpers.browser_companion_release import browser_companion_release_status
+from plugins._browser.helpers.bridge_foundation import get_browser_bridge_gate
+
+
+def browser_bridge_setup_status(*, environ: Mapping[str, str] | None = None) -> dict:
+    extension_id = configured_extension_id(environ=environ)
+    enabled = get_browser_bridge_gate(environ=environ).state == "available" and extension_id is not None
+    release = browser_companion_release_status(environ=environ)
+    artifacts = release["artifacts"] if enabled and release["state"] == "available" else []
+    return {
+        "contract": "a0.browser-bridge.setup.v1",
+        "setup_enabled": enabled,
+        "browser_control_ready": False,
+        "install_target": "browser_host",
+        "host_verification_required": True,
+        "extension_id": extension_id if enabled else None,
+        "extension_url": f"https://chromewebstore.google.com/detail/{extension_id}" if enabled else None,
+        "companion_version": release["release"]["version"] if artifacts else None,
+        "installers": [
+            {"platform": item["platform"], "arch": item["arch"], "url": item["download_url"]}
+            for item in artifacts if item["kind"] in {"installer", "bootstrap"}
+        ],
+    }

--- a/plugins/_a0_connector/helpers/browser_bridge_setup.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_setup.py.dox.md
@@ -1,0 +1,7 @@
+# Browser setup projection
+
+Read-only public setup guidance for Browser settings. Compose the configured production extension ID with the instance `available` rollout gate; neither config nor links imply a live runtime or a published Web Store item. Return no extension link or installer when this setup gate is off.
+
+Installer links come only from the existing strict, compatible server-configured release presentation metadata. That is not cryptographic verification or an availability probe: the browser-host installer still verifies the signed catalog and selected artifact against its own publisher root before execution. Never synthesize absent OS artifacts or place the native companion inside Docker. No request-selected URL, platform override, credential, filesystem path, download, pairing, selection or install effect is accepted here.
+
+The exact `a0.browser-bridge.setup.v1` projection states `browser_control_ready: false`, `install_target: browser_host`, and `host_verification_required: true`; each installer has only platform, architecture and canonical HTTPS URL. Keep the three OS choices visible in the client even when no release exists for one of them.

--- a/plugins/_a0_connector/helpers/browser_bridge_site_authority.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_site_authority.py
@@ -1,0 +1,1494 @@
+"""Bounded site-challenge decisions and exact operation/turn origin grants.
+
+This process-owned repository derives authority only from a current broker
+operation, its exact owned lease, and an explicit protected-user decision.  It
+does not persist URLs or page text, infer decisions from natural language, or
+advertise Browser runtime readiness.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from dataclasses import dataclass, field
+import hashlib
+import json
+import re
+import threading
+import time
+from typing import Any, Awaitable, Callable
+import uuid
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    BrowserBridgeContextRoute,
+)
+from plugins._a0_connector.helpers.browser_bridge_events import (
+    SiteChallengeNotice,
+)
+from plugins._a0_connector.helpers.browser_bridge_operations import (
+    BrokerCompletion,
+    ControlTicket,
+    OperationBinding,
+    OperationTicket,
+)
+from plugins._a0_connector.helpers.browser_bridge_policy import (
+    BrowserBridgePolicyError,
+    normalize_site_origin,
+)
+from plugins._a0_connector.helpers.browser_bridge_selection import (
+    selection_current as server_selection_current,
+)
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+    require_transport_principal_identity,
+)
+
+
+SITE_AUTHORITY_CONTRACT = "a0.browser-bridge.site-authority.v1"
+SITE_AUTHORITY_VERSION = 1
+MAX_SITE_AUTHORITY_REQUEST_BYTES = 8 * 1024
+MAX_SITE_CHALLENGE_TTL_MS = 120_000
+MAX_TURN_GRANT_TTL_MS = 2 * 60 * 60 * 1_000
+MAX_SITE_CHALLENGES = 128
+MAX_SITE_DECISIONS = 128
+MAX_SITE_GRANTS = 256
+MAX_SITE_TOMBSTONES = 2_048
+MAX_SITE_SUMMARY_BYTES = 512
+DEFAULT_RESOLUTION_TIMEOUT_MS = 10_000
+
+SITE_DECISIONS = frozenset({"deny", "allow_once", "allow_turn"})
+SITE_OPTIONS = ("deny", "allow_once", "allow_turn")
+
+_NATIVE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+_CORE_ID = re.compile(r"[A-Za-z0-9_-]{1,128}")
+_DIGEST = re.compile(r"[a-f0-9]{64}")
+
+
+class BrowserBridgeSiteAuthorityError(ValueError):
+    """A site challenge, decision, or dependency value is invalid."""
+
+
+class BrowserBridgeSiteAuthorityUnavailable(RuntimeError):
+    """Exact current site authority cannot be established."""
+
+
+@dataclass(frozen=True, slots=True)
+class SiteChallenge:
+    challenge_id: str
+    server_instance_id: str
+    route: BrowserBridgeContextRoute = field(repr=False)
+    operation: OperationTicket = field(repr=False)
+    origin: str
+    canonical_parameter_hash: str
+    target_fingerprint: str
+    lease_id_digest: str = field(repr=False)
+    browser_id_digest: str = field(repr=False)
+    document_id: str | None = field(repr=False)
+    document_epoch: int = field(repr=False)
+    summary: str
+    created_at_ms: int
+    expires_at_ms: int
+    event_hash: str = field(repr=False)
+
+    def as_public_dict(self) -> dict[str, Any]:
+        return {
+            "challenge_id": self.challenge_id,
+            "origin": self.origin,
+            "action_class": "navigate",
+            "summary": self.summary,
+            "options": list(SITE_OPTIONS),
+            "expires_at_ms": self.expires_at_ms,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SiteOriginGrant:
+    origin_grant_id: str
+    server_instance_id: str = field(repr=False)
+    scope: str
+    origin: str
+    expires_at_ms: int
+    principal: WsPrincipal = field(repr=False)
+    connector_sid: str = field(repr=False)
+    load_generation_id: str = field(repr=False)
+    context_id: str = field(repr=False)
+    browser_session_id: str = field(repr=False)
+    turn_id: str = field(repr=False)
+    op_id: str | None = field(default=None, repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class SiteDecision:
+    challenge: SiteChallenge = field(repr=False)
+    decision: str
+    control_id: str
+    decided_at_ms: int
+    control_expires_at_ms: int
+    grant: SiteOriginGrant | None = field(default=None, repr=False)
+    saved_grant_id: str | None = field(default=None, repr=False)
+
+    @property
+    def challenge_id(self) -> str:
+        return self.challenge.challenge_id
+
+    def as_public_dict(self) -> dict[str, Any]:
+        return {
+            "challenge_id": self.challenge_id,
+            "decision": self.decision,
+            "control_id": self.control_id,
+            "status": "accepted",
+            "expires_at_ms": self.control_expires_at_ms,
+        }
+
+    def resolution(self) -> dict[str, Any]:
+        challenge = self.challenge
+        operation = challenge.operation
+        grant = None
+        if self.grant is not None:
+            grant = {
+                "origin_grant_id": self.grant.origin_grant_id,
+                "scope": self.grant.scope,
+                "origin": self.grant.origin,
+                # The resolve control is authority only for the currently
+                # waiting operation. Its wire grant never outlives that wait.
+                "expires_at_ms": min(
+                    self.control_expires_at_ms,
+                    self.grant.expires_at_ms,
+                ),
+            }
+        return {
+            "challenge_id": challenge.challenge_id,
+            "tab_handle": operation.target_tab_handle,
+            "document_id": challenge.document_id,
+            "document_epoch": challenge.document_epoch,
+            "canonical_parameter_hash": challenge.canonical_parameter_hash,
+            "target_fingerprint": challenge.target_fingerprint,
+            "origin": challenge.origin,
+            "action_class": "navigate",
+            "decision": self.decision,
+            "grant": grant,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SiteAuthorityInvalidationSummary:
+    challenges: int
+    decisions: int
+    grants: int
+
+
+CurrentOperation = Callable[..., OperationTicket | None]
+RemainingOperation = Callable[[OperationTicket], int]
+LeaseResolver = Callable[[Any, str], Any | None]
+RouteVerifier = Callable[[BrowserBridgeContextRoute], bool]
+TurnCurrent = Callable[[OperationBinding], bool]
+BeginResolution = Callable[..., Awaitable[ControlTicket]]
+WaitControl = Callable[[ControlTicket], Awaitable[BrokerCompletion]]
+
+
+class BrowserBridgeSiteAuthorityRepository:
+    """Register exact site challenges and mint no broader than requested."""
+
+    def __init__(
+        self,
+        *,
+        current_operation: CurrentOperation | None = None,
+        remaining_operation_ms: RemainingOperation | None = None,
+        lease_for: LeaseResolver | None = None,
+        route_verifier: RouteVerifier | None = None,
+        turn_current: TurnCurrent | None = None,
+        selection_current: Callable[[str, str], bool] | None = None,
+        saved_origin_grant: Callable[[OperationBinding, str], str | None] | None = None,
+        begin_resolution: BeginResolution | None = None,
+        wait_control: WaitControl | None = None,
+        server_instance_id: Callable[[], str] | None = None,
+        clock_ms: Callable[[], int] | None = None,
+        control_id_factory: Callable[[], str] | None = None,
+        grant_id_factory: Callable[[], str] | None = None,
+        max_challenges: int = MAX_SITE_CHALLENGES,
+        max_decisions: int = MAX_SITE_DECISIONS,
+        max_grants: int = MAX_SITE_GRANTS,
+        max_tombstones: int = MAX_SITE_TOMBSTONES,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        for value, maximum, name in (
+            (max_challenges, MAX_SITE_CHALLENGES, "challenge"),
+            (max_decisions, MAX_SITE_DECISIONS, "decision"),
+            (max_grants, MAX_SITE_GRANTS, "grant"),
+            (max_tombstones, MAX_SITE_TOMBSTONES, "tombstone"),
+        ):
+            if type(value) is not int or not 1 <= value <= maximum:
+                raise ValueError(f"invalid site {name} bound")
+        self._current_operation = current_operation or _no_operation
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        self._remaining_operation_ms = remaining_operation_ms or (
+            lambda _operation: 0
+        )
+        self._lease_for = lease_for or (lambda _binding, _handle: None)
+        self._route_verifier = route_verifier or (lambda _route: False)
+        self._turn_current = turn_current or (lambda _binding: False)
+        self._selection_current = selection_current or server_selection_current
+        self._saved_origin_grant = saved_origin_grant
+        self._begin_resolution = begin_resolution or _resolution_unavailable
+        self._wait_control = wait_control or _wait_unavailable
+        self._server_instance_id = server_instance_id or _server_unavailable
+        self._clock_ms = clock_ms or (lambda: time.time_ns() // 1_000_000)
+        self._control_id_factory = control_id_factory or (
+            lambda: uuid.uuid4().hex
+        )
+        self._grant_id_factory = grant_id_factory or (lambda: str(uuid.uuid4()))
+        self._max_challenges = max_challenges
+        self._max_decisions = max_decisions
+        self._max_grants = max_grants
+        self._max_tombstones = max_tombstones
+        self._challenges: dict[str, SiteChallenge] = {}
+        self._decisions: dict[str, SiteDecision] = {}
+        self._decision_outcomes: dict[str, str] = {}
+        self._operation_challenges: dict[tuple[Any, ...], str] = {}
+        self._operation_grants: dict[str, SiteOriginGrant] = {}
+        self._turn_grants: dict[tuple[Any, ...], SiteOriginGrant] = {}
+        self._tombstones: dict[str, str] = {}
+        self._tombstone_order: deque[str] = deque()
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._closed = False
+        self._lock = threading.RLock()
+
+    @property
+    def pending_count(self) -> int:
+        with self._lock:
+            return len(self._challenges)
+
+    @property
+    def resolution_task_count(self) -> int:
+        with self._lock:
+            return len(self._tasks)
+
+    def register_event(self, notice: SiteChallengeNotice) -> None:
+        self.register_challenge(notice)
+
+    def register_challenge(self, notice: SiteChallengeNotice) -> SiteChallenge:
+        _validate_notice(notice, self._transport_profile)
+        now = self._now()
+        event_hash = _notice_hash(notice)
+        with self._lock:
+            self._ensure_open_locked()
+            self._expire_locked(now)
+            existing = self._challenges.get(notice.challenge_id)
+            if existing is not None:
+                if existing.event_hash == event_hash and self._challenge_current(
+                    existing
+                ):
+                    return existing
+                self._invalidate_challenge_locked(existing, "mismatch")
+                raise BrowserBridgeSiteAuthorityUnavailable(
+                    "site challenge mismatch"
+                )
+            decision = self._decisions.get(notice.challenge_id)
+            if decision is not None:
+                if (
+                    decision.challenge.event_hash == event_hash
+                    and self._challenge_current(decision.challenge)
+                ):
+                    return decision.challenge
+                raise BrowserBridgeSiteAuthorityUnavailable(
+                    "site challenge is terminal"
+                )
+            if notice.challenge_id in self._tombstones:
+                raise BrowserBridgeSiteAuthorityUnavailable(
+                    "site challenge is terminal"
+                )
+            if len(self._challenges) >= self._max_challenges:
+                raise BrowserBridgeSiteAuthorityUnavailable(
+                    "site challenge limit reached"
+                )
+            operation, remaining = self._resolve_notice(notice)
+            if notice.expires_at_ms <= now or (
+                notice.expires_at_ms - now > MAX_SITE_CHALLENGE_TTL_MS
+            ):
+                raise BrowserBridgeSiteAuthorityUnavailable(
+                    "site challenge expired"
+                )
+            operation_key = _operation_key(operation)
+            if operation_key in self._operation_challenges:
+                raise BrowserBridgeSiteAuthorityUnavailable(
+                    "operation already has a site challenge"
+                )
+            expires_at_ms = min(notice.expires_at_ms, now + remaining)
+            if expires_at_ms <= now:
+                raise BrowserBridgeSiteAuthorityUnavailable(
+                    "site challenge expired"
+                )
+            challenge = SiteChallenge(
+                challenge_id=notice.challenge_id,
+                server_instance_id=self._server_id(),
+                route=BrowserBridgeContextRoute(
+                    notice.principal,
+                    notice.connector_sid,
+                    notice.load_generation_id,
+                    self._transport_profile,
+                ),
+                operation=operation,
+                origin=notice.origin,
+                canonical_parameter_hash=notice.canonical_parameter_hash,
+                target_fingerprint=notice.target_fingerprint,
+                lease_id_digest=notice.lease_id_digest,
+                browser_id_digest=notice.browser_id_digest,
+                document_id=notice.document_id,
+                document_epoch=notice.document_epoch,
+                summary=_safe_summary(notice.origin),
+                created_at_ms=now,
+                expires_at_ms=expires_at_ms,
+                event_hash=event_hash,
+            )
+            self._challenges[challenge.challenge_id] = challenge
+            self._operation_challenges[operation_key] = challenge.challenge_id
+            grant = self._turn_grant_locked(
+                operation.binding, challenge.origin, now
+            )
+            saved_grant = self._saved_grant_for(challenge)
+            if grant is not None:
+                self._start_decision_locked(
+                    challenge,
+                    "allow_turn",
+                    now=now,
+                    grant=grant,
+                )
+            elif saved_grant is not None:
+                self._start_decision_locked(challenge, "allow_once", now=now,
+                    saved_grant_id=saved_grant)
+            return challenge
+
+    def list_pending(
+        self,
+        *,
+        subject_id: Any,
+        context_id: Any | None = None,
+        bridge_id: Any | None = None,
+    ) -> tuple[dict[str, Any], ...]:
+        subject = _identifier(subject_id, "subject_id")
+        context, bridge = _list_scope(context_id, bridge_id)
+        now = self._now()
+        with self._lock:
+            self._ensure_open_locked()
+            self._expire_locked(now)
+            result: list[dict[str, Any]] = []
+            for challenge in tuple(self._challenges.values()):
+                if challenge.route.principal.subject_id != subject:
+                    continue
+                binding = challenge.operation.binding
+                if context is not None and (
+                    binding.context_id != context or binding.bridge_id != bridge
+                ):
+                    continue
+                if not self._challenge_current(challenge):
+                    self._invalidate_challenge_locked(challenge, "invalidated")
+                    continue
+                result.append(challenge.as_public_dict())
+            result.sort(key=lambda item: (item["expires_at_ms"], item["challenge_id"]))
+            return tuple(result)
+
+    async def decide(
+        self,
+        *,
+        subject_id: Any,
+        challenge_id: Any,
+        decision: Any,
+        expected_route: BrowserBridgeContextRoute | None = None,
+    ) -> SiteDecision:
+        subject = _identifier(subject_id, "subject_id")
+        challenge_key = _identifier(challenge_id, "challenge_id")
+        if not isinstance(decision, str) or decision not in SITE_DECISIONS:
+            raise BrowserBridgeSiteAuthorityError("invalid site decision")
+        now = self._now()
+        with self._lock:
+            self._ensure_open_locked()
+            self._expire_locked(now)
+            existing = self._decisions.get(challenge_key)
+            retained = existing.challenge if existing is not None else self._challenges.get(challenge_key)
+            if expected_route is not None and (
+                retained is None
+                or retained.route.principal is not expected_route.principal
+                or retained.route.connector_sid != expected_route.connector_sid
+                or retained.route.load_generation_id != expected_route.load_generation_id
+                or retained.route.transport_profile is not expected_route.transport_profile
+                or not self._challenge_current(retained)
+            ):
+                raise BrowserBridgeSiteAuthorityUnavailable("site challenge unavailable")
+            if existing is not None:
+                if (
+                    existing.challenge.route.principal.subject_id == subject
+                    and existing.decision == decision
+                    and self._selected(existing.challenge.operation.binding)
+                ):
+                    return existing
+                raise BrowserBridgeSiteAuthorityUnavailable(
+                    "site challenge already decided"
+                )
+            challenge = self._challenges.get(challenge_key)
+            if (
+                challenge is None
+                or challenge.route.principal.subject_id != subject
+                or not self._challenge_current(challenge)
+            ):
+                if challenge is not None:
+                    self._invalidate_challenge_locked(challenge, "invalidated")
+                raise BrowserBridgeSiteAuthorityUnavailable(
+                    "site challenge unavailable"
+                )
+            return self._start_decision_locked(
+                challenge,
+                decision,
+                now=now,
+            )
+
+    def turn_grant_for(
+        self,
+        binding: OperationBinding,
+        *,
+        origin: Any,
+    ) -> SiteOriginGrant | None:
+        """Return only a current exact-turn grant before dispatching a new op."""
+
+        if not isinstance(binding, OperationBinding):
+            raise BrowserBridgeSiteAuthorityError("invalid browser operation binding")
+        try:
+            canonical_origin = normalize_site_origin(origin)
+        except BrowserBridgePolicyError as error:
+            raise BrowserBridgeSiteAuthorityError("invalid site origin") from error
+        now = self._now()
+        with self._lock:
+            self._ensure_open_locked()
+            self._expire_locked(now)
+            return self._turn_grant_locked(binding, canonical_origin, now)
+
+    def grant_for_operation(
+        self,
+        operation: OperationTicket,
+        *,
+        origin: Any,
+    ) -> SiteOriginGrant | None:
+        if not isinstance(operation, OperationTicket):
+            raise BrowserBridgeSiteAuthorityError("invalid browser operation")
+        try:
+            canonical_origin = normalize_site_origin(origin)
+        except BrowserBridgePolicyError as error:
+            raise BrowserBridgeSiteAuthorityError("invalid site origin") from error
+        try:
+            server_id = self._server_id()
+        except BrowserBridgeSiteAuthorityUnavailable:
+            return None
+        now = self._now()
+        with self._lock:
+            self._ensure_open_locked()
+            self._expire_locked(now)
+            selected = self._selected(operation.binding)
+            if (
+                not selected
+                or self._current_ticket(operation) is not operation
+                or operation.action != "navigate"
+                or operation.destination_origin != canonical_origin
+            ):
+                if not selected:
+                    self._operation_grants = {
+                        challenge_id: grant
+                        for challenge_id, grant in self._operation_grants.items()
+                        if grant.op_id != operation.binding.op_id
+                    }
+                    self._turn_grants.pop(
+                        _turn_binding_key(operation.binding, canonical_origin),
+                        None,
+                    )
+                return None
+            for challenge_id, grant in tuple(self._operation_grants.items()):
+                decision = self._decisions.get(challenge_id)
+                if decision is None:
+                    self._operation_grants.pop(challenge_id, None)
+                    continue
+                if (
+                    decision.challenge.operation is operation
+                    and grant.server_instance_id == server_id
+                    and grant.origin == canonical_origin
+                    and grant.expires_at_ms > now
+                    and self._decision_outcomes.get(challenge_id) == "resolved"
+                ):
+                    return grant
+            return self._turn_grant_locked(
+                operation.binding,
+                canonical_origin,
+                now,
+                server_id=server_id,
+            )
+
+    def cancel_operation(
+        self, operation: OperationTicket
+    ) -> SiteAuthorityInvalidationSummary:
+        if not isinstance(operation, OperationTicket):
+            raise BrowserBridgeSiteAuthorityError("invalid browser operation")
+        return self._invalidate_matching(
+            lambda challenge: challenge.operation is operation,
+            lambda grant: grant.op_id == operation.binding.op_id,
+        )
+
+    def finalize_turn(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: Any,
+        load_generation_id: Any,
+        context_id: Any,
+        browser_session_id: Any,
+        turn_id: Any,
+    ) -> SiteAuthorityInvalidationSummary:
+        values = _lifecycle_values(
+            principal,
+            connector_sid,
+            load_generation_id,
+            context_id,
+            browser_session_id,
+            turn_id,
+        )
+        return self._invalidate_matching(
+            lambda challenge: _challenge_turn(challenge) == values,
+            lambda grant: _grant_turn(grant) == values,
+        )
+
+    def disconnect(
+        self,
+        *,
+        principal: WsPrincipal,
+        connector_sid: Any,
+        load_generation_id: Any,
+    ) -> SiteAuthorityInvalidationSummary:
+        if not isinstance(principal, WsPrincipal):
+            raise BrowserBridgeSiteAuthorityError("invalid bridge principal")
+        sid = _identifier(connector_sid, "connector_sid")
+        generation = _identifier(load_generation_id, "load_generation_id")
+        return self._invalidate_matching(
+            lambda challenge: (
+                challenge.route.principal is principal
+                and challenge.route.connector_sid == sid
+                and challenge.route.load_generation_id == generation
+            ),
+            lambda grant: (
+                grant.principal is principal
+                and grant.connector_sid == sid
+                and grant.load_generation_id == generation
+            ),
+        )
+
+    def finalize_context(
+        self, *, context_id: Any
+    ) -> SiteAuthorityInvalidationSummary:
+        """Withdraw only pending/turn authority owned by one context."""
+
+        context = _identifier(context_id, "context_id")
+        return self._invalidate_matching(
+            lambda challenge: challenge.operation.binding.context_id == context,
+            lambda grant: grant.context_id == context,
+        )
+
+    def revoke_bridge(
+        self,
+        *,
+        server_instance_id: Any,
+        bridge_id: Any,
+        subject_id: Any,
+    ) -> SiteAuthorityInvalidationSummary:
+        server = _identifier(server_instance_id, "server_instance_id")
+        bridge = _identifier(bridge_id, "bridge_id")
+        subject = _identifier(subject_id, "subject_id")
+        return self._invalidate_matching(
+            lambda challenge: (
+                challenge.server_instance_id == server
+                and challenge.route.principal.principal_id == bridge
+                and challenge.route.principal.subject_id == subject
+            ),
+            lambda grant: (
+                grant.server_instance_id == server
+                and grant.principal.principal_id == bridge
+                and grant.principal.subject_id == subject
+            ),
+        )
+
+    def expire(
+        self, now_ms: int | None = None
+    ) -> SiteAuthorityInvalidationSummary:
+        now = self._now() if now_ms is None else _timestamp(now_ms)
+        with self._lock:
+            return self._expire_locked(now)
+
+    async def close(self) -> SiteAuthorityInvalidationSummary:
+        with self._lock:
+            if self._closed:
+                return SiteAuthorityInvalidationSummary(0, 0, 0)
+            self._closed = True
+            summary = self._invalidate_all_locked("closed")
+            tasks = tuple(self._tasks.values())
+            self._tasks.clear()
+            for task in tasks:
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        return summary
+
+    async def _resolve_decision(self, decision: SiteDecision) -> None:
+        try:
+            timeout_ms = min(
+                DEFAULT_RESOLUTION_TIMEOUT_MS,
+                self._remaining(decision.challenge.operation),
+                max(0, decision.control_expires_at_ms - self._now()),
+            )
+            if timeout_ms <= 0:
+                raise BrowserBridgeSiteAuthorityUnavailable(
+                    "site resolution expired"
+                )
+            ticket = await self._begin_resolution(
+                decision.challenge.operation,
+                control_id=decision.control_id,
+                resolution=decision.resolution(),
+                authorization_current=lambda: self._decision_current(decision),
+                timeout_ms=timeout_ms,
+            )
+            if not isinstance(ticket, ControlTicket):
+                raise BrowserBridgeSiteAuthorityUnavailable(
+                    "site resolution unavailable"
+                )
+            completion = await self._wait_control(ticket)
+            if not _matching_completion(decision, completion):
+                raise BrowserBridgeSiteAuthorityUnavailable(
+                    "site resolution failed"
+                )
+            with self._lock:
+                if not self._decision_current_locked(decision):
+                    return
+                self._decision_outcomes[decision.challenge_id] = "resolved"
+                if decision.grant is not None:
+                    if self._grant_count_locked() >= self._max_grants:
+                        self._decision_outcomes[decision.challenge_id] = "failed"
+                        return
+                    if decision.grant.scope == "operation":
+                        self._operation_grants[
+                            decision.challenge_id
+                        ] = decision.grant
+                    else:
+                        self._turn_grants[
+                            _grant_key(decision.grant)
+                        ] = decision.grant
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            with self._lock:
+                if self._decisions.get(decision.challenge_id) is decision:
+                    self._decision_outcomes[decision.challenge_id] = "failed"
+
+    def _start_decision_locked(
+        self,
+        challenge: SiteChallenge,
+        decision: str,
+        *,
+        now: int,
+        grant: SiteOriginGrant | None = None,
+        saved_grant_id: str | None = None,
+    ) -> SiteDecision:
+        if len(self._decisions) >= self._max_decisions:
+            raise BrowserBridgeSiteAuthorityUnavailable(
+                "site decision limit reached"
+            )
+        remaining = self._remaining(challenge.operation)
+        control_expires_at_ms = min(
+            challenge.expires_at_ms,
+            now + remaining,
+        )
+        if control_expires_at_ms <= now:
+            self._invalidate_challenge_locked(challenge, "expired")
+            raise BrowserBridgeSiteAuthorityUnavailable(
+                "site challenge expired"
+            )
+        control_id = self._fresh_id(
+            self._control_id_factory, "control_id", core=True
+        )
+        if grant is None:
+            grant = self._grant_for_decision(
+                challenge,
+                decision,
+                now=now,
+                control_expires_at_ms=control_expires_at_ms,
+            )
+        result = SiteDecision(
+            challenge=challenge,
+            decision=decision,
+            control_id=control_id,
+            decided_at_ms=now,
+            control_expires_at_ms=control_expires_at_ms,
+            grant=grant,
+            saved_grant_id=saved_grant_id,
+        )
+        self._challenges.pop(challenge.challenge_id, None)
+        self._decisions[challenge.challenge_id] = result
+        self._decision_outcomes[challenge.challenge_id] = "resolving"
+        task = asyncio.create_task(
+            self._resolve_decision(result),
+            name=f"browser-bridge-site:{challenge.challenge_id}",
+        )
+        self._tasks[challenge.challenge_id] = task
+        task.add_done_callback(self._resolution_finished)
+        return result
+
+    def _turn_grant_locked(
+        self,
+        binding: OperationBinding,
+        origin: str,
+        now: int,
+        *,
+        server_id: str | None = None,
+    ) -> SiteOriginGrant | None:
+        if not _operation_binding_valid(binding, self._transport_profile):
+            return None
+        try:
+            current_server = server_id or self._server_id()
+            route = BrowserBridgeContextRoute(
+                binding.principal,
+                binding.connector_sid,
+                binding.load_generation_id,
+                self._transport_profile,
+            )
+            current_turn = self._turn_current(binding) is True
+            selected = self._selected(binding)
+        except Exception:
+            return None
+        grant_key = _turn_binding_key(binding, origin)
+        if not selected:
+            self._turn_grants.pop(grant_key, None)
+            return None
+        if (
+            not current_turn
+            or not self._route_current(route)
+        ):
+            return None
+        grant = self._turn_grants.get(grant_key)
+        if (
+            grant is None
+            or grant.server_instance_id != current_server
+            or grant.principal is not binding.principal
+            or grant.connector_sid != binding.connector_sid
+            or grant.load_generation_id != binding.load_generation_id
+            or grant.context_id != binding.context_id
+            or grant.browser_session_id != binding.browser_session_id
+            or grant.turn_id != binding.turn_id
+            or grant.origin != origin
+            or grant.expires_at_ms <= now
+        ):
+            return None
+        return grant
+
+    def _resolution_finished(self, task: asyncio.Task[None]) -> None:
+        with self._lock:
+            for challenge_id, current in tuple(self._tasks.items()):
+                if current is task:
+                    self._tasks.pop(challenge_id, None)
+                    break
+        try:
+            task.exception()
+        except asyncio.CancelledError:
+            pass
+
+    def _resolve_notice(
+        self, notice: SiteChallengeNotice
+    ) -> tuple[OperationTicket, int]:
+        route = BrowserBridgeContextRoute(
+            notice.principal,
+            notice.connector_sid,
+            notice.load_generation_id,
+            self._transport_profile,
+        )
+        if not self._route_current(route):
+            raise BrowserBridgeSiteAuthorityUnavailable("site route unavailable")
+        operation = self._lookup_operation(notice)
+        if not isinstance(operation, OperationTicket):
+            raise BrowserBridgeSiteAuthorityUnavailable(
+                "site operation unavailable"
+            )
+        binding = operation.binding
+        if (
+            binding.principal is not notice.principal
+            or binding.connector_sid != notice.connector_sid
+            or binding.load_generation_id != notice.load_generation_id
+            or binding.context_id != notice.context_id
+            or binding.browser_session_id != notice.browser_session_id
+            or binding.turn_id != notice.turn_id
+            or binding.action_id != notice.action_id
+            or binding.op_id != notice.op_id
+            or operation.action != "navigate"
+            or not operation.target_tab_handle
+            or operation.canonical_parameter_hash
+            != notice.canonical_parameter_hash
+            or operation.destination_origin != notice.origin
+            or _target_fingerprint(notice) != notice.target_fingerprint
+            or not self._selected(binding)
+        ):
+            raise BrowserBridgeSiteAuthorityUnavailable(
+                "site operation mismatch"
+            )
+        remaining = self._remaining(operation)
+        if remaining <= 0:
+            raise BrowserBridgeSiteAuthorityUnavailable(
+                "site operation expired"
+            )
+        lease = self._lease_for(binding, operation.target_tab_handle)
+        if (
+            lease is None
+            or getattr(lease, "tab_handle", None) != operation.target_tab_handle
+            or _hash_identifier(getattr(lease, "lease_id", None))
+            != notice.lease_id_digest
+            or _hash_identifier(getattr(lease, "tab_handle", None))
+            != notice.browser_id_digest
+        ):
+            raise BrowserBridgeSiteAuthorityUnavailable("site lease mismatch")
+        return operation, remaining
+
+    def _challenge_current(self, challenge: SiteChallenge) -> bool:
+        try:
+            if self._server_id() != challenge.server_instance_id:
+                return False
+            route = challenge.route
+            if (
+                not self._route_current(route)
+                or not self._selected(challenge.operation.binding)
+            ):
+                return False
+            operation = self._current_ticket(challenge.operation)
+            if operation is not challenge.operation or self._remaining(operation) <= 0:
+                return False
+            lease = self._lease_for(
+                operation.binding, operation.target_tab_handle
+            )
+            return bool(
+                lease is not None
+                and getattr(lease, "tab_handle", None)
+                == operation.target_tab_handle
+                and _hash_identifier(getattr(lease, "lease_id", None))
+                == challenge.lease_id_digest
+                and _hash_identifier(getattr(lease, "tab_handle", None))
+                == challenge.browser_id_digest
+            )
+        except Exception:
+            return False
+
+    def _selected(self, binding: OperationBinding) -> bool:
+        try:
+            return self._selection_current(
+                binding.context_id, binding.bridge_id
+            ) is True
+        except Exception:
+            return False
+
+    def _decision_current(self, decision: SiteDecision) -> bool:
+        with self._lock:
+            return self._decision_current_locked(decision)
+
+    def _decision_current_locked(self, decision: SiteDecision) -> bool:
+        now = self._now()
+        return bool(
+            not self._closed
+            and self._decisions.get(decision.challenge_id) is decision
+            and self._decision_outcomes.get(decision.challenge_id)
+            == "resolving"
+            and now < decision.control_expires_at_ms
+            and (
+                decision.grant is None
+                or now < decision.grant.expires_at_ms
+            )
+            and self._challenge_current(decision.challenge)
+            and (decision.saved_grant_id is None or self._saved_grant_for(decision.challenge) == decision.saved_grant_id)
+        )
+
+    def _saved_grant_for(self, challenge: SiteChallenge) -> str | None:
+        if self._transport_profile is not PRODUCTION_BROWSER_BRIDGE_TRANSPORT or self._saved_origin_grant is None:
+            return None
+        try:
+            value = self._saved_origin_grant(challenge.operation.binding, challenge.origin)
+            return _identifier(value, "grant_id") if value is not None else None
+        except Exception:
+            return None
+
+    def _lookup_operation(
+        self, notice: SiteChallengeNotice
+    ) -> OperationTicket | None:
+        try:
+            return self._current_operation(
+                principal=notice.principal,
+                connector_sid=notice.connector_sid,
+                load_generation_id=notice.load_generation_id,
+                op_id=notice.op_id,
+            )
+        except Exception:
+            return None
+
+    def _current_ticket(
+        self, operation: OperationTicket
+    ) -> OperationTicket | None:
+        binding = operation.binding
+        try:
+            return self._current_operation(
+                principal=binding.principal,
+                connector_sid=binding.connector_sid,
+                load_generation_id=binding.load_generation_id,
+                op_id=binding.op_id,
+            )
+        except Exception:
+            return None
+
+    def _remaining(self, operation: OperationTicket) -> int:
+        try:
+            value = self._remaining_operation_ms(operation)
+        except Exception:
+            return 0
+        if type(value) is not int or not 0 <= value <= MAX_SITE_CHALLENGE_TTL_MS:
+            return 0
+        return value
+
+    def _route_current(self, route: BrowserBridgeContextRoute) -> bool:
+        try:
+            return self._route_verifier(route) is True
+        except Exception:
+            return False
+
+    def _server_id(self) -> str:
+        try:
+            return _identifier(self._server_instance_id(), "server_instance_id")
+        except Exception:
+            raise BrowserBridgeSiteAuthorityUnavailable(
+                "site server unavailable"
+            ) from None
+
+    def _grant_for_decision(
+        self,
+        challenge: SiteChallenge,
+        decision: str,
+        *,
+        now: int,
+        control_expires_at_ms: int,
+    ) -> SiteOriginGrant | None:
+        if decision == "deny":
+            return None
+        grant_id = self._fresh_id(
+            self._grant_id_factory, "origin_grant_id", core=False
+        )
+        binding = challenge.operation.binding
+        scope = "operation" if decision == "allow_once" else "turn"
+        expires_at_ms = (
+            control_expires_at_ms
+            if scope == "operation"
+            else now + MAX_TURN_GRANT_TTL_MS
+        )
+        return SiteOriginGrant(
+            origin_grant_id=grant_id,
+            server_instance_id=challenge.server_instance_id,
+            scope=scope,
+            origin=challenge.origin,
+            expires_at_ms=expires_at_ms,
+            principal=binding.principal,
+            connector_sid=binding.connector_sid,
+            load_generation_id=binding.load_generation_id,
+            context_id=binding.context_id,
+            browser_session_id=binding.browser_session_id,
+            turn_id=binding.turn_id,
+            op_id=binding.op_id if scope == "operation" else None,
+        )
+
+    def _fresh_id(
+        self,
+        factory: Callable[[], str],
+        field: str,
+        *,
+        core: bool,
+    ) -> str:
+        try:
+            value = _core_identifier(factory(), field) if core else _identifier(
+                factory(), field
+            )
+        except Exception:
+            raise BrowserBridgeSiteAuthorityUnavailable(
+                "site identity unavailable"
+            ) from None
+        used = {
+            decision.control_id for decision in self._decisions.values()
+        } | {
+            decision.grant.origin_grant_id
+            for decision in self._decisions.values()
+            if decision.grant is not None
+        } | {
+            grant.origin_grant_id
+            for grant in self._operation_grants.values()
+        } | {
+            grant.origin_grant_id for grant in self._turn_grants.values()
+        }
+        if value in used:
+            raise BrowserBridgeSiteAuthorityUnavailable(
+                "site identity collision"
+            )
+        return value
+
+    def _invalidate_matching(
+        self,
+        challenge_match: Callable[[SiteChallenge], bool],
+        grant_match: Callable[[SiteOriginGrant], bool],
+    ) -> SiteAuthorityInvalidationSummary:
+        with self._lock:
+            challenges = [
+                challenge
+                for challenge in self._challenges.values()
+                if challenge_match(challenge)
+            ]
+            decisions = [
+                decision
+                for decision in self._decisions.values()
+                if challenge_match(decision.challenge)
+            ]
+            for challenge in challenges:
+                self._invalidate_challenge_locked(challenge, "invalidated")
+            for decision in decisions:
+                self._invalidate_decision_locked(decision, "invalidated")
+            before = self._grant_count_locked()
+            self._operation_grants = {
+                key: grant
+                for key, grant in self._operation_grants.items()
+                if not grant_match(grant)
+            }
+            self._turn_grants = {
+                key: grant
+                for key, grant in self._turn_grants.items()
+                if not grant_match(grant)
+            }
+            return SiteAuthorityInvalidationSummary(
+                len(challenges), len(decisions), before - self._grant_count_locked()
+            )
+
+    def _expire_locked(self, now: int) -> SiteAuthorityInvalidationSummary:
+        challenges = [
+            challenge
+            for challenge in self._challenges.values()
+            if challenge.expires_at_ms <= now
+        ]
+        decisions = [
+            decision
+            for decision in self._decisions.values()
+            if decision.control_expires_at_ms <= now
+        ]
+        for challenge in challenges:
+            self._invalidate_challenge_locked(challenge, "expired")
+        for decision in decisions:
+            self._invalidate_decision_locked(decision, "expired")
+        before = self._grant_count_locked()
+        self._operation_grants = {
+            key: grant
+            for key, grant in self._operation_grants.items()
+            if grant.expires_at_ms > now
+        }
+        self._turn_grants = {
+            key: grant
+            for key, grant in self._turn_grants.items()
+            if grant.expires_at_ms > now
+        }
+        return SiteAuthorityInvalidationSummary(
+            len(challenges), len(decisions), before - self._grant_count_locked()
+        )
+
+    def _invalidate_challenge_locked(
+        self, challenge: SiteChallenge, reason: str
+    ) -> None:
+        if self._challenges.get(challenge.challenge_id) is not challenge:
+            return
+        self._challenges.pop(challenge.challenge_id, None)
+        self._operation_challenges.pop(_operation_key(challenge.operation), None)
+        self._remember_locked(challenge.challenge_id, reason)
+
+    def _invalidate_decision_locked(
+        self, decision: SiteDecision, reason: str
+    ) -> None:
+        if self._decisions.get(decision.challenge_id) is not decision:
+            return
+        self._decisions.pop(decision.challenge_id, None)
+        self._decision_outcomes.pop(decision.challenge_id, None)
+        self._operation_grants.pop(decision.challenge_id, None)
+        self._operation_challenges.pop(
+            _operation_key(decision.challenge.operation), None
+        )
+        self._remember_locked(decision.challenge_id, reason)
+
+    def _invalidate_all_locked(
+        self, reason: str
+    ) -> SiteAuthorityInvalidationSummary:
+        challenges = tuple(self._challenges.values())
+        decisions = tuple(self._decisions.values())
+        grants = self._grant_count_locked()
+        for challenge in challenges:
+            self._invalidate_challenge_locked(challenge, reason)
+        for decision in decisions:
+            self._invalidate_decision_locked(decision, reason)
+        self._operation_grants.clear()
+        self._turn_grants.clear()
+        return SiteAuthorityInvalidationSummary(
+            len(challenges), len(decisions), grants
+        )
+
+    def _remember_locked(self, challenge_id: str, reason: str) -> None:
+        if challenge_id in self._tombstones:
+            return
+        self._tombstones[challenge_id] = reason
+        self._tombstone_order.append(challenge_id)
+        while len(self._tombstone_order) > self._max_tombstones:
+            self._tombstones.pop(self._tombstone_order.popleft(), None)
+
+    def _grant_count_locked(self) -> int:
+        return len(self._operation_grants) + len(self._turn_grants)
+
+    def _ensure_open_locked(self) -> None:
+        if self._closed:
+            raise BrowserBridgeSiteAuthorityUnavailable(
+                "site authority closed"
+            )
+
+    def _now(self) -> int:
+        return _timestamp(self._clock_ms())
+
+
+def _matching_completion(
+    decision: SiteDecision, completion: BrokerCompletion
+) -> bool:
+    return bool(
+        isinstance(completion, BrokerCompletion)
+        and completion.ok is True
+        and completion.result
+        == {
+            "contract_version": SITE_AUTHORITY_VERSION,
+            "control_id": decision.control_id,
+            "challenge_id": decision.challenge_id,
+            "status": "resolved",
+            "decision": decision.decision,
+        }
+    )
+
+
+def _operation_key(operation: OperationTicket) -> tuple[Any, ...]:
+    binding = operation.binding
+    return (
+        id(binding.principal),
+        binding.connector_sid,
+        binding.load_generation_id,
+        binding.context_id,
+        binding.browser_session_id,
+        binding.turn_id,
+        binding.action_id,
+        binding.op_id,
+    )
+
+
+def _turn_key(operation: OperationTicket, origin: str) -> tuple[Any, ...]:
+    return _turn_binding_key(operation.binding, origin)
+
+
+def _turn_binding_key(
+    binding: OperationBinding, origin: str
+) -> tuple[Any, ...]:
+    return (
+        id(binding.principal),
+        binding.connector_sid,
+        binding.load_generation_id,
+        binding.context_id,
+        binding.browser_session_id,
+        binding.turn_id,
+        origin,
+    )
+
+
+def _operation_binding_valid(
+    binding: OperationBinding,
+    transport_profile: BrowserBridgeTransportProfile,
+) -> bool:
+    principal = binding.principal
+    try:
+        require_transport_principal_identity(principal, transport_profile)
+    except ValueError:
+        return False
+    if (
+        not {"browser.operate", "browser.control", "browser.approval"}
+        <= principal.scopes
+    ):
+        return False
+    try:
+        for field in (
+            "connector_sid",
+            "load_generation_id",
+            "context_id",
+            "browser_session_id",
+            "turn_id",
+            "action_id",
+            "op_id",
+        ):
+            _identifier(getattr(binding, field), field)
+    except BrowserBridgeSiteAuthorityError:
+        return False
+    return True
+
+
+def _grant_key(grant: SiteOriginGrant) -> tuple[Any, ...]:
+    return (
+        id(grant.principal),
+        grant.connector_sid,
+        grant.load_generation_id,
+        grant.context_id,
+        grant.browser_session_id,
+        grant.turn_id,
+        grant.origin,
+    )
+
+
+def _challenge_turn(challenge: SiteChallenge) -> tuple[Any, ...]:
+    binding = challenge.operation.binding
+    return (
+        id(binding.principal),
+        binding.connector_sid,
+        binding.load_generation_id,
+        binding.context_id,
+        binding.browser_session_id,
+        binding.turn_id,
+    )
+
+
+def _grant_turn(grant: SiteOriginGrant) -> tuple[Any, ...]:
+    return (
+        id(grant.principal),
+        grant.connector_sid,
+        grant.load_generation_id,
+        grant.context_id,
+        grant.browser_session_id,
+        grant.turn_id,
+    )
+
+
+def _lifecycle_values(
+    principal: WsPrincipal,
+    connector_sid: Any,
+    load_generation_id: Any,
+    context_id: Any,
+    browser_session_id: Any,
+    turn_id: Any,
+) -> tuple[Any, ...]:
+    if not isinstance(principal, WsPrincipal):
+        raise BrowserBridgeSiteAuthorityError("invalid bridge principal")
+    return (
+        id(principal),
+        _identifier(connector_sid, "connector_sid"),
+        _identifier(load_generation_id, "load_generation_id"),
+        _identifier(context_id, "context_id"),
+        _identifier(browser_session_id, "browser_session_id"),
+        _identifier(turn_id, "turn_id"),
+    )
+
+
+def _notice_hash(notice: SiteChallengeNotice) -> str:
+    values = (
+        id(notice.principal),
+        notice.connector_sid,
+        notice.load_generation_id,
+        notice.context_id,
+        notice.browser_session_id,
+        notice.turn_id,
+        notice.action_id,
+        notice.op_id,
+        notice.challenge_id,
+        notice.origin,
+        notice.canonical_parameter_hash,
+        notice.target_fingerprint,
+        notice.lease_id_digest,
+        notice.browser_id_digest,
+        notice.document_id,
+        notice.document_epoch,
+        hashlib.sha256(_utf8(notice.summary)).hexdigest(),
+        notice.expires_at_ms,
+    )
+    return hashlib.sha256(repr(values).encode("utf-8")).hexdigest()
+
+
+def _validate_notice(
+    notice: Any,
+    transport_profile: BrowserBridgeTransportProfile,
+) -> SiteChallengeNotice:
+    if not isinstance(notice, SiteChallengeNotice):
+        raise BrowserBridgeSiteAuthorityError("invalid site challenge")
+    principal = notice.principal
+    try:
+        require_transport_principal_identity(principal, transport_profile)
+    except ValueError:
+        raise BrowserBridgeSiteAuthorityError("invalid bridge principal") from None
+    if (
+        not {"browser.operate", "browser.control", "browser.approval"}
+        <= principal.scopes
+    ):
+        raise BrowserBridgeSiteAuthorityError("invalid bridge principal")
+    for field in (
+        "connector_sid",
+        "load_generation_id",
+        "context_id",
+        "browser_session_id",
+        "turn_id",
+        "action_id",
+        "op_id",
+        "challenge_id",
+    ):
+        _identifier(getattr(notice, field), field)
+    if notice.document_id is not None:
+        _identifier(notice.document_id, "document_id")
+    for field in (
+        "canonical_parameter_hash",
+        "target_fingerprint",
+        "lease_id_digest",
+        "browser_id_digest",
+    ):
+        value = getattr(notice, field)
+        if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+            raise BrowserBridgeSiteAuthorityError(f"invalid {field}")
+    try:
+        origin = normalize_site_origin(notice.origin)
+    except BrowserBridgePolicyError as error:
+        raise BrowserBridgeSiteAuthorityError("invalid site origin") from error
+    if origin != notice.origin:
+        raise BrowserBridgeSiteAuthorityError("invalid site origin")
+    if (
+        not isinstance(notice.summary, str)
+        or not notice.summary
+        or not notice.summary.isprintable()
+        or len(_utf8(notice.summary)) > MAX_SITE_SUMMARY_BYTES
+        or isinstance(notice.document_epoch, bool)
+        or not isinstance(notice.document_epoch, int)
+        or not 0 <= notice.document_epoch <= 2**53 - 1
+    ):
+        raise BrowserBridgeSiteAuthorityError("invalid site challenge")
+    _timestamp(notice.expires_at_ms)
+    return notice
+
+
+def _hash_identifier(value: Any) -> str | None:
+    if not isinstance(value, str) or _NATIVE_ID.fullmatch(value) is None:
+        return None
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _target_fingerprint(notice: SiteChallengeNotice) -> str:
+    value = {
+        "action_class": "navigate",
+        "browser_id_digest": notice.browser_id_digest,
+        "document_epoch": notice.document_epoch,
+        "document_id": notice.document_id,
+        "lease_id_digest": notice.lease_id_digest,
+        "load_generation_id": notice.load_generation_id,
+        "origin": notice.origin,
+    }
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _safe_summary(origin: str) -> str:
+    value = f"Allow navigation to {origin}?"
+    if len(_utf8(value)) > MAX_SITE_SUMMARY_BYTES:
+        raise BrowserBridgeSiteAuthorityUnavailable("site summary unavailable")
+    return value
+
+
+def _utf8(value: str) -> bytes:
+    try:
+        return value.encode("utf-8")
+    except UnicodeError:
+        raise BrowserBridgeSiteAuthorityError("invalid site text") from None
+
+
+def _identifier(value: Any, field: str) -> str:
+    if not isinstance(value, str) or _NATIVE_ID.fullmatch(value) is None:
+        raise BrowserBridgeSiteAuthorityError(f"invalid {field}")
+    return value
+
+
+def _list_scope(
+    context_id: Any | None, bridge_id: Any | None
+) -> tuple[str | None, str | None]:
+    if context_id is None and bridge_id is None:
+        return None, None
+    if context_id is None or bridge_id is None:
+        raise BrowserBridgeSiteAuthorityError("incomplete site list scope")
+    return (
+        _identifier(context_id, "context_id"),
+        _identifier(bridge_id, "bridge_id"),
+    )
+
+
+def _core_identifier(value: Any, field: str) -> str:
+    if not isinstance(value, str) or _CORE_ID.fullmatch(value) is None:
+        raise BrowserBridgeSiteAuthorityError(f"invalid {field}")
+    return value
+
+
+def _timestamp(value: Any) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= 2**53 - 1
+    ):
+        raise BrowserBridgeSiteAuthorityUnavailable(
+            "site authority clock unavailable"
+        )
+    return value
+
+
+def _no_operation(**_kwargs: Any) -> None:
+    return None
+
+
+async def _resolution_unavailable(*_args: Any, **_kwargs: Any) -> ControlTicket:
+    raise BrowserBridgeSiteAuthorityUnavailable("site resolution unavailable")
+
+
+async def _wait_unavailable(_ticket: ControlTicket) -> BrokerCompletion:
+    raise BrowserBridgeSiteAuthorityUnavailable("site resolution unavailable")
+
+
+def _server_unavailable() -> str:
+    raise BrowserBridgeSiteAuthorityUnavailable("site server unavailable")
+
+
+_repository: BrowserBridgeSiteAuthorityRepository | None = None
+_repository_lock = threading.Lock()
+
+
+def bind_browser_bridge_site_authority_repository(
+    repository: BrowserBridgeSiteAuthorityRepository | None,
+) -> None:
+    """Install or clear the server-owned repository for the protected API."""
+
+    if repository is not None and not isinstance(
+        repository, BrowserBridgeSiteAuthorityRepository
+    ):
+        raise BrowserBridgeSiteAuthorityError("invalid site authority repository")
+    global _repository
+    with _repository_lock:
+        _repository = repository
+
+
+def get_browser_bridge_site_authority_repository(
+) -> BrowserBridgeSiteAuthorityRepository:
+    with _repository_lock:
+        repository = _repository
+    if repository is None:
+        raise BrowserBridgeSiteAuthorityUnavailable(
+            "site authority repository unavailable"
+        )
+    return repository

--- a/plugins/_a0_connector/helpers/browser_bridge_transport.py
+++ b/plugins/_a0_connector/helpers/browser_bridge_transport.py
@@ -1,0 +1,147 @@
+"""Fixed internal identities for trusted Browser bridge transports.
+
+Transport identity is not runtime admission. Only the production constant created
+in this module is accepted by composed Core helpers; protocol documents,
+environment values, and callers cannot construct another accepted profile.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from helpers.ws_principal import WsPrincipal
+
+
+RUNTIME_REQUIRED_SCOPES = frozenset(
+    {
+        "bridge.connect",
+        "context.list",
+        "context.read",
+        "context.message",
+        "browser.operate",
+        "browser.control",
+        "browser.artifact",
+        "browser.approval",
+    }
+)
+RUNTIME_REQUIRED_INBOUND_EVENTS = frozenset(
+    {
+        "connector_hello",
+        "connector_context_list",
+        "connector_subscribe_context",
+        "connector_unsubscribe_context",
+        "connector_send_message",
+        "connector_message_queue_add",
+        "connector_message_queue_remove",
+        "connector_message_queue_send",
+        "connector_browser_op_result",
+        "connector_browser_control_result",
+        "connector_browser_event",
+        "connector_browser_artifact_chunk",
+        "connector_browser_artifact_ack",
+        "connector_browser_approval_decision",
+        "connector_bridge_credential_control",
+    }
+)
+RUNTIME_REQUIRED_OUTBOUND_EVENTS = frozenset(
+    {
+        "connector_context_snapshot",
+        "connector_context_event",
+        "connector_message_queue_updated",
+        "connector_context_complete",
+        "connector_context_error",
+        "connector_browser_op",
+        "connector_browser_control",
+        "connector_browser_event_ack",
+        "connector_browser_artifact_ack",
+        "connector_browser_artifact_chunk",
+        "connector_bridge_credential_status",
+        "connector_bridge_forced_disconnect",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class BrowserBridgeTransportProfile:
+    """One process-owned transport identity; equality is object identity."""
+
+    profile_id: str
+    principal_type: str
+    handler_path: str
+    handler_id: str
+    namespace: str
+
+
+PRODUCTION_BROWSER_BRIDGE_TRANSPORT = BrowserBridgeTransportProfile(
+    profile_id="production",
+    principal_type="browser_bridge",
+    handler_path="plugins/_a0_connector/ws_connector",
+    handler_id="ws_connector.WsConnector",
+    namespace="/ws",
+)
+def require_browser_bridge_transport_profile(
+    value: Any,
+) -> BrowserBridgeTransportProfile:
+    """Accept only the exact module-owned production constant."""
+
+    if value is not PRODUCTION_BROWSER_BRIDGE_TRANSPORT:
+        raise ValueError("invalid Browser bridge transport profile")
+    return PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+
+
+def runtime_transport_profile_for_principal(
+    principal: Any,
+) -> BrowserBridgeTransportProfile:
+    """Recognize a full-runtime principal for one fixed transport identity."""
+
+    if (
+        not isinstance(principal, WsPrincipal)
+        or principal.scopes != RUNTIME_REQUIRED_SCOPES
+        or principal.inbound_events != RUNTIME_REQUIRED_INBOUND_EVENTS
+        or principal.outbound_events != RUNTIME_REQUIRED_OUTBOUND_EVENTS
+        or type(principal.key_generation) is not int
+        or principal.key_generation < 1
+    ):
+        raise ValueError("invalid Browser bridge runtime principal")
+    return transport_profile_for_principal_identity(principal)
+
+
+def transport_profile_for_principal_identity(
+    principal: Any,
+) -> BrowserBridgeTransportProfile:
+    """Recognize only the fixed principal/handler identity, not capabilities."""
+
+    profile = PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    if (
+        not isinstance(principal, WsPrincipal)
+        or principal.principal_type != profile.principal_type
+        or principal.handler_path != profile.handler_path
+        or principal.handler_id != profile.handler_id
+    ):
+        raise ValueError("invalid Browser bridge transport principal")
+    return profile
+
+
+def require_runtime_transport_principal(
+    principal: Any,
+    profile: BrowserBridgeTransportProfile,
+) -> WsPrincipal:
+    """Require one full-runtime principal for the server-selected profile."""
+
+    selected = require_browser_bridge_transport_profile(profile)
+    if runtime_transport_profile_for_principal(principal) is not selected:
+        raise ValueError("Browser bridge transport profile mismatch")
+    return principal
+
+
+def require_transport_principal_identity(
+    principal: Any,
+    profile: BrowserBridgeTransportProfile,
+) -> WsPrincipal:
+    """Require the fixed identity selected by composition, without adding scopes."""
+
+    selected = require_browser_bridge_transport_profile(profile)
+    if transport_profile_for_principal_identity(principal) is not selected:
+        raise ValueError("Browser bridge transport profile mismatch")
+    return principal

--- a/plugins/_a0_connector/helpers/browser_bridge_transport.py.dox.md
+++ b/plugins/_a0_connector/helpers/browser_bridge_transport.py.dox.md
@@ -1,0 +1,35 @@
+# Browser bridge transport profiles DOX
+
+## Purpose
+
+- Own the fixed production Browser bridge transport identity.
+- Separate principal/handler routing identity from runtime admission and from
+  each controller's lane-specific scope and event checks.
+
+## Local Contracts
+
+- Accept only the exact module-owned production profile
+  object. Protocol fields, environment strings, configuration values and
+  caller-constructed lookalikes never select a transport.
+- Validate that single identity directly; there is no profile registry or
+  alternate-channel search. Identity-only validation still grants no scopes.
+- Production uses `browser_bridge`, `plugins/_a0_connector/ws_connector` and
+  `ws_connector.WsConnector`, on `/ws`. Retired development identities and
+  caller-created lookalikes are rejected, even with full production scopes.
+- Structural helpers may recognize a fixed principal/handler identity while
+  preserving their existing lane-specific scope and event checks. Only the
+  runtime registry requires the complete immutable runtime sets.
+- Transport identity grants no readiness, capability, route, persistence or
+  Browser authority. Complete runtime admission and activation serialization
+  remain production-only.
+- Composed emitters use the selected profile's handler ID and namespace and
+  recheck exact profile identity at controller, settlement and route seams.
+  Production is the compatibility default.
+## Verification
+
+- Run `pytest tests/test_browser_bridge_transport_profiles.py` plus the
+  directly affected Browser bridge runtime/controller/authority groups.
+
+## Child DOX Index
+
+No child DOX files.

--- a/plugins/_a0_connector/helpers/browser_companion_release.py
+++ b/plugins/_a0_connector/helpers/browser_companion_release.py
@@ -1,0 +1,475 @@
+"""Read-only, allowlisted Browser companion release metadata projection."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import re
+import unicodedata
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+
+INSTALL_CONTRACT = "a0.browser-bridge.install.v1"
+RELEASE_METADATA_CONTRACT = "a0.browser-bridge.release-metadata.v1"
+RELEASE_METADATA_SCHEMA_VERSION = 1
+SERVER_MINIMUM_SECURE_COMPANION = "2.12.0"
+CATALOG_URL_ENV = "A0_BROWSER_COMPANION_CATALOG_URL"
+CATALOG_KEY_FINGERPRINT_ENV = "A0_BROWSER_COMPANION_CATALOG_KEY_FINGERPRINT"
+RELEASE_METADATA_ENV = "A0_BROWSER_COMPANION_RELEASE_METADATA"
+MAX_RELEASE_METADATA_BYTES = 128 * 1024
+MAX_ARTIFACTS = 32
+MAX_ARTIFACT_BYTES = 2 * 1024 * 1024 * 1024
+MAX_PUBLIC_URL_BYTES = 4096
+SUPPORTED_PROTOCOL = 1
+SUPPORTED_TRUST = 1
+
+_HEX_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+_KEY_FINGERPRINT_RE = re.compile(r"^sha256:[0-9a-fA-F]{64}$")
+_RELEASE_RE = re.compile(r"^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$")
+_SAFE_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_ARTIFACT_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$")
+_PUBLISHED_AT_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+
+_ALLOWED_TOP_LEVEL_KEYS = frozenset(
+    {
+        "schema_version",
+        "release",
+        "channel",
+        "published_at",
+        "protocol",
+        "trust",
+        "minimum_secure_companion",
+        "catalog_signature_url",
+        "release_key_id",
+        "artifacts",
+    }
+)
+_REQUIRED_TOP_LEVEL_KEYS = _ALLOWED_TOP_LEVEL_KEYS
+_ALLOWED_ARTIFACT_KEYS = frozenset(
+    {"name", "platform", "arch", "kind", "download_url", "sha256", "size"}
+)
+_PLATFORM_ARCHES = {
+    "macos": frozenset({"universal2", "x86_64", "arm64"}),
+    "windows": frozenset({"x86_64", "arm64"}),
+    "linux": frozenset({"any", "x86_64", "aarch64"}),
+}
+_ARTIFACT_KINDS = frozenset({"installer", "bootstrap", "payload"})
+_REQUIRED_ARTIFACTS = frozenset(
+    {
+        ("macos", "universal2", "installer"),
+        ("macos", "universal2", "payload"),
+        ("windows", "x86_64", "installer"),
+        ("windows", "x86_64", "payload"),
+        ("windows", "arm64", "installer"),
+        ("windows", "arm64", "payload"),
+        ("linux", "any", "bootstrap"),
+        ("linux", "x86_64", "payload"),
+        ("linux", "aarch64", "payload"),
+    }
+)
+
+
+class _MetadataError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserCompanionArtifact:
+    name: str
+    platform: str
+    arch: str
+    kind: str
+    download_url: str
+    sha256: str
+    size: int
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "platform": self.platform,
+            "arch": self.arch,
+            "kind": self.kind,
+            "download_url": self.download_url,
+            "sha256": self.sha256,
+            "size": self.size,
+        }
+
+
+def browser_companion_release_status(
+    *, environ: Mapping[str, str] | None = None
+) -> dict[str, Any]:
+    """Return public release metadata without fetching or installing anything."""
+
+    source = os.environ if environ is None else environ
+    catalog_url = str(source.get(CATALOG_URL_ENV, "") or "")
+    key_fingerprint = str(
+        source.get(CATALOG_KEY_FINGERPRINT_ENV, "") or ""
+    ).strip()
+    raw_metadata = str(source.get(RELEASE_METADATA_ENV, "") or "").strip()
+    configured = {
+        "catalog_url": bool(catalog_url),
+        "catalog_key_fingerprint": bool(key_fingerprint),
+        "release_metadata": bool(raw_metadata),
+    }
+
+    if not all(configured.values()):
+        return _unavailable(
+            reason_code="browser_companion_release_not_configured",
+            message="Signed Browser companion release metadata is not configured.",
+            configured=configured,
+        )
+
+    try:
+        if len(raw_metadata.encode("utf-8")) > MAX_RELEASE_METADATA_BYTES:
+            raise _MetadataError("metadata too large")
+        if not _is_safe_https_url(catalog_url):
+            raise _MetadataError("invalid catalog URL")
+        if not _KEY_FINGERPRINT_RE.fullmatch(key_fingerprint):
+            raise _MetadataError("invalid key fingerprint")
+        document = json.loads(
+            raw_metadata,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_non_finite_number,
+        )
+        release = _parse_release_document(document)
+    except (TypeError, ValueError, UnicodeError, RecursionError):
+        return _unavailable(
+            reason_code="browser_companion_release_invalid",
+            message="Signed Browser companion release metadata is invalid.",
+            configured=configured,
+        )
+
+    if (
+        not _range_contains(release["protocol"], SUPPORTED_PROTOCOL)
+        or not _range_contains(release["trust"], SUPPORTED_TRUST)
+        or _semantic_version_tuple(release["release"])
+        < _semantic_version_tuple(SERVER_MINIMUM_SECURE_COMPANION)
+    ):
+        return _unavailable(
+            reason_code="browser_companion_release_incompatible",
+            message="No configured Browser companion release is compatible with this server.",
+            configured=configured,
+        )
+
+    artifacts: tuple[BrowserCompanionArtifact, ...] = release["artifacts"]
+    return {
+        "ok": True,
+        "contract": RELEASE_METADATA_CONTRACT,
+        "schema_version": RELEASE_METADATA_SCHEMA_VERSION,
+        "install_contract": INSTALL_CONTRACT,
+        "install_ready": False,
+        "state": "available",
+        "reason_code": "browser_companion_release_available",
+        "message": (
+            "Pinned presentation metadata is available for browser-host delivery; "
+            "installation is not verified."
+        ),
+        "delivery": _delivery_projection(),
+        "verification": _verification_projection(),
+        "configuration": configured,
+        "catalog": {
+            "url": catalog_url,
+            "signature_url": release["catalog_signature_url"],
+            "key_fingerprint": key_fingerprint.lower(),
+            "release_key_id": release["release_key_id"],
+        },
+        "compatibility": {
+            "protocol": release["protocol"],
+            "trust": release["trust"],
+            "server_protocol": SUPPORTED_PROTOCOL,
+            "server_trust": SUPPORTED_TRUST,
+            "server_minimum_secure_companion": SERVER_MINIMUM_SECURE_COMPANION,
+            "compatible": True,
+        },
+        "release": {
+            "version": release["release"],
+            "channel": release["channel"],
+            "published_at": release["published_at"],
+            "minimum_secure_companion": release["minimum_secure_companion"],
+            "effective_minimum_secure_companion": _maximum_semantic_version(
+                release["minimum_secure_companion"],
+                SERVER_MINIMUM_SECURE_COMPANION,
+            ),
+        },
+        "artifacts": [artifact.to_public_dict() for artifact in artifacts],
+    }
+
+
+def _unavailable(
+    *, reason_code: str, message: str, configured: dict[str, bool]
+) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "contract": RELEASE_METADATA_CONTRACT,
+        "schema_version": RELEASE_METADATA_SCHEMA_VERSION,
+        "install_contract": INSTALL_CONTRACT,
+        "install_ready": False,
+        "state": "unavailable",
+        "reason_code": reason_code,
+        "message": message,
+        "delivery": _delivery_projection(),
+        "verification": _verification_projection(),
+        "configuration": configured,
+        "catalog": None,
+        "compatibility": {
+            "server_protocol": SUPPORTED_PROTOCOL,
+            "server_trust": SUPPORTED_TRUST,
+            "server_minimum_secure_companion": SERVER_MINIMUM_SECURE_COMPANION,
+            "compatible": False,
+        },
+        "release": None,
+        "artifacts": [],
+    }
+
+
+def _delivery_projection() -> dict[str, Any]:
+    return {
+        "target": "browser_host",
+        "docker_container_install": False,
+        "message": (
+            "Download and run the installer on the computer that runs your browser. "
+            "Agent Zero does not install the native companion inside its Docker container."
+        ),
+    }
+
+
+def _verification_projection() -> dict[str, Any]:
+    return {
+        "server_validation": "metadata_shape_and_compatibility_only",
+        "catalog_signature_verified": False,
+        "artifact_verified": False,
+        "host_verification_required": True,
+    }
+
+
+def _parse_release_document(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise _MetadataError("unexpected release metadata fields")
+    schema_version = value.get("schema_version")
+    if (
+        isinstance(schema_version, bool)
+        or not isinstance(schema_version, int)
+        or schema_version not in (1, 2)
+    ):
+        raise _MetadataError("unsupported release metadata schema")
+    expected_keys = _REQUIRED_TOP_LEVEL_KEYS | ({"platforms"} if schema_version == 2 else set())
+    if set(value) != expected_keys:
+        raise _MetadataError("unexpected release metadata fields")
+    platforms = value.get("platforms") if schema_version == 2 else sorted(_PLATFORM_ARCHES)
+    if (not isinstance(platforms, list) or not platforms
+        or any(not isinstance(item, str) or item not in _PLATFORM_ARCHES for item in platforms)
+        or platforms != sorted(set(platforms))):
+        raise _MetadataError("invalid release platforms")
+    required_artifacts = frozenset(item for item in _REQUIRED_ARTIFACTS if item[0] in platforms)
+
+    release = _required_match(value.get("release"), _RELEASE_RE)
+    minimum_secure = _required_match(
+        value.get("minimum_secure_companion"), _RELEASE_RE
+    )
+    if value.get("channel") != "stable":
+        raise _MetadataError("unsupported release channel")
+    published_at = _required_match(value.get("published_at"), _PUBLISHED_AT_RE)
+    datetime.strptime(published_at, "%Y-%m-%dT%H:%M:%SZ")
+    if _semantic_version_tuple(minimum_secure) > _semantic_version_tuple(release):
+        raise _MetadataError("release is below the minimum secure companion")
+    release_key_id = _required_match(value.get("release_key_id"), _SAFE_TOKEN_RE)
+    signature_url = str(value.get("catalog_signature_url") or "")
+    if not _is_safe_https_url(signature_url):
+        raise _MetadataError("invalid catalog signature URL")
+
+    protocol = _parse_compatibility_range(value.get("protocol"))
+    trust = _parse_compatibility_range(value.get("trust"))
+    artifacts_value = value.get("artifacts")
+    if not isinstance(artifacts_value, list) or not (
+        1 <= len(artifacts_value) <= MAX_ARTIFACTS
+    ):
+        raise _MetadataError("invalid artifacts")
+    artifacts = tuple(_parse_artifact(item) for item in artifacts_value)
+    identities = {(item.platform, item.arch, item.kind) for item in artifacts}
+    names = {item.name for item in artifacts}
+    urls = {item.download_url for item in artifacts}
+    if len(identities) != len(artifacts) or identities != required_artifacts:
+        raise _MetadataError("incomplete or duplicate artifact matrix")
+    if len(names) != len(artifacts) or len(urls) != len(artifacts):
+        raise _MetadataError("duplicate artifact name or URL")
+
+    return {
+        "release": release,
+        "channel": "stable",
+        "published_at": published_at,
+        "protocol": protocol,
+        "trust": trust,
+        "minimum_secure_companion": minimum_secure,
+        "catalog_signature_url": signature_url,
+        "release_key_id": release_key_id,
+        "artifacts": artifacts,
+    }
+
+
+def _parse_artifact(value: Any) -> BrowserCompanionArtifact:
+    if not isinstance(value, dict) or set(value) != _ALLOWED_ARTIFACT_KEYS:
+        raise _MetadataError("unexpected artifact fields")
+    name = _required_match(value.get("name"), _ARTIFACT_NAME_RE)
+    platform = str(value.get("platform") or "").strip()
+    arch = str(value.get("arch") or "").strip()
+    kind = str(value.get("kind") or "").strip()
+    download_url = str(value.get("download_url") or "")
+    sha256 = str(value.get("sha256") or "").strip().lower()
+    size = value.get("size")
+
+    if platform not in _PLATFORM_ARCHES or arch not in _PLATFORM_ARCHES[platform]:
+        raise _MetadataError("unsupported artifact target")
+    if kind not in _ARTIFACT_KINDS:
+        raise _MetadataError("unsupported artifact kind")
+    if not _is_safe_https_url(download_url, expected_name=name):
+        raise _MetadataError("invalid artifact URL")
+    if not _HEX_SHA256_RE.fullmatch(sha256):
+        raise _MetadataError("invalid artifact digest")
+    if isinstance(size, bool) or not isinstance(size, int) or not (
+        1 <= size <= MAX_ARTIFACT_BYTES
+    ):
+        raise _MetadataError("invalid artifact size")
+    return BrowserCompanionArtifact(
+        name=name,
+        platform=platform,
+        arch=arch,
+        kind=kind,
+        download_url=download_url,
+        sha256=sha256,
+        size=size,
+    )
+
+
+def _parse_compatibility_range(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict) or set(value) != {"min", "max"}:
+        raise _MetadataError("invalid compatibility range")
+    minimum = value.get("min")
+    maximum = value.get("max")
+    if (
+        isinstance(minimum, bool)
+        or isinstance(maximum, bool)
+        or not isinstance(minimum, int)
+        or not isinstance(maximum, int)
+        or minimum < 1
+        or maximum < minimum
+        or maximum > 65535
+    ):
+        raise _MetadataError("invalid compatibility range")
+    return {"min": minimum, "max": maximum}
+
+
+def _range_contains(value: dict[str, int], current: int) -> bool:
+    return value["min"] <= current <= value["max"]
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    document: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in document:
+            raise _MetadataError("duplicate metadata field")
+        document[key] = value
+    return document
+
+
+def _reject_non_finite_number(_value: str) -> None:
+    raise _MetadataError("non-finite metadata number")
+
+
+def _semantic_version_tuple(value: str) -> tuple[int, int, int]:
+    major, minor, patch = value.split(".")
+    return int(major), int(minor), int(patch)
+
+
+def _maximum_semantic_version(first: str, second: str) -> str:
+    if _semantic_version_tuple(first) >= _semantic_version_tuple(second):
+        return first
+    return second
+
+
+def _required_match(value: Any, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str):
+        raise _MetadataError("invalid public metadata value")
+    normalized = value.strip()
+    if not pattern.fullmatch(normalized):
+        raise _MetadataError("invalid public metadata value")
+    return normalized
+
+
+def _is_safe_https_url(value: str, *, expected_name: str | None = None) -> bool:
+    if (
+        not value
+        or len(value.encode("utf-8")) > MAX_PUBLIC_URL_BYTES
+        or not value.isascii()
+        or not value.startswith("https://")
+        or "\\" in value
+        or "?" in value
+        or "#" in value
+        or "%" in value
+        or _contains_control_character(value)
+    ):
+        return False
+    try:
+        parsed = urlsplit(value)
+        parsed_port = parsed.port
+    except ValueError:
+        return False
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.netloc.endswith(":")
+        or (parsed_port is not None and not (1 <= parsed_port <= 65535))
+        or not parsed.path.startswith("/")
+        or parsed.path.startswith("//")
+        or not _is_unambiguous_hostname(parsed.hostname)
+        or any(part in {".", ".."} for part in parsed.path.split("/"))
+    ):
+        return False
+    if expected_name is not None:
+        path_name = parsed.path.rsplit("/", 1)[-1]
+        if path_name != expected_name:
+            return False
+    return True
+
+
+def _contains_control_character(value: str) -> bool:
+    return any(
+        character.isspace() or unicodedata.category(character) == "Cc"
+        for character in value
+    )
+
+
+def _is_unambiguous_hostname(hostname: str) -> bool:
+    if (
+        not hostname
+        or hostname.startswith(".")
+        or hostname.endswith(".")
+        or ".." in hostname
+    ):
+        return False
+    if ":" in hostname:
+        try:
+            return str(ipaddress.ip_address(hostname)) == hostname
+        except ValueError:
+            return False
+    if hostname != hostname.lower():
+        return False
+    if all(character.isdigit() or character == "." for character in hostname):
+        try:
+            return str(ipaddress.ip_address(hostname)) == hostname
+        except ValueError:
+            return False
+    return len(hostname) <= 253 and all(
+        1 <= len(label) <= 63
+        and not label.startswith("-")
+        and not label.endswith("-")
+        and all(character.isalnum() or character == "-" for character in label)
+        for label in hostname.split(".")
+    )

--- a/plugins/_browser/AGENTS.md
+++ b/plugins/_browser/AGENTS.md
@@ -15,6 +15,15 @@
 
 ## Local Contracts
 
+- Extension target origins come from a bounded process-only index populated by
+  exact correlated successful open results, not caller handles or URL guesses.
+  Require distinct lease and tab identities, the requested granted origin, and
+  the expected disposition; bind entries to the exact current principal, SID,
+  generation, context, and browser session. Do not retain titles, full URLs,
+  page payloads, or provider IDs. Withdraw entries when finalization begins or
+  authority is invalidated; the extension independently verifies every live
+  lease/document. Reconnect recovery cannot silently restore target authority.
+
 - Keep browser actions safe around external pages, credentials, and user data.
 - Preserve Patchright lifecycle cleanup and WebSocket viewer compatibility across regular host browsers and Electron WebContentsView embedding.
 - Keep the WebUI Browser inside its own modal/canvas affordance; do not replace it with page-level navigation.
@@ -38,6 +47,39 @@
 - Show an accessible in-panel startup state while the on-demand shared Browser runtime is cold-starting; keep that one runtime warm until Browser configuration changes or Agent Zero shuts down.
 - Keep narrow WebUI Browser controls usable by grouping navigation with Annotate/settings above a full-width address bar.
 - For Bring Your Own Browser with an existing host profile, `host_browser_selection` may target automatic host selection, a browser family/id, an HTTP CDP discovery address, or a full DevTools WebSocket endpoint and must be forwarded to the connector runtime as `browser_selection`.
+- Reserve `host_browser_selection=extension:<bridge_id>` for the typed Chrome-extension backend. Preserve an already-stored valid selection exactly; new selections require the protected production selection API, active paired record and project-scoped readback, never generic config writes. Allow clearing or switching to `container`. A change retires the exact former bridge route before writing shared config. Reject malformed reserved values. When `host_required` activates an extension selection, never route it through the internal browser or a legacy A0 CLI candidate; until the extension runtime is available and enabled, fail with repair guidance and no browser mutation. The top-level `container` backend continues to ignore host-browser selection.
+- Keep the instance-scoped `A0_BROWSER_BRIDGE_ROLLOUT` gate limited to `disabled`, `preview`, and `available`, with missing or invalid values failing closed to `disabled`. Never persist this gate in per-project Browser settings, and gate configuration never selects a browser. Browser status adds a versioned, identifier-redacted `extension_bridge` scope without changing or removing existing status keys; the additive scope must report unavailable project or remote evidence as `not_checked` or `unknown` rather than inferring health.
+- MV3 discovery preserves the runtime, adapter and protocol identifiers and its
+  disabled response shape. Its validation flags are false: actual lease and
+  finalization validation belongs to `extension_sessions`, `extension_leases`
+  and the operation broker, not duplicate discovery-only types. This static
+  metadata is not connection status. The native runtime stays on the browser
+  host, never in Docker.
+- Browser status may project the `a0.browser-bridge.trust.v1` pairing foundation and whether its server-side create/exchange gate is configured, but it must not project the pinned extension ID or any pairing code, public key, bridge identity, session proof, or remote-health inference. Pairing availability never makes connector-session or browser-control readiness true.
+- The extension-browser lifecycle registry is created only for an explicit
+  `host_required` plus exact `extension:<bridge_id>` selection with a current
+  restricted route. Keep its KVP state bounded to opaque context/session/turn
+  IDs, the selected browser/bridge, lease dispositions, lifecycle tombstones,
+  an event cursor, and timestamps; never persist route authority, SID/load
+  generation, Chrome IDs, URLs, page content, selectors, scripts, or typed
+  input. A session stays pinned to one bridge, while each monologue gets a
+  fresh turn.
+- Extension turn finalization is process-owned, idempotent, and exact-bound.
+  Missing authority leaves a durable pending intent, transport uncertainty is
+  retained as `outcome_unknown`, and even a successful control receipt must
+  not be presented as proof that remote tabs were closed. Lifecycle hooks stay
+  inert until the restricted route resolver and broker-backed sender are
+  explicitly injected; container and legacy browser behavior is unchanged.
+- Browser Settings may create, poll, cancel, regenerate, and explicitly copy a five-minute pairing code through the protected pairing API. Keep the code only in the open Alpine panel, clear it on cancel, expiry, replacement, and teardown, and never write it to project config, local/session storage, URLs, logs, or the public exchange endpoint. Status is an allowlisted redacted projection, and the panel must state that the companion/private key belong on the browser computer rather than in Agent Zero's Docker container.
+- Browser Settings recognizes production `extension:` selections independently
+  of legacy A0 CLI/CDP settings; never ask production users to enable remote
+  debugging or keep CLI open. Pairing is saved, but authoritative current-chat
+  readiness remains separate. While the panel is mounted and visible, refresh
+  pairing, paired inventory and selection read-only; preserve typed site drafts,
+  exact context/generation fences, explicit selection and site consent. A single
+  Check connection action refreshes all production setup projections. Setup links
+  come only from the protected public setup API; OS suggestions use the visiting
+  browser, not Docker. Missing OS artifacts have no download fallback.
 - Browser Settings must refresh connected host-browser inventory while the settings view is open so newly authorized endpoints appear without saving or reopening.
 - Browser Settings keeps the Host browser dropdown focused on automatic selection, stable IDs for advertised debug endpoints, and advertised Safari WebDriver targets instead of listing every installed local profile. Describe host access as available through Launcher or A0 CLI without presenting the CLI as the only runtime. Present host-browser setup without an outer container treatment: Chromium-family guidance comes first on the left and Safari/macOS second on the right, with narrow layouts stacking naturally and manual endpoint fallback progressively disclosed. Chrome, Opera, and Edge setup buttons appear only when a compatible connected host advertises that installed browser, then use the authenticated connector bridge to open its fixed internal inspect page; mention Brave, Vivaldi, and Chromium without adding more primary buttons. Safari guidance must name Safari Settings > Advanced > Show features for web developers and Developer > Allow remote automation, and explain its dedicated automation window. An exact legacy endpoint advertised by a connected host migrates to that browser's stable ID in both settings and runtime operations; unmatched custom endpoints remain exact and fail closed. Preserve endpoint path/query case and let the connected host resolve discovery addresses.
 - Browser URL-intent handling must only claim web URL schemes and leave custom Agent Zero schemes to their owning surfaces.
@@ -56,6 +98,142 @@
 - Browser startup must install the shared virtual-desktop route hook itself; do not make Browser depend on the Desktop plugin being enabled.
 
 ## Work Guidance
+
+- The existing server-resolved `autofocus_active_page` setting also requests
+  foreground display for production Chrome open/hover/click/type/scroll/upload
+  operations. Read the current agent-scoped setting after any site-approval
+  wait; missing or failed settings evidence leaves foreground false. This is
+  presentation only: existing route, lease, site and action checks still gate
+  dispatch. Never accept a foreground override from tool arguments or focus
+  tabs for passive events, list/state/content/navigation or status.
+
+- Production selector acquisition may wait up to 25 seconds for the exact
+  already-installed factory owner and unchanged current selection to obtain a
+  verified reconciled route after reconnect. Recheck gate, owner and selection
+  at every bounded poll; withdrawal, replacement and cancellation stop the
+  wait. No operation or consent request is sent or replayed by acquisition.
+  Missing factory returns immediately. Failure guidance must describe an
+  unverified connection, never falsely claim this release lacks the runtime or
+  recommend another browser/tool to bypass the selected host. An earlier
+  unknown-effect operation remains unknown and must not be repeated.
+
+- `extension_first_open` owns a separate production-only, process-memory
+  approval before an owned tab exists. Its sidecar defines exact request/turn
+  fences, bounded waiting and resulting-lease access. Never invent a native
+  navigation challenge. Only the explicit production first-open `allow_site`
+  choice persists exact-origin saved policy, with successful readback before
+  dispatch; once/turn decisions stay temporary. Its primary UI control says
+  “Always allow site” and explains that access is remembered across chats.
+  Keep consent in a compact theme-native strip: exact origin and scope beside
+  the primary choice and Deny; put once/turn alternatives and settings-based
+  removal under More options. Do not hide the origin or saved-scope meaning.
+  The protected site inbox accepts production `open` and `navigate` requests;
+  Permission denial or expiry must give
+  explain-to-user guidance, never suggest curl, code_execution_tool, another
+  browser or another tool as a way around consent.
+
+- `extension_uploads` and the user_message_ui source hook own the bounded
+  current-chat attachment registry and immutable source-byte check. The sidecar
+  defines the no-arbitrary-path rule, per-context metadata, no-follow reads and
+  upload permit lifetime. Runtime/services send only opaque descriptors after
+  exact operation dispatch; staging is not the separate site-upload approval.
+
+- `helpers/extension_runtime.py` is a separate canonical Browser-tool codec, not
+  a subclass of the legacy CDP runtime. It currently supports the negotiated
+  open/list/state/content/navigate/ref-scroll/ref-hover/viewport-screenshot/ensure/status subset, rejects
+  selectors, scripts, caller policy IDs, numeric provider IDs, unsupported
+  actions and unverified artifacts/receipts. Cross-origin navigation requires
+  an explicitly composed site challenge lane; the source-origin permission
+  can only start that wait, never approve the destination. Exact
+  route/session/turn bindings and target origins are injected server-owned
+  services; persistent exact-origin policy is rechecked at queued dispatch.
+  Cancellation schedules an exact bounded broker control without claiming
+  rollback. The selector can use only an explicitly bootstrapped factory under
+  the available instance gate, with exact context/bridge readback. Its default
+  is unconfigured and unavailable; importing this adapter never activates or
+  selects the extension or falls back to another browser.
+- The negotiated semantic-ref click codec always supplies expected risk `unknown`,
+  rejects caller risk downgrades/modifiers/coordinates, and requires a composed
+  action authority before initial and queued dispatch. Its three transport
+  layers and protected decision UI are composed; full activation is separate.
+  Correlated content results alone may populate the bounded process-local
+  lease document index with document ID, epoch, and opaque refs; no labels,
+  page text, or challenge-supplied identities enter that index. Navigation,
+  successful click, lease invalidation, and turn retirement withdraw cached
+  document authority. A click receipt never authorizes a second click.
+- `extension_artifacts` consumes one exact screenshot descriptor from the private
+  verified receiver, rechecks the retained lease and active turn/current route,
+  validates bounded JPEG/PNG bytes, and uses the existing Core-owned chat media
+  destination. Peer paths, additive result fields, mismatched descriptors and
+  raw image bytes never enter tool results. The `screenshot_file` codec maps
+  explicit bounded JPEG quality, rejects full-page/custom-path requests, and
+  requires an installed materializer before sending. No production capability
+  is inferred merely from this composition seam.
+- `helpers/extension_services.py` composes that codec with the hook-owned
+  lifecycle and restricted broker. Direct calls get an exact synthetic turn
+  finalized in `finally`; monologue calls keep their existing turn. Production
+  bootstrap must supply `get_extension_session_lifecycle()`, not
+  a separate instance invisible to monologue hooks. Successive tool calls in
+  one monologue share the exact turn/session and retain its owned lease until
+  real monologue finalization; direct calls remain independently finalized.
+  Revalidate real/synthetic ownership at dispatch. Finalization cancels only pending
+  operations from the same principal/SID/generation/session/turn, then waits for
+  the exact control acknowledgement; transport errors or per-lease errors
+  persist uncertainty, not a tab-closure claim. This explicit bootstrap seam is
+  not installed by configuration, imports, or client hello metadata. Runtime
+  factory and lifecycle installation are exact-object-owned and reject a
+  competing owner; uninstall withdraws only that service's factory, makes new
+  hooks inert, and durably stages tracked cleanup with the established
+  `restarted` reason before configuration can be reused. It never cancels an
+  in-flight finalizer or converts missing-route cleanup into `not_applied`.
+- Only the fixed production transport owns Browser factories and lifecycle.
+  Monologue, direct-call and context cleanup hooks delegate directly to the
+  same `_lifecycle` singleton; do not reintroduce multi-channel fan-out.
+  The retired `development-extension:` namespace remains reserved solely to
+  reject stale settings without CLI/CDP or container fallback. No old keys or
+  site grants transfer into production; users must explicitly pair and select
+  the production extension. The production unpacked build uses this same path.
+
+- The extension Browser panel's `browser-site-requests` component presents
+  exact server-listed pending site requests as plain canonical origins, never
+  page-provided descriptions. Send only challenge ID and explicit user decision;
+  receipt acceptance is not navigation success. Poll only while mounted, fence
+  asynchronous responses by generation, reject expired decisions, and destroy
+  timers/view state on teardown. Never persist grants or infer runtime readiness.
+  Normal decision acknowledgements disappear after three seconds using the
+  existing polling clock; uncertain decisions retain their bounded warning.
+- Composer approval inboxes stay visually absent when empty, including the
+  pending site and action lanes. Successful decision notices expire after three
+  seconds on the existing poll clock; uncertain decisions remain visible until
+  their request expires. Both request stores retain known unexpired
+  current-chat prompts on list failure, with decisions disabled until a valid
+  list succeeds. One presentation-only coordinator reports a shared outage
+  through the A0 notification center once per chat/outage, without a composer
+  recovery control or toast. Existing read-only polling recovers automatically.
+  It never filters pending consent by connection-status guesses,
+  grants authority, or retries an uncertain decision.
+- `browser-bridge-access-store.js` owns the replaceable WebUI view of paired
+  browsers and saved exact-origin permissions. It uses protected bridge/policy
+  APIs, keeps drafts and IDs only in the mounted panel, drops stale responses
+  after teardown or host selection, and confirms revocation before sending.
+  Inventory remains usable when rollout is disabled. Revoke/allow responses
+  never imply native-key deletion, tab closure, or runtime readiness. Transient
+  outcomes use frontend-only Agent Zero notifications, not inline alert boxes.
+- Its production All websites control requires explicit confirmation, sends
+  only selected bridge and bounded site mode to the protected policy endpoint,
+  and updates from exact readback. Fence confirmation/replies on mounted bridge
+  generation. Explain persistent across-chat browsing and separate action
+  approvals. Turning it off preserves individually saved sites. First-open
+  uses the repository's exact-origin derived grant before creating a prompt;
+  no site request is necessary while that explicit mode is current.
+- `browser-bridge-selection-store.js` owns explicit production Use this Chrome
+  browser and confirmed internal-browser default actions, including without a
+  chat. The protected default-selection contract checks the previous global
+  bridge as a compare-and-swap precondition. Existing project/profile overrides
+  stay unchanged and appear as a separate current-chat projection. It uses only the
+  protected selection API, fences replies by chat/mount generation, and refreshes
+  the modal's own settings scope after authoritative readback. Selection is not
+  readiness and never creates a new pairing or site/action grant.
 
 - Coordinate tool, helper, and panel changes so browser state shown in the UI matches tool behavior.
 - Do not depend on nested Electron `<webview>` support or launcher-specific preload bridges unless the launcher exposes that bridge as an explicit contract.

--- a/plugins/_browser/api/status.py
+++ b/plugins/_browser/api/status.py
@@ -1,4 +1,12 @@
 from helpers.api import ApiHandler, Request
+from plugins._a0_connector.helpers.browser_bridge_cutover import (
+    build_cutover_foundation_status,
+    detect_installed_legacy_browser_bridge,
+)
+from plugins._browser.helpers.bridge_foundation import (
+    build_browser_bridge_status,
+    get_browser_bridge_gate,
+)
 from plugins._browser.helpers.config import build_browser_launch_config, get_browser_config
 from plugins._browser.helpers.interactive_view import collect_status as collect_interactive_status
 from plugins._browser.helpers.playwright import (
@@ -21,6 +29,13 @@ class Status(ApiHandler):
             host_browser = {"connectors": []}
         else:
             host_browser = {"connectors": all_host_browser_metadata()}
+        extension_bridge = build_browser_bridge_status(
+            None,
+            get_browser_bridge_gate(),
+        )
+        extension_bridge["cutover"] = build_cutover_foundation_status(
+            detect_installed_legacy_browser_bridge()
+        )
         return {
             "plugin": "_browser",
             "playwright": {
@@ -40,4 +55,5 @@ class Status(ApiHandler):
             "host_browser": host_browser,
             "interactive_view": collect_interactive_status(),
             "contexts": known_context_ids(),
+            "extension_bridge": extension_bridge,
         }

--- a/plugins/_browser/extensions/python/_functions/agent/Agent/monologue/end/_05_finalize_extension_session.py
+++ b/plugins/_browser/extensions/python/_functions/agent/Agent/monologue/end/_05_finalize_extension_session.py
@@ -1,0 +1,12 @@
+from helpers.extension import Extension
+from plugins._browser.helpers.extension_sessions import finalize_extension_monologue
+
+
+class FinalizeExtensionBrowserAfterMonologueEscape(Extension):
+    def execute(self, data: dict = {}, **kwargs):
+        args = data.get("args", ())
+        agent = args[0] if isinstance(args, tuple) and args else self.agent
+        if agent is None:
+            return
+        reason = "failed" if isinstance(data.get("exception"), BaseException) else "completed"
+        finalize_extension_monologue(agent, reason=reason)

--- a/plugins/_browser/extensions/python/_functions/agent/AgentContext/__init__/start/_05_finalize_replaced_extension_session.py
+++ b/plugins/_browser/extensions/python/_functions/agent/AgentContext/__init__/start/_05_finalize_replaced_extension_session.py
@@ -1,0 +1,30 @@
+from helpers.extension import Extension
+from plugins._browser.helpers.extension_sessions import finalize_extension_context
+
+
+class FinalizeReplacedExtensionBrowserContext(Extension):
+    def execute(self, data: dict = {}, **kwargs):
+        args = data.get("args", ())
+        call_kwargs = data.get("kwargs", {})
+        if not isinstance(args, tuple) or not args:
+            return
+        if not isinstance(call_kwargs, dict):
+            call_kwargs = {}
+
+        candidate = args[0]
+        context_id = call_kwargs.get("id")
+        if context_id is None and len(args) > 2:
+            context_id = args[2]
+        if not context_id:
+            return
+
+        # Import lazily: this hook executes while agent.py is constructing a
+        # context and must not introduce a module-import cycle.
+        from agent import AgentContext
+
+        existing = AgentContext.get(str(context_id))
+        if existing is not None and existing is not candidate:
+            finalize_extension_context(
+                existing,
+                reason="replaced",
+            )

--- a/plugins/_browser/extensions/python/_functions/agent/AgentContext/kill_process/start/_05_finalize_extension_session.py
+++ b/plugins/_browser/extensions/python/_functions/agent/AgentContext/kill_process/start/_05_finalize_extension_session.py
@@ -1,0 +1,10 @@
+from helpers.extension import Extension
+from plugins._browser.helpers.extension_sessions import finalize_extension_context
+
+
+class FinalizeExtensionBrowserOnKill(Extension):
+    def execute(self, data: dict = {}, **kwargs):
+        args = data.get("args", ())
+        context = args[0] if isinstance(args, tuple) and args else None
+        if context is not None:
+            finalize_extension_context(context, reason="canceled")

--- a/plugins/_browser/extensions/python/_functions/agent/AgentContext/remove/start/_05_finalize_extension_session.py
+++ b/plugins/_browser/extensions/python/_functions/agent/AgentContext/remove/start/_05_finalize_extension_session.py
@@ -1,0 +1,22 @@
+from helpers.extension import Extension
+from plugins._browser.helpers.extension_sessions import finalize_extension_context
+
+
+class FinalizeExtensionBrowserOnRemove(Extension):
+    def execute(self, data: dict = {}, **kwargs):
+        args = data.get("args", ())
+        context_id = args[0] if isinstance(args, tuple) and args else ""
+        if not context_id:
+            return
+
+        # The start hook runs before AgentContext removes the live context.
+        from agent import AgentContext
+
+        context = AgentContext.get(str(context_id))
+        if context is not None:
+            finalize_extension_context(
+                context,
+                reason="removed",
+                retire=True,
+                remove=True,
+            )

--- a/plugins/_browser/extensions/python/_functions/agent/AgentContext/reset/start/_05_finalize_extension_session.py
+++ b/plugins/_browser/extensions/python/_functions/agent/AgentContext/reset/start/_05_finalize_extension_session.py
@@ -1,0 +1,14 @@
+from helpers.extension import Extension
+from plugins._browser.helpers.extension_sessions import finalize_extension_context
+
+
+class FinalizeExtensionBrowserOnReset(Extension):
+    def execute(self, data: dict = {}, **kwargs):
+        args = data.get("args", ())
+        context = args[0] if isinstance(args, tuple) and args else None
+        if context is not None:
+            finalize_extension_context(
+                context,
+                reason="reset",
+                retire=True,
+            )

--- a/plugins/_browser/extensions/python/monologue_end/_10_extension_session.py
+++ b/plugins/_browser/extensions/python/monologue_end/_10_extension_session.py
@@ -1,0 +1,8 @@
+from helpers.extension import Extension
+from plugins._browser.helpers.extension_sessions import finalize_extension_monologue
+
+
+class FinalizeExtensionBrowserTurn(Extension):
+    def execute(self, **kwargs):
+        if self.agent:
+            finalize_extension_monologue(self.agent, reason="completed")

--- a/plugins/_browser/extensions/python/monologue_start/_15_extension_session.py
+++ b/plugins/_browser/extensions/python/monologue_start/_15_extension_session.py
@@ -1,0 +1,8 @@
+from helpers.extension import Extension
+from plugins._browser.helpers.extension_sessions import begin_extension_monologue
+
+
+class BeginExtensionBrowserTurn(Extension):
+    def execute(self, **kwargs):
+        if self.agent:
+            begin_extension_monologue(self.agent)

--- a/plugins/_browser/extensions/python/user_message_ui/_20_browser_upload_sources.py
+++ b/plugins/_browser/extensions/python/user_message_ui/_20_browser_upload_sources.py
@@ -1,0 +1,10 @@
+import asyncio
+
+from helpers.extension import Extension
+from plugins._browser.helpers.extension_uploads import record_user_attachments
+
+
+class RememberBrowserUploadSources(Extension):
+    async def execute(self, data: dict, **kwargs):
+        if self.agent and isinstance(data, dict):
+            await asyncio.to_thread(record_user_attachments, self.agent.context, data.get("attachment_paths"))

--- a/plugins/_browser/extensions/webui/chat-input-start/browser-approvals.html
+++ b/plugins/_browser/extensions/webui/chat-input-start/browser-approvals.html
@@ -1,0 +1,14 @@
+<!-- Host-browser approvals belong beside the current chat's composer, not
+     in the unrelated container-browser viewer or its tab-ID namespace. -->
+<script type="module">
+  import { store } from "/plugins/_browser/webui/browser-approval-inbox-store.js";
+</script>
+<div class="browser-approval-inbox" x-data x-effect="$store.browserApprovalInbox.observe()" aria-label="Browser approvals for this chat">
+  <x-component path="/plugins/_browser/webui/browser-site-requests.html"></x-component>
+  <x-component path="/plugins/_browser/webui/browser-action-requests.html"></x-component>
+</div>
+<style>
+  .browser-approval-inbox { width: 100%; flex: 0 0 auto; max-height: min(45vh, 360px); overflow: auto; scrollbar-color: var(--color-border) transparent; }
+  .browser-approval-inbox .browser-site-requests { max-height: none; overflow: visible; }
+  .browser-approval-inbox:empty { display: none; }
+</style>

--- a/plugins/_browser/extensions/webui/get_tool_message_handler/browser-tool-handler.js
+++ b/plugins/_browser/extensions/webui/get_tool_message_handler/browser-tool-handler.js
@@ -89,6 +89,14 @@ function browserIdFromResult(result = {}, kvps = {}) {
   );
 }
 
+// Extension leases are not container viewer tab IDs. Never let the viewer's
+// fallback selection turn an extension tool result into container control.
+function isExtensionBrowserTarget(result = {}, kvps = {}) {
+  if (kvps._browser_backend === "chrome_extension") return true;
+  const id = browserIdFromResult(result, kvps);
+  return typeof id === "string" && (id.startsWith("a0t1.") || id.startsWith("extension:"));
+}
+
 function browserContextIdFromResult(result = {}, kvps = {}) {
   const snapshotMeta = browserSnapshotMeta(kvps);
   const browserId = browserIdFromResult(result, kvps);
@@ -131,6 +139,7 @@ const FOCUS_ACTIONS = new Set([
 ]);
 
 function shouldSyncOpenBrowserCanvas(args, result) {
+  if (isExtensionBrowserTarget(result, args?.kvps || {})) return false;
   if (!isBrowserCanvasAlreadyOpen()) return false;
   if (!isFreshToolMessage(args?.timestamp)) return false;
   const action = String(args?.kvps?.action || "").trim().toLowerCase().replace("-", "_");
@@ -166,6 +175,7 @@ function currentBrowserContextId(result = {}, kvps = {}) {
 }
 
 function buildBrowserCanvasPayload(result = {}, kvps = {}, source = "tool-kvp") {
+  if (isExtensionBrowserTarget(result, kvps)) return null;
   const browserId = browserIdFromResult(result, kvps);
   const contextId = currentBrowserContextId(result, kvps);
   if (!browserId && !contextId) return null;
@@ -244,6 +254,7 @@ function browserResultFromRenderedStep(step) {
 }
 
 function shouldRenderBrowserScreenshotKvp(result = {}, kvps = {}) {
+  if (isExtensionBrowserTarget(result, kvps)) return false;
   if (buildBrowserCanvasPayload(result, kvps)) return true;
   const action = normalizeBrowserAction(kvps);
   return Boolean(action && !NO_SCREENSHOT_ACTIONS.has(action));
@@ -500,6 +511,7 @@ function drawBrowserTool({
     displayKvps[BROWSER_SCREENSHOT_KVP_KEY] = screenshotUri;
   }
   delete displayKvps[BROWSER_SNAPSHOT_META_KEY];
+  delete displayKvps._browser_backend;
   const browserButton = createActionButton(
     "visibility",
     "Browser",
@@ -516,7 +528,7 @@ function drawBrowserTool({
   browserButton.setAttribute("aria-label", "Open Browser");
   browserButton.setAttribute("data-bs-placement", "top");
   browserButton.setAttribute("data-bs-trigger", "hover");
-  const actionButtons = [browserButton];
+  const actionButtons = isExtensionBrowserTarget(browserResult, kvps) ? [] : [browserButton];
 
   if (contentText.trim()) {
     actionButtons.push(

--- a/plugins/_browser/extensions/webui/set_messages_after_loop/auto-open-browser-results.js
+++ b/plugins/_browser/extensions/webui/set_messages_after_loop/auto-open-browser-results.js
@@ -96,6 +96,9 @@ const FOCUS_ACTIONS = new Set([
 ]);
 
 function shouldSyncOpenBrowserCanvas(args = {}, payload = {}, result = {}) {
+  if (payload._browser_backend === "chrome_extension") return false;
+  const browserId = getBrowserId(payload, result);
+  if (typeof browserId === "string" && (browserId.startsWith("a0t1.") || browserId.startsWith("extension:"))) return false;
   if (!isBrowserCanvasAlreadyOpen()) return false;
   if (!isFresh(args.timestamp, payload.last_modified || result.last_modified)) return false;
   const action = String(payload.action || "").trim().toLowerCase().replace("-", "_");

--- a/plugins/_browser/helpers/bridge_foundation.py
+++ b/plugins/_browser/helpers/bridge_foundation.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Mapping
+
+from plugins._browser.helpers.mv3_runtime_foundation import (
+    build_mv3_runtime_foundation_status,
+)
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    build_browser_bridge_pairing_foundation_status,
+)
+
+
+BROWSER_BRIDGE_ROLLOUT_KEY = "browser_bridge_rollout"
+BROWSER_BRIDGE_ROLLOUT_ENV = "A0_BROWSER_BRIDGE_ROLLOUT"
+BROWSER_BRIDGE_FOUNDATION_CONTRACT = "a0.browser-bridge.foundation.v1"
+BROWSER_BRIDGE_GATE_CONTRACT = "a0.browser-bridge.rollout.v1"
+BROWSER_BRIDGE_STATUS_CONTRACT = "a0.browser-bridge.status.v1"
+BROWSER_BRIDGE_ROLLOUT_STATES = frozenset({"disabled", "preview", "available"})
+DEFAULT_BROWSER_BRIDGE_ROLLOUT = "disabled"
+
+_REMOTE_LAYER_NAMES = (
+    "credential",
+    "companion",
+    "browser_registration",
+    "extension",
+    "chrome_permission",
+    "site_policy",
+    "runtime",
+)
+
+
+def _checked_at_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserBridgeGate:
+    state: str
+    reason_code: str
+    configured: bool
+
+    @classmethod
+    def from_value(cls, value: Any) -> BrowserBridgeGate:
+        configured = value is not None
+        normalized = str(value or "").strip().lower()
+        if normalized in BROWSER_BRIDGE_ROLLOUT_STATES:
+            return cls(
+                state=normalized,
+                reason_code=f"rollout_{normalized}",
+                configured=configured,
+            )
+        return cls(
+            state=DEFAULT_BROWSER_BRIDGE_ROLLOUT,
+            reason_code=(
+                "rollout_disabled"
+                if not normalized
+                else "invalid_rollout_defaulted_disabled"
+            ),
+            configured=configured,
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "gate_contract": BROWSER_BRIDGE_GATE_CONTRACT,
+            "state": self.state,
+            "reason_code": self.reason_code,
+            "configured": self.configured,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserBridgeStatusLayer:
+    state: str
+    reason_code: str
+    message: str
+    checked_at: str | None
+    source: str
+    action_id: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "state": self.state,
+            "reason_code": self.reason_code,
+            "message": self.message,
+            "checked_at": self.checked_at,
+            "source": self.source,
+        }
+        if self.action_id:
+            result["action_id"] = self.action_id
+        return result
+
+
+def get_browser_bridge_gate(
+    *, environ: Mapping[str, str] | None = None
+) -> BrowserBridgeGate:
+    """Read the instance gate without consulting project-scoped Browser config."""
+
+    source = os.environ if environ is None else environ
+    return BrowserBridgeGate.from_value(source.get(BROWSER_BRIDGE_ROLLOUT_ENV))
+
+
+def _redacted_selection(browser_config: dict[str, Any] | None) -> dict[str, Any]:
+    if browser_config is None:
+        return {
+            "runtime_backend": None,
+            "browser_selection": "",
+            "configured_backend_id": None,
+            "state": "not_checked",
+            "reason_code": "project_selection_scope_unavailable",
+            "source": "not_checked",
+        }
+
+    runtime_backend = str(browser_config.get("runtime_backend", "container") or "container")
+    configured_selection = str(browser_config.get("host_browser_selection", "") or "")
+
+    if runtime_backend not in {"container", "host_required"}:
+        runtime_backend = None
+        selection = ""
+        configured_backend_id = None
+        state = "blocked"
+        reason_code = "invalid_runtime_backend"
+    elif runtime_backend != "host_required":
+        selection = ""
+        configured_backend_id: str | None = "container"
+        state = "selected"
+        reason_code = "container_selected"
+    else:
+        from plugins._browser.helpers.config import parse_extension_browser_selection
+
+        try:
+            extension_selection = parse_extension_browser_selection(configured_selection)
+        except ValueError:
+            selection = "extension:<invalid>"
+            configured_backend_id = None
+            state = "blocked"
+            reason_code = "invalid_extension_browser_selection"
+        else:
+            if extension_selection is not None:
+                selection = "extension:<redacted>"
+                configured_backend_id = "chrome_extension"
+                state = "configured"
+                reason_code = "extension_selection_configured"
+            elif configured_selection:
+                selection = "legacy:<redacted>"
+                configured_backend_id = "legacy_cdp"
+                state = "selected"
+                reason_code = "legacy_selection_configured"
+            else:
+                selection = ""
+                configured_backend_id = None
+                state = "not_selected"
+                reason_code = "host_selection_automatic"
+
+    return {
+        "runtime_backend": runtime_backend,
+        "browser_selection": selection,
+        "configured_backend_id": configured_backend_id,
+        "state": state,
+        "reason_code": reason_code,
+        "source": "supplied_project_config",
+    }
+
+
+def _server_layer(gate: BrowserBridgeGate, checked_at: str) -> BrowserBridgeStatusLayer:
+    if gate.reason_code == "invalid_rollout_defaulted_disabled":
+        return BrowserBridgeStatusLayer(
+            state="blocked",
+            reason_code=gate.reason_code,
+            message="The configured bridge rollout is invalid; the server failed closed.",
+            checked_at=checked_at,
+            source="server_environment",
+        )
+    if gate.state == "disabled":
+        return BrowserBridgeStatusLayer(
+            state="blocked",
+            reason_code="rollout_disabled",
+            message="The extension bridge server gate is disabled.",
+            checked_at=checked_at,
+            source="server_environment",
+        )
+    return BrowserBridgeStatusLayer(
+        state="configured",
+        reason_code=gate.reason_code,
+        message=(
+            "The extension bridge preview gate is configured; remote readiness is not checked."
+            if gate.state == "preview"
+            else (
+                "The extension bridge availability gate is configured; "
+                "remote readiness is not checked."
+            )
+        ),
+        checked_at=checked_at,
+        source="server_environment",
+    )
+
+
+def _remote_layer(
+    gate: BrowserBridgeGate,
+    *,
+    extension_selected: bool,
+    selection_block_reason: str,
+    selection_checked: bool,
+) -> BrowserBridgeStatusLayer:
+    if gate.state == "disabled":
+        return BrowserBridgeStatusLayer(
+            state="not_checked",
+            reason_code="rollout_disabled",
+            message="This remote layer was not checked because the server gate is disabled.",
+            checked_at=None,
+            source="not_checked",
+        )
+    if not selection_checked:
+        return BrowserBridgeStatusLayer(
+            state="not_checked",
+            reason_code="project_selection_scope_unavailable",
+            message="This remote layer was not checked without a project selection scope.",
+            checked_at=None,
+            source="not_checked",
+        )
+    if selection_block_reason:
+        return BrowserBridgeStatusLayer(
+            state="not_checked",
+            reason_code=selection_block_reason,
+            message=(
+                "This remote layer was not checked because the project "
+                "configuration is invalid."
+            ),
+            checked_at=None,
+            source="not_checked",
+        )
+    if not extension_selected:
+        return BrowserBridgeStatusLayer(
+            state="not_checked",
+            reason_code="extension_not_selected",
+            message="This remote layer was not checked because no extension bridge is selected.",
+            checked_at=None,
+            source="not_checked",
+        )
+    return BrowserBridgeStatusLayer(
+        state="unknown",
+        reason_code="status_source_unavailable",
+        message="No authenticated remote status source is available for this layer.",
+        checked_at=None,
+        source="unavailable",
+    )
+
+
+def build_browser_bridge_status(
+    browser_config: dict[str, Any] | None,
+    gate: BrowserBridgeGate,
+    *,
+    checked_at: str | None = None,
+) -> dict[str, Any]:
+    safe_checked_at = checked_at or _checked_at_now()
+    selection = _redacted_selection(browser_config)
+    remote_layer = _remote_layer(
+        gate,
+        extension_selected=selection["configured_backend_id"] == "chrome_extension",
+        selection_block_reason=(
+            selection["reason_code"] if selection["state"] == "blocked" else ""
+        ),
+        selection_checked=selection["state"] != "not_checked",
+    )
+    layers = {"server": _server_layer(gate, safe_checked_at).as_dict()}
+    layers.update({name: remote_layer.as_dict() for name in _REMOTE_LAYER_NAMES})
+
+    return {
+        "scope": "extension_bridge_foundation",
+        "foundation_contract": BROWSER_BRIDGE_FOUNDATION_CONTRACT,
+        "status_contract": BROWSER_BRIDGE_STATUS_CONTRACT,
+        "gate": gate.as_dict(),
+        "selection": selection,
+        "layers": layers,
+        "trust": build_browser_bridge_pairing_foundation_status(gate),
+        "mv3_runtime": build_mv3_runtime_foundation_status(),
+        "actions": [],
+    }

--- a/plugins/_browser/helpers/config.py
+++ b/plugins/_browser/helpers/config.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
+from contextvars import ContextVar
+import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -33,6 +37,76 @@ DEFAULT_MAX_OPEN_TABS = 32
 MIN_MAX_OPEN_TABS = 1
 HARD_MAX_OPEN_TABS = 50
 DEFAULT_HOST_BROWSER_PRIVACY_POLICY = "allow"
+EXTENSION_BROWSER_SELECTION_PREFIX = "extension:"
+INVALID_EXTENSION_BROWSER_SELECTION = EXTENSION_BROWSER_SELECTION_PREFIX
+DEVELOPMENT_EXTENSION_BROWSER_SELECTION_PREFIX = "development-extension:"
+INVALID_DEVELOPMENT_EXTENSION_BROWSER_SELECTION = (
+    DEVELOPMENT_EXTENSION_BROWSER_SELECTION_PREFIX
+)
+_EXTENSION_NAMESPACE_RE = re.compile(
+    r"^extension(?:[^A-Za-z0-9._/-]*:|$)",
+    re.IGNORECASE | re.ASCII,
+)
+_EXTENSION_BRIDGE_ID_RE = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,126}[A-Za-z0-9])?$"
+)
+_DEVELOPMENT_EXTENSION_NAMESPACE_RE = re.compile(
+    r"^development-extension(?:[^A-Za-z0-9._/-]*:|$)",
+    re.IGNORECASE | re.ASCII,
+)
+_production_selection_write = ContextVar("browser_production_selection_write", default=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionBrowserSelection:
+    value: str
+    bridge_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class DevelopmentExtensionBrowserSelection:
+    value: str
+    bridge_id: str
+
+
+def parse_development_extension_browser_selection(
+    value: Any,
+) -> DevelopmentExtensionBrowserSelection | None:
+    """Parse the separate development namespace without legacy fallback."""
+
+    selection = str(value or "").strip()
+    if not _DEVELOPMENT_EXTENSION_NAMESPACE_RE.match(selection):
+        return None
+    if not selection.startswith(DEVELOPMENT_EXTENSION_BROWSER_SELECTION_PREFIX):
+        raise ValueError(
+            "the reserved development extension prefix must be exactly "
+            "'development-extension:'"
+        )
+    bridge_id = selection.removeprefix(
+        DEVELOPMENT_EXTENSION_BROWSER_SELECTION_PREFIX
+    )
+    if not _EXTENSION_BRIDGE_ID_RE.fullmatch(bridge_id):
+        raise ValueError("the development extension bridge ID is invalid")
+    return DevelopmentExtensionBrowserSelection(selection, bridge_id)
+
+
+def parse_extension_browser_selection(value: Any) -> ExtensionBrowserSelection | None:
+    """Parse the reserved extension selection without accepting a legacy fallback."""
+    selection = str(value or "").strip()
+    if not _EXTENSION_NAMESPACE_RE.match(selection):
+        return None
+    if not selection.startswith(EXTENSION_BROWSER_SELECTION_PREFIX):
+        raise ValueError(
+            "the reserved extension browser prefix must be exactly 'extension:'"
+        )
+
+    bridge_id = selection.removeprefix(EXTENSION_BROWSER_SELECTION_PREFIX)
+    if not _EXTENSION_BRIDGE_ID_RE.fullmatch(bridge_id):
+        raise ValueError(
+            "the extension browser bridge ID must be 1-128 ASCII letters, digits, dots, "
+            "underscores, or hyphens"
+        )
+    return ExtensionBrowserSelection(value=selection, bridge_id=bridge_id)
 
 
 def _normalize_extension_paths(value: Any) -> list[str]:
@@ -65,13 +139,93 @@ def _normalize_host_browser_selection(value: Any) -> str:
     raw = str(value or "").strip()
     if not raw:
         return ""
+    try:
+        development_selection = parse_development_extension_browser_selection(raw)
+    except ValueError:
+        return INVALID_DEVELOPMENT_EXTENSION_BROWSER_SELECTION
+    if development_selection is not None:
+        return development_selection.value
+    try:
+        extension_selection = parse_extension_browser_selection(raw)
+    except ValueError:
+        # Keep malformed values in the reserved namespace so runtime selection
+        # rejects them instead of routing them through the legacy connector.
+        return INVALID_EXTENSION_BROWSER_SELECTION
+    if extension_selection is not None:
+        return extension_selection.value
     endpoint_like = "://" in raw or (
         raw.rpartition(":")[0] and raw.rpartition(":")[2].isdigit()
     )
     if endpoint_like:
         return "".join(ch for ch in raw if ch.isprintable() and not ch.isspace())[:2048]
     normalized = raw.lower().replace(" ", "_")
-    return "".join(ch for ch in normalized if ch.isalnum() or ch in {"_", "-", ":", ".", "/"})[:200]
+    return "".join(
+        ch for ch in normalized if ch.isalnum() or ch in {"_", "-", ":", ".", "/"}
+    )[:200]
+
+
+def normalize_host_browser_selection(value: Any) -> str:
+    """Normalize legacy selections while reserving extension values fail-closed."""
+
+    return _normalize_host_browser_selection(value)
+
+
+def validate_extension_browser_selection_change(
+    *,
+    proposed_value: Any,
+    current_value: Any,
+    proposed_runtime_backend: Any,
+    current_runtime_backend: Any,
+) -> None:
+    """Block new extension selections until the atomic activation flow exists."""
+
+    proposed = _normalize_host_browser_selection(proposed_value)
+    current = _normalize_host_browser_selection(current_value)
+    try:
+        development_selection = parse_development_extension_browser_selection(
+            proposed
+        )
+    except ValueError as exc:
+        raise ValueError(
+            "The reserved development extension browser selection is invalid."
+        ) from exc
+    if development_selection is not None:
+        proposed_backend = _normalize_runtime_backend(proposed_runtime_backend)
+        current_backend = _normalize_runtime_backend(current_runtime_backend)
+        if proposed == current and not (
+            proposed_backend == "host_required" and current_backend != "host_required"
+        ):
+            return
+        raise ValueError(
+            "Development Chrome extension selection is retired. Use the production "
+            "browser pairing flow."
+        )
+    try:
+        extension_selection = parse_extension_browser_selection(proposed)
+    except ValueError as exc:
+        raise ValueError("The reserved extension browser selection is invalid.") from exc
+    if extension_selection is not None:
+        proposed_backend = _normalize_runtime_backend(proposed_runtime_backend)
+        current_backend = _normalize_runtime_backend(current_runtime_backend)
+        if proposed == current and not (
+            proposed_backend == "host_required" and current_backend != "host_required"
+        ):
+            return
+        if _production_selection_write.get() is True:
+            return
+        raise ValueError(
+            "Choose this paired browser using the protected browser selection flow."
+        )
+
+
+@contextmanager
+def protected_production_selection_write():
+    """Lexical capability held only by the protected paired-browser selector."""
+    token = _production_selection_write.set(True)
+    try:
+        yield
+    finally:
+        _production_selection_write.reset(token)
 
 
 def _normalize_default_homepage(value: Any) -> str:

--- a/plugins/_browser/helpers/extension_artifacts.py
+++ b/plugins/_browser/helpers/extension_artifacts.py
@@ -1,0 +1,90 @@
+"""Consume verified screenshot output into Core-owned chat media, never a peer path."""
+
+import io
+import hashlib
+import re
+from typing import Any, Callable
+
+from plugins._a0_connector.helpers.browser_bridge_artifacts import ArtifactBinding, BrowserBridgeArtifactReceiver, MAX_ARTIFACT_BYTES
+
+
+class ExtensionArtifactError(ValueError):
+    pass
+
+
+class ExtensionScreenshotMaterializer:
+    def __init__(self, *, receiver: BrowserBridgeArtifactReceiver, lease_for: Callable,
+                 current: Callable[[ArtifactBinding], bool], save_image: Callable | None = None):
+        self._receiver = receiver
+        self._transport_profile = receiver.transport_profile
+        self._lease_for = lease_for
+        self._current = current
+        self._save_image = save_image or _save_chat_image
+
+    def __call__(self, binding, call, completion) -> dict[str, Any]:
+        result = completion.result
+        if (call.action != "screenshot" or call.target is None or not completion.ok or completion.receipts
+                or len(completion.artifacts) != 1 or not isinstance(result, dict)
+                or set(result) != {"lease_id", "browser_id", "tab_handle", "artifact_id"}):
+            raise ExtensionArtifactError("INVALID_SCREENSHOT_RESULT")
+        handle = call.target["tab_handle"]
+        lease = self._lease_for(binding, handle)
+        if (lease is None or result["lease_id"] != lease.lease_id
+                or result["browser_id"] != handle or result["tab_handle"] != handle):
+            raise ExtensionArtifactError("LEASE_CONFLICT")
+        claimed = completion.artifacts[0]
+        expected_mime = "image/jpeg" if call.args.get("format") == "jpeg" else "image/png"
+        if (not isinstance(claimed, dict) or set(claimed) != {"artifact_id", "mime_type", "byte_count", "sha256", "purpose"}
+                or claimed["artifact_id"] != result["artifact_id"] or claimed["purpose"] != "screenshot"
+                or claimed["mime_type"] != expected_mime or type(claimed["byte_count"]) is not int
+                or not 1 <= claimed["byte_count"] <= MAX_ARTIFACT_BYTES
+                or not isinstance(claimed["sha256"], str) or re.fullmatch(r"sha256:[a-f0-9]{64}", claimed["sha256"]) is None):
+            raise ExtensionArtifactError("INVALID_SCREENSHOT_DESCRIPTOR")
+        artifact = ArtifactBinding(
+            binding.principal, binding.connector_sid, binding.load_generation_id, binding.bridge_id,
+            binding.context_id, binding.browser_session_id, binding.turn_id, binding.action_id, binding.op_id,
+            claimed["artifact_id"], "output", "screenshot",
+            transport_profile=self._transport_profile,
+        )
+
+        def consume(stream, descriptor):
+            if descriptor.as_dict() != claimed:
+                raise ExtensionArtifactError("ARTIFACT_INTEGRITY_MISMATCH")
+            payload = stream.read(MAX_ARTIFACT_BYTES + 1)
+            if len(payload) != descriptor.byte_count or "sha256:" + hashlib.sha256(payload).hexdigest() != descriptor.sha256:
+                raise ExtensionArtifactError("ARTIFACT_INTEGRITY_MISMATCH")
+            _validate_image(payload, expected_mime)
+            # Decoding/verification cannot extend a turn or revive a lease.
+            current_lease = self._lease_for(binding, handle)
+            if (self._current(artifact) is not True or current_lease is None
+                    or current_lease.lease_id != lease.lease_id or current_lease.origin != lease.origin):
+                raise ExtensionArtifactError("SCOPE_DENIED")
+            saved = self._save_image(context_id=binding.context_id, payload=payload, mime_type=expected_mime,
+                                     category="screenshots", source="browser", preferred_name="browser-screenshot",
+                                     max_bytes=MAX_ARTIFACT_BYTES)
+            return {
+                "browser_id": handle, "tab_handle": handle, "lease_id": lease.lease_id,
+                "context_id": binding.context_id, "path": saved.path, "a0_path": saved.a0_path,
+                "mime": expected_mime, "ephemeral": False, "chat_scoped": True,
+                "vision_load": {"tool_name": "vision_load", "tool_args": {"paths": [saved.a0_path]}},
+            }
+
+        return self._receiver.consume(artifact, consume)
+
+
+def _validate_image(payload: bytes, mime: str) -> None:
+    from PIL import Image
+
+    try:
+        with Image.open(io.BytesIO(payload)) as image:
+            if image.format != ("JPEG" if mime == "image/jpeg" else "PNG") or image.width < 1 or image.height < 1 or image.width * image.height > 64_000_000:
+                raise ValueError("invalid screenshot dimensions or format")
+            image.verify()
+    except Exception:
+        raise ExtensionArtifactError("INVALID_SCREENSHOT_IMAGE") from None
+
+
+def _save_chat_image(**kwargs):
+    from helpers.chat_media import save_image_bytes
+
+    return save_image_bytes(**kwargs)

--- a/plugins/_browser/helpers/extension_first_open.py
+++ b/plugins/_browser/helpers/extension_first_open.py
@@ -1,0 +1,183 @@
+"""Process-only user consent before an owned tab exists; not a native receipt."""
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+import threading
+import time
+import uuid
+
+from plugins._a0_connector.helpers.browser_bridge_policy import normalize_site_origin
+from plugins._a0_connector.helpers.browser_bridge_operations import OperationBinding
+
+
+class FirstOpenDenied(RuntimeError):
+    pass
+
+
+@dataclass(repr=False)
+class _Request:
+    challenge_id: str
+    binding: OperationBinding
+    origin: str
+    current: object
+    expires: int
+    future: Future = field(default_factory=Future)
+    decision: str | None = None
+    grant_id: str = field(default_factory=lambda: "open-grant-" + uuid.uuid4().hex)
+    decision_id: str = field(default_factory=lambda: "open-decision-" + uuid.uuid4().hex)
+    grant_expires: int = 0
+    lease_handle: str | None = None
+
+
+def _same_turn(a, b):
+    return a.principal is b.principal and all(getattr(a, key) == getattr(b, key) for key in (
+        "connector_sid", "load_generation_id", "bridge_id", "context_id", "browser_session_id", "turn_id"))
+
+
+class FirstOpenSiteAuthority:
+    def __init__(self, *, clock_ms=None, approval_ms=120_000, grant_ms=7_200_000, max_entries=64,
+                 policy_repository=None, server_instance_id=None):
+        if (any(type(value) is not int for value in (approval_ms, grant_ms, max_entries))
+                or not 1 <= approval_ms <= 120_000 or not 1 <= grant_ms <= 7_200_000 or not 1 <= max_entries <= 64):
+            raise ValueError("invalid first-open bounds")
+        self._clock = clock_ms or (lambda: time.time_ns() // 1_000_000)
+        self._approval_ms, self._grant_ms, self._max = approval_ms, grant_ms, max_entries
+        self._entries = {}
+        self._lock = threading.RLock()
+        self._policy = policy_repository
+        self._server_id = server_instance_id
+
+    def _saved_grant(self, entry):
+        if self._policy is None or self._server_id is None:
+            raise FirstOpenDenied()
+        return self._policy.active_grant(server_instance_id=self._server_id,
+            bridge_id=entry.binding.bridge_id, subject_id=entry.binding.principal.subject_id,
+            origin=entry.origin)
+
+    def _live(self, entry):
+        try:
+            return entry.current(entry.binding) is True
+        except Exception:
+            return False
+
+    def _prune(self):
+        now = self._clock()
+        for key, entry in tuple(self._entries.items()):
+            deadline = entry.expires if entry.decision is None or entry.decision == "deny" else entry.grant_expires
+            if now >= deadline or not self._live(entry):
+                self._remove(key)
+
+    def _remove(self, key):
+        entry = self._entries.pop(key, None)
+        if entry is not None and not entry.future.done():
+            entry.future.set_result(False)
+
+    async def request(self, binding, origin, *, current):
+        if not isinstance(binding, OperationBinding) or not callable(current) or current(binding) is not True:
+            raise FirstOpenDenied()
+        origin = normalize_site_origin(origin)
+        with self._lock:
+            self._prune()
+            existing = self.grant_for(binding, origin)
+            if existing is not None:
+                return existing
+            if len(self._entries) >= self._max:
+                raise FirstOpenDenied()
+            entry = _Request("open-site-" + uuid.uuid4().hex, binding, origin, current,
+                             self._clock() + self._approval_ms)
+            self._entries[entry.challenge_id] = entry
+        try:
+            allowed = await asyncio.wait_for(asyncio.wrap_future(entry.future), self._approval_ms / 1000)
+            grant = self.grant_for(binding, origin)
+            if not allowed or grant is None or current(binding) is not True:
+                raise FirstOpenDenied()
+            return grant
+        except BaseException:
+            with self._lock:
+                self._remove(entry.challenge_id)
+            raise
+
+    def list_pending(self, *, subject_id, context_id, bridge_id):
+        with self._lock:
+            self._prune()
+            return tuple({"challenge_id": entry.challenge_id, "origin": entry.origin,
+                "action_class": "open", "summary": "Open this site in an Agent Zero-owned tab.",
+                "options": ["deny", "allow_once", "allow_turn", "allow_site"], "expires_at_ms": entry.expires}
+                for entry in self._entries.values() if entry.decision is None
+                and entry.binding.principal.subject_id == subject_id
+                and entry.binding.context_id == context_id and entry.binding.bridge_id == bridge_id)
+
+    def decide(self, *, subject_id, challenge_id, decision):
+        if decision not in {"deny", "allow_once", "allow_turn", "allow_site"}:
+            raise FirstOpenDenied()
+        with self._lock:
+            self._prune()
+            entry = self._entries.get(challenge_id)
+            if (entry is None or entry.binding.principal.subject_id != subject_id
+                    or self._clock() >= entry.expires or not self._live(entry)):
+                raise FirstOpenDenied()
+            if entry.decision is not None and entry.decision != decision:
+                raise FirstOpenDenied()
+            if entry.decision is None:
+                if decision == "allow_site":
+                    if self._policy is None or self._server_id is None:
+                        raise FirstOpenDenied()
+                    # Persist only this explicit exact-origin choice, before
+                    # releasing the waiter. No caller-supplied policy fields.
+                    grant = self._policy.allow(server_instance_id=self._server_id,
+                        bridge_id=entry.binding.bridge_id, subject_id=entry.binding.principal.subject_id,
+                        origin=entry.origin)
+                    saved = self._saved_grant(entry)
+                    if (saved is None or saved.grant_id != grant.grant_id
+                            or not self._live(entry) or self._clock() >= entry.expires):
+                        self._remove(challenge_id)
+                        raise FirstOpenDenied()
+                    entry.grant_id = saved.grant_id
+                entry.decision = decision
+                entry.grant_expires = self._clock() + self._grant_ms
+                if not entry.future.done():
+                    entry.future.set_result(decision != "deny")
+            return {"challenge_id": challenge_id, "decision": decision,
+                    "control_id": entry.decision_id, "status": "accepted", "expires_at_ms": entry.expires}
+
+    def grant_for(self, binding, origin, target_handle=None):
+        with self._lock:
+            self._prune()
+            for entry in self._entries.values():
+                if entry.origin != origin or not _same_turn(entry.binding, binding) or not self._live(entry):
+                    continue
+                if entry.decision == "allow_site":
+                    saved = self._saved_grant(entry)
+                    return saved.grant_id if saved is not None and saved.grant_id == entry.grant_id else None
+                if entry.decision == "allow_turn" or (entry.decision == "allow_once" and (
+                    (target_handle is None and entry.lease_handle is None
+                     and entry.binding.op_id == binding.op_id and entry.binding.action_id == binding.action_id)
+                    or (target_handle is not None and entry.lease_handle == target_handle))):
+                    return entry.grant_id
+        return None
+
+    def observe_open(self, binding, origin, result):
+        handle = result.get("tab_handle") if isinstance(result, dict) else None
+        if not isinstance(handle, str) or not handle or len(handle) > 256:
+            return
+        with self._lock:
+            self._prune()
+            for entry in self._entries.values():
+                if (_same_turn(entry.binding, binding) and entry.binding.op_id == binding.op_id
+                        and entry.binding.action_id == binding.action_id and entry.origin == origin
+                        and entry.decision == "allow_once" and self._live(entry)):
+                    entry.lease_handle = handle
+
+    def retire(self, predicate=lambda _binding: True):
+        with self._lock:
+            for key, entry in tuple(self._entries.items()):
+                if predicate(entry.binding):
+                    self._remove(key)
+
+
+def current_first_open_authority():
+    from plugins._a0_connector.helpers.browser_bridge_bootstrap import get_browser_bridge_application
+    application = get_browser_bridge_application()
+    return getattr(application.browser, "first_open_authority", None) if application is not None and application.installed else None

--- a/plugins/_browser/helpers/extension_first_open.py.dox.md
+++ b/plugins/_browser/helpers/extension_first_open.py.dox.md
@@ -1,0 +1,59 @@
+# First-open site authority
+
+## Purpose and ownership
+
+The installed production Browser service owns a separate process-only approval
+before sending an `open` operation for an origin without existing permission.
+This is not an extension challenge, native resolution control or native receipt.
+The protected site inbox exposes its fixed `open` action class and origin only.
+
+## Contract
+
+- The caller first checks saved browsing policy. An explicitly enabled
+  production All websites setting yields a generation-bound exact-origin
+  grant, so no first-open request is created for that permitted origin.
+  Neither pairing nor this helper enables the setting. Queued dispatch still
+  rechecks the exact current policy grant, route and turn; disabling the setting
+  withdraws its derived grants. Restricted URLs and consequential-action
+  approvals remain independent. The rules below govern requests that were
+  actually created because no saved permission existed.
+
+- Retain at most 64 entries, a canonical HTTP(S) origin, opaque generated IDs,
+  exact immutable operation binding and a server-owned current-binding check.
+  Never retain full URLs, arguments or page content in these requests.
+- Wait at most two minutes before broker dispatch. Only an explicit protected
+  `deny`, `allow_once`, `allow_turn` or `allow_site` decision may settle the request. Validate
+  subject, exact current principal object/SID/load/context/session/turn and
+  selected bridge at decision, grant lookup and queued dispatch.
+- `allow_once` initially permits only its original operation/action. After the
+  real lease index accepts its correlated successful open result, permit site
+  access only on that resulting exact owned handle in the same active turn.
+  A second open, foreign lease or subsequent turn needs separate permission.
+- `allow_turn` permits the same canonical origin for that exact route and live
+  turn. Both choices expire within two hours, with no route or turn adoption.
+  Existing per-action consequential consent remains independent.
+- `allow_site` alone persists an exact-origin allow through the composed
+  BrowserBridgePolicyRepository. Derive server instance from the owner and
+  bridge/subject/origin from the retained request. Write and read back before
+  releasing the waiter, then recheck current selection/turn and request expiry.
+  A failed or uncertain save never releases the waiting operation. If authority
+  disappears during a successful save, do not dispatch; the user's explicit
+  saved-site choice may nevertheless remain and can be removed in settings.
+  Normal saved-policy lookup owns later chat/turn access, rechecking the active
+  bridge route and exact origin. Temporary request retirement never deletes an
+  explicitly remembered policy. No wildcard, neighboring origin or native
+  navigation `allow_site` choice is introduced.
+- Request cancellation, expiry, route retirement, finalization and service
+  uninstall withdraw pending state and wake waiters without browser dispatch.
+  Stale bindings are pruned on every authority lookup. Unknown effects never
+  create resulting-lease permission. Importing this helper installs nothing.
+- The browser-host open handler independently enforces the server-origin grant
+  and records the resulting owned lease. No wire schema or native grant-receipt
+  rules are relaxed; cross-origin navigate keeps its existing native lane.
+
+## Verification
+
+Run the focused first-open, canonical runtime, site-authority and site-inbox
+tests with synthetic routes/leases and an isolated framework runtime. Tests
+must prove no send before choice/persistence, no saved policy write for temporary choices, exact once/turn scope,
+stale/deny/expiry/cancel behavior and development-channel exclusion.

--- a/plugins/_browser/helpers/extension_leases.py
+++ b/plugins/_browser/helpers/extension_leases.py
@@ -1,0 +1,222 @@
+"""Bounded current-route ownership learned only from correlated Browser results.
+
+This index is not Chrome authority and is never persisted. The extension still
+checks its exact live lease/document before every effect. URLs, titles, page
+content and provider tab IDs do not belong in this index.
+"""
+
+from dataclasses import dataclass, replace
+import hashlib
+import re
+import threading
+from typing import Any, Callable
+
+from plugins._a0_connector.helpers.browser_bridge_operations import OperationBinding, TurnBinding
+from plugins._a0_connector.helpers.browser_bridge_policy import normalize_site_origin
+
+
+_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+
+
+class ExtensionLeaseError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionDocument:
+    document_id: str
+    document_epoch: int
+    refs: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionLease:
+    binding: OperationBinding
+    lease_id: str
+    tab_handle: str
+    origin: str
+    disposition: str
+    document: ExtensionDocument | None = None
+
+
+class ExtensionLeaseIndex:
+    def __init__(self, *, authorizer: Callable[[OperationBinding], bool], max_leases: int = 1024):
+        if type(max_leases) is not int or not 1 <= max_leases <= 4096:
+            raise ValueError("invalid lease bound")
+        self._authorizer = authorizer
+        self._max_leases = max_leases
+        self._leases: dict[tuple[int, str, str, str], ExtensionLease] = {}
+        self._lock = threading.RLock()
+
+    def _current(self, binding: OperationBinding) -> bool:
+        try:
+            return self._authorizer(binding) is True
+        except Exception:
+            return False
+
+    @staticmethod
+    def _key(binding: OperationBinding, handle: str) -> tuple[int, str, str, str]:
+        return (id(binding.principal), binding.connector_sid, binding.load_generation_id, handle)
+
+    def origin_for(self, binding: OperationBinding, handle: str) -> str | None:
+        lease = self.lease_for(binding, handle)
+        return lease.origin if lease is not None else None
+
+    def document_for(self, binding: OperationBinding, handle: str) -> ExtensionDocument | None:
+        lease = self.lease_for(binding, handle)
+        return lease.document if lease is not None else None
+
+    def clear_document(self, binding: OperationBinding, handle: str) -> None:
+        with self._lock:
+            lease = self._leases.get(self._key(binding, handle))
+            if lease is not None and _same_session(lease.binding, binding):
+                self._leases[self._key(binding, handle)] = replace(lease, document=None)
+
+    def observe_content(self, binding: OperationBinding, handle: str, result: dict[str, Any]) -> None:
+        """Remember only document/ref provenance from correlated inspection.
+
+        Labels, DOM and text remain tool output, not approval authority. A
+        challenge cannot populate this record or introduce an unseen ref.
+        """
+        with self._lock:
+            lease = self.lease_for(binding, handle)
+            if (lease is None or not isinstance(result, dict)
+                    or set(result) != {"lease_id", "browser_id", "tab_handle", "document_id", "document_epoch", "title", "text", "nodes", "truncated"}
+                    or result["lease_id"] != lease.lease_id or result["browser_id"] != handle or result["tab_handle"] != handle):
+                raise ExtensionLeaseError("LEASE_CONFLICT")
+            document_id = _identifier(result["document_id"])
+            epoch = result["document_epoch"]
+            if (not isinstance(epoch, str) or re.fullmatch(r"0|[1-9][0-9]{0,15}", epoch) is None
+                    or int(epoch) > 2**53 - 1 or not isinstance(result["nodes"], list) or len(result["nodes"]) > 128):
+                raise ExtensionLeaseError("DOCUMENT_CONFLICT")
+            refs = []
+            for node in result["nodes"]:
+                if not isinstance(node, dict) or set(node) != {"ref", "role", "name"}:
+                    raise ExtensionLeaseError("DOCUMENT_CONFLICT")
+                ref = _identifier(node["ref"])
+                if len(ref) > 128:
+                    raise ExtensionLeaseError("DOCUMENT_CONFLICT")
+                refs.append(ref)
+            if len(set(refs)) != len(refs) or not self._current(binding):
+                raise ExtensionLeaseError("DOCUMENT_CONFLICT")
+            document = ExtensionDocument(document_id, int(epoch), frozenset(refs))
+            if lease.document is not None:
+                previous = lease.document
+                if (document.document_epoch < previous.document_epoch or
+                        (document.document_epoch == previous.document_epoch and document.document_id != previous.document_id)):
+                    raise ExtensionLeaseError("DOCUMENT_CONFLICT")
+            self._leases[self._key(binding, handle)] = replace(lease, document=document)
+
+    def lease_for(self, binding: OperationBinding, handle: str) -> ExtensionLease | None:
+        if not self._current(binding):
+            return None
+        with self._lock:
+            lease = self._leases.get(self._key(binding, handle))
+            if lease is None or not _same_session(lease.binding, binding):
+                return None
+            return lease if self._current(binding) else None
+
+    def observe_open(self, binding: OperationBinding, result: dict[str, Any], expected_origin: str) -> ExtensionLease:
+        """Call only after exact broker settlement of a successful open."""
+        if not isinstance(result, dict) or not self._current(binding):
+            raise ExtensionLeaseError("SCOPE_DENIED")
+        lease_id, handle = _identifier(result.get("lease_id")), _identifier(result.get("tab_handle"))
+        if lease_id == handle or result.get("browser_id") != handle:
+            raise ExtensionLeaseError("LEASE_CONFLICT")
+        try:
+            origin = normalize_site_origin(result.get("origin"))
+        except Exception:
+            raise ExtensionLeaseError("ORIGIN_BLOCKED") from None
+        disposition = result.get("disposition")
+        if origin != expected_origin or disposition != "ephemeral":
+            raise ExtensionLeaseError("LEASE_CONFLICT")
+        lease = ExtensionLease(binding, lease_id, handle, origin, disposition)
+        with self._lock:
+            key = self._key(binding, handle)
+            old = self._leases.get(key)
+            if old is not None and old != lease:
+                raise ExtensionLeaseError("LEASE_CONFLICT")
+            if any(
+                other.lease_id == lease_id and other_key != key
+                and other.binding.principal is binding.principal
+                and other.binding.load_generation_id == binding.load_generation_id
+                for other_key, other in self._leases.items()
+            ):
+                raise ExtensionLeaseError("LEASE_CONFLICT")
+            if old is None and len(self._leases) >= self._max_leases:
+                raise ExtensionLeaseError("LEASE_REGISTRY_FULL")
+            if not self._current(binding):
+                raise ExtensionLeaseError("SCOPE_DENIED")
+            self._leases[key] = lease
+        return lease
+
+    def invalidate(self, *, principal, connector_sid: str, load_generation_id: str, tab_handle: str | None = None) -> None:
+        with self._lock:
+            self._leases = {
+                key: lease for key, lease in self._leases.items()
+                if not (
+                    lease.binding.principal is principal
+                    and lease.binding.connector_sid == connector_sid
+                    and lease.binding.load_generation_id == load_generation_id
+                    and (tab_handle is None or lease.tab_handle == tab_handle)
+                )
+            }
+
+    def observe_navigation(self, binding: OperationBinding, handle: str, result: dict[str, Any], expected_origin: str) -> None:
+        """Advance only the exact retained lease after correlated success."""
+        with self._lock:
+            lease = self.lease_for(binding, handle)
+            if lease is None or not isinstance(result, dict) or set(result) != {"lease_id", "browser_id", "tab_handle", "origin"}:
+                raise ExtensionLeaseError("LEASE_CONFLICT")
+            if (result["lease_id"] != lease.lease_id or result["browser_id"] != handle
+                    or result["tab_handle"] != handle or result["origin"] != expected_origin
+                    or normalize_site_origin(expected_origin) != expected_origin):
+                raise ExtensionLeaseError("LEASE_CONFLICT")
+            if not self._current(binding):
+                raise ExtensionLeaseError("SCOPE_DENIED")
+            self._leases[self._key(binding, handle)] = replace(lease, origin=expected_origin, document=None)
+
+    def retire_turn(self, turn: TurnBinding) -> None:
+        # Even a retained tab does not silently acquire permission in a future
+        # turn. Explicit reconciliation/claim is a separate authority boundary.
+        with self._lock:
+            self._leases = {
+                key: lease for key, lease in self._leases.items()
+                if not (_same_session(lease.binding, turn) and lease.binding.turn_id == turn.turn_id)
+            }
+
+    def invalidate_digests(self, *, principal, connector_sid: str, load_generation_id: str,
+                          context_id: str, browser_session_id: str, turn_id: str,
+                          lease_id_digest: str, browser_id_digest: str) -> None:
+        """Idempotent negative authority for a redacted, authenticated event."""
+        with self._lock:
+            self._leases = {
+                key: lease for key, lease in self._leases.items()
+                if not (
+                    lease.binding.principal is principal
+                    and lease.binding.connector_sid == connector_sid
+                    and lease.binding.load_generation_id == load_generation_id
+                    and lease.binding.context_id == context_id
+                    and lease.binding.browser_session_id == browser_session_id
+                    and lease.binding.turn_id == turn_id
+                    and hashlib.sha256(lease.lease_id.encode()).hexdigest() == lease_id_digest
+                    and hashlib.sha256(lease.tab_handle.encode()).hexdigest() == browser_id_digest
+                )
+            }
+
+
+def _identifier(value: Any) -> str:
+    if not isinstance(value, str) or _ID.fullmatch(value) is None:
+        raise ExtensionLeaseError("LEASE_CONFLICT")
+    return value
+
+
+def _same_session(left: OperationBinding, right: OperationBinding | TurnBinding) -> bool:
+    return bool(
+        left.principal is right.principal
+        and left.connector_sid == right.connector_sid
+        and left.load_generation_id == right.load_generation_id
+        and left.context_id == right.context_id
+        and left.browser_session_id == right.browser_session_id
+        and left.turn_id == right.turn_id
+    )

--- a/plugins/_browser/helpers/extension_runtime.py
+++ b/plugins/_browser/helpers/extension_runtime.py
@@ -1,0 +1,495 @@
+"""Canonical Browser-tool adapter for an explicitly selected extension route.
+
+Construction requires server-owned authority and lifecycle services. This
+module never discovers a legacy socket, interprets a CDP endpoint, enables the
+rollout, or turns client-supplied policy IDs into permission.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from dataclasses import dataclass, field
+import re
+import threading
+from typing import Any, Callable, ContextManager
+from urllib.parse import urlsplit, urlunsplit
+import uuid
+
+from plugins._a0_connector.helpers.browser_bridge_operations import (
+    BrowserBridgeBrokerError,
+    BrowserBridgeOperationBroker,
+    OperationBinding,
+)
+from plugins._a0_connector.helpers.browser_bridge_policy import (
+    BrowserBridgePolicyRepository,
+    normalize_site_origin,
+)
+
+
+_SUPPORTED = frozenset({"open", "list", "state", "content", "navigate", "scroll", "hover", "click", "type", "ensure", "status", "screenshot_file"})
+_TARGETED = frozenset({"state", "content", "navigate", "scroll", "hover", "click", "type", "screenshot_file"})
+_FOREGROUND_ACTIONS = frozenset({"open", "hover", "click", "type", "scroll", "upload_file"})
+_OPAQUE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+_factory_lock = threading.RLock()
+_runtime_factory: Callable[[Any, str], "ExtensionBrowserRuntime | None"] | None = None
+_runtime_factory_owner: object | None = None
+_legacy_runtime_factory_owner = object()
+
+
+def install_extension_runtime_factory(
+    *,
+    owner: object,
+    factory: Callable[[Any, str], "ExtensionBrowserRuntime | None"],
+) -> bool:
+    """Install one exact process owner without replacing another owner."""
+
+    if owner is None:
+        raise TypeError("Extension runtime factory owner is required")
+    if not callable(factory):
+        raise TypeError("Extension runtime factory must be callable")
+    global _runtime_factory, _runtime_factory_owner
+    with _factory_lock:
+        if _runtime_factory_owner is owner:
+            _runtime_factory = factory
+            return False
+        if _runtime_factory_owner is not None:
+            raise RuntimeError("Extension runtime factory is already installed")
+        _runtime_factory = factory
+        _runtime_factory_owner = owner
+        return True
+
+
+def uninstall_extension_runtime_factory(*, owner: object) -> bool:
+    """Withdraw only ``owner``'s factory; never clear a competing owner."""
+
+    global _runtime_factory, _runtime_factory_owner
+    with _factory_lock:
+        if _runtime_factory_owner is not owner:
+            return False
+        _runtime_factory = None
+        _runtime_factory_owner = None
+        return True
+
+
+def extension_runtime_factory_owned_by(owner: object) -> bool:
+    with _factory_lock:
+        return _runtime_factory_owner is owner and _runtime_factory is not None
+
+
+def configure_extension_runtime_factory(
+    factory: Callable[[Any, str], "ExtensionBrowserRuntime | None"] | None,
+) -> None:
+    """Legacy/test bootstrap seam, isolated as its own exact owner.
+
+    Production composition uses :func:`install_extension_runtime_factory`.
+    Clearing this seam cannot withdraw a separately installed server owner.
+    """
+    if factory is None:
+        uninstall_extension_runtime_factory(owner=_legacy_runtime_factory_owner)
+        return
+    install_extension_runtime_factory(
+        owner=_legacy_runtime_factory_owner,
+        factory=factory,
+    )
+
+
+def selected_extension_runtime(agent: Any, bridge_id: str) -> "ExtensionBrowserRuntime | None":
+    from plugins._browser.helpers.bridge_foundation import get_browser_bridge_gate
+
+    if get_browser_bridge_gate().state != "available":
+        return None
+    with _factory_lock:
+        factory = _runtime_factory
+    if factory is None:
+        return None
+    try:
+        runtime = factory(agent, bridge_id)
+        if (
+            isinstance(runtime, ExtensionBrowserRuntime)
+            and runtime.context_id == str(agent.context.id)
+            and runtime.bridge_id == bridge_id
+        ):
+            return runtime
+    except Exception:
+        pass
+    return None
+
+
+async def wait_selected_extension_runtime(agent: Any, bridge_id: str) -> "ExtensionBrowserRuntime | None":
+    """Wait only for a selected owner's pre-operation reconnect, never replay work."""
+    from plugins._browser.helpers.bridge_foundation import get_browser_bridge_gate
+    from plugins._browser.helpers.config import get_browser_config, parse_extension_browser_selection
+
+    with _factory_lock:
+        factory, owner = _runtime_factory, _runtime_factory_owner
+    if factory is None:
+        return None
+    # Native's first exact repeated hello begins reconciliation after 15s.
+    # Bound this presentation/selection wait; no operation or grant exists yet.
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 25.0
+    def still_selected() -> bool:
+        with _factory_lock:
+            if _runtime_factory is not factory or _runtime_factory_owner is not owner:
+                return False
+        if get_browser_bridge_gate().state != "available":
+            return False
+        try:
+            config = get_browser_config(agent=agent)
+            selection = parse_extension_browser_selection(config.get("host_browser_selection"))
+            return config.get("runtime_backend") == "host_required" and selection is not None and selection.bridge_id == bridge_id
+        except Exception:
+            return False
+    while True:
+        if not still_selected():
+            return None
+        runtime = selected_extension_runtime(agent, bridge_id)
+        if runtime is not None:
+            return runtime if still_selected() else None
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return None
+        await asyncio.sleep(min(0.25, remaining))
+
+
+class ExtensionBrowserError(RuntimeError):
+    def __init__(self, code: str, *, outcome: str = "not_applied") -> None:
+        # Deliberately never include provider exceptions, URLs, or arguments in
+        # errors consumed by the Browser tool's history/log path.
+        super().__init__(f"Chrome extension browser: {code}; outcome={outcome}. No fallback was attempted.")
+        self.code = code
+        self.outcome = outcome
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionCall:
+    action: str
+    target: dict[str, str] | None
+    args: dict[str, Any] = field(repr=False)
+    origin: str | None
+    required_capabilities: tuple[str, ...]
+    upload_source: Any = field(default=None, repr=False)
+
+
+class ExtensionBrowserRuntime:
+    """One call facade; injected services, not this object, own session state."""
+
+    def __init__(
+        self,
+        context_id: str,
+        bridge_id: str,
+        *,
+        broker: BrowserBridgeOperationBroker,
+        binding_factory: Callable[[], OperationBinding],
+        policy_repository: BrowserBridgePolicyRepository,
+        server_instance_id: str,
+        target_origin_resolver: Callable[[OperationBinding, str], str | None],
+        timeout_ms: int = 30_000,
+        call_scope: Callable[[], ContextManager[OperationBinding]] | None = None,
+        binding_current: Callable[[OperationBinding], bool] | None = None,
+        result_observer: Callable[[OperationBinding, ExtensionCall, dict[str, Any]], None] | None = None,
+        site_challenge_ready: Callable[[OperationBinding], bool] | None = None,
+        turn_origin_grant: Callable[[OperationBinding, str], Any] | None = None,
+        artifact_materializer: Callable | None = None,
+        action_challenge_ready: Callable[[OperationBinding], bool] | None = None,
+        prepare_upload: Callable | None = None,
+        upload_sender: Callable | None = None,
+        first_open_authority=None,
+        foreground_preference: Callable[[], bool] | None = None,
+    ) -> None:
+        self.context_id = _opaque(context_id)
+        self.bridge_id = _opaque(bridge_id)
+        self._server_instance_id = _opaque(server_instance_id)
+        if isinstance(timeout_ms, bool) or not isinstance(timeout_ms, int) or not 1 <= timeout_ms <= 120_000:
+            raise ExtensionBrowserError("INVALID_STATE")
+        self._broker = broker
+        self._binding_factory = binding_factory
+        self._policy = policy_repository
+        self._target_origin_resolver = target_origin_resolver
+        self._timeout_ms = timeout_ms
+        self._call_scope = call_scope
+        self._binding_current = binding_current
+        self._result_observer = result_observer
+        self._site_challenge_ready = site_challenge_ready
+        self._turn_origin_grant = turn_origin_grant
+        self._artifact_materializer = artifact_materializer
+        self._action_challenge_ready = action_challenge_ready
+        self._prepare_upload = prepare_upload
+        self._upload_sender = upload_sender
+        self._first_open_authority = first_open_authority
+        self._foreground_preference = foreground_preference
+
+    def _operation_display(self, action: str) -> dict[str, bool]:
+        foreground = False
+        if action in _FOREGROUND_ACTIONS and self._foreground_preference is not None:
+            try:
+                foreground = self._foreground_preference() is True
+            except Exception:
+                # Unavailable settings must not unexpectedly switch host tabs.
+                pass
+        return {
+            "cursor": action in {"scroll", "hover", "click", "type", "upload_file"},
+            "foreground": foreground,
+        }
+
+    async def call(self, method: str, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        if method == "upload_file":
+            from plugins._browser.helpers.extension_uploads import PreparedUpload, UploadSourceDenied
+            if (len(args) != 2 or not set(kwargs) <= {"path", "paths"}
+                or self._prepare_upload is None or self._upload_sender is None):
+                raise ExtensionBrowserError("UNSUPPORTED_CAPABILITY")
+            try:
+                source = self._prepare_upload(**kwargs)
+            except UploadSourceDenied:
+                raise ExtensionBrowserError("UPLOAD_SOURCE_UNAVAILABLE") from None
+            if not isinstance(source, PreparedUpload) or source.context_id != self.context_id:
+                raise ExtensionBrowserError("SCOPE_DENIED")
+            proposed = ExtensionCall("upload_file", {"tab_handle": _opaque(args[0])},
+                {"ref": _opaque(args[1], limit=128), "artifact_id": source.artifact_id,
+                 "mime_type": source.mime_type, "byte_count": source.byte_count, "sha256": source.sha256,
+                 "expected_action_class": "external_side_effect"}, None,
+                ("upload_file", "semantic_dom_v1", "artifacts_v1", "trusted_input_v1", "cursor_v1"), source)
+        else:
+            proposed = encode_extension_call(method, args, kwargs)
+        if self._call_scope is not None:
+            with self._call_scope() as binding:
+                return await self._call_bound(proposed, binding)
+        try:
+            binding = self._binding_factory()
+        except Exception:
+            raise ExtensionBrowserError("SCOPE_DENIED") from None
+        return await self._call_bound(proposed, binding)
+
+    async def _call_bound(self, proposed: ExtensionCall, binding: OperationBinding) -> dict[str, Any]:
+        if (
+            not isinstance(binding, OperationBinding)
+            or binding.context_id != self.context_id
+            or binding.bridge_id != self.bridge_id
+        ):
+            raise ExtensionBrowserError("SCOPE_DENIED")
+        if proposed.action == "screenshot" and self._artifact_materializer is None:
+            raise ExtensionBrowserError("UNSUPPORTED_CAPABILITY")
+        if proposed.action in {"click", "type", "upload_file"} and (
+                self._action_challenge_ready is None or self._action_challenge_ready(binding) is not True):
+            raise ExtensionBrowserError("APPROVAL_REQUIRED")
+
+        target_origin = self._target_origin(binding, proposed)
+        cross_origin = proposed.action == "navigate" and proposed.origin != target_origin
+        if cross_origin and (self._site_challenge_ready is None or self._site_challenge_ready(binding) is not True):
+            raise ExtensionBrowserError("APPROVAL_REQUIRED")
+        # Starting a cross-origin request authorizes only work on the current
+        # owned source. The extension must suspend before navigation until the
+        # server resolves its exact destination/document-bound challenge.
+        origin = target_origin if cross_origin else proposed.origin or target_origin
+        target_handle = proposed.target.get("tab_handle") if proposed.target else None
+        grant = self._origin_grant(binding, origin, target_handle)
+        if (origin is not None and grant is None and proposed.action == "open"
+                and self._first_open_authority is not None and self._binding_current is not None):
+            from plugins._browser.helpers.extension_first_open import FirstOpenDenied
+            try:
+                grant = await self._first_open_authority.request(binding, origin, current=self._binding_current)
+            except TimeoutError:
+                raise ExtensionBrowserError("APPROVAL_EXPIRED") from None
+            except FirstOpenDenied:
+                raise ExtensionBrowserError("APPROVAL_DENIED") from None
+        if origin is not None and grant is None:
+            raise ExtensionBrowserError("ORIGIN_BLOCKED")
+
+        def policy_still_current() -> bool:
+            if self._binding_current is not None and self._binding_current(binding) is not True:
+                return False
+            if cross_origin and self._site_challenge_ready(binding) is not True:
+                return False
+            if proposed.action in {"click", "type", "upload_file"} and self._action_challenge_ready(binding) is not True:
+                return False
+            if self._target_origin(binding, proposed) != target_origin:
+                return False
+            latest = self._origin_grant(binding, origin, target_handle)
+            return latest == grant
+
+        try:
+            ticket = await self._broker.begin_operation(
+                binding, action=proposed.action, target=proposed.target,
+                args=proposed.args, timeout_ms=self._timeout_ms,
+                required_capabilities=proposed.required_capabilities,
+                policy={"origin_grant_id": grant, "action_grant_id": None},
+                display=self._operation_display(proposed.action),
+                dispatch_preflight=policy_still_current,
+            )
+            try:
+                if proposed.action == "upload_file":
+                    try:
+                        await self._upload_sender(binding, ticket, proposed.upload_source)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        try:
+                            await self._broker.begin_cancel(ticket, control_id=str(uuid.uuid4()),
+                                reason="request_canceled", timeout_ms=min(self._timeout_ms, 10_000))
+                        except Exception:
+                            pass
+                        raise ExtensionBrowserError("ARTIFACT_VERIFICATION_FAILED", outcome="unknown") from None
+                result = await self._broker.wait_operation(ticket)
+            except asyncio.CancelledError:
+                # begin_cancel has no suspending work before its bounded,
+                # process-owned send is installed. The requester's canceled
+                # wait is not evidence that the remote operation was undone.
+                try:
+                    await self._broker.begin_cancel(
+                        ticket, control_id=str(uuid.uuid4()), reason="request_canceled",
+                        timeout_ms=min(self._timeout_ms, 10_000),
+                    )
+                except Exception:
+                    pass
+                raise
+        except BrowserBridgeBrokerError as exc:
+            raise ExtensionBrowserError(exc.code, outcome=exc.outcome) from None
+        if not result.ok:
+            raise ExtensionBrowserError(result.code or "INTERNAL_ERROR", outcome=result.outcome or "unknown")
+        if proposed.action == "screenshot":
+            if self._artifact_materializer is None:
+                raise ExtensionBrowserError("UNSUPPORTED_CAPABILITY", outcome="unknown")
+            try:
+                return await asyncio.to_thread(self._artifact_materializer, binding, proposed, result)
+            except Exception:
+                raise ExtensionBrowserError("ARTIFACT_VERIFICATION_FAILED", outcome="unknown") from None
+        # Artifact and receipt verifiers are a separate boundary. Do not expose
+        # an unverified path/descriptor or treat it as approval authority.
+        if result.artifacts or result.receipts or not isinstance(result.result, dict):
+            raise ExtensionBrowserError("UNSUPPORTED_CAPABILITY", outcome="unknown")
+        if self._binding_current is not None and self._binding_current(binding) is not True:
+            raise ExtensionBrowserError("SCOPE_DENIED", outcome="unknown")
+        if self._result_observer is not None:
+            try:
+                self._result_observer(binding, proposed, result.result)
+            except Exception:
+                raise ExtensionBrowserError("LEASE_CONFLICT", outcome="unknown") from None
+        return result.result
+
+    def _target_origin(self, binding: OperationBinding, call: ExtensionCall) -> str | None:
+        if call.target is None:
+            return None
+        try:
+            value = self._target_origin_resolver(binding, call.target["tab_handle"])
+            return normalize_site_origin(value)
+        except Exception:
+            raise ExtensionBrowserError("TAB_NOT_OWNED") from None
+
+    def _origin_grant(self, binding: OperationBinding, origin: str | None, target_handle=None) -> str | None:
+        if origin is None:
+            return None
+        try:
+            grant = self._policy.active_grant(
+                server_instance_id=self._server_instance_id, bridge_id=self.bridge_id,
+                subject_id=binding.principal.subject_id, origin=origin,
+            )
+        except Exception:
+            raise ExtensionBrowserError("ORIGIN_BLOCKED") from None
+        if grant is not None:
+            return grant.grant_id
+        if self._turn_origin_grant is not None:
+            try:
+                turn_grant = self._turn_origin_grant(binding, origin)
+                if turn_grant is not None:
+                    return _opaque(turn_grant.origin_grant_id)
+            except Exception:
+                raise ExtensionBrowserError("ORIGIN_BLOCKED") from None
+        if self._first_open_authority is not None:
+            return self._first_open_authority.grant_for(binding, origin, target_handle)
+        return None
+
+
+def encode_extension_call(method: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> ExtensionCall:
+    """Translate only supported Browser-tool forms; never silently drop fields."""
+    if not isinstance(method, str) or method not in _SUPPORTED:
+        raise ExtensionBrowserError("UNSUPPORTED_CAPABILITY")
+    if method == "hover" and len(args) == 1:
+        if (not set(kwargs) <= {"ref", "x", "y", "offset_x", "offset_y"}
+                or any(type(kwargs.get(key, 0)) not in {int, float} or kwargs.get(key, 0) != 0
+                       for key in ("x", "y", "offset_x", "offset_y"))):
+            raise ExtensionBrowserError("UNSUPPORTED_CAPABILITY")
+        args = (args[0], kwargs.get("ref"))
+        kwargs = {}
+    expected = {"open": 1, "list": 0, "state": 1, "content": 2, "navigate": 2, "scroll": 2, "hover": 2, "click": 2, "type": 3, "ensure": 0, "status": 0, "screenshot_file": 1}[method]
+    if len(args) != expected:
+        raise ExtensionBrowserError("INVALID_STATE")
+    allowed_kwargs = {"include_content"} if method == "list" else {"quality", "full_page", "path"} if method == "screenshot_file" else set()
+    if not set(kwargs) <= allowed_kwargs:
+        raise ExtensionBrowserError("UNSUPPORTED_CAPABILITY")
+    target = {"tab_handle": _opaque(args[0])} if method in _TARGETED else None
+    payload: dict[str, Any] = {}
+    origin = None
+    capabilities = [method]
+    if method in {"open", "navigate"}:
+        payload["url"], origin = _url(args[0] if method == "open" else args[1])
+        if method == "open":
+            payload["disposition"] = "ephemeral"
+            capabilities.extend(("tab_leases_v1", "tab_groups_v1"))
+    elif method == "content":
+        options = args[1]
+        if options is not None and options != {}:
+            # CSS selectors/scripts and old integer refs are deliberately not
+            # interpreted by this semantic document-bound runtime.
+            raise ExtensionBrowserError("UNSUPPORTED_CAPABILITY")
+        capabilities.append("semantic_dom_v1")
+    elif method in {"scroll", "hover", "click", "type"}:
+        payload["ref"] = _opaque(args[1], limit=128)
+        capabilities.extend(("semantic_dom_v1", "cursor_v1"))
+        if method in {"hover", "click", "type"}:
+            capabilities.append("trusted_input_v1")
+        if method == "click":
+            # The existing Browser tool provides no independently verified
+            # risk classification. Never infer approval from model intent.
+            payload["expected_action_class"] = "unknown"
+        elif method == "type":
+            text = args[2]
+            if not isinstance(text, str) or "\x00" in text or "\r" in text:
+                raise ExtensionBrowserError("INVALID_STATE")
+            try:
+                encoded = text.encode("utf-8", errors="strict")
+            except UnicodeError:
+                raise ExtensionBrowserError("INVALID_STATE") from None
+            if not 1 <= len(encoded) <= 32768:
+                raise ExtensionBrowserError("INVALID_STATE")
+            payload.update(text=text, text_sha256=hashlib.sha256(encoded).hexdigest(),
+                           expected_action_class="sensitive_input")
+    elif method == "list":
+        include = kwargs.get("include_content", False)
+        if not isinstance(include, bool):
+            raise ExtensionBrowserError("INVALID_STATE")
+        if include:
+            raise ExtensionBrowserError("UNSUPPORTED_CAPABILITY")
+    elif method == "screenshot_file":
+        quality = kwargs.get("quality", 80)
+        if (type(quality) is not int or not 20 <= quality <= 95
+                or kwargs.get("full_page", False) is not False or kwargs.get("path", "") != ""):
+            raise ExtensionBrowserError("UNSUPPORTED_CAPABILITY")
+        payload = {"format": "jpeg", "quality": quality}
+        capabilities = ["screenshot", "screenshots_v1", "artifacts_v1"]
+        method = "screenshot"
+    return ExtensionCall(method, target, payload, origin, tuple(capabilities))
+
+
+def _opaque(value: Any, *, limit: int = 256) -> str:
+    if not isinstance(value, str) or len(value) > limit or _OPAQUE.fullmatch(value) is None:
+        raise ExtensionBrowserError("INVALID_STATE")
+    return value
+
+
+def _url(value: Any) -> tuple[str, str]:
+    if (
+        not isinstance(value, str) or not value or len(value.encode("utf-8")) > 8192
+        or value != value.strip() or "\\" in value
+        or any(ord(character) <= 0x20 or ord(character) == 0x7f for character in value)
+    ):
+        raise ExtensionBrowserError("INVALID_STATE")
+    try:
+        parsed = urlsplit(value)
+        if parsed.username is not None or parsed.password is not None:
+            raise ValueError("credentials are not a browser URL")
+        origin = normalize_site_origin(urlunsplit((parsed.scheme, parsed.netloc, "", "", "")))
+        canonical = urlsplit(origin)
+        return urlunsplit((canonical.scheme, canonical.netloc, parsed.path or "/", parsed.query, parsed.fragment)), origin
+    except Exception:
+        raise ExtensionBrowserError("INVALID_STATE") from None

--- a/plugins/_browser/helpers/extension_services.py
+++ b/plugins/_browser/helpers/extension_services.py
@@ -1,0 +1,439 @@
+"""Explicit composition of the extension codec, lifecycle and control broker.
+
+The authenticated connector runtime must install this service after validating
+the complete release/capability boundary. Nothing imports or installs it by
+default, and its route resolver must never draw from the legacy CLI registry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+import re
+import threading
+from typing import Any, Callable
+import uuid
+
+from plugins._a0_connector.helpers.browser_bridge_operations import (
+    BrowserBridgeBrokerError, BrowserBridgeOperationBroker, OperationBinding, TurnBinding,
+)
+from plugins._a0_connector.helpers.browser_bridge_policy import BrowserBridgePolicyRepository
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+)
+from plugins._browser.helpers.extension_leases import ExtensionLeaseIndex
+from plugins._browser.helpers.extension_runtime import (
+    ExtensionBrowserError,
+    ExtensionBrowserRuntime,
+    extension_runtime_factory_owned_by,
+    install_extension_runtime_factory,
+    uninstall_extension_runtime_factory,
+)
+from plugins._browser.helpers.extension_sessions import (
+    ExtensionFinalizationIntent, ExtensionSessionLifecycle, ValidatedExtensionRoute,
+    TURN_FINALIZED, TURN_OUTCOME_UNKNOWN,
+)
+
+
+class ExtensionBrowserServices:
+    def __init__(
+        self,
+        *,
+        lifecycle: ExtensionSessionLifecycle,
+        broker: BrowserBridgeOperationBroker,
+        route_resolver: Callable[[str, str], ValidatedExtensionRoute | None],
+        target_origin_resolver: Callable[[OperationBinding, str], str | None] | None = None,
+        policy_repository: BrowserBridgePolicyRepository,
+        server_instance_id: str,
+        site_authority=None,
+        artifact_materializer=None,
+        action_authority=None,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        if isinstance(broker, BrowserBridgeOperationBroker) and (
+            broker.transport_profile is not self._transport_profile
+        ):
+            raise ValueError("Browser bridge broker transport mismatch")
+        if policy_repository.transport_profile is not self._transport_profile:
+            raise ValueError("Browser bridge policy transport mismatch")
+        self.lifecycle = lifecycle
+        self.broker = broker
+        self._route_resolver = route_resolver
+        self.leases = ExtensionLeaseIndex(authorizer=self._binding_route_current)
+        self._target_origin_resolver = target_origin_resolver or self.leases.origin_for
+        self._policy = policy_repository
+        self._server_instance_id = server_instance_id
+        self.site_authority = site_authority
+        from plugins._browser.helpers.extension_first_open import FirstOpenSiteAuthority
+        self.first_open_authority = (FirstOpenSiteAuthority(
+            policy_repository=policy_repository, server_instance_id=server_instance_id)
+            if self._transport_profile is PRODUCTION_BROWSER_BRIDGE_TRANSPORT else None)
+        self.artifact_materializer = artifact_materializer
+        self.action_authority = action_authority
+        self.input_artifact_sender = None
+        self._input_permits = {}
+        self._input_lock = threading.RLock()
+        self._runtime_factory = self.runtime_for_agent
+        self._install_lock = threading.RLock()
+        self._installed = False
+        self._factory_installed = False
+
+    @property
+    def installed(self) -> bool:
+        with self._install_lock:
+            return bool(
+                self._installed
+                and self._factory_owned()
+                and self.lifecycle.configured_for(self)
+            )
+
+    @property
+    def policy_repository(self) -> BrowserBridgePolicyRepository:
+        return self._policy
+
+    def _factory_owned(self) -> bool:
+        return extension_runtime_factory_owned_by(self)
+
+    def _install_factory(self) -> None:
+        install_extension_runtime_factory(
+            owner=self,
+            factory=self._runtime_factory,
+        )
+
+    def _uninstall_factory(self) -> bool:
+        return uninstall_extension_runtime_factory(owner=self)
+
+    def _binding_route_current(self, binding: OperationBinding) -> bool:
+        route = self._route(binding.context_id, binding.bridge_id)
+        return bool(
+            route is not None and route.principal is binding.principal
+            and route.connector_sid == binding.connector_sid
+            and route.load_generation_id == binding.load_generation_id
+        )
+
+    def _observe_result(self, binding, call, result) -> None:
+        if call.action == "open":
+            self.leases.observe_open(binding, result, call.origin)
+            if self.first_open_authority is not None:
+                self.first_open_authority.observe_open(binding, call.origin, result)
+        elif call.action == "navigate":
+            self.leases.observe_navigation(binding, call.target["tab_handle"], result, call.origin)
+        elif call.action == "content":
+            self.leases.observe_content(binding, call.target["tab_handle"], result)
+        elif call.action in {"hover", "click", "type", "upload_file"}:
+            handle = call.target["tab_handle"]
+            lease = self.leases.lease_for(binding, handle)
+            fields = {"lease_id", "browser_id", "tab_handle", "document_epoch", "ref"}
+            if call.action in {"click", "type", "upload_file"}:
+                fields.add("action_class")
+            if (lease is None or set(result) != fields
+                    or result["lease_id"] != lease.lease_id or result["browser_id"] != handle or result["tab_handle"] != handle
+                    or result["ref"] != call.args["ref"] or not isinstance(result["document_epoch"], str)
+                    or re.fullmatch(r"0|[1-9][0-9]{0,15}", result["document_epoch"]) is None
+                    or int(result["document_epoch"]) > 2**53 - 1):
+                raise ExtensionBrowserError("LEASE_CONFLICT", outcome="unknown")
+            if call.action in {"click", "type", "upload_file"}:
+                document = self.leases.document_for(binding, handle)
+                self.leases.clear_document(binding, handle)
+                if (document is None or document.document_epoch != int(result["document_epoch"])
+                        or result["ref"] not in document.refs
+                        or result["action_class"] != call.args["expected_action_class"]):
+                    raise ExtensionBrowserError("DOCUMENT_CONFLICT", outcome="unknown")
+
+    def invalidate_lease_event(self, event) -> None:
+        from plugins._a0_connector.helpers.browser_bridge_events import LeaseInvalidation
+
+        if not isinstance(event, LeaseInvalidation):
+            raise ValueError("invalid lease invalidation")
+        self.leases.invalidate_digests(**{
+            name: getattr(event, name) for name in (
+                "principal", "connector_sid", "load_generation_id", "context_id",
+                "browser_session_id", "turn_id", "lease_id_digest", "browser_id_digest",
+            )
+        })
+
+    def install(self, *, submitter=None) -> tuple[str, ...]:
+        """Server bootstrap only; a config save or hello cannot call this."""
+        with self._install_lock:
+            if self._installed:
+                if not self.installed:
+                    raise RuntimeError("Extension browser service ownership was lost")
+                return self.lifecycle.replay_pending()
+            self._install_factory()
+            self._factory_installed = True
+            try:
+                replayed = self.lifecycle.configure(
+                    route_resolver=self._route,
+                    sender=self.finalize,
+                    submitter=submitter,
+                    owner=self,
+                )
+            except Exception:
+                self._uninstall_factory()
+                self._factory_installed = False
+                raise
+            self._installed = True
+            return replayed
+
+    def uninstall(self) -> tuple[str, ...]:
+        """Withdraw only this service while preserving durable uncertainty."""
+
+        if self.first_open_authority is not None:
+            self.first_open_authority.retire()
+        with self._install_lock:
+            if not self._installed:
+                return ()
+            try:
+                scheduled = self.lifecycle.unconfigure(owner=self)
+            except Exception:
+                # A persistence failure keeps lifecycle ownership retryable,
+                # but Browser selection must still fail closed immediately.
+                if self._factory_installed:
+                    self._uninstall_factory()
+                    self._factory_installed = False
+                raise
+            removed = (
+                self._uninstall_factory()
+                if self._factory_installed
+                else True
+            )
+            self._factory_installed = False
+            self._installed = False
+            if not removed:
+                # Never clear a competing factory to make teardown look clean.
+                raise RuntimeError("Extension browser runtime factory owner mismatch")
+            return scheduled
+
+    def _route(self, context_id: str, bridge_id: str) -> ValidatedExtensionRoute | None:
+        try:
+            route = self._route_resolver(context_id, bridge_id)
+        except Exception:
+            return None
+        if (
+            not isinstance(route, ValidatedExtensionRoute)
+            or route.bridge_id != bridge_id
+            or route.transport_profile is not self._transport_profile
+        ):
+            return None
+        if route.browser_id != f"extension:{bridge_id}":
+            return None
+        return route
+
+    def runtime_for_agent(self, agent: Any, bridge_id: str) -> ExtensionBrowserRuntime | None:
+        context_id = str(getattr(getattr(agent, "context", None), "id", ""))
+        if self._route(context_id, bridge_id) is None:
+            return None
+
+        def binding_for(active) -> OperationBinding:
+            route = self._route(context_id, bridge_id)
+            if (
+                active is None or route is None
+                or active.context_id != context_id or active.bridge_id != bridge_id
+                or active.browser_id != route.browser_id
+            ):
+                raise ExtensionBrowserError("SCOPE_DENIED")
+            return OperationBinding(
+                route.principal, route.connector_sid, route.load_generation_id,
+                context_id, active.browser_session_id, active.turn_id,
+                str(uuid.uuid4()), str(uuid.uuid4()),
+            )
+
+        @contextmanager
+        def call_scope():
+            active = self.lifecycle.active_agent_turn(agent)
+            synthetic = None
+            if active is None:
+                synthetic = self.lifecycle.begin_synthetic_turn(agent)
+                active = synthetic
+            try:
+                yield binding_for(active)
+            finally:
+                if synthetic is not None:
+                    self.lifecycle.finalize_synthetic_turn(agent, synthetic, reason="direct")
+
+        def binding_current(binding: OperationBinding) -> bool:
+            from plugins._browser.helpers.extension_sessions import ActiveExtensionTurnBinding
+
+            route = self._route(context_id, bridge_id)
+            return bool(
+                route is not None and route.principal is binding.principal
+                and route.connector_sid == binding.connector_sid
+                and route.load_generation_id == binding.load_generation_id
+                and self.lifecycle.is_current_turn(agent, ActiveExtensionTurnBinding(
+                    context_id, binding.browser_session_id, route.browser_id, bridge_id, binding.turn_id,
+                ))
+            )
+
+        from plugins._browser.helpers.extension_uploads import prepare_upload
+        from plugins._browser.helpers.config import get_browser_config
+        return ExtensionBrowserRuntime(
+            context_id, bridge_id, broker=self.broker,
+            binding_factory=lambda: binding_for(self.lifecycle.active_agent_turn(agent)),
+            policy_repository=self._policy, server_instance_id=self._server_instance_id,
+            target_origin_resolver=self._target_origin_resolver,
+            call_scope=call_scope, binding_current=binding_current,
+            result_observer=self._observe_result,
+            first_open_authority=self.first_open_authority,
+            foreground_preference=lambda: (
+                self._transport_profile is PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+                and get_browser_config(agent=agent).get("autofocus_active_page") is True
+            ),
+            site_challenge_ready=lambda binding: self.site_authority is not None and binding_current(binding),
+            turn_origin_grant=lambda binding, origin: (
+                self.site_authority.turn_grant_for(binding, origin=origin) if self.site_authority is not None else None
+            ),
+            artifact_materializer=self.artifact_materializer,
+            action_challenge_ready=lambda binding: (
+                self.action_authority is not None and binding_current(binding)
+                and self.action_authority.ready_for(binding)
+            ),
+            prepare_upload=lambda **kwargs: prepare_upload(agent.context, **kwargs),
+            upload_sender=self.send_input_artifact if self.input_artifact_sender is not None else None,
+        )
+
+    def authorize_input_artifact(self, binding) -> bool:
+        with self._input_lock:
+            permit = self._input_permits.get(binding.artifact_id)
+        if permit is None or permit is not binding:
+            return False
+        route = self._route(binding.context_id, binding.bridge_id)
+        return bool(route is not None and route.principal is binding.principal
+                    and route.connector_sid == binding.connector_sid
+                    and route.load_generation_id == binding.load_generation_id)
+
+    async def send_input_artifact(self, operation, ticket, source):
+        from plugins._a0_connector.helpers.browser_bridge_artifacts import ArtifactBinding
+        from plugins._browser.helpers.extension_uploads import PreparedUpload
+        if (self._transport_profile is not PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+            or self.input_artifact_sender is None or not isinstance(source, PreparedUpload)
+            or source.context_id != operation.context_id or ticket.binding is not operation
+            or ticket.action != "upload_file"):
+            raise ExtensionBrowserError("SCOPE_DENIED")
+        binding = ArtifactBinding(operation.principal, operation.connector_sid, operation.load_generation_id,
+            operation.bridge_id, operation.context_id, operation.browser_session_id, operation.turn_id,
+            operation.action_id, operation.op_id, source.artifact_id, "input", "upload_file")
+        with self._input_lock:
+            if len(self._input_permits) >= 16 or source.artifact_id in self._input_permits:
+                raise ExtensionBrowserError("CAPACITY_EXCEEDED")
+            self._input_permits[source.artifact_id] = binding
+        try:
+            await self.broker.wait_dispatched(ticket)
+            data = await asyncio.to_thread(source.read)
+            if not self.authorize_input_artifact(binding):
+                raise ExtensionBrowserError("SCOPE_DENIED")
+            await self.input_artifact_sender.send(binding, data=data, mime_type=source.mime_type)
+        finally:
+            with self._input_lock:
+                if self._input_permits.get(source.artifact_id) is binding:
+                    self._input_permits.pop(source.artifact_id, None)
+
+    async def finalize(self, intent: ExtensionFinalizationIntent, _scheduled_route: ValidatedExtensionRoute) -> str:
+        if self.first_open_authority is not None:
+            self.first_open_authority.retire(lambda binding: (
+                binding.context_id == intent.context_id and binding.bridge_id == intent.bridge_id
+                and binding.browser_session_id == intent.browser_session_id and binding.turn_id == intent.turn_id))
+        route = self._route(intent.context_id, intent.bridge_id)
+        if route is None or route.browser_id != intent.browser_id:
+            return TURN_OUTCOME_UNKNOWN
+        turn = TurnBinding(
+            route.principal, route.connector_sid, route.load_generation_id,
+            intent.context_id, intent.browser_session_id, intent.turn_id,
+        )
+        # Finalization starts by withdrawing local target authority regardless
+        # of whether the remote cleanup can ultimately be acknowledged.
+        self.leases.retire_turn(turn)
+        if self.action_authority is not None:
+            self.action_authority.finalize_turn(
+                principal=turn.principal, connector_sid=turn.connector_sid, load_generation_id=turn.load_generation_id,
+                context_id=turn.context_id, browser_session_id=turn.browser_session_id, turn_id=turn.turn_id,
+            )
+        if self.site_authority is not None:
+            self.site_authority.finalize_turn(
+                principal=turn.principal, connector_sid=turn.connector_sid, load_generation_id=turn.load_generation_id,
+                context_id=turn.context_id, browser_session_id=turn.browser_session_id, turn_id=turn.turn_id,
+            )
+
+        async def cancel(operation) -> None:
+            try:
+                ticket = await self.broker.begin_cancel(
+                    operation, control_id=str(uuid.uuid4()), reason="turn_finalizing", timeout_ms=5_000,
+                )
+                await self.broker.wait_control(ticket)
+            except BrowserBridgeBrokerError:
+                # Already-settled operations no longer need cancellation. The
+                # finalizer independently checks lease/turn ownership.
+                pass
+
+        operations = self.broker.pending_operations_for_turn(turn)
+        if operations:
+            await asyncio.gather(*(cancel(operation) for operation in operations))
+        latest = self._route(intent.context_id, intent.bridge_id)
+        if (
+            latest is None or latest.principal is not route.principal
+            or latest.connector_sid != route.connector_sid
+            or latest.load_generation_id != route.load_generation_id
+        ):
+            return TURN_OUTCOME_UNKNOWN
+        try:
+            ticket = await self.broker.begin_finalize(
+                turn, control_id=intent.control_id, dispositions=intent.disposition_mapping(),
+                reason=intent.reason, timeout_ms=30_000,
+            )
+            completion = await self.broker.wait_control(ticket)
+        except BrowserBridgeBrokerError:
+            return TURN_OUTCOME_UNKNOWN
+        result = completion.result
+        if not completion.ok or not valid_finalization_result(result, intent.control_id):
+            return TURN_OUTCOME_UNKNOWN
+        # This means the exact finalization was acknowledged, not that every
+        # tab was closed: claimed/deliverable/orphan tabs may be retained.
+        return TURN_FINALIZED
+
+
+def valid_finalization_result(result: Any, control_id: str) -> bool:
+    groups = ("closed", "released", "retained", "already_finalized", "errors")
+    if (
+        not isinstance(result, dict)
+        or set(result) != {"contract_version", "control_id", *groups}
+        or type(result["contract_version"]) is not int or result["contract_version"] != 1
+        or result["control_id"] != control_id
+        or any(not isinstance(result[key], list) or len(result[key]) > 256 for key in groups)
+        or sum(len(result[key]) for key in groups) > 256 or result["errors"]
+    ):
+        return False
+    seen = set()
+    reasons = {
+        "user_takeover", "claimed_tab", "non_ephemeral", "generation_mismatch",
+        "handle_mismatch", "context_mismatch", "browser_session_mismatch", "turn_mismatch",
+        "control_mismatch", "identity_mismatch", "tab_missing", "protected", "ambiguous",
+        "unresolved_reconciliation", "not_active", "outcome_unknown",
+    }
+    for key in groups[:-1]:
+        for entry in result[key]:
+            if key == "retained":
+                if (
+                    not isinstance(entry, dict) or set(entry) != {"lease_id", "tab_handle", "reason"}
+                    or not isinstance(entry["reason"], str) or entry["reason"] not in reasons
+                    or not _valid_id(entry["tab_handle"])
+                ):
+                    return False
+                lease_id = entry["lease_id"]
+                if lease_id == entry["tab_handle"]:
+                    return False
+            else:
+                lease_id = entry
+            if not _valid_id(lease_id) or lease_id in seen:
+                return False
+            seen.add(lease_id)
+    return True
+
+
+def _valid_id(value: Any) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}", value) is not None

--- a/plugins/_browser/helpers/extension_sessions.py
+++ b/plugins/_browser/helpers/extension_sessions.py
@@ -1,0 +1,1618 @@
+"""Durable, sanitized lifecycle intent for the typed extension browser.
+
+This module is deliberately transport-agnostic and inactive by default.  The
+future activation path must inject both an exact route resolver and a sender
+that delegates finalization to the restricted browser operation broker.
+Neither persisted state nor Browser project configuration supplies authority.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import OrderedDict
+from concurrent.futures import Future
+from dataclasses import dataclass, replace
+import json
+import re
+import threading
+import time
+from typing import Any, Awaitable, Callable, Mapping, Protocol
+import uuid
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    BrowserBridgeTransportProfile,
+    require_browser_bridge_transport_profile,
+    require_transport_principal_identity,
+)
+from plugins._browser.helpers.config import (
+    HOST_BROWSER_SELECTION_KEY,
+    RUNTIME_BACKEND_KEY,
+    get_browser_config,
+    parse_extension_browser_selection,
+)
+
+
+SESSION_STORE_CONTRACT = "a0.browser-bridge.extension-sessions.v1"
+SESSION_STORE_VERSION = 1
+SESSION_STORE_KEY = "browser_extension_sessions_v1"
+CONTROL_EVENT = "connector_browser_control"
+
+MAX_IDENTIFIER_BYTES = 256
+MAX_REASON_BYTES = 128
+MAX_CONTEXTS = 128
+MAX_TURNS_PER_SESSION = 64
+MAX_DISPOSITIONS_PER_TURN = 256
+MAX_STORE_BYTES = 512 * 1024
+MAX_AGENT_TURN_BINDINGS = 1_024
+
+TURN_ACTIVE = "active"
+TURN_FINALIZATION_PENDING = "finalization_pending"
+TURN_FINALIZED = "finalized"
+TURN_OUTCOME_UNKNOWN = "outcome_unknown"
+TURN_STATES = frozenset(
+    {
+        TURN_ACTIVE,
+        TURN_FINALIZATION_PENDING,
+        TURN_FINALIZED,
+        TURN_OUTCOME_UNKNOWN,
+    }
+)
+FINALIZATION_TERMINAL_STATES = frozenset({TURN_FINALIZED, TURN_OUTCOME_UNKNOWN})
+LEASE_DISPOSITIONS = frozenset({"ephemeral", "deliverable", "handoff"})
+
+_CORRELATION_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,128}")
+_GENERATION_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+
+
+class ExtensionSessionStateError(RuntimeError):
+    """A lifecycle request or durable state failed closed."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedExtensionRoute:
+    """Process-only current route; none of these fields are persisted."""
+
+    bridge_id: str
+    browser_id: str
+    principal: WsPrincipal
+    connector_sid: str
+    load_generation_id: str
+    transport_profile: BrowserBridgeTransportProfile = (
+        PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    )
+
+    def __post_init__(self) -> None:
+        bridge_id = _identifier(self.bridge_id, "bridge_id")
+        profile = require_browser_bridge_transport_profile(
+            self.transport_profile
+        )
+        browser_id = _browser_id(self.browser_id, bridge_id, profile)
+        connector_sid = _identifier(self.connector_sid, "connector_sid")
+        generation_id = _identifier(
+            self.load_generation_id, "load_generation_id"
+        )
+        if not _GENERATION_ID_RE.fullmatch(generation_id):
+            raise ExtensionSessionStateError(
+                "INVALID_ROUTE", "The route generation ID is invalid"
+            )
+        principal = self.principal
+        try:
+            require_transport_principal_identity(principal, profile)
+        except ValueError:
+            raise ExtensionSessionStateError(
+                "INVALID_ROUTE", "The route principal is not authorized for control"
+            ) from None
+        if (
+            principal.principal_id != bridge_id
+            or "browser.control" not in principal.scopes
+            or not principal.permits_outbound(CONTROL_EVENT, profile.handler_id)
+        ):
+            raise ExtensionSessionStateError(
+                "INVALID_ROUTE", "The route principal is not authorized for control"
+            )
+        object.__setattr__(self, "bridge_id", bridge_id)
+        object.__setattr__(self, "browser_id", browser_id)
+        object.__setattr__(self, "connector_sid", connector_sid)
+        object.__setattr__(self, "load_generation_id", generation_id)
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionTurnIntent:
+    turn_id: str
+    state: str
+    dispositions: tuple[tuple[str, str], ...]
+    control_id: str | None
+    reason: str | None
+    started_at_ms: int
+    finalization_requested_at_ms: int | None
+    settled_at_ms: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionSessionIntent:
+    context_id: str
+    browser_session_id: str
+    browser_id: str
+    bridge_id: str
+    turns: tuple[ExtensionTurnIntent, ...]
+    last_acked_event_sequence: int
+    created_at_ms: int
+    updated_at_ms: int
+    retire_requested: bool
+    remove_requested: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveExtensionTurnBinding:
+    """Sanitized active binding used by a future operation-binding factory."""
+
+    context_id: str
+    browser_session_id: str
+    browser_id: str
+    bridge_id: str
+    turn_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionFinalizationIntent:
+    control_id: str
+    context_id: str
+    browser_session_id: str
+    browser_id: str
+    bridge_id: str
+    turn_id: str
+    dispositions: tuple[tuple[str, str], ...]
+    reason: str
+    requested_at_ms: int
+    contract_version: int = 1
+
+    def disposition_mapping(self) -> dict[str, str]:
+        return dict(self.dispositions)
+
+
+class ExtensionSessionPersistence(Protocol):
+    def load(self) -> Any: ...
+
+    def save(self, value: Mapping[str, Any]) -> None: ...
+
+
+class KvpExtensionSessionPersistence:
+    """Small adapter over Agent Zero's atomic persistent KVP writes."""
+
+    def __init__(self, key: str = SESSION_STORE_KEY) -> None:
+        self._key = key
+
+    def load(self) -> Any:
+        from helpers import kvp
+
+        return kvp.get_persistent(self._key, None)
+
+    def save(self, value: Mapping[str, Any]) -> None:
+        from helpers import kvp
+
+        kvp.set_persistent(self._key, dict(value))
+
+
+class ExtensionSessionRegistry:
+    """Concurrency-safe bounded registry for durable lifecycle intent."""
+
+    def __init__(
+        self,
+        *,
+        persistence: ExtensionSessionPersistence | None = None,
+        clock_ms: Callable[[], int] | None = None,
+        id_factory: Callable[[], str] | None = None,
+        max_contexts: int = MAX_CONTEXTS,
+        max_turns_per_session: int = MAX_TURNS_PER_SESSION,
+        max_dispositions_per_turn: int = MAX_DISPOSITIONS_PER_TURN,
+        max_store_bytes: int = MAX_STORE_BYTES,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        if min(
+            max_contexts,
+            max_turns_per_session,
+            max_dispositions_per_turn,
+            max_store_bytes,
+        ) < 1:
+            raise ValueError("Extension session bounds must be positive")
+        self._persistence = persistence or KvpExtensionSessionPersistence()
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        self._clock_ms = clock_ms or (lambda: time.time_ns() // 1_000_000)
+        self._id_factory = id_factory or (lambda: uuid.uuid4().hex)
+        self._max_contexts = max_contexts
+        self._max_turns = max_turns_per_session
+        self._max_dispositions = max_dispositions_per_turn
+        self._max_store_bytes = max_store_bytes
+        self._lock = threading.RLock()
+
+    @property
+    def transport_profile(self) -> BrowserBridgeTransportProfile:
+        return self._transport_profile
+
+    def sessions(self) -> tuple[ExtensionSessionIntent, ...]:
+        with self._lock:
+            sessions = self._load_locked()
+            return tuple(sessions[key] for key in sorted(sessions))
+
+    def session(self, context_id: str) -> ExtensionSessionIntent | None:
+        context_id = _identifier(context_id, "context_id")
+        with self._lock:
+            return self._load_locked().get(context_id)
+
+    def begin_turn(
+        self, *, context_id: str, browser_id: str, bridge_id: str
+    ) -> tuple[ExtensionSessionIntent, ExtensionTurnIntent]:
+        context_id = _identifier(context_id, "context_id")
+        bridge_id = _identifier(bridge_id, "bridge_id")
+        browser_id = _browser_id(browser_id, bridge_id, self._transport_profile)
+        with self._lock:
+            sessions = self._load_locked()
+            now = _timestamp(self._clock_ms(), "clock")
+            current = sessions.get(context_id)
+            if current is None:
+                if len(sessions) >= self._max_contexts:
+                    raise ExtensionSessionStateError(
+                        "REGISTRY_FULL", "The extension session registry is full"
+                    )
+                current = ExtensionSessionIntent(
+                    context_id=context_id,
+                    browser_session_id=self._fresh_session_id(sessions),
+                    browser_id=browser_id,
+                    bridge_id=bridge_id,
+                    turns=(),
+                    last_acked_event_sequence=0,
+                    created_at_ms=now,
+                    updated_at_ms=now,
+                    retire_requested=False,
+                    remove_requested=False,
+                )
+            elif current.browser_id != browser_id or current.bridge_id != bridge_id:
+                raise ExtensionSessionStateError(
+                    "BRIDGE_PIN_CONFLICT",
+                    "A browser session cannot migrate to another bridge",
+                )
+            elif current.retire_requested or current.remove_requested:
+                raise ExtensionSessionStateError(
+                    "SESSION_RETIRING", "The browser session is retiring"
+                )
+
+            turns = list(current.turns)
+            while len(turns) >= self._max_turns and turns[0].state == TURN_FINALIZED:
+                turns.pop(0)
+            if len(turns) >= self._max_turns:
+                raise ExtensionSessionStateError(
+                    "TURN_REGISTRY_FULL", "The extension turn registry is full"
+                )
+            turn = ExtensionTurnIntent(
+                turn_id=self._fresh_turn_id(turns),
+                state=TURN_ACTIVE,
+                dispositions=(),
+                control_id=None,
+                reason=None,
+                started_at_ms=now,
+                finalization_requested_at_ms=None,
+                settled_at_ms=None,
+            )
+            turns.append(turn)
+            current = replace(current, turns=tuple(turns), updated_at_ms=now)
+            sessions[context_id] = current
+            self._save_locked(sessions)
+            return current, turn
+
+    def active_turn_binding(
+        self, *, context_id: str, turn_id: str
+    ) -> ActiveExtensionTurnBinding | None:
+        context_id = _identifier(context_id, "context_id")
+        turn_id = _identifier(turn_id, "turn_id")
+        with self._lock:
+            session = self._load_locked().get(context_id)
+            if session is None:
+                return None
+            turns = list(session.turns)
+            try:
+                turn = turns[_turn_index(turns, turn_id)]
+            except ExtensionSessionStateError:
+                return None
+            if turn.state != TURN_ACTIVE:
+                return None
+            return ActiveExtensionTurnBinding(
+                context_id=session.context_id,
+                browser_session_id=session.browser_session_id,
+                browser_id=session.browser_id,
+                bridge_id=session.bridge_id,
+                turn_id=turn.turn_id,
+            )
+
+    def record_disposition(
+        self,
+        *,
+        context_id: str,
+        browser_session_id: str,
+        turn_id: str,
+        lease_id: str,
+        disposition: str,
+    ) -> ExtensionTurnIntent:
+        """Record only a lease ID and disposition, never remote tab metadata."""
+
+        context_id = _identifier(context_id, "context_id")
+        browser_session_id = _identifier(browser_session_id, "browser_session_id")
+        turn_id = _identifier(turn_id, "turn_id")
+        lease_id = _identifier(lease_id, "lease_id")
+        if disposition not in LEASE_DISPOSITIONS:
+            raise ExtensionSessionStateError(
+                "INVALID_DISPOSITION", "The lease disposition is invalid"
+            )
+        with self._lock:
+            sessions = self._load_locked()
+            session = _require_session(sessions, context_id, browser_session_id)
+            turns = list(session.turns)
+            index = _turn_index(turns, turn_id)
+            turn = turns[index]
+            if turn.state != TURN_ACTIVE:
+                raise ExtensionSessionStateError(
+                    "TURN_FINALIZING", "The turn no longer accepts dispositions"
+                )
+            dispositions = dict(turn.dispositions)
+            if lease_id not in dispositions and len(dispositions) >= self._max_dispositions:
+                raise ExtensionSessionStateError(
+                    "DISPOSITION_REGISTRY_FULL", "The turn disposition registry is full"
+                )
+            dispositions[lease_id] = disposition
+            turn = replace(turn, dispositions=tuple(sorted(dispositions.items())))
+            turns[index] = turn
+            now = _timestamp(self._clock_ms(), "clock")
+            sessions[context_id] = replace(
+                session, turns=tuple(turns), updated_at_ms=now
+            )
+            self._save_locked(sessions)
+            return turn
+
+    def stage_finalize(
+        self,
+        *,
+        context_id: str,
+        turn_id: str | None = None,
+        reason: str,
+        retire: bool = False,
+        remove: bool = False,
+    ) -> tuple[ExtensionFinalizationIntent, ...]:
+        context_id = _identifier(context_id, "context_id")
+        if turn_id is not None:
+            turn_id = _identifier(turn_id, "turn_id")
+        reason = _reason(reason)
+        with self._lock:
+            sessions = self._load_locked()
+            session = sessions.get(context_id)
+            if session is None:
+                return ()
+            now = _timestamp(self._clock_ms(), "clock")
+            turns = list(session.turns)
+            target_indexes = (
+                [_turn_index(turns, turn_id)]
+                if turn_id is not None
+                else list(range(len(turns)))
+            )
+            intents: list[ExtensionFinalizationIntent] = []
+            allocated_control_ids = {
+                candidate.control_id
+                for candidate_session in sessions.values()
+                for candidate in candidate_session.turns
+                if candidate.control_id is not None
+            }
+            for index in target_indexes:
+                turn = turns[index]
+                if turn.state == TURN_ACTIVE:
+                    control_id = self._fresh_unique(
+                        allocated_control_ids, "control_id", correlation=True
+                    )
+                    allocated_control_ids.add(control_id)
+                    turn = replace(
+                        turn,
+                        state=TURN_FINALIZATION_PENDING,
+                        control_id=control_id,
+                        reason=reason,
+                        finalization_requested_at_ms=now,
+                    )
+                    turns[index] = turn
+                if turn.state == TURN_FINALIZATION_PENDING:
+                    intents.append(_finalization_intent(session, turn))
+
+            updated = replace(
+                session,
+                turns=tuple(turns),
+                updated_at_ms=now,
+                retire_requested=session.retire_requested or retire or remove,
+                remove_requested=session.remove_requested or remove,
+            )
+            if _can_delete(updated):
+                sessions.pop(context_id, None)
+            else:
+                sessions[context_id] = updated
+            self._save_locked(sessions)
+            return tuple(intents)
+
+    def pending_finalizations(self) -> tuple[ExtensionFinalizationIntent, ...]:
+        with self._lock:
+            intents: list[ExtensionFinalizationIntent] = []
+            sessions = self._load_locked()
+            for context_id in sorted(sessions):
+                session = sessions[context_id]
+                for turn in session.turns:
+                    if turn.state == TURN_FINALIZATION_PENDING:
+                        intents.append(_finalization_intent(session, turn))
+            return tuple(intents)
+
+    def settle_finalization(
+        self,
+        intent: ExtensionFinalizationIntent,
+        status: str,
+    ) -> str:
+        if status not in FINALIZATION_TERMINAL_STATES:
+            raise ExtensionSessionStateError(
+                "INVALID_SETTLEMENT", "The finalization settlement is invalid"
+            )
+        with self._lock:
+            sessions = self._load_locked()
+            session = sessions.get(intent.context_id)
+            if session is None:
+                return "not_found"
+            if (
+                session.browser_session_id != intent.browser_session_id
+                or session.browser_id != intent.browser_id
+                or session.bridge_id != intent.bridge_id
+            ):
+                return "mismatch"
+            turns = list(session.turns)
+            try:
+                index = _turn_index(turns, intent.turn_id)
+            except ExtensionSessionStateError:
+                return "not_found"
+            turn = turns[index]
+            if turn.state in FINALIZATION_TERMINAL_STATES:
+                return "duplicate"
+            if (
+                turn.state != TURN_FINALIZATION_PENDING
+                or turn.control_id != intent.control_id
+                or turn.reason != intent.reason
+                or turn.dispositions != intent.dispositions
+                or turn.finalization_requested_at_ms != intent.requested_at_ms
+            ):
+                return "mismatch"
+            now = _timestamp(self._clock_ms(), "clock")
+            turns[index] = replace(turn, state=status, settled_at_ms=now)
+            updated = replace(session, turns=tuple(turns), updated_at_ms=now)
+            if _can_delete(updated):
+                sessions.pop(intent.context_id, None)
+            else:
+                sessions[intent.context_id] = updated
+            self._save_locked(sessions)
+            return "settled"
+
+    def update_event_cursor(
+        self,
+        *,
+        context_id: str,
+        browser_session_id: str,
+        sequence: int,
+    ) -> ExtensionSessionIntent:
+        context_id = _identifier(context_id, "context_id")
+        browser_session_id = _identifier(browser_session_id, "browser_session_id")
+        sequence = _nonnegative_int(sequence, "sequence")
+        with self._lock:
+            sessions = self._load_locked()
+            session = _require_session(sessions, context_id, browser_session_id)
+            if sequence < session.last_acked_event_sequence:
+                raise ExtensionSessionStateError(
+                    "STALE_EVENT_CURSOR", "The event cursor cannot move backwards"
+                )
+            now = _timestamp(self._clock_ms(), "clock")
+            session = replace(
+                session, last_acked_event_sequence=sequence, updated_at_ms=now
+            )
+            sessions[context_id] = session
+            self._save_locked(sessions)
+            return session
+
+    def _fresh_id(self, field: str) -> str:
+        return _identifier(self._id_factory(), field)
+
+    def _fresh_correlation_id(self, field: str) -> str:
+        value = self._fresh_id(field)
+        if not _CORRELATION_ID_RE.fullmatch(value):
+            raise ExtensionSessionStateError(
+                "INVALID_IDENTIFIER", f"Generated {field} is not a safe correlation ID"
+            )
+        return value
+
+    def _fresh_session_id(
+        self, sessions: Mapping[str, ExtensionSessionIntent]
+    ) -> str:
+        existing = {session.browser_session_id for session in sessions.values()}
+        return self._fresh_unique(existing, "browser_session_id", correlation=False)
+
+    def _fresh_turn_id(self, turns: list[ExtensionTurnIntent]) -> str:
+        return self._fresh_unique(
+            {turn.turn_id for turn in turns}, "turn_id", correlation=True
+        )
+
+    def _fresh_unique(
+        self, existing: set[str], field: str, *, correlation: bool
+    ) -> str:
+        for _attempt in range(8):
+            value = (
+                self._fresh_correlation_id(field)
+                if correlation
+                else self._fresh_id(field)
+            )
+            if value not in existing:
+                return value
+        raise ExtensionSessionStateError(
+            "IDENTIFIER_COLLISION", f"Could not allocate a fresh {field}"
+        )
+
+    def _load_locked(self) -> dict[str, ExtensionSessionIntent]:
+        try:
+            raw = self._persistence.load()
+        except Exception:
+            raise ExtensionSessionStateError(
+                "STORE_UNAVAILABLE", "The extension session store is unavailable"
+            ) from None
+        if raw is None:
+            return {}
+        return _decode_store(
+            raw,
+            max_contexts=self._max_contexts,
+            max_turns=self._max_turns,
+            max_dispositions=self._max_dispositions,
+            transport_profile=self._transport_profile,
+        )
+
+    def _save_locked(self, sessions: Mapping[str, ExtensionSessionIntent]) -> None:
+        document = _encode_store(sessions)
+        encoded = json.dumps(
+            document, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+        if len(encoded) > self._max_store_bytes:
+            raise ExtensionSessionStateError(
+                "STORE_FULL", "The extension session store exceeds its byte bound"
+            )
+        try:
+            self._persistence.save(document)
+        except Exception:
+            raise ExtensionSessionStateError(
+                "STORE_UNAVAILABLE", "The extension session store is unavailable"
+            ) from None
+
+
+RouteResolver = Callable[[str, str], ValidatedExtensionRoute | None]
+FinalizationSender = Callable[
+    [ExtensionFinalizationIntent, ValidatedExtensionRoute], Awaitable[str]
+]
+CoroutineSubmitter = Callable[[Awaitable[None]], Future[Any]]
+
+
+class ProcessFinalizationDispatcher:
+    """Process-owned delivery whose futures outlive any requesting agent task."""
+
+    def __init__(
+        self,
+        *,
+        registry: ExtensionSessionRegistry,
+        route_resolver: RouteResolver,
+        sender: FinalizationSender,
+        submitter: CoroutineSubmitter | None = None,
+        max_inflight: int = 128,
+    ) -> None:
+        if max_inflight < 1:
+            raise ValueError("max_inflight must be positive")
+        self._registry = registry
+        self._route_resolver = route_resolver
+        self._sender = sender
+        self._submitter = submitter or _background_submitter
+        self._max_inflight = max_inflight
+        self._inflight: dict[str, Future[Any]] = {}
+        self._lock = threading.RLock()
+
+    @property
+    def inflight_count(self) -> int:
+        with self._lock:
+            return len(self._inflight)
+
+    def schedule(
+        self, intents: tuple[ExtensionFinalizationIntent, ...]
+    ) -> tuple[str, ...]:
+        scheduled: list[str] = []
+        for intent in intents:
+            with self._lock:
+                if intent.control_id in self._inflight:
+                    continue
+                if len(self._inflight) >= self._max_inflight:
+                    break
+                if self._resolve_route(intent) is None:
+                    continue
+                coroutine = self._dispatch(intent)
+                try:
+                    future = self._submitter(coroutine)
+                except Exception:
+                    if asyncio.iscoroutine(coroutine):
+                        coroutine.close()
+                    continue
+                self._inflight[intent.control_id] = future
+            future.add_done_callback(
+                lambda _future, control_id=intent.control_id: self._finished(control_id)
+            )
+            scheduled.append(intent.control_id)
+        return tuple(scheduled)
+
+    def replay_pending(self) -> tuple[str, ...]:
+        return self.schedule(self._registry.pending_finalizations())
+
+    def _resolve_route(
+        self, intent: ExtensionFinalizationIntent
+    ) -> ValidatedExtensionRoute | None:
+        try:
+            route = self._route_resolver(intent.context_id, intent.bridge_id)
+        except Exception:
+            return None
+        if not isinstance(route, ValidatedExtensionRoute):
+            return None
+        if route.bridge_id != intent.bridge_id or route.browser_id != intent.browser_id:
+            return None
+        return route
+
+    async def _dispatch(
+        self,
+        intent: ExtensionFinalizationIntent,
+    ) -> None:
+        # Route/SID/generation are live process authority. Re-resolve after the
+        # thread handoff so a schedule-to-send race cannot use a captured SID.
+        route = self._resolve_route(intent)
+        if route is None:
+            return
+        try:
+            result = await self._sender(intent, route)
+        except asyncio.CancelledError:
+            # Process shutdown is not evidence that a control did or did not apply.
+            raise
+        except Exception:
+            result = TURN_OUTCOME_UNKNOWN
+        status = TURN_FINALIZED if result == TURN_FINALIZED else TURN_OUTCOME_UNKNOWN
+        self._registry.settle_finalization(intent, status)
+
+    def _finished(self, control_id: str) -> None:
+        with self._lock:
+            self._inflight.pop(control_id, None)
+
+
+class ExtensionSessionLifecycle:
+    """Narrow hook-facing adapter, unconfigured and effect-free by default."""
+
+    def __init__(
+        self,
+        *,
+        registry: ExtensionSessionRegistry | None = None,
+        config_loader: Callable[[Any], Mapping[str, Any]] | None = None,
+        max_agent_bindings: int = MAX_AGENT_TURN_BINDINGS,
+        transport_profile: BrowserBridgeTransportProfile = (
+            PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+        ),
+    ) -> None:
+        if max_agent_bindings < 1:
+            raise ValueError("max_agent_bindings must be positive")
+        self._transport_profile = require_browser_bridge_transport_profile(
+            transport_profile
+        )
+        self.registry = registry or ExtensionSessionRegistry(
+            transport_profile=self._transport_profile
+        )
+        if self.registry.transport_profile is not self._transport_profile:
+            raise ValueError("Extension lifecycle transport mismatch")
+        self._config_loader = config_loader or get_browser_config
+        self._max_agent_bindings = max_agent_bindings
+        self._route_resolver: RouteResolver | None = None
+        self._dispatcher: ProcessFinalizationDispatcher | None = None
+        self._configuration_owner: object | None = None
+        self._configuration_retiring = False
+        self._agent_turns: OrderedDict[tuple[str, int], str] = OrderedDict()
+        self._synthetic_turns: OrderedDict[
+            tuple[str, int], ActiveExtensionTurnBinding
+        ] = OrderedDict()
+        self._lock = threading.RLock()
+
+    @property
+    def transport_profile(self) -> BrowserBridgeTransportProfile:
+        return self._transport_profile
+
+    @property
+    def configured(self) -> bool:
+        with self._lock:
+            return (
+                self._configuration_owner is not None
+                and not self._configuration_retiring
+                and self._dispatcher is not None
+                and self._route_resolver is not None
+            )
+
+    def configured_for(self, owner: object) -> bool:
+        with self._lock:
+            return (
+                owner is not None
+                and self._configuration_owner is owner
+                and not self._configuration_retiring
+                and self._dispatcher is not None
+                and self._route_resolver is not None
+            )
+
+    def configure(
+        self,
+        *,
+        route_resolver: RouteResolver,
+        sender: FinalizationSender,
+        submitter: CoroutineSubmitter | None = None,
+        max_inflight: int = 128,
+        owner: object | None = None,
+    ) -> tuple[str, ...]:
+        configuration_owner = _legacy_lifecycle_owner if owner is None else owner
+        with self._lock:
+            if (
+                self._configuration_owner is not None
+                or self._configuration_retiring
+                or self._dispatcher is not None
+                or self._route_resolver is not None
+            ):
+                raise ExtensionSessionStateError(
+                    "ALREADY_CONFIGURED",
+                    "The extension session lifecycle is already configured",
+                )
+            dispatcher = ProcessFinalizationDispatcher(
+                registry=self.registry,
+                route_resolver=route_resolver,
+                sender=sender,
+                submitter=submitter,
+                max_inflight=max_inflight,
+            )
+            self._configuration_owner = configuration_owner
+            self._configuration_retiring = False
+            self._route_resolver = route_resolver
+            self._dispatcher = dispatcher
+        return dispatcher.replay_pending()
+
+    def unconfigure(self, *, owner: object) -> tuple[str, ...]:
+        """Withdraw one exact owner and durably finalize its tracked turns.
+
+        Existing process-owned sends are not cancelled or relabelled.  New hook
+        calls become inert before the tracked bindings are detached.  The
+        established ``restarted`` wire reason is used for reload/owner retire;
+        no private lifecycle reason is sent to the extension.
+        """
+
+        if owner is None:
+            raise ExtensionSessionStateError(
+                "OWNER_MISMATCH", "The extension session lifecycle owner is invalid"
+            )
+        with self._lock:
+            if (
+                self._configuration_owner is not owner
+                or self._configuration_retiring
+            ):
+                raise ExtensionSessionStateError(
+                    "OWNER_MISMATCH",
+                    "The extension session lifecycle is owned by another component",
+                )
+            dispatcher = self._dispatcher
+            self._configuration_retiring = True
+            agent_turns = tuple(
+                (context_id, turn_id)
+                for (context_id, _agent_id), turn_id in self._agent_turns.items()
+            )
+            synthetic_turns = tuple(
+                (binding.context_id, binding.turn_id)
+                for binding in self._synthetic_turns.values()
+            )
+
+        intents: list[ExtensionFinalizationIntent] = []
+        seen: set[tuple[str, str]] = set()
+        for context_id, turn_id in (*agent_turns, *synthetic_turns):
+            key = (context_id, turn_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            try:
+                staged = self.registry.stage_finalize(
+                    context_id=context_id,
+                    turn_id=turn_id,
+                    reason="restarted",
+                )
+            except Exception:
+                with self._lock:
+                    if self._configuration_owner is owner:
+                        self._configuration_retiring = False
+                raise
+            intents.extend(staged)
+        with self._lock:
+            if self._configuration_owner is not owner:
+                self._configuration_retiring = False
+                raise ExtensionSessionStateError(
+                    "OWNER_MISMATCH",
+                    "The extension session lifecycle owner changed during retirement",
+                )
+            self._configuration_owner = None
+            self._configuration_retiring = False
+            self._route_resolver = None
+            self._dispatcher = None
+            self._agent_turns.clear()
+            self._synthetic_turns.clear()
+        if dispatcher is None:
+            return ()
+        return dispatcher.schedule(tuple(intents))
+
+    def begin_agent_turn(self, agent: Any) -> ExtensionTurnIntent | None:
+        selection = self._validated_selection(agent, require_route=True)
+        if selection is None:
+            return None
+        context_id, browser_id, bridge_id = selection
+        key = (context_id, id(agent))
+        with self._lock:
+            if key in self._synthetic_turns:
+                return None
+            existing_turn = self._agent_turns.pop(key, None)
+            if (
+                existing_turn is None
+                and len(self._agent_turns) + len(self._synthetic_turns)
+                >= self._max_agent_bindings
+            ):
+                return None
+        if existing_turn is not None:
+            self._stage_and_dispatch(
+                context_id=context_id,
+                turn_id=existing_turn,
+                reason="restarted",
+            )
+        try:
+            _session, turn = self.registry.begin_turn(
+                context_id=context_id,
+                browser_id=browser_id,
+                bridge_id=bridge_id,
+            )
+        except ExtensionSessionStateError:
+            return None
+        conflicting_owner = False
+        configuration_lost = False
+        with self._lock:
+            if self._configuration_owner is None or self._configuration_retiring:
+                configuration_lost = True
+            elif key in self._agent_turns or key in self._synthetic_turns:
+                conflicting_owner = True
+            elif (
+                len(self._agent_turns) + len(self._synthetic_turns)
+                >= self._max_agent_bindings
+            ):
+                conflicting_owner = True
+            else:
+                self._agent_turns[key] = turn.turn_id
+                self._agent_turns.move_to_end(key)
+        if configuration_lost or conflicting_owner:
+            self._stage_and_dispatch(
+                context_id=context_id,
+                turn_id=turn.turn_id,
+                reason="restarted" if configuration_lost else "superseded",
+            )
+            return None
+        self._attach_task_done_finalizer(agent, context_id, turn.turn_id)
+        return turn
+
+    def finalize_agent_turn(self, agent: Any, *, reason: str) -> tuple[str, ...]:
+        context_id = str(getattr(getattr(agent, "context", None), "id", "") or "")
+        try:
+            context_id = _identifier(context_id, "context_id")
+        except ExtensionSessionStateError:
+            return ()
+        key = (context_id, id(agent))
+        with self._lock:
+            turn_id = self._agent_turns.pop(key, None)
+        if turn_id is None:
+            return ()
+        return self._stage_and_dispatch(
+            context_id=context_id, turn_id=turn_id, reason=reason
+        )
+
+    def finalize_tracked_agent_turn(
+        self, agent: Any, *, turn_id: str, reason: str
+    ) -> tuple[str, ...]:
+        """Finalize a callback's exact turn without touching a replacement."""
+
+        context_id = str(getattr(getattr(agent, "context", None), "id", "") or "")
+        key = (context_id, id(agent))
+        with self._lock:
+            if self._agent_turns.get(key) != turn_id:
+                return ()
+            self._agent_turns.pop(key, None)
+        return self._stage_and_dispatch(
+            context_id=context_id, turn_id=turn_id, reason=reason
+        )
+
+    def active_agent_turn(self, agent: Any) -> ActiveExtensionTurnBinding | None:
+        """Return only an exact, currently routed active turn for this agent."""
+
+        selection = self._validated_selection(agent, require_route=True)
+        if selection is None:
+            return None
+        context_id, browser_id, bridge_id = selection
+        key = (context_id, id(agent))
+        with self._lock:
+            turn_id = self._agent_turns.get(key)
+        if turn_id is None:
+            return None
+        try:
+            binding = self.registry.active_turn_binding(
+                context_id=context_id, turn_id=turn_id
+            )
+        except ExtensionSessionStateError:
+            return None
+        if (
+            binding is None
+            or binding.browser_id != browser_id
+            or binding.bridge_id != bridge_id
+        ):
+            return None
+        return binding
+
+    def is_current_turn(
+        self, agent: Any, binding: ActiveExtensionTurnBinding
+    ) -> bool:
+        """Revalidate exact real or synthetic ownership immediately before send."""
+
+        if not isinstance(binding, ActiveExtensionTurnBinding):
+            return False
+        selection = self._validated_selection(agent, require_route=True)
+        if selection is None:
+            return False
+        context_id, browser_id, bridge_id = selection
+        if (
+            binding.context_id != context_id
+            or binding.browser_id != browser_id
+            or binding.bridge_id != bridge_id
+        ):
+            return False
+        key = (context_id, id(agent))
+        with self._lock:
+            owned = (
+                self._agent_turns.get(key) == binding.turn_id
+                or self._synthetic_turns.get(key) == binding
+            )
+        if not owned:
+            return False
+        try:
+            current = self.registry.active_turn_binding(
+                context_id=context_id, turn_id=binding.turn_id
+            )
+        except ExtensionSessionStateError:
+            return False
+        return current == binding
+
+    def begin_synthetic_turn(self, agent: Any) -> ActiveExtensionTurnBinding | None:
+        """Allocate one direct-call turn without changing monologue ownership."""
+
+        selection = self._validated_selection(agent, require_route=True)
+        if selection is None:
+            return None
+        context_id, browser_id, bridge_id = selection
+        key = (context_id, id(agent))
+        with self._lock:
+            if (
+                key in self._agent_turns
+                or key in self._synthetic_turns
+                or len(self._agent_turns) + len(self._synthetic_turns)
+                >= self._max_agent_bindings
+            ):
+                return None
+        try:
+            session, turn = self.registry.begin_turn(
+                context_id=context_id,
+                browser_id=browser_id,
+                bridge_id=bridge_id,
+            )
+        except ExtensionSessionStateError:
+            return None
+        binding = ActiveExtensionTurnBinding(
+            context_id=context_id,
+            browser_session_id=session.browser_session_id,
+            browser_id=browser_id,
+            bridge_id=bridge_id,
+            turn_id=turn.turn_id,
+        )
+        conflicting_owner = False
+        configuration_lost = False
+        with self._lock:
+            # A concurrent owner cannot be safely replaced. Finalize the turn we
+            # just allocated and preserve the existing exact owner.
+            if self._configuration_owner is None or self._configuration_retiring:
+                configuration_lost = True
+            elif (
+                key in self._agent_turns
+                or key in self._synthetic_turns
+                or len(self._agent_turns) + len(self._synthetic_turns)
+                >= self._max_agent_bindings
+            ):
+                conflicting_owner = True
+            else:
+                self._synthetic_turns[key] = binding
+        if configuration_lost or conflicting_owner:
+            self._stage_and_dispatch(
+                context_id=context_id,
+                turn_id=turn.turn_id,
+                reason="restarted" if configuration_lost else "superseded",
+            )
+            return None
+        return binding
+
+    def finalize_synthetic_turn(
+        self,
+        agent: Any,
+        binding: ActiveExtensionTurnBinding,
+        *,
+        reason: str = "direct",
+    ) -> tuple[str, ...]:
+        """Finalize only the exact synthetic binding returned to this caller."""
+
+        if not isinstance(binding, ActiveExtensionTurnBinding):
+            return ()
+        context_id = str(getattr(getattr(agent, "context", None), "id", "") or "")
+        key = (context_id, id(agent))
+        with self._lock:
+            current = self._synthetic_turns.get(key)
+            if current != binding:
+                return ()
+            self._synthetic_turns.pop(key, None)
+        return self._stage_and_dispatch(
+            context_id=binding.context_id,
+            turn_id=binding.turn_id,
+            reason=reason,
+        )
+
+    def finalize_context(
+        self,
+        context: Any,
+        *,
+        reason: str,
+        retire: bool = False,
+        remove: bool = False,
+    ) -> tuple[str, ...]:
+        with self._lock:
+            if self._configuration_owner is None or self._configuration_retiring:
+                return ()
+        context_id = str(getattr(context, "id", "") or "")
+        try:
+            context_id = _identifier(context_id, "context_id")
+            if self.registry.session(context_id) is None:
+                return ()
+        except ExtensionSessionStateError:
+            return ()
+        with self._lock:
+            for key in tuple(self._agent_turns):
+                if key[0] == context_id:
+                    self._agent_turns.pop(key, None)
+            for key in tuple(self._synthetic_turns):
+                if key[0] == context_id:
+                    self._synthetic_turns.pop(key, None)
+        return self._stage_and_dispatch(
+            context_id=context_id,
+            turn_id=None,
+            reason=reason,
+            retire=retire,
+            remove=remove,
+        )
+
+    def replay_pending(self) -> tuple[str, ...]:
+        with self._lock:
+            dispatcher = self._dispatcher
+        return () if dispatcher is None else dispatcher.replay_pending()
+
+    def _attach_task_done_finalizer(
+        self, agent: Any, context_id: str, turn_id: str
+    ) -> None:
+        task = getattr(getattr(agent, "context", None), "task", None)
+        add_done_callback = getattr(task, "add_done_callback", None)
+        if not callable(add_done_callback):
+            return
+
+        def finalize_after_task(_future: Any) -> None:
+            self.finalize_tracked_agent_turn(
+                agent, turn_id=turn_id, reason="task_done"
+            )
+
+        try:
+            add_done_callback(finalize_after_task)
+        except Exception:
+            return
+
+    def _validated_selection(
+        self, agent: Any, *, require_route: bool
+    ) -> tuple[str, str, str] | None:
+        if agent is None:
+            return None
+        with self._lock:
+            route_resolver = self._route_resolver
+            dispatcher = self._dispatcher
+            retiring = self._configuration_retiring
+        if retiring or route_resolver is None or dispatcher is None:
+            return None
+        context_id = str(getattr(getattr(agent, "context", None), "id", "") or "")
+        try:
+            context_id = _identifier(context_id, "context_id")
+            config = self._config_loader(agent)
+            if (
+                not isinstance(config, Mapping)
+                or config.get(RUNTIME_BACKEND_KEY) != "host_required"
+            ):
+                return None
+            selection = parse_extension_browser_selection(
+                config.get(HOST_BROWSER_SELECTION_KEY)
+            )
+        except Exception:
+            return None
+        if selection is None:
+            return None
+        if require_route:
+            try:
+                route = route_resolver(context_id, selection.bridge_id)
+            except Exception:
+                return None
+            if (
+                not isinstance(route, ValidatedExtensionRoute)
+                or route.bridge_id != selection.bridge_id
+                or route.browser_id != selection.value
+            ):
+                return None
+        return context_id, selection.value, selection.bridge_id
+
+    def _stage_and_dispatch(
+        self,
+        *,
+        context_id: str,
+        turn_id: str | None,
+        reason: str,
+        retire: bool = False,
+        remove: bool = False,
+    ) -> tuple[str, ...]:
+        with self._lock:
+            dispatcher = self._dispatcher
+        try:
+            intents = self.registry.stage_finalize(
+                context_id=context_id,
+                turn_id=turn_id,
+                reason=reason,
+                retire=retire,
+                remove=remove,
+            )
+        except ExtensionSessionStateError:
+            return ()
+        return () if dispatcher is None else dispatcher.schedule(intents)
+
+
+_legacy_lifecycle_owner = object()
+_lifecycle = ExtensionSessionLifecycle()
+
+
+def get_extension_session_lifecycle() -> ExtensionSessionLifecycle:
+    """Return the hook-owned singleton for explicit production composition."""
+
+    return _lifecycle
+
+
+def configure_extension_session_lifecycle(
+    *,
+    route_resolver: RouteResolver,
+    sender: FinalizationSender,
+    submitter: CoroutineSubmitter | None = None,
+    max_inflight: int = 128,
+) -> tuple[str, ...]:
+    """Inject the future restricted broker seam and replay durable controls."""
+
+    return _lifecycle.configure(
+        route_resolver=route_resolver,
+        sender=sender,
+        submitter=submitter,
+        max_inflight=max_inflight,
+    )
+
+
+def replay_extension_finalizations() -> tuple[str, ...]:
+    """Retry durable pending controls after a trusted route becomes current."""
+
+    return _lifecycle.replay_pending()
+
+
+def begin_extension_monologue(agent: Any) -> ExtensionTurnIntent | None:
+    return _lifecycle.begin_agent_turn(agent)
+
+
+def finalize_extension_monologue(agent: Any, *, reason: str) -> tuple[str, ...]:
+    return _lifecycle.finalize_agent_turn(agent, reason=reason)
+
+
+def get_active_extension_turn(agent: Any) -> ActiveExtensionTurnBinding | None:
+    """Resolve the current turn from the hook-owned production lifecycle."""
+
+    return _lifecycle.active_agent_turn(agent)
+
+
+def is_current_extension_turn(
+    agent: Any, binding: ActiveExtensionTurnBinding
+) -> bool:
+    """Revalidate an exact turn for a broker dispatch preflight."""
+
+    return _lifecycle.is_current_turn(agent, binding)
+
+
+def begin_extension_synthetic_turn(agent: Any) -> ActiveExtensionTurnBinding | None:
+    """Begin a direct Browser-call scope when no monologue turn owns the agent."""
+
+    return _lifecycle.begin_synthetic_turn(agent)
+
+
+def finalize_extension_synthetic_turn(
+    agent: Any,
+    binding: ActiveExtensionTurnBinding,
+    *,
+    reason: str = "direct",
+) -> tuple[str, ...]:
+    """Finalize a matching direct-call scope from the caller's ``finally`` block."""
+
+    return _lifecycle.finalize_synthetic_turn(agent, binding, reason=reason)
+
+
+def finalize_extension_context(
+    context: Any,
+    *,
+    reason: str,
+    retire: bool = False,
+    remove: bool = False,
+) -> tuple[str, ...]:
+    return _lifecycle.finalize_context(
+        context, reason=reason, retire=retire, remove=remove,
+    )
+
+
+def _background_submitter(coroutine: Awaitable[None]) -> Future[Any]:
+    from helpers.defer import EventLoopThread
+
+    return EventLoopThread("BrowserExtensionFinalization").run_coroutine(coroutine)
+
+
+def _identifier(value: Any, field: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or len(value.encode("utf-8")) > MAX_IDENTIFIER_BYTES
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+    ):
+        raise ExtensionSessionStateError(
+            "INVALID_IDENTIFIER", f"The {field} is invalid"
+        )
+    return value
+
+
+def _browser_id(
+    value: Any,
+    bridge_id: str,
+    transport_profile: BrowserBridgeTransportProfile = (
+        PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    ),
+) -> str:
+    browser_id = _identifier(value, "browser_id")
+    require_browser_bridge_transport_profile(transport_profile)
+    try:
+        selection = parse_extension_browser_selection(browser_id)
+    except ValueError:
+        selection = None
+    if selection is None or selection.bridge_id != bridge_id:
+        raise ExtensionSessionStateError(
+            "INVALID_BROWSER_ID", "The browser ID does not match the bridge"
+        )
+    return browser_id
+
+
+def _reason(value: Any) -> str:
+    reason = _identifier(value, "reason")
+    if len(reason.encode("utf-8")) > MAX_REASON_BYTES:
+        raise ExtensionSessionStateError(
+            "INVALID_REASON", "The finalization reason is too long"
+        )
+    return reason
+
+
+def _timestamp(value: Any, field: str) -> int:
+    if type(value) is not int or value < 0:
+        raise ExtensionSessionStateError("INVALID_STATE", f"The {field} is invalid")
+    return value
+
+
+def _nonnegative_int(value: Any, field: str) -> int:
+    return _timestamp(value, field)
+
+
+def _optional_timestamp(value: Any, field: str) -> int | None:
+    return None if value is None else _timestamp(value, field)
+
+
+def _turn_index(turns: list[ExtensionTurnIntent], turn_id: str) -> int:
+    for index, turn in enumerate(turns):
+        if turn.turn_id == turn_id:
+            return index
+    raise ExtensionSessionStateError("TURN_NOT_FOUND", "The extension turn was not found")
+
+
+def _require_session(
+    sessions: Mapping[str, ExtensionSessionIntent],
+    context_id: str,
+    browser_session_id: str,
+) -> ExtensionSessionIntent:
+    session = sessions.get(context_id)
+    if session is None or session.browser_session_id != browser_session_id:
+        raise ExtensionSessionStateError(
+            "SESSION_NOT_FOUND", "The extension session was not found"
+        )
+    return session
+
+
+def _finalization_intent(
+    session: ExtensionSessionIntent, turn: ExtensionTurnIntent
+) -> ExtensionFinalizationIntent:
+    if (
+        turn.control_id is None
+        or turn.reason is None
+        or turn.finalization_requested_at_ms is None
+    ):
+        raise ExtensionSessionStateError(
+            "INVALID_STATE", "The pending finalization is incomplete"
+        )
+    return ExtensionFinalizationIntent(
+        control_id=turn.control_id,
+        context_id=session.context_id,
+        browser_session_id=session.browser_session_id,
+        browser_id=session.browser_id,
+        bridge_id=session.bridge_id,
+        turn_id=turn.turn_id,
+        dispositions=turn.dispositions,
+        reason=turn.reason,
+        requested_at_ms=turn.finalization_requested_at_ms,
+    )
+
+
+def _can_delete(session: ExtensionSessionIntent) -> bool:
+    if not (session.retire_requested or session.remove_requested):
+        return False
+    return all(turn.state == TURN_FINALIZED for turn in session.turns)
+
+
+def _encode_store(
+    sessions: Mapping[str, ExtensionSessionIntent],
+) -> dict[str, Any]:
+    return {
+        "contract": SESSION_STORE_CONTRACT,
+        "schema_version": SESSION_STORE_VERSION,
+        "sessions": [_encode_session(sessions[key]) for key in sorted(sessions)],
+    }
+
+
+def _encode_session(session: ExtensionSessionIntent) -> dict[str, Any]:
+    return {
+        "context_id": session.context_id,
+        "browser_session_id": session.browser_session_id,
+        "browser_id": session.browser_id,
+        "bridge_id": session.bridge_id,
+        "turns": [_encode_turn(turn) for turn in session.turns],
+        "last_acked_event_sequence": session.last_acked_event_sequence,
+        "created_at_ms": session.created_at_ms,
+        "updated_at_ms": session.updated_at_ms,
+        "retire_requested": session.retire_requested,
+        "remove_requested": session.remove_requested,
+    }
+
+
+def _encode_turn(turn: ExtensionTurnIntent) -> dict[str, Any]:
+    return {
+        "turn_id": turn.turn_id,
+        "state": turn.state,
+        "dispositions": dict(turn.dispositions),
+        "control_id": turn.control_id,
+        "reason": turn.reason,
+        "started_at_ms": turn.started_at_ms,
+        "finalization_requested_at_ms": turn.finalization_requested_at_ms,
+        "settled_at_ms": turn.settled_at_ms,
+    }
+
+
+def _decode_store(
+    value: Any,
+    *,
+    max_contexts: int,
+    max_turns: int,
+    max_dispositions: int,
+    transport_profile: BrowserBridgeTransportProfile = (
+        PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    ),
+) -> dict[str, ExtensionSessionIntent]:
+    if not isinstance(value, Mapping) or set(value) != {
+        "contract",
+        "schema_version",
+        "sessions",
+    }:
+        raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid session store")
+    if (
+        value.get("contract") != SESSION_STORE_CONTRACT
+        or value.get("schema_version") != SESSION_STORE_VERSION
+    ):
+        raise ExtensionSessionStateError("CORRUPT_STORE", "Unsupported session store")
+    raw_sessions = value.get("sessions")
+    if not isinstance(raw_sessions, list) or len(raw_sessions) > max_contexts:
+        raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid session records")
+    sessions: dict[str, ExtensionSessionIntent] = {}
+    browser_session_ids: set[str] = set()
+    control_ids: set[str] = set()
+    for raw in raw_sessions:
+        session = _decode_session(
+            raw,
+            max_turns=max_turns,
+            max_dispositions=max_dispositions,
+            transport_profile=transport_profile,
+        )
+        if session.context_id in sessions:
+            raise ExtensionSessionStateError("CORRUPT_STORE", "Duplicate context record")
+        if session.browser_session_id in browser_session_ids:
+            raise ExtensionSessionStateError("CORRUPT_STORE", "Duplicate browser session")
+        browser_session_ids.add(session.browser_session_id)
+        for turn in session.turns:
+            if turn.control_id is not None:
+                if turn.control_id in control_ids:
+                    raise ExtensionSessionStateError(
+                        "CORRUPT_STORE", "Duplicate finalization control"
+                    )
+                control_ids.add(turn.control_id)
+        sessions[session.context_id] = session
+    return sessions
+
+
+def _decode_session(
+    value: Any,
+    *,
+    max_turns: int,
+    max_dispositions: int,
+    transport_profile: BrowserBridgeTransportProfile = (
+        PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    ),
+) -> ExtensionSessionIntent:
+    expected = {
+        "context_id",
+        "browser_session_id",
+        "browser_id",
+        "bridge_id",
+        "turns",
+        "last_acked_event_sequence",
+        "created_at_ms",
+        "updated_at_ms",
+        "retire_requested",
+        "remove_requested",
+    }
+    if not isinstance(value, Mapping) or set(value) != expected:
+        raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid session record")
+    context_id = _identifier(value.get("context_id"), "context_id")
+    bridge_id = _identifier(value.get("bridge_id"), "bridge_id")
+    browser_id = _browser_id(
+        value.get("browser_id"), bridge_id, transport_profile
+    )
+    raw_turns = value.get("turns")
+    if not isinstance(raw_turns, list) or len(raw_turns) > max_turns:
+        raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid turn records")
+    turns = tuple(
+        _decode_turn(raw, max_dispositions=max_dispositions) for raw in raw_turns
+    )
+    if len({turn.turn_id for turn in turns}) != len(turns):
+        raise ExtensionSessionStateError("CORRUPT_STORE", "Duplicate turn record")
+    created = _timestamp(value.get("created_at_ms"), "created_at_ms")
+    updated = _timestamp(value.get("updated_at_ms"), "updated_at_ms")
+    if updated < created:
+        raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid session timestamps")
+    if type(value.get("retire_requested")) is not bool or type(
+        value.get("remove_requested")
+    ) is not bool:
+        raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid session flags")
+    if value["remove_requested"] and not value["retire_requested"]:
+        raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid removal state")
+    return ExtensionSessionIntent(
+        context_id=context_id,
+        browser_session_id=_identifier(
+            value.get("browser_session_id"), "browser_session_id"
+        ),
+        browser_id=browser_id,
+        bridge_id=bridge_id,
+        turns=turns,
+        last_acked_event_sequence=_nonnegative_int(
+            value.get("last_acked_event_sequence"), "last_acked_event_sequence"
+        ),
+        created_at_ms=created,
+        updated_at_ms=updated,
+        retire_requested=value["retire_requested"],
+        remove_requested=value["remove_requested"],
+    )
+
+
+def _decode_turn(value: Any, *, max_dispositions: int) -> ExtensionTurnIntent:
+    expected = {
+        "turn_id",
+        "state",
+        "dispositions",
+        "control_id",
+        "reason",
+        "started_at_ms",
+        "finalization_requested_at_ms",
+        "settled_at_ms",
+    }
+    if not isinstance(value, Mapping) or set(value) != expected:
+        raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid turn record")
+    state = value.get("state")
+    if state not in TURN_STATES:
+        raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid turn state")
+    raw_dispositions = value.get("dispositions")
+    if not isinstance(raw_dispositions, Mapping) or len(
+        raw_dispositions
+    ) > max_dispositions:
+        raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid dispositions")
+    dispositions: list[tuple[str, str]] = []
+    for raw_lease_id, raw_disposition in raw_dispositions.items():
+        lease_id = _identifier(raw_lease_id, "lease_id")
+        if raw_disposition not in LEASE_DISPOSITIONS:
+            raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid disposition")
+        dispositions.append((lease_id, raw_disposition))
+    control_id = value.get("control_id")
+    reason = value.get("reason")
+    requested = _optional_timestamp(
+        value.get("finalization_requested_at_ms"), "finalization_requested_at_ms"
+    )
+    settled = _optional_timestamp(value.get("settled_at_ms"), "settled_at_ms")
+    if state == TURN_ACTIVE:
+        if (
+            control_id is not None
+            or reason is not None
+            or requested is not None
+            or settled is not None
+        ):
+            raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid active turn")
+    else:
+        control_id = _identifier(control_id, "control_id")
+        if not _CORRELATION_ID_RE.fullmatch(control_id):
+            raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid control ID")
+        reason = _reason(reason)
+        if requested is None:
+            raise ExtensionSessionStateError("CORRUPT_STORE", "Missing request timestamp")
+        if state == TURN_FINALIZATION_PENDING and settled is not None:
+            raise ExtensionSessionStateError("CORRUPT_STORE", "Pending turn is settled")
+        if state in FINALIZATION_TERMINAL_STATES and settled is None:
+            raise ExtensionSessionStateError("CORRUPT_STORE", "Terminal turn is unsettled")
+    started = _timestamp(value.get("started_at_ms"), "started_at_ms")
+    if requested is not None and requested < started:
+        raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid turn timestamps")
+    if settled is not None and (requested is None or settled < requested):
+        raise ExtensionSessionStateError("CORRUPT_STORE", "Invalid turn timestamps")
+    return ExtensionTurnIntent(
+        turn_id=_identifier(value.get("turn_id"), "turn_id"),
+        state=state,
+        dispositions=tuple(sorted(dispositions)),
+        control_id=control_id,
+        reason=reason,
+        started_at_ms=started,
+        finalization_requested_at_ms=requested,
+        settled_at_ms=settled,
+    )

--- a/plugins/_browser/helpers/extension_uploads.py
+++ b/plugins/_browser/helpers/extension_uploads.py
@@ -1,0 +1,155 @@
+"""Context-owned user attachment sources; never arbitrary tool-selected paths."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+import mimetypes
+import os
+from pathlib import Path
+import re
+import stat
+import threading
+import uuid
+
+STORE_KEY = "browser_extension_upload_sources_v1"
+MAX_BYTES = 25 * 1024 * 1024
+MAX_SOURCES = 32
+_source_lock = threading.RLock()
+_MIME = re.compile(r"[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}")
+
+
+class UploadSourceDenied(ValueError):
+    def __init__(self):
+        super().__init__("Upload source unavailable; attach the file to this chat again.")
+
+
+def _root():
+    from helpers import files
+    return Path(files.get_abs_path("usr/uploads")).resolve()
+
+
+def _relative(path, root):
+    if not isinstance(path, str) or not path or len(path) > 4096 or "\x00" in path:
+        raise UploadSourceDenied()
+    from helpers import files
+    actual = Path(files.fix_dev_path(path))
+    try:
+        relative = actual.relative_to(root)
+    except ValueError:
+        raise UploadSourceDenied() from None
+    if not relative.parts or any(part in {"", ".", ".."} for part in relative.parts):
+        raise UploadSourceDenied()
+    return relative
+
+
+def _read_exact(root: Path, relative: Path, expected=None):
+    """Open each component relative to the retained root; reject link aliases."""
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise UploadSourceDenied()
+    directory = os.open(root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    descriptor = None
+    try:
+        def check_directory(fd):
+            info = os.fstat(fd)
+            if not stat.S_ISDIR(info.st_mode) or info.st_uid != os.getuid() or info.st_mode & 0o022:
+                raise UploadSourceDenied()
+        check_directory(directory)
+        for part in relative.parts[:-1]:
+            child = os.open(part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=directory)
+            os.close(directory)
+            directory = child
+            check_directory(directory)
+        descriptor = os.open(relative.name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=directory)
+        before = os.fstat(descriptor)
+        identity = [before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns, before.st_ctime_ns]
+        if (not stat.S_ISREG(before.st_mode) or before.st_nlink != 1
+            or before.st_uid != os.getuid() or before.st_mode & 0o022
+            or not 1 <= before.st_size <= MAX_BYTES or (expected is not None and identity != expected)):
+            raise UploadSourceDenied()
+        with os.fdopen(descriptor, "rb", closefd=False) as handle:
+            data = handle.read(MAX_BYTES + 1)
+        after = os.fstat(descriptor)
+        if identity != [after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_ctime_ns] or len(data) != before.st_size:
+            raise UploadSourceDenied()
+        return data, identity
+    except (OSError, ValueError):
+        raise UploadSourceDenied() from None
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(directory)
+
+
+def record_user_attachments(context, paths, *, root=None):
+    """Called only by the trusted user_message_ui hook after framework upload."""
+    with _source_lock:
+        _record_user_attachments(context, paths, root=root)
+
+
+def _record_user_attachments(context, paths, *, root=None):
+    if not isinstance(paths, list) or not paths:
+        return
+    root = root or _root()
+    previous = context.get_data(STORE_KEY, recursive=False)
+    records = list(previous) if isinstance(previous, list) and len(previous) <= MAX_SOURCES else []
+    for path in paths[:MAX_SOURCES]:
+        try:
+            relative = _relative(path, root)
+            data, identity = _read_exact(root, relative)
+            mime = mimetypes.guess_type(relative.name)[0] or "application/octet-stream"
+            if not _MIME.fullmatch(mime):
+                mime = "application/octet-stream"
+            record = {"context_id": str(context.id), "source": path, "relative": str(relative),
+                      "identity": identity, "sha256": "sha256:" + hashlib.sha256(data).hexdigest(),
+                      "mime_type": mime, "byte_count": len(data)}
+            records = [item for item in records if isinstance(item, dict) and item.get("source") != path]
+            records.append(record)
+        except (UploadSourceDenied, OSError):
+            continue  # Chat delivery is independent of optional browser upload support.
+    context.set_data(STORE_KEY, records[-MAX_SOURCES:], recursive=False)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedUpload:
+    context_id: str
+    artifact_id: str
+    mime_type: str
+    byte_count: int
+    sha256: str
+    root: Path = field(repr=False)
+    relative: Path = field(repr=False)
+    identity: tuple[int, ...] = field(repr=False)
+
+    def read(self) -> bytes:
+        data, _ = _read_exact(self.root, self.relative, list(self.identity))
+        if len(data) != self.byte_count or "sha256:" + hashlib.sha256(data).hexdigest() != self.sha256:
+            raise UploadSourceDenied()
+        return data
+
+
+def prepare_upload(context, *, path="", paths=None, root=None) -> PreparedUpload:
+    if not isinstance(path, str) or (paths is not None and not isinstance(paths, list)):
+        raise UploadSourceDenied()
+    choices = ([path] if path else []) + (paths or [])
+    if len(choices) != 1 or not isinstance(choices[0], str):
+        raise UploadSourceDenied()
+    stored = context.get_data(STORE_KEY, recursive=False)
+    if not isinstance(stored, list) or len(stored) > MAX_SOURCES:
+        raise UploadSourceDenied()
+    matches = [record for record in stored if isinstance(record, dict) and record.get("context_id") == str(context.id)
+               and record.get("source") == choices[0]]
+    if len(matches) != 1:
+        raise UploadSourceDenied()
+    record = matches[0]
+    root = root or _root()
+    relative = _relative(choices[0], root)
+    identity = record.get("identity")
+    if (set(record) != {"context_id", "source", "relative", "identity", "sha256", "mime_type", "byte_count"}
+        or str(relative) != record["relative"] or not isinstance(identity, list) or len(identity) != 5
+        or any(type(value) is not int or value < 0 for value in identity)
+        or not isinstance(record["sha256"], str) or not re.fullmatch(r"sha256:[a-f0-9]{64}", record["sha256"])
+        or not isinstance(record["mime_type"], str) or not _MIME.fullmatch(record["mime_type"])
+        or type(record["byte_count"]) is not int or not 1 <= record["byte_count"] <= MAX_BYTES):
+        raise UploadSourceDenied()
+    return PreparedUpload(str(context.id), str(uuid.uuid4()), record["mime_type"], record["byte_count"],
+                          record["sha256"], root, relative, tuple(identity))

--- a/plugins/_browser/helpers/extension_uploads.py.dox.md
+++ b/plugins/_browser/helpers/extension_uploads.py.dox.md
@@ -1,0 +1,26 @@
+# Context-owned Browser upload sources
+
+The user_message_ui hook records at most32 actual uploaded-file references for
+its exact context, with an immutable byte count, SHA-256, MIME and filesystem
+identity. No bytes or server path enter the extension/UI projection. Registry
+records live in context data, never inherited from another chat. No tool call
+may register a source, choose arbitrary server files, or use an unrecorded path.
+Earlier attachments without evidence must be attached again. Ordinary chat
+delivery is independent of optional Browser source capture.
+
+Read only beneath Core's configured usr/uploads root, opening each child from
+retained directory descriptors with no-follow flags. Reject symlink/hardlink
+aliases, non-regular/group-writable/foreign-owned files, traversal, changes,
+empty or over25MiB input. Recheck filesystem identity around bounded reads and
+compare the original hash before transport. PreparedUpload is server-owned,
+non-persistent and hides paths from repr. Each call gets a new opaque artifactID.
+
+The runtime sends only descriptor fields and the current semantic ref, waits
+for exact browser.perform dispatch before ordered input frames, and cancels
+failed transfers conservatively. Services retain a bounded exact-binding source
+permit only during transfer. Native keeps verified bytes private until the
+extension's separate once-only external-side-effect approval and file-field
+validation. Staging on the companion is not consent to send bytes to a site.
+
+Verification: tests/test_browser_extension_uploads.py (synthetic owned files)
+plus runtime/broker/artifact integration fixtures. No live uploads or approvals.

--- a/plugins/_browser/helpers/mv3_runtime_foundation.py
+++ b/plugins/_browser/helpers/mv3_runtime_foundation.py
@@ -1,0 +1,32 @@
+"""Static MV3 discovery metadata, never a runtime lease validator."""
+
+from typing import Any
+
+MV3_RUNTIME_CONTRACT = "a0.browser-bridge.mv3-runtime.v1"
+CORE_ADAPTER_CONTRACT = "a0.browser-bridge.adapter.v1"
+BRIDGE_PROTOCOL_CONTRACT = "a0.browser-bridge.v1"
+BRIDGE_CONTRACT_VERSION = 1
+MV3_RUNTIME_FOUNDATION_FEATURE = "browser_extension_mv3_runtime_foundation"
+
+
+def build_mv3_runtime_foundation_status() -> dict[str, Any]:
+    """Preserve discovery shape without asserting live validation or readiness."""
+    return {
+        "contract": MV3_RUNTIME_CONTRACT,
+        "adapter_contract": CORE_ADAPTER_CONTRACT,
+        "protocol_contract": BRIDGE_PROTOCOL_CONTRACT,
+        "contract_version": BRIDGE_CONTRACT_VERSION,
+        "state": "disabled",
+        "reason_code": "mv3_runtime_foundation_only",
+        "runtime_ready": False,
+        "pairing_enabled": False,
+        "dispatch_enabled": False,
+        "browser_mutation_enabled": False,
+        "validation": {
+            "mode": "schema_only",
+            "task_lease_binding": False,
+            "turn_finalization": False,
+        },
+        "native_runtime_location": "user_browser_host",
+        "docker_browser_host_access": False,
+    }

--- a/plugins/_browser/helpers/selector.py
+++ b/plugins/_browser/helpers/selector.py
@@ -3,15 +3,25 @@ from __future__ import annotations
 from typing import Any
 
 from helpers.errors import RepairableException
-from plugins._browser.helpers.config import RUNTIME_BACKEND_KEY, get_browser_config
-from plugins._browser.helpers.runtime import get_runtime as get_container_runtime
-
+from plugins._browser.helpers.config import (
+    HOST_BROWSER_SELECTION_KEY,
+    RUNTIME_BACKEND_KEY,
+    get_browser_config,
+    parse_development_extension_browser_selection,
+    parse_extension_browser_selection,
+)
 
 DOCKER_BROWSER_RECOVERY_HELP = (
     "To use Agent Zero's internal Docker browser instead, open Browser settings and "
     "set Browser location to Internal Docker browser, or run `/browser container` "
     "from A0 CLI."
 )
+
+
+async def get_container_runtime(context_id: str):
+    from plugins._browser.helpers.runtime import get_runtime
+
+    return await get_runtime(context_id)
 
 
 async def get_tool_runtime(agent: Any):
@@ -21,6 +31,42 @@ async def get_tool_runtime(agent: Any):
 
     if backend == "container":
         return await get_container_runtime(context_id)
+
+    selection = config.get(HOST_BROWSER_SELECTION_KEY, "")
+    try:
+        development_selection = parse_development_extension_browser_selection(
+            selection
+        )
+    except ValueError as exc:
+        raise RepairableException(
+            "The development Chrome extension browser selection is invalid. "
+            "Choose it again from Browser settings. Agent Zero did not fall back."
+        ) from exc
+    if development_selection is not None:
+        raise RepairableException(
+            "This development browser connection has been retired. Pair and select the "
+            "production Chrome extension in Browser settings. No fallback was attempted."
+        )
+    try:
+        extension_selection = parse_extension_browser_selection(selection)
+    except ValueError as exc:
+        raise RepairableException(
+            "The Chrome extension browser selection is invalid. Choose a paired browser "
+            "from Browser settings and retry. Agent Zero did not fall back to another browser."
+        ) from exc
+    if extension_selection is not None:
+        from plugins._browser.helpers.extension_runtime import wait_selected_extension_runtime
+
+        runtime = await wait_selected_extension_runtime(agent, extension_selection.bridge_id)
+        if runtime is not None:
+            return runtime
+        raise RepairableException(
+            "The selected Chrome browser has not established a verified connection for this chat. "
+            "Keep Chrome open and check its Agent Zero extension connection status. "
+            "No browser action was sent by this attempt, and no other browser or tool was used. "
+            "Agent Zero did not fall back to another browser. "
+            "Do not repeat an earlier action whose outcome was unknown."
+        )
 
     sid = _select_host_browser_candidate_sid(context_id)
     if sid:

--- a/plugins/_browser/hooks.py
+++ b/plugins/_browser/hooks.py
@@ -14,6 +14,7 @@ from plugins._browser.helpers.config import (
     PLUGIN_NAME,
     browser_runtime_config,
     normalize_browser_config,
+    validate_extension_browser_selection_change,
 )
 from plugins._browser.helpers.playwright import (
     ensure_playwright_binary,
@@ -62,6 +63,27 @@ def save_plugin_config(settings=None, project_name="", agent_profile="", **kwarg
     current = normalize_browser_config(
         _load_saved_browser_config(project_name=project_name, agent_profile=agent_profile)
     )
+    validate_extension_browser_selection_change(
+        proposed_value=normalized.get("host_browser_selection"),
+        current_value=current.get("host_browser_selection"),
+        proposed_runtime_backend=normalized.get("runtime_backend"),
+        current_runtime_backend=current.get("runtime_backend"),
+    )
+    from plugins._browser.helpers.config import parse_extension_browser_selection
+
+    try:
+        previous_extension = parse_extension_browser_selection(current.get("host_browser_selection"))
+    except ValueError:
+        previous_extension = None
+    if previous_extension is not None and (
+        normalized.get("host_browser_selection") != previous_extension.value
+        or normalized.get("runtime_backend") != "host_required"
+    ):
+        from plugins._a0_connector.helpers.browser_bridge_bootstrap import get_browser_bridge_application
+
+        application = get_browser_bridge_application()
+        if application is not None:
+            application.registry.retire_bridge(previous_extension.bridge_id)
     if browser_runtime_config(normalized) != browser_runtime_config(current):
         close_all_runtimes_sync()
     return normalized

--- a/plugins/_browser/prompts/agent.system.tool.browser.md
+++ b/plugins/_browser/prompts/agent.system.tool.browser.md
@@ -10,6 +10,7 @@ For rendered browsing workflows, multi-step interaction, screenshots, downloads,
 Actions: tabs `open`, `list`, `state`, `set_active`, `navigate`, `back`, `forward`, `reload`, `close`, `close_all`; inspect `content`, `detail`, `screenshot`; interact `click`, `hover`, `double_click`, `right_click`, `drag`, `type`, `submit`, `type_submit`, `scroll`, `select_option`, `set_checked`, `upload_file`; advanced `evaluate`, `key_chord`, `mouse`, `wheel`, `keyboard`, `clipboard`, `set_viewport`, `multi`.
 
 Rules:
+- For Chrome extension browser use, site approval is explicit. A new-site request waits for the user's decision in the WebUI. If permission is denied, expires, or remains unavailable, explain that to the user; never work around it with `code_execution_tool`, curl, another browser, or another fetching tool. A browser permission failure is not authorization to switch tools. The Chrome extension does not need remote debugging setup.
 - If the user asks for an existing tab, page title, or already-open URL, call `list` first, match by `title` or `currentUrl`, then use `set_active` or `navigate` on that `browser_id`.
 - Prefer DOM/CDP actions: use refs from the latest `content`, including frame-chain refs, or same-page `selector`; use coordinates only when refs/selectors are unavailable or the user explicitly asks for visual manual control.
 - Screenshots are explicit only; the browser does not automatically load screenshots. Call `vision_load` with the returned `vision_load.tool_args.paths` value before reasoning visually.

--- a/plugins/_browser/tools/browser.py
+++ b/plugins/_browser/tools/browser.py
@@ -10,8 +10,11 @@ from typing import Any
 from helpers import files
 from helpers.print_style import PrintStyle
 from helpers.tool import Response, Tool
-from plugins._browser.helpers.config import activate_browser_model
+from plugins._browser.helpers.config import (
+    activate_browser_model, get_browser_config, parse_extension_browser_selection,
+)
 from plugins._browser.helpers.selector import get_tool_runtime
+from plugins._browser.helpers.extension_runtime import ExtensionBrowserError
 
 
 HISTORY_SCREENSHOT_QUALITY = 62
@@ -312,16 +315,50 @@ class Browser(Tool):
                 )
             await self._record_history_screenshot(runtime, action, result, browser_id)
         except Exception as exc:
+            if isinstance(exc, ExtensionBrowserError) and exc.code in {
+                "ORIGIN_BLOCKED", "APPROVAL_REQUIRED", "APPROVAL_DENIED", "APPROVAL_EXPIRED",
+            }:
+                return Response(
+                    message=(
+                        f"Browser {action} stopped: {exc} "
+                        "Site or action permission is missing, denied, or expired. "
+                        "Explain the permission issue to the user; do not bypass it with "
+                        "code_execution_tool, curl, another browser, or another fetching tool. "
+                        "Do not retry a denied request without new user approval."
+                    ),
+                    break_loop=False,
+                )
             return Response(message=f"Browser {action} failed: {exc}", break_loop=False)
 
         return Response(message=self._format_result(action, result), break_loop=False)
+
+    def _presentation_arguments(self):
+        kvps = dict(self.args)
+        kvps.pop("_browser_backend", None)
+        try:
+            config = get_browser_config(agent=self.agent)
+            if (config.get("runtime_backend") != "container"
+                    and parse_extension_browser_selection(config.get("host_browser_selection", "")) is not None):
+                # Presentation-only negative guard, including targetless calls
+                # and unavailable-runtime errors. It grants no browser access.
+                kvps["_browser_backend"] = "chrome_extension"
+                if "text" in kvps:
+                    kvps["text"] = "[Input text withheld]"
+        except Exception:
+            # Unavailable selection metadata is not permission to log input.
+            if "text" in kvps:
+                kvps["text"] = "[Input text withheld]"
+        return kvps
+
+    def get_display_args(self):
+        return {key: value for key, value in self._presentation_arguments().items() if key != "_browser_backend"}
 
     def get_log_object(self):
         return self.agent.context.log.log(
             type="tool",
             heading=f"icon://captive_portal {self.agent.agent_name}: Using browser",
             content="",
-            kvps=self.args,
+            kvps=self._presentation_arguments(),
             _tool_name=self.name,
         )
 

--- a/plugins/_browser/webui/browser-action-requests-store.js
+++ b/plugins/_browser/webui/browser-action-requests-store.js
@@ -1,0 +1,132 @@
+import { createStore } from "/js/AlpineStore.js";
+import { callJsonApi } from "/js/api.js";
+
+const API = "/plugins/_a0_connector/browser_bridge_approval";
+const CONTRACT = "a0.browser-bridge.approval.v1";
+const choices = ["decline", "approve_once"];
+const classes = ["sensitive_input", "external_side_effect", "unknown"];
+const identifier = (value) => typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/.test(value);
+
+function envelope(value) {
+  if (value?.contract !== CONTRACT || value.approval_version !== 1 || value.browser_control_ready !== false) throw new Error("Invalid action authority");
+  return value;
+}
+
+function parseRequests(value, contextId) {
+  const response = envelope(value);
+  if (!Array.isArray(response.challenges) || response.challenges.length > 128) throw new Error("Invalid action requests");
+  const requests = response.challenges.map((request) => {
+    if (!identifier(request?.challenge_id) || !["click", "type", "upload_file"].includes(request.action) || !classes.includes(request.action_class)
+      || (request.action === "type" && request.action_class !== "sensitive_input")
+      || (request.action === "upload_file" && request.action_class !== "external_side_effect")
+      || JSON.stringify(request.options) !== JSON.stringify(choices)
+      || !Number.isSafeInteger(request.expires_at_ms) || request.expires_at_ms < 1
+      || typeof request.origin !== "string" || request.origin.length > 2048) throw new Error("Invalid action request");
+    const url = new URL(request.origin);
+    if (!["https:", "http:"].includes(url.protocol) || url.origin !== request.origin) throw new Error("Invalid action origin");
+    // Page descriptions, DOM, input data and authority bindings are not UI copy.
+    return { id: request.challenge_id, action: request.action, origin: request.origin, expires: request.expires_at_ms,
+      contextId };
+  });
+  if (new Set(requests.map((request) => request.id)).size !== requests.length) throw new Error("Duplicate action request");
+  return requests;
+}
+
+export function createActionRequestsModel({ api, selection = () => null, now = Date.now, schedule = setTimeout, unschedule = clearTimeout }) {
+  // Session-local uncertainty survives component close/reopen. A failed HTTP
+  // reply cannot prove that Core did not record the decision.
+  const unresolved = new Map();
+  const prune = (time = now()) => { for (const [id, request] of unresolved) if (request.expires <= time) unresolved.delete(id); };
+  const uncertainNotice = "This decision could not be confirmed. Refresh to check the request; do not repeat the action.";
+  return {
+    active: false, generation: 0, listSequence: 0, timer: null, loading: false, busyId: "",
+    requests: [], state: "not_checked", stateContextId: "", notice: "", noticeContextId: "", noticeExpires: 0, decisionUnconfirmed: false, clock: 0,
+    async mount() { this.cleanup(); this.active = true; await this.refresh(); },
+    cleanup() {
+      this.active = false; this.generation += 1; this.listSequence += 1;
+      if (this.timer !== null) unschedule(this.timer);
+      this.timer = null; this.requests = []; this.loading = false; this.busyId = "";
+      this.state = "not_checked"; this.stateContextId = ""; this.notice = ""; this.noticeContextId = ""; this.noticeExpires = 0; this.decisionUnconfirmed = false;
+    },
+    current(generation) { return this.active && this.generation === generation; },
+    hasUnconfirmedDecision() {
+      prune(Math.max(this.clock, now()));
+      return this.active && [...unresolved.values()].some((request) => request.id !== this.busyId && this.matchesSelection(request));
+    },
+    visibleNotice() {
+      if (this.hasUnconfirmedDecision()) return uncertainNotice;
+      if (this.noticeExpires && Math.max(this.clock, now()) >= this.noticeExpires) return "";
+      return this.active && !this.decisionUnconfirmed && this.noticeContextId === selection()?.contextId ? this.notice : "";
+    },
+    unavailableHere() { return this.state === "unavailable" && this.stateContextId === selection()?.contextId; },
+    matchesSelection(request) {
+      const selected = selection();
+      return Boolean(selected && request.contextId === selected.contextId);
+    },
+    visibleRequests() { prune(); return this.requests.filter((request) => this.matchesSelection(request)
+      && request.expires > Math.max(this.clock, now()) && !unresolved.has(request.id)); },
+    canDecide(request) {
+      prune();
+      return this.active && !this.busyId && this.state === "loaded"
+        && unresolved.size < 128 && !unresolved.has(request.id)
+        && this.matchesSelection(request) && this.requests.some((item) => item.id === request.id) && request.expires > now();
+    },
+    async refresh() {
+      if (!this.active || this.loading) return;
+      if (this.timer !== null) unschedule(this.timer);
+      this.timer = null;
+      const generation = this.generation, sequence = ++this.listSequence;
+      const contextId = selection()?.contextId || "";
+      this.loading = true; this.clock = now();
+      try {
+        const requests = identifier(contextId) ? parseRequests(await api(API, { action: "list", context_id: contextId }), contextId) : [];
+        if (!this.current(generation) || sequence !== this.listSequence || contextId !== (selection()?.contextId || "")) return;
+        this.requests = requests.filter((request) => request.expires > now()); this.state = "loaded"; this.stateContextId = contextId;
+        prune();
+        if ([...unresolved.values()].some((request) => this.matchesSelection(request))) {
+          this.decisionUnconfirmed = true; this.notice = uncertainNotice;
+        }
+      } catch {
+        if (!this.current(generation) || sequence !== this.listSequence || contextId !== (selection()?.contextId || "")) return;
+        // Preserve known prompts through a transport failure without retaining
+        // decision authority: canDecide requires a successful current list.
+        this.requests = this.requests.filter((request) => this.matchesSelection(request) && request.expires > now());
+        this.state = "unavailable"; this.stateContextId = contextId;
+      } finally {
+        if (this.current(generation)) {
+          this.loading = false; this.clock = now();
+          this.timer = schedule(() => { void this.refresh(); }, this.state === "unavailable" ? 10_000 : 2_000);
+        }
+      }
+    },
+    async decide(request, choice) {
+      if (!choices.includes(choice) || !this.canDecide(request)) return;
+      const generation = this.generation;
+      unresolved.set(request.id, { ...request });
+      this.noticeExpires = 0;
+      this.listSequence += 1; this.busyId = request.id; this.notice = "Recording your decision…"; this.noticeContextId = request.contextId; this.decisionUnconfirmed = false;
+      try {
+        const response = envelope(await api(API, { challenge_id: request.id, choice }));
+        if (response.challenge_id !== request.id || response.decision !== (choice === "approve_once" ? "approved" : "declined")
+          || !identifier(response.control_id) || response.status !== "accepted") throw new Error("Invalid action acknowledgement");
+        unresolved.delete(request.id);
+        if (!this.current(generation)) return;
+        this.listSequence += 1; this.requests = this.requests.filter((item) => item.id !== request.id);
+        this.notice = choice === "decline" ? "Decline recorded. Waiting for the browser to confirm cancellation."
+          : "Approval recorded for this action only. The browser will recheck the target before continuing.";
+        this.noticeExpires = now() + 3_000;
+      } catch {
+        if (this.current(generation)) {
+          this.listSequence += 1; this.requests = this.requests.filter((item) => item.id !== request.id);
+          this.decisionUnconfirmed = true;
+          this.notice = uncertainNotice;
+        }
+      } finally { if (this.current(generation)) this.busyId = ""; }
+    },
+  };
+}
+
+export const store = createStore("browserActionRequests", createActionRequestsModel({
+  api: callJsonApi,
+  selection: () => ({ contextId: globalThis.Alpine?.store("chats")?.selected || "" }),
+}));

--- a/plugins/_browser/webui/browser-action-requests.html
+++ b/plugins/_browser/webui/browser-action-requests.html
@@ -1,0 +1,33 @@
+<html>
+<head>
+  <script type="module">
+    import { store } from "/plugins/_browser/webui/browser-action-requests-store.js";
+  </script>
+</head>
+<body>
+  <!-- Inherit the existing site-request component's visual contract. This
+       panel is composed alongside it; no page-provided description is shown. -->
+  <section class="browser-site-requests" x-data x-init="$store.browserActionRequests.mount()"
+    x-destroy="$store.browserActionRequests.cleanup()" aria-label="Browser action requests" x-cloak
+    x-show="$store.browserActionRequests.visibleRequests().length || $store.browserActionRequests.visibleNotice()">
+    <template x-for="request in $store.browserActionRequests.visibleRequests()" :key="request.id">
+      <div class="browser-site-request" :aria-busy="$store.browserActionRequests.busyId === request.id">
+        <p class="browser-site-request-title" x-text="request.action === 'upload_file' ? 'Share this attachment?' : request.action === 'type' ? 'Allow text entry?' : 'Allow this click?'"></p>
+        <p class="browser-site-request-origin" x-text="request.origin"></p>
+        <p class="browser-site-request-help" x-text="request.action === 'upload_file' ? 'Check the highlighted file field and the attachment you asked Agent Zero to share. Selecting the file can immediately send it to this site. This approves one file selection, not future uploads.' : request.action === 'type' ? 'Check the highlighted empty field and the text you asked Agent Zero to enter. The page can read text as it is entered, including passwords. This approves one text entry, not submission or future actions.' : 'Inspect the highlighted target in Chrome before approving. Its effect could not be verified as reversible. This approves one click, not future actions.'"></p>
+        <div class="browser-site-request-actions">
+          <button type="button" :disabled="!$store.browserActionRequests.canDecide(request) || request.expires &lt;= $store.browserActionRequests.clock"
+            @click="$store.browserActionRequests.decide(request, 'decline')">Decline</button>
+          <button type="button" :disabled="!$store.browserActionRequests.canDecide(request) || request.expires &lt;= $store.browserActionRequests.clock"
+            @click="$store.browserActionRequests.decide(request, 'approve_once')" x-text="request.action === 'upload_file' ? 'Share once' : request.action === 'type' ? 'Allow text entry' : 'Allow this click'"></button>
+        </div>
+      </div>
+    </template>
+    <p class="browser-site-request-help" role="status" x-show="$store.browserActionRequests.visibleNotice()">
+      <span x-text="$store.browserActionRequests.visibleNotice()"></span>
+      <button type="button" x-show="$store.browserActionRequests.hasUnconfirmedDecision()" @click="$store.browserActionRequests.refresh()"
+        :disabled="$store.browserActionRequests.loading">Refresh requests</button>
+    </p>
+  </section>
+</body>
+</html>

--- a/plugins/_browser/webui/browser-approval-inbox-store.js
+++ b/plugins/_browser/webui/browser-approval-inbox-store.js
@@ -1,0 +1,34 @@
+import { createStore } from "/js/AlpineStore.js";
+import { store as site } from "/plugins/_browser/webui/browser-site-requests-store.js";
+import { store as action } from "/plugins/_browser/webui/browser-action-requests-store.js";
+import { store as notifications } from "/components/notifications/notification-store.js";
+import { getCurrentUserISOString } from "/js/time-utils.js";
+
+// Presentation only. Each inbox still owns its context fencing, polling and
+// explicit decision boundary; this coordinator never creates an approval.
+export function createApprovalInboxModel({ stores, selection = () => "", notify = () => {} }) {
+  let notifiedContext = null;
+  return {
+    unavailable() { return stores().some((store) => store.active && store.unavailableHere()); },
+    observe() {
+      const contextId = selection();
+      if (!this.unavailable()) { notifiedContext = null; return; }
+      if (!contextId || notifiedContext === contextId) return;
+      notifiedContext = contextId;
+      notify("Browser permission requests are temporarily unavailable. Pending requests remain paused. Agent Zero will check again automatically while this chat is open.");
+    },
+  };
+}
+
+export const store = createStore("browserApprovalInbox", createApprovalInboxModel({
+  stores: () => [site, action],
+  selection: () => globalThis.Alpine?.store("chats")?.selected || "",
+  notify: (message) => {
+    // Keep connection diagnostics in the notification center, not the composer
+    // or a new toast. A stable frontend ID also bounds repeated outage entries.
+    notifications.addOrUpdateNotification({ id: "frontend-browser-permission-sync", type: "info", title: "Browser permissions",
+      message, detail: "", timestamp: getCurrentUserISOString(), display_time: 0, read: false, frontend: true,
+      group: "browser-permission-sync", priority: 10 });
+    notifications.updateUnreadCount();
+  },
+}));

--- a/plugins/_browser/webui/browser-approval-inbox-store.js.dox.md
+++ b/plugins/_browser/webui/browser-approval-inbox-store.js.dox.md
@@ -1,0 +1,16 @@
+# Composer approval recovery
+
+This presentation-only coordinator observes the two independently scoped
+site and action inboxes. It has no API mutation, grant,
+selection, credential, timer or persistent-state authority.
+
+Empty inbox sections are hidden; pending requests and uncertain decisions are
+not filtered using connection or browser-selection guesses. Each owning store
+keeps unexpired current-chat prompts after failed polling and disables their
+decision controls until a successful list response revalidates them.
+
+Transport failures produce one frontend-only A0 notification-center entry per
+chat/outage, with a stable ID bounding repeated entries. No recovery control,
+inline outage row or toast is added to the composer. The mounted stores' existing
+bounded polling automatically retries only their read-only list requests.
+The coordinator never resends a decision or owns a retry loop.

--- a/plugins/_browser/webui/browser-bridge-access-store.js
+++ b/plugins/_browser/webui/browser-bridge-access-store.js
@@ -1,0 +1,220 @@
+import { createStore } from "/js/AlpineStore.js";
+import { callJsonApi } from "/js/api.js";
+import { showConfirmDialog } from "/js/confirmDialog.js";
+import { store as notifications } from "/components/notifications/notification-store.js";
+
+const BRIDGES_API = "/plugins/_a0_connector/browser_bridge_bridges";
+const POLICY_API = "/plugins/_a0_connector/browser_bridge_policy";
+const BRIDGES_CONTRACT = "a0.browser-bridge.bridges.v1";
+const POLICY_CONTRACT = "a0.browser-bridge.site-policy.v1";
+const identifier = (value) => typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/.test(value);
+const text = (value, limit) => typeof value === "string" && value.length > 0
+  && new TextEncoder().encode(value).length <= limit && !/\p{C}/u.test(value);
+
+export function normalizeSiteOrigin(value) {
+  if (typeof value !== "string") return "";
+  const raw = value.trim();
+  if (!raw || raw.length > 2048 || /[\s\\%?#*]/u.test(raw)) return "";
+  try {
+    const url = new URL(raw);
+    if (!["https:", "http:"].includes(url.protocol) || !url.hostname || url.username || url.password
+      || url.pathname !== "/" || url.search || url.hash || url.hostname.endsWith(".")) return "";
+    return url.origin;
+  } catch { return ""; }
+}
+
+function parseBridges(response) {
+  if (response?.contract !== BRIDGES_CONTRACT || response.trust_version !== 1
+    || response.browser_control_ready !== false || !Array.isArray(response.bridges)
+    || response.bridges.length > 128) throw new Error("Invalid browser inventory");
+  const bridges = response.bridges.map((bridge) => {
+    if (!identifier(bridge?.bridge_id) || !text(bridge.display_name, 192)
+      || !["active", "revoked"].includes(bridge.state) || !Number.isSafeInteger(bridge.key_generation)
+      || bridge.key_generation < 1) throw new Error("Invalid browser entry");
+    return { id: bridge.bridge_id, name: bridge.display_name, state: bridge.state };
+  });
+  if (new Set(bridges.map((bridge) => bridge.id)).size !== bridges.length) throw new Error("Duplicate browser entry");
+  return bridges;
+}
+
+function parseGrants(response, bridgeId) {
+  if (response?.contract !== POLICY_CONTRACT || response.policy_version !== 1
+    || response.bridge_id !== bridgeId || !["ask_per_site", "allow_all_websites"].includes(response.site_mode)
+    || response.operation_grants_enabled !== false || response.browser_control_ready !== false
+    || !Array.isArray(response.grants) || response.grants.length > 256) throw new Error("Invalid site permissions");
+  const grants = response.grants.map((grant) => {
+    if (!identifier(grant?.grant_id) || !grant.origin || normalizeSiteOrigin(grant.origin) !== grant.origin) throw new Error("Invalid site permission");
+    return { id: grant.grant_id, origin: grant.origin };
+  });
+  if (new Set(grants.map((grant) => grant.origin)).size !== grants.length) throw new Error("Duplicate site permission");
+  return { grants, siteMode: response.site_mode };
+}
+
+export function createBridgeAccessModel({ api, confirm, notify }) {
+  return {
+    active: false, generation: 0, policySequence: 0,
+    bridges: [], grants: [], selectedId: "", originDraft: "", siteMode: "ask_per_site",
+    inventoryState: "not_checked", policyState: "not_checked",
+    loading: false, busy: false,
+
+    async mount() {
+      this.cleanup();
+      this.active = true;
+      await this.refresh();
+    },
+
+    cleanup() {
+      this.active = false;
+      this.generation += 1;
+      this.policySequence += 1;
+      this.bridges = []; this.grants = []; this.selectedId = ""; this.originDraft = "";
+      this.siteMode = "ask_per_site";
+      this.inventoryState = "not_checked"; this.policyState = "not_checked";
+      this.loading = false; this.busy = false;
+    },
+
+    current(generation, bridgeId = this.selectedId) {
+      return this.active && this.generation === generation && this.selectedId === bridgeId;
+    },
+
+    selectedBridge() { return this.bridges.find((bridge) => bridge.id === this.selectedId) || null; },
+    canManageSites() { return this.selectedBridge()?.state === "active" && !this.busy && !this.loading; },
+    canAllowSite() { return this.canManageSites() && Boolean(normalizeSiteOrigin(this.originDraft)); },
+
+    async refresh({ background = false } = {}) {
+      if (!this.active || this.loading || (background && this.busy)) return;
+      const generation = this.generation;
+      this.loading = true;
+      try {
+        const bridges = parseBridges(await api(BRIDGES_API, { action: "list" }));
+        if (!this.active || this.generation !== generation) return;
+        const previous = this.selectedBridge();
+        this.bridges = bridges;
+        this.inventoryState = "loaded";
+        const selection = bridges.find((bridge) => bridge.id === this.selectedId)
+          || bridges.find((bridge) => bridge.state === "active") || bridges[0];
+        // Quiet inventory checks must not erase a site address being typed or
+        // race a user switching the browser whose permissions are on screen.
+        if (!background || previous?.id !== selection?.id || previous?.state !== selection?.state
+          || this.policyState !== "loaded") await this.selectBridge(selection?.id || "");
+      } catch {
+        if (!this.active || this.generation !== generation) return;
+        this.inventoryState = "unavailable";
+        this.bridges = []; this.grants = []; this.selectedId = "";
+        this.policySequence += 1;
+      } finally {
+        if (this.generation === generation) this.loading = false;
+      }
+    },
+
+    async selectBridge(bridgeId) {
+      if (!this.active || (bridgeId && !this.bridges.some((bridge) => bridge.id === bridgeId))) return;
+      this.selectedId = bridgeId;
+      this.originDraft = "";
+      this.grants = [];
+      this.siteMode = "ask_per_site";
+      const sequence = ++this.policySequence;
+      this.policyState = "not_checked";
+      if (this.selectedBridge()?.state !== "active") return;
+      const generation = this.generation;
+      this.policyState = "loading";
+      try {
+        const grants = parseGrants(await api(POLICY_API, { action: "list", bridge_id: bridgeId }), bridgeId);
+        if (!this.current(generation, bridgeId) || sequence !== this.policySequence) return;
+        this.grants = grants.grants;
+        this.siteMode = grants.siteMode;
+        this.policyState = "loaded";
+      } catch {
+        if (this.current(generation, bridgeId) && sequence === this.policySequence) this.policyState = "unavailable";
+      }
+    },
+
+    async allowSite() {
+      if (!this.canAllowSite()) return;
+      await this.changeSite("allow", normalizeSiteOrigin(this.originDraft));
+    },
+
+    async setAllWebsites(enabled) {
+      if (typeof enabled !== "boolean" || !this.canManageSites() || this.policyState !== "loaded") return;
+      const generation = this.generation;
+      const bridgeId = this.selectedId;
+      const sequence = ++this.policySequence;
+      this.busy = true;
+      try {
+        if (enabled) {
+          const approved = await confirm({ title: "Allow all websites?", message: "Remember browsing access to all supported websites for this Chrome browser across chats. Purchases, submissions, sensitive input and uploads still require their separate approvals. You can turn this off here.", confirmText: "Allow all websites", type: "warning" });
+          if (!approved || !this.current(generation, bridgeId)) return;
+        }
+        const result = parseGrants(await api(POLICY_API, { action: "set_mode", bridge_id: bridgeId,
+          site_mode: enabled ? "allow_all_websites" : "ask_per_site" }), bridgeId);
+        if (!this.current(generation, bridgeId) || sequence !== this.policySequence) return;
+        if (result.siteMode !== (enabled ? "allow_all_websites" : "ask_per_site")) throw new Error("Unconfirmed site mode");
+        this.grants = result.grants; this.siteMode = result.siteMode;
+        notify("success", enabled ? "All websites allowed for this Chrome browser." : "All-websites access turned off. Individually saved sites remain allowed.");
+      } catch {
+        if (this.current(generation, bridgeId)) {
+          this.policyState = "unavailable";
+          notify("error", "Website access could not be confirmed. Check connection before changing it again.");
+        }
+      } finally {
+        if (this.generation === generation) this.busy = false;
+      }
+    },
+
+    async revokeSite(origin) {
+      if (!this.canManageSites() || !this.grants.some((grant) => grant.origin === origin)) return;
+      await this.changeSite("revoke", origin);
+    },
+
+    async changeSite(action, origin) {
+      if (!this.canManageSites()) return;
+      const generation = this.generation;
+      const bridgeId = this.selectedId;
+      const sequence = ++this.policySequence;
+      this.busy = true;
+      try {
+        const grants = parseGrants(await api(POLICY_API, { action, bridge_id: bridgeId, origin }), bridgeId);
+        if (!this.current(generation, bridgeId) || sequence !== this.policySequence) return;
+        this.grants = grants.grants;
+        this.siteMode = grants.siteMode;
+        this.policyState = "loaded";
+        if (action === "allow") this.originDraft = "";
+        notify("success", action === "allow" ? "Site permission saved. Browser control is still gated separately." : "Site permission removed.");
+      } catch {
+        if (this.current(generation, bridgeId)) notify("error", "Site permission could not be updated. Refresh and try again.");
+      } finally {
+        if (this.generation === generation) this.busy = false;
+      }
+    },
+
+    async revokeBridge() {
+      if (!this.canManageSites()) return;
+      const generation = this.generation;
+      const bridgeId = this.selectedId;
+      this.busy = true;
+      try {
+        const approved = await confirm({ title: "Revoke browser access?", message: "This browser must pair again before reconnecting. Revocation does not delete the key on your computer or close browser tabs.", confirmText: "Revoke access", type: "danger" });
+        if (!approved || !this.current(generation, bridgeId)) return;
+        const response = await api(BRIDGES_API, { action: "revoke", bridge_id: bridgeId });
+        if (!this.current(generation, bridgeId)) return;
+        if (response?.contract !== BRIDGES_CONTRACT || response.trust_version !== 1
+          || response.revoked !== true || response.bridge?.bridge_id !== bridgeId || response.bridge.state !== "revoked") throw new Error("Invalid revocation");
+        this.grants = []; this.policySequence += 1;
+        notify("success", "Browser access revoked. Your tabs and the key on your computer were not deleted.");
+        await this.refresh();
+      } catch {
+        if (this.current(generation, bridgeId)) notify("error", "Revocation could not be confirmed. Refresh browser access before trying again.");
+      } finally {
+        if (this.generation === generation) this.busy = false;
+      }
+    },
+  };
+}
+
+export const store = createStore("browserBridgeAccess", createBridgeAccessModel({
+  api: callJsonApi,
+  confirm: showConfirmDialog,
+  notify: (type, message) => {
+    void notifications.frontendNotification({ type, message, title: "Browser access", frontendOnly: true }).catch(() => {});
+  },
+}));

--- a/plugins/_browser/webui/browser-bridge-selection-store.js
+++ b/plugins/_browser/webui/browser-bridge-selection-store.js
@@ -1,0 +1,138 @@
+import { createStore } from "/js/AlpineStore.js";
+import { callJsonApi } from "/js/api.js";
+import { showConfirmDialog } from "/js/confirmDialog.js";
+import { store as notifications } from "/components/notifications/notification-store.js";
+export async function refreshBrowserSettingsScope(api, settingsContext, current) {
+  if (!settingsContext || settingsContext.pluginName !== "_browser" || !current()) return;
+  const config = settingsContext.settings;
+  const projectName = settingsContext.projectName || "";
+  const agentProfile = settingsContext.agentProfileKey || "";
+  const result = await api("/plugins", { action: "get_config", plugin_name: "_browser",
+    project_name: projectName, agent_profile: agentProfile });
+  if (!current() || settingsContext.pluginName !== "_browser" || settingsContext.settings !== config
+    || (settingsContext.projectName || "") !== projectName
+    || (settingsContext.agentProfileKey || "") !== agentProfile) return;
+  if (result?.ok !== true || !result.data || typeof result.data.runtime_backend !== "string"
+    || typeof result.data.host_browser_selection !== "string") throw new Error("Settings readback unavailable");
+  // The modal may edit Global settings while selection belongs to a project chat.
+  // Only authoritative routing for the modal's own scope may replace its draft.
+  config.runtime_backend = result.data.runtime_backend;
+  config.host_browser_selection = result.data.host_browser_selection;
+}
+
+
+const API = "/plugins/_a0_connector/browser_bridge_selection";
+const identifier = (value) => typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/.test(value);
+function parseSelection(value, contextId) {
+  const isDefault = contextId === undefined;
+  const keys = ["contract", ...(isDefault ? [] : ["context_id"]), "bridge_id", "selected", "browser_control_ready", "reconnect_required"];
+  if (!value || typeof value !== "object" || Array.isArray(value)
+    || Object.keys(value).length !== keys.length || !keys.every((key) => Object.hasOwn(value, key))
+    || value.contract !== (isDefault ? "a0.browser-bridge.default-selection.v1" : "a0.browser-bridge.selection.v1")
+    || (!isDefault && value.context_id !== contextId)
+    || ["selected", "browser_control_ready", "reconnect_required"].some((key) => typeof value[key] !== "boolean")
+    || (value.selected ? !identifier(value.bridge_id) : value.bridge_id !== null)
+    || (value.browser_control_ready && (!value.selected || value.reconnect_required))
+    || (value.reconnect_required && !value.selected)) throw new Error("Invalid browser selection");
+  return { bridgeId: value.bridge_id, selected: value.selected, ready: value.browser_control_ready, reconnect: value.reconnect_required };
+}
+
+export function createBridgeSelectionModel({ api, context, notify, confirm, onSelected = async () => {},
+  schedule = setInterval, unschedule = clearInterval, visible = () => globalThis.document?.visibilityState !== "hidden" }) {
+  return {
+    active: false, generation: 0, contextId: "", settingsContext: null, timer: null,
+    selection: null, defaultSelection: null, contextState: "not_checked", state: "not_checked", busy: false, loading: false,
+    async mount(settingsContext) {
+      this.cleanup(); this.active = true; this.contextId = context() || "";
+      const generation = this.generation;
+      this.settingsContext = settingsContext; await this.refresh();
+      if (this.current(generation)) this.timer = schedule(() => {
+        if (this.current(generation) && visible()) void this.refresh();
+      }, 5000);
+    },
+    cleanup() {
+      this.active = false; this.generation += 1; this.contextId = "";
+      if (this.timer !== null) unschedule(this.timer);
+      this.timer = null;
+      this.settingsContext = null; this.selection = null; this.defaultSelection = null; this.contextState = "not_checked"; this.state = "not_checked";
+      this.busy = false; this.loading = false;
+    },
+    current(generation = this.generation) {
+      return this.active && this.generation === generation && (context() || "") === this.contextId;
+    },
+    selectedHere(bridgeId) { return this.current() && this.selection?.selected && this.selection.bridgeId === bridgeId; },
+    selectedDefault(bridgeId) { return this.current() && this.defaultSelection?.selected && this.defaultSelection.bridgeId === bridgeId; },
+    canSelect(bridgeId) { return this.current() && this.state === "loaded" && identifier(bridgeId) && !this.busy && !this.loading && !this.selectedDefault(bridgeId); },
+    statusText() {
+      if (!this.current()) return "Reopen Browser settings to check the current browser selection.";
+      if (this.loading && this.state !== "loaded") return "Checking browser control…";
+      if (this.state === "unavailable") return "Browser control could not be checked. Refresh to retry.";
+      if (!this.defaultSelection?.selected) return "Choose your Chrome browser once. Agent Zero will use it across chats unless a project has its own Browser settings.";
+      if (this.defaultSelection.ready) return "Chrome is connected. This browser is the default for your chats.";
+      return "Browser selected. Waiting for Chrome to connect and complete its security checks. Keep Chrome open; your pairing is saved.";
+    },
+    contextStatusText() {
+      if (!this.current() || !identifier(this.contextId) || !this.defaultSelection?.selected) return "";
+      if (this.contextState === "unavailable") return "The default is saved, but this chat's Browser settings could not be checked.";
+      if (this.contextState === "loaded" && this.selection?.bridgeId !== this.defaultSelection.bridgeId)
+        return "This chat has different Browser settings. Its project settings are kept; changing the default does not override them.";
+      return "";
+    },
+    async refreshContext(generation) {
+      if (!identifier(this.contextId)) return;
+      try {
+        const selected = parseSelection(await api(API, { action: "status", context_id: this.contextId }), this.contextId);
+        if (this.current(generation)) { this.selection = selected; this.contextState = "loaded"; }
+      } catch { if (this.current(generation)) { this.selection = null; this.contextState = "unavailable"; } }
+    },
+    async refresh() {
+      if (!this.current() || this.loading || this.busy) return;
+      const generation = this.generation; this.loading = true;
+      try {
+        const selected = parseSelection(await api(API, { action: "default_status" }));
+        if (this.current(generation)) { this.defaultSelection = selected; this.state = "loaded"; await this.refreshContext(generation); }
+      } catch { if (this.current(generation)) { this.defaultSelection = null; this.state = "unavailable"; } }
+      finally { if (this.generation === generation) this.loading = false; }
+    },
+    async useBrowser(bridgeId) {
+      if (this.canSelect(bridgeId)) await this.change("use_default", bridgeId);
+    },
+    async clear() {
+      if (!this.current() || this.state !== "loaded" || !this.defaultSelection?.selected || this.busy || this.loading) return;
+      const generation = this.generation; const bridgeId = this.defaultSelection.bridgeId;
+      this.busy = true;
+      try {
+        const approved = await confirm({ title: "Stop using Chrome by default?", message: "Chats without their own Browser settings will use the internal browser. Project settings, your saved pairing and Chrome tabs are kept.", confirmText: "Use internal browser" });
+        if (!approved || !this.current(generation) || this.defaultSelection?.bridgeId !== bridgeId) return;
+        this.busy = false; await this.change("clear_default", bridgeId);
+      } catch { if (this.current(generation)) notify("error", "Browser selection could not be changed."); }
+      finally { if (this.generation === generation) this.busy = false; }
+    },
+    async change(action, bridgeId) {
+      if (!this.current() || this.busy || this.loading) return;
+      const generation = this.generation; const previousBridge = this.defaultSelection?.bridgeId ?? null;
+      this.busy = true;
+      try {
+        const body = { action, ...(action === "use_default" ? { bridge_id: bridgeId } : {}), expected_bridge_id: previousBridge };
+        const selected = parseSelection(await api(API, body));
+        if ((action === "use_default" && selected.bridgeId !== bridgeId) || (action === "clear_default" && selected.selected)) throw new Error("Selection mismatch");
+        if (!this.current(generation)) return;
+        this.defaultSelection = selected; this.state = "loaded";
+        await onSelected(this.settingsContext, () => this.current(generation));
+        if (!this.current(generation)) return;
+        await this.refreshContext(generation);
+        if (this.current(generation)) notify("success", selected.selected ? "Chrome is now your default browser for Agent Zero. Existing project settings are kept." : "Agent Zero now defaults to its internal browser. Existing project settings are kept.");
+      } catch {
+        if (this.current(generation)) { this.defaultSelection = null; this.state = "unavailable";
+          notify("error", "Browser selection could not be confirmed. Use Check connection before trying again."); }
+      } finally { if (this.generation === generation) this.busy = false; }
+    },
+  };
+}
+
+export const store = createStore("browserBridgeSelection", createBridgeSelectionModel({
+  api: callJsonApi, context: () => globalThis.Alpine?.store("chats")?.selected || "",
+  confirm: showConfirmDialog,
+  notify: (type, message) => { void notifications.frontendNotification({ type, message, title: "Browser connection", frontendOnly: true }).catch(() => {}); },
+  onSelected: (settingsContext, current) => refreshBrowserSettingsScope(callJsonApi, settingsContext, current),
+}));

--- a/plugins/_browser/webui/browser-bridge-selection-store.js.dox.md
+++ b/plugins/_browser/webui/browser-bridge-selection-store.js.dox.md
@@ -1,0 +1,27 @@
+# Production browser selection view
+
+Owns the replaceable Browser Settings projection of the protected
+`browser_bridge_selection` API. An explicit Use this Chrome browser button sets
+the global default through the exact v1 default-selection contract, including
+when no chat exists. Clearing is confirmed. Reads never select or pair.
+
+Exact response keys, contract, context (for the separate chat projection) and bridge are checked. Every async result
+is fenced by mount generation and current chat. Readiness comes only from the
+protected response, not inventory, pairing or a local setting. Only authoritative
+settings readback for the modal's own scope updates its routing draft, preserving
+Global versus project separation. Cleanup removes only presentation state.
+
+Default writes include `expected_bridge_id` from the last successful default
+readback (null only for use with no prior default); unavailable status disables
+new writes. Existing explicit project/profile choices remain unchanged and the
+current-chat projection explains any different selection without claiming the
+default failed. No context ID is sent to the three default actions. Default
+readiness is server-derived, never inferred from the current chat or pairing.
+
+The selection store owns a five-second read-only readiness refresh while mounted
+and the document is visible, independently of the Browser config coordinator's
+inventory refresh. Its injected timer is stopped on cleanup; mount generation,
+current chat, loading and mutation-busy guards prevent stale or overlapping
+checks. Late initial refresh cannot create a timer after cleanup. A quiet in-flight check preserves the previous
+status label; an actual failure clears readiness. No timer can select a browser,
+move a settings modal to a different chat, or imply readiness from saved pairing.

--- a/plugins/_browser/webui/browser-bridge-setup-store.js
+++ b/plugins/_browser/webui/browser-bridge-setup-store.js
@@ -1,0 +1,79 @@
+import { createStore } from "/js/AlpineStore.js";
+import { callJsonApi } from "/js/api.js";
+
+const SETUP_API = "/plugins/_a0_connector/browser_bridge_setup";
+const PLATFORMS = { macos: "macOS", windows: "Windows", linux: "Linux" };
+const INSTALLER_ARCHES = { macos: ["universal2"], windows: ["x86_64", "arm64"], linux: ["any"] };
+
+function browserHostPlatform(navigatorValue = globalThis.navigator) {
+  const platform = navigatorValue?.userAgentData?.platform || navigatorValue?.platform || "";
+  if (/mac/i.test(platform)) return "macos";
+  if (/win/i.test(platform)) return "windows";
+  if (/linux/i.test(platform) && !/android/i.test(navigatorValue?.userAgent || "")) return "linux";
+  return "";
+}
+
+function canonicalHttps(value) {
+  if (typeof value !== "string" || value.length > 4096 || /[\s\\]/.test(value)) return false;
+  try {
+    const url = new URL(value);
+    return url.href === value && url.protocol === "https:" && Boolean(url.hostname)
+      && !url.username && !url.password && !url.search && !url.hash;
+  } catch { return false; }
+}
+
+function parseSetup(value) {
+  const keys = ["contract", "setup_enabled", "browser_control_ready", "install_target",
+    "host_verification_required", "extension_id", "extension_url", "companion_version", "installers"];
+  if (!value || typeof value !== "object" || Array.isArray(value)
+    || Object.keys(value).length !== keys.length || !keys.every(key => Object.hasOwn(value, key))
+    || value.contract !== "a0.browser-bridge.setup.v1" || typeof value.setup_enabled !== "boolean"
+    || value.browser_control_ready !== false || value.install_target !== "browser_host"
+    || value.host_verification_required !== true || !Array.isArray(value.installers) || value.installers.length > 4
+    || (value.setup_enabled ? !/^[a-p]{32}$/.test(value.extension_id || "")
+      || value.extension_url !== `https://chromewebstore.google.com/detail/${value.extension_id}`
+      : value.extension_id !== null || value.extension_url !== null || value.installers.length !== 0)
+    || (value.companion_version !== null && !/^\d+\.\d+\.\d+$/.test(value.companion_version))) throw new Error("Invalid browser setup");
+  const identities = new Set();
+  for (const item of value.installers) {
+    if (!item || typeof item !== "object" || Object.keys(item).sort().join() !== "arch,platform,url"
+      || !INSTALLER_ARCHES[item.platform]?.includes(item.arch) || !canonicalHttps(item.url)
+      || identities.has(`${item.platform}:${item.arch}`) || value.companion_version === null) throw new Error("Invalid browser installer");
+    identities.add(`${item.platform}:${item.arch}`);
+  }
+  return value;
+}
+
+export function createBrowserSetupModel({ api, platform = browserHostPlatform() }) {
+  return {
+    active: false, generation: 0, loading: false, state: "not_checked", setup: null,
+    platform: Object.hasOwn(PLATFORMS, platform) ? platform : "",
+    async mount() { this.cleanup(); this.active = true; await this.refresh(); },
+    cleanup() { this.active = false; this.generation += 1; this.loading = false; this.setup = null; this.state = "not_checked"; },
+    async refresh() {
+      if (!this.active || this.loading) return;
+      const generation = this.generation; this.loading = true;
+      try {
+        const setup = parseSetup(await api(SETUP_API, {}));
+        if (this.active && this.generation === generation) { this.setup = setup; this.state = "loaded"; }
+      } catch {
+        if (this.active && this.generation === generation) { this.setup = null; this.state = "unavailable"; }
+      } finally { if (this.generation === generation) this.loading = false; }
+    },
+    installers() { return (this.setup?.installers || []).filter(item => item.platform === this.platform); },
+    installerLabel(item) {
+      const arch = { universal2: "Intel and Apple silicon", x86_64: "Intel / AMD", arm64: "ARM64", any: "all supported architectures" };
+      return `${PLATFORMS[item.platform]} companion (${arch[item.arch]})`;
+    },
+    availabilityText() {
+      if (this.state === "not_checked") return "Checking companion downloads…";
+      if (this.state === "unavailable") return "Setup details could not be loaded. Check connection to retry.";
+      if (!this.setup?.setup_enabled) return "Chrome setup has not been enabled on this Agent Zero server. Ask the person who manages it to finish browser setup.";
+      if (!this.platform) return "Choose the operating system of the computer running Chrome, not the Docker server.";
+      if (!this.installers().length) return `No ${PLATFORMS[this.platform]} companion download is configured for this release. Do not use another operating system's installer.`;
+      return `Companion ${this.setup.companion_version}. Download and run it on this ${PLATFORMS[this.platform]} computer, outside Docker.`;
+    },
+  };
+}
+
+export const store = createStore("browserBridgeSetup", createBrowserSetupModel({ api: callJsonApi }));

--- a/plugins/_browser/webui/browser-bridge-setup-store.js.dox.md
+++ b/plugins/_browser/webui/browser-bridge-setup-store.js.dox.md
@@ -1,0 +1,7 @@
+# Browser setup UI
+
+Production setup uses the read-only setup API, never client-built download URLs or runtime flags. Validate the exact projection, configured production extension URL, bounded installer list and canonical HTTPS URLs before rendering links. The projection is server-configured presentation metadata, not a signature/install/runtime proof. The browser-host installer is responsible for cryptographic verification.
+
+Use the visiting browser's platform as a suggestion, never the Linux Docker server's OS. Allow explicit macOS, Windows and Linux selection and unknown OS. Missing OS artifacts remain unavailable with no substitute installer. Windows architecture is explicit because browser platform strings cannot reliably identify emulated hardware.
+
+Mount/cleanup fence asynchronous replies. Refresh never downloads, pairs, changes chat selection or grants site permission. Keep setup one-time guidance separate from authoritative current-chat runtime status and existing paired inventory. A stored pair does not prove full control, nor does losing a connection require a new pair.

--- a/plugins/_browser/webui/browser-config-store.js
+++ b/plugins/_browser/webui/browser-config-store.js
@@ -1,11 +1,12 @@
 import { createStore } from "/js/AlpineStore.js";
 import { callJsonApi } from "/js/api.js";
 import { showConfirmDialog } from "/js/confirmDialog.js";
-import { store as notificationStore } from "/components/notifications/notification-store.js";
+import { store as notifications } from "/components/notifications/notification-store.js";
 
 const BROWSER_EXTENSIONS_API = "/plugins/_browser/extensions";
 const BROWSER_SETUP_API = "/plugins/_browser/host_browser_setup";
 const BROWSER_STATUS_API = "/plugins/_browser/status";
+const BROWSER_BRIDGE_PAIRING_API = "/plugins/_a0_connector/browser_bridge_pairing";
 const RUNTIME_BACKENDS = new Set(["container", "host_required"]);
 const BROWSER_TAB_SCOPES = new Set(["per_context", "shared"]);
 const HOST_PRIVACY_POLICIES = new Set(["enforce_local", "warn", "allow"]);
@@ -14,7 +15,22 @@ const DEFAULT_MAX_OPEN_TABS = 32;
 const MIN_MAX_OPEN_TABS = 1;
 const HARD_MAX_OPEN_TABS = 50;
 const HOST_BROWSER_STATUS_REFRESH_MS = 1000;
+const BROWSER_BRIDGE_PAIRING_REFRESH_MS = 3000;
+const PAIRING_TTL_MS = 5 * 60 * 1000;
+const PAIRING_DISPLAY_NAME_MAX_BYTES = 192;
 const CUSTOM_HOST_BROWSER_SELECTION = "__custom_endpoint__";
+const RESERVED_EXTENSION_SELECTION = /^extension(?:[^A-Za-z0-9._/-]*:|$)/i;
+const RESERVED_DEVELOPMENT_SELECTION = /^development-extension(?:[^A-Za-z0-9._/-]*:|$)/i;
+const BROWSER_BRIDGE_TRUST_CONTRACT = "a0.browser-bridge.trust.v1";
+const PAIRING_CODE_PATTERN = /^A0B1-[0-9A-F]{8}-[0-9A-HJKMNP-TV-Z]{32}$/i;
+const EXTENSION_ID_PATTERN = /^[a-p]{32}$/;
+const INSTANCE_FINGERPRINT_PATTERN = /^sha256:[0-9a-f]{20}$/;
+const PAIRING_STATES = new Set([
+  "unpaired",
+  "pairing_pending",
+  "paired",
+  "repair_required",
+]);
 
 function normalizePathList(value) {
   const source = Array.isArray(value)
@@ -88,6 +104,14 @@ function normalizeRuntimeBackend(value) {
 
 function normalizeHostBrowserSelection(value) {
   const raw = String(value || "").trim();
+  if (/^development-extension:[A-Za-z0-9](?:[A-Za-z0-9._-]{0,126}[A-Za-z0-9])?$/.test(raw)) return raw;
+  if (RESERVED_DEVELOPMENT_SELECTION.test(raw)) return "development-extension:";
+  if (/^extension:[A-Za-z0-9](?:[A-Za-z0-9._-]{0,126}[A-Za-z0-9])?$/.test(raw)) {
+    return raw;
+  }
+  if (RESERVED_EXTENSION_SELECTION.test(raw)) {
+    return "extension:";
+  }
   if (raw.includes("://") || /^(?:\[[^\]]+\]|[^/:\s]+):\d+$/.test(raw)) {
     return raw.replace(/\s+/g, "").slice(0, 2048);
   }
@@ -96,7 +120,7 @@ function normalizeHostBrowserSelection(value) {
 
 function normalizeCustomHostBrowserEndpoint(value) {
   const raw = String(value || "").trim();
-  if (!raw) return "";
+  if (!raw || RESERVED_EXTENSION_SELECTION.test(raw) || RESERVED_DEVELOPMENT_SELECTION.test(raw)) return "";
   const candidate = raw.includes("://") ? raw : `http://${raw}`;
   try {
     const url = new URL(candidate);
@@ -145,6 +169,102 @@ function normalizeBoolean(value, fallback = true) {
   return fallback;
 }
 
+function boundedPairingString(value, maximumBytes) {
+  if (typeof value !== "string" || value !== value.trim() || !value) return "";
+  if (/\p{C}/u.test(value)) return "";
+  try {
+    return new TextEncoder().encode(value).length <= maximumBytes ? value : "";
+  } catch (_error) {
+    return "";
+  }
+}
+
+function normalizePairingStatus(value) {
+  if (
+    !value
+    || typeof value !== "object"
+    || value.contract !== BROWSER_BRIDGE_TRUST_CONTRACT
+    || value.trust_version !== 1
+    || !PAIRING_STATES.has(value.state)
+    || value.pairing_code_present !== false
+    || Object.prototype.hasOwnProperty.call(value, "pairing_code")
+    || Object.prototype.hasOwnProperty.call(value, "public_key")
+    || value.native_runtime_location !== "user_browser_host"
+    || value.docker_install_target !== false
+    || value.connector_session_ready !== false
+    || value.browser_control_ready !== false
+  ) {
+    return null;
+  }
+  const pending = value.state === "pairing_pending";
+  const pairingId = pending ? boundedPairingString(value.pairing_id, 512) : "";
+  const expiresAtMs = pending && Number.isSafeInteger(value.expires_at_ms)
+    ? value.expires_at_ms
+    : 0;
+  if (pending && (!pairingId || expiresAtMs <= 0)) return null;
+  return {
+    state: value.state,
+    reasonCode: boundedPairingString(value.reason_code, 128) || "status_unavailable",
+    pairingId,
+    expiresAtMs,
+    serverPairingEnabled: value.server_pairing_enabled === true,
+  };
+}
+
+function normalizePairingCreation(value) {
+  if (
+    !value
+    || typeof value !== "object"
+    || value.contract !== BROWSER_BRIDGE_TRUST_CONTRACT
+    || value.trust_version !== 1
+    || value.state !== "pairing_pending"
+  ) {
+    return null;
+  }
+  const pairingId = boundedPairingString(value.pairing_id, 512);
+  const pairingCode = typeof value.pairing_code === "string"
+    && PAIRING_CODE_PATTERN.test(value.pairing_code)
+    ? value.pairing_code.toUpperCase()
+    : "";
+  const createdAtMs = Number.isSafeInteger(value.created_at_ms) ? value.created_at_ms : 0;
+  const expiresAtMs = Number.isSafeInteger(value.expires_at_ms) ? value.expires_at_ms : 0;
+  const serverBaseUrl = boundedPairingString(value.server?.base_url, 2048);
+  const instanceFingerprint = boundedPairingString(
+    value.server?.instance_fingerprint,
+    64,
+  );
+  const displayName = boundedPairingString(
+    value.display_name,
+    PAIRING_DISPLAY_NAME_MAX_BYTES,
+  );
+  if (
+    !pairingId
+    || !pairingCode
+    || !serverBaseUrl
+    || !INSTANCE_FINGERPRINT_PATTERN.test(instanceFingerprint)
+    || !EXTENSION_ID_PATTERN.test(value.extension_id)
+    || !displayName
+    || createdAtMs <= 0
+    || expiresAtMs - createdAtMs !== PAIRING_TTL_MS
+    || value.expires_in_seconds !== PAIRING_TTL_MS / 1000
+    || pairingId.replace(/-/g, "").slice(0, 8).toUpperCase() !== pairingCode.slice(5, 13)
+    || value.native_runtime_location !== "user_browser_host"
+    || value.docker_install_target !== false
+    || value.connector_session_ready !== false
+    || value.browser_control_ready !== false
+  ) {
+    return null;
+  }
+  return {
+    pairingId,
+    pairingCode,
+    createdAtMs,
+    expiresAtMs,
+    serverBaseUrl,
+    displayName,
+  };
+}
+
 function hostBrowserFamilyLabel(value) {
   const family = String(value || "").trim().toLowerCase();
   const a0Profile = family.endsWith("-a0");
@@ -188,15 +308,51 @@ export const store = createStore("browserConfig", {
   hostBrowserSetupOpening: "",
   hostBrowserCustomEndpoint: "",
   hostBrowserCustomMode: false,
+  pairingStatus: {
+    state: "not_checked",
+    reasonCode: "not_checked",
+    pairingId: "",
+    expiresAtMs: 0,
+    serverPairingEnabled: false,
+  },
+  pairingStatusLoading: false,
+  pairingActionLoading: false,
+  pairingStatusRefreshTimer: null,
+  pairingClockTimer: null,
+  pairingPanelActive: false,
+  pairingPanelGeneration: 0,
+  pairingNowMs: Date.now(),
+  pairingDisplayName: "My browser",
+  pairingCode: "",
+  pairingCodePairingId: "",
+  pairingServerBaseUrl: "",
+  pairingMessage: "",
+  pairingError: "",
 
   async init(config) {
+    // Alpine calls init on store registration before a settings panel owns a
+    // config. Do not start a request that can strand a later mount's loading flag.
+    if (!config || typeof config !== "object") return;
+    this.pairingPanelGeneration += 1;
+    this.pairingPanelActive = true;
+    const generation = this.pairingPanelGeneration;
     this.bindConfig(config);
-    await Promise.all([this.loadExtensionsList(), this.loadHostBrowserStatus()]);
+    await Promise.all([
+      this.loadExtensionsList(),
+      this.loadHostBrowserStatus(),
+      this.loadBrowserBridgePairingStatus(),
+    ]);
+    if (!this.pairingPanelActive || generation !== this.pairingPanelGeneration) return;
     this.startHostBrowserStatusRefresh();
+    this.startBrowserBridgePairingRefresh();
   },
 
   cleanup() {
+    this.pairingPanelActive = false;
+    this.pairingPanelGeneration += 1;
     this.stopHostBrowserStatusRefresh();
+    this.stopBrowserBridgePairingRefresh();
+    this.clearPairingCode();
     this.config = null;
     this.extensionsList = [];
     this.extensionsError = "";
@@ -207,6 +363,18 @@ export const store = createStore("browserConfig", {
     this.hostBrowserSetupOpening = "";
     this.hostBrowserCustomEndpoint = "";
     this.hostBrowserCustomMode = false;
+    this.pairingStatus = {
+      state: "not_checked",
+      reasonCode: "not_checked",
+      pairingId: "",
+      expiresAtMs: 0,
+      serverPairingEnabled: false,
+    };
+    this.pairingStatusLoading = false;
+    this.pairingActionLoading = false;
+    this.pairingDisplayName = "My browser";
+    this.pairingMessage = "";
+    this.pairingError = "";
   },
 
   startHostBrowserStatusRefresh() {
@@ -221,6 +389,48 @@ export const store = createStore("browserConfig", {
     if (!this.hostBrowserStatusRefreshTimer) return;
     window.clearInterval(this.hostBrowserStatusRefreshTimer);
     this.hostBrowserStatusRefreshTimer = null;
+  },
+
+  startBrowserBridgePairingRefresh() {
+    this.stopBrowserBridgePairingRefresh();
+    this.pairingClockTimer = window.setInterval(() => {
+      this.tickPairingClock();
+    }, 1000);
+    this.pairingStatusRefreshTimer = window.setInterval(() => {
+      if (document.visibilityState === "hidden") return;
+      this.loadBrowserBridgePairingStatus();
+      this.refreshProductionBrowserStatus(true);
+    }, BROWSER_BRIDGE_PAIRING_REFRESH_MS);
+  },
+
+  async refreshProductionBrowserStatus(background = false) {
+    if (!this.pairingPanelActive) return;
+    await Promise.all([
+      ...(!background ? [globalThis.Alpine?.store("browserBridgeSetup")?.refresh(), this.loadBrowserBridgePairingStatus()] : []),
+      globalThis.Alpine?.store("browserBridgeAccess")?.refresh({ background }),
+      globalThis.Alpine?.store("browserBridgeSelection")?.refresh(),
+    ]);
+  },
+
+  stopBrowserBridgePairingRefresh() {
+    if (this.pairingClockTimer) window.clearInterval(this.pairingClockTimer);
+    if (this.pairingStatusRefreshTimer) window.clearInterval(this.pairingStatusRefreshTimer);
+    this.pairingClockTimer = null;
+    this.pairingStatusRefreshTimer = null;
+  },
+
+  tickPairingClock() {
+    if (!this.pairingPanelActive) return;
+    this.pairingNowMs = Date.now();
+    if (
+      this.pairingCode
+      && this.pairingStatus.expiresAtMs > 0
+      && this.pairingStatus.expiresAtMs <= this.pairingNowMs
+    ) {
+      this.clearPairingCode();
+      this.pairingMessage = "";
+      this.loadBrowserBridgePairingStatus();
+    }
   },
 
   bindConfig(config) {
@@ -328,6 +538,20 @@ export const store = createStore("browserConfig", {
     return selected;
   },
 
+  isDevelopmentBrowserSelected() {
+    return this.config?.runtime_backend === "host_required"
+      && String(this.config?.host_browser_selection || "").startsWith("development-extension:");
+  },
+
+  isProductionBrowserSelected() {
+    return this.config?.runtime_backend === "host_required"
+      && String(this.config?.host_browser_selection || "").startsWith("extension:");
+  },
+
+  isCompanionSelected() {
+    return this.isProductionBrowserSelected() || this.isDevelopmentBrowserSelected();
+  },
+
   setHostBrowserSelection(value) {
     const safeConfig = ensureConfig(this.config);
     if (!safeConfig) return;
@@ -398,6 +622,229 @@ export const store = createStore("browserConfig", {
     }
   },
 
+  async loadBrowserBridgePairingStatus() {
+    if (
+      !this.pairingPanelActive
+      || this.pairingStatusLoading
+      || this.pairingActionLoading
+    ) return;
+    const generation = this.pairingPanelGeneration;
+    this.pairingStatusLoading = true;
+    try {
+      const response = await callJsonApi(BROWSER_BRIDGE_PAIRING_API, {
+        action: "status",
+      });
+      const status = normalizePairingStatus(response);
+      if (!status) throw new Error("invalid pairing status");
+      if (!this.pairingPanelActive || generation !== this.pairingPanelGeneration) return;
+      const codeStillCurrent = Boolean(
+        this.pairingCode
+        && this.pairingCodePairingId
+        && this.pairingCodePairingId === status.pairingId
+        && status.serverPairingEnabled
+        && status.expiresAtMs > Date.now(),
+      );
+      if (!codeStillCurrent) this.clearPairingCode();
+      this.pairingStatus = status;
+      this.pairingNowMs = Date.now();
+      this.pairingError = "";
+    } catch (_error) {
+      if (!this.pairingPanelActive || generation !== this.pairingPanelGeneration) return;
+      if (!this.pairingCodeAvailable()) {
+        this.pairingStatus = {
+          state: "not_checked",
+          reasonCode: "status_unavailable",
+          pairingId: "",
+          expiresAtMs: 0,
+          serverPairingEnabled: false,
+        };
+      }
+      this.pairingNotice("error", "Pairing status could not be checked. No browser control was enabled.");
+    } finally {
+      if (generation === this.pairingPanelGeneration) {
+        this.pairingStatusLoading = false;
+      }
+    }
+  },
+
+  pairingNotice(type, message) {
+    const field = type === "error" ? "pairingError" : "pairingMessage";
+    if (this[field] === message) return;
+    this[field] = message;
+    void notifications.frontendNotification({type, message, title: "Browser setup", frontendOnly: true}).catch(() => {});
+  },
+
+  pairingDisplayNameValid() {
+    return Boolean(
+      boundedPairingString(
+        String(this.pairingDisplayName || "").trim(),
+        PAIRING_DISPLAY_NAME_MAX_BYTES,
+      ),
+    );
+  },
+
+  canCreateBrowserBridgePairing() {
+    return Boolean(
+      this.pairingStatus.serverPairingEnabled
+      && this.pairingDisplayNameValid()
+      && this.pairingPanelActive
+      && !this.pairingActionLoading,
+    );
+  },
+
+  pairingPrimaryActionLabel() {
+    if (this.pairingActionLoading) return "Working…";
+    if (this.pairingStatus.state === "pairing_pending") return "Regenerate code";
+    if (this.pairingStatus.state === "paired") return "Pair another host";
+    return "Create pairing code";
+  },
+
+  async createBrowserBridgePairing() {
+    this.pairingMessage = "";
+    this.pairingError = "";
+    if (!this.pairingDisplayNameValid()) {
+      this.pairingNotice("error", "Enter a browser host name no longer than 192 bytes.");
+      return;
+    }
+    if (!this.canCreateBrowserBridgePairing()) {
+      this.pairingNotice("error", "Pairing is not enabled for this Agent Zero instance.");
+      return;
+    }
+    const generation = this.pairingPanelGeneration;
+    this.pairingActionLoading = true;
+    this.clearPairingCode();
+    try {
+      const response = await callJsonApi(BROWSER_BRIDGE_PAIRING_API, {
+        action: "create",
+        display_name: String(this.pairingDisplayName).trim(),
+      });
+      const creation = normalizePairingCreation(response);
+      if (
+        !creation
+        || creation.displayName !== String(this.pairingDisplayName).trim()
+      ) throw new Error("invalid pairing creation response");
+      if (!this.pairingPanelActive || generation !== this.pairingPanelGeneration) return;
+      this.pairingCode = creation.pairingCode;
+      this.pairingCodePairingId = creation.pairingId;
+      this.pairingServerBaseUrl = creation.serverBaseUrl;
+      this.pairingNowMs = Date.now();
+      this.pairingStatus = {
+        state: "pairing_pending",
+        reasonCode: "pairing_intent_active",
+        pairingId: creation.pairingId,
+        expiresAtMs: creation.expiresAtMs,
+        serverPairingEnabled: true,
+      };
+      this.pairingNotice("success", "A new single-use pairing code is ready.");
+    } catch (_error) {
+      if (!this.pairingPanelActive || generation !== this.pairingPanelGeneration) return;
+      this.pairingNotice("error", "A pairing code could not be created. No browser control was enabled.");
+    } finally {
+      if (generation === this.pairingPanelGeneration) {
+        this.pairingActionLoading = false;
+      }
+    }
+  },
+
+  async cancelBrowserBridgePairing() {
+    const pairingId = boundedPairingString(this.pairingStatus.pairingId, 512);
+    if (!pairingId || this.pairingActionLoading) return;
+    const generation = this.pairingPanelGeneration;
+    this.pairingActionLoading = true;
+    this.pairingMessage = "";
+    this.pairingError = "";
+    this.clearPairingCode();
+    try {
+      const response = await callJsonApi(BROWSER_BRIDGE_PAIRING_API, {
+        action: "cancel",
+        pairing_id: pairingId,
+      });
+      const status = normalizePairingStatus(response);
+      if (!status) throw new Error("invalid pairing cancel response");
+      if (!this.pairingPanelActive || generation !== this.pairingPanelGeneration) return;
+      this.pairingStatus = status;
+      this.pairingNotice("success", response.canceled === true
+        ? "The pairing code was canceled."
+        : "No active pairing code remained.");
+    } catch (_error) {
+      if (!this.pairingPanelActive || generation !== this.pairingPanelGeneration) return;
+      this.pairingNotice("error", "The pairing code could not be canceled. Its status is unknown; do not reuse it.");
+    } finally {
+      if (generation === this.pairingPanelGeneration) {
+        this.pairingActionLoading = false;
+      }
+    }
+  },
+
+  async copyBrowserBridgePairingCode() {
+    const pairingCode = this.pairingCodeAvailable() ? this.pairingCode : "";
+    if (!pairingCode) return;
+    const generation = this.pairingPanelGeneration;
+    this.pairingMessage = "";
+    this.pairingError = "";
+    try {
+      if (!navigator.clipboard?.writeText) throw new Error("clipboard unavailable");
+      await navigator.clipboard.writeText(pairingCode);
+      if (!this.pairingPanelActive || generation !== this.pairingPanelGeneration) return;
+      this.pairingNotice("success", "Pairing code copied. Paste it only into the Agent Zero browser companion.");
+    } catch (_error) {
+      if (!this.pairingPanelActive || generation !== this.pairingPanelGeneration) return;
+      this.pairingNotice("error", "The code could not be copied. Select it and copy it manually.");
+    }
+  },
+
+  clearPairingCode() {
+    this.pairingCode = "";
+    this.pairingCodePairingId = "";
+    this.pairingServerBaseUrl = "";
+  },
+
+  pairingCodeAvailable() {
+    return Boolean(
+      this.pairingCode
+      && this.pairingCodePairingId
+      && this.pairingCodePairingId === this.pairingStatus.pairingId
+      && this.pairingStatus.expiresAtMs > Math.max(this.pairingNowMs, Date.now())
+      && PAIRING_CODE_PATTERN.test(this.pairingCode),
+    );
+  },
+
+  pairingExpiryLabel() {
+    const remainingMs = this.pairingStatus.expiresAtMs - this.pairingNowMs;
+    if (remainingMs <= 0) return "Expired — regenerate the code";
+    const remainingSeconds = Math.ceil(remainingMs / 1000);
+    const minutes = Math.floor(remainingSeconds / 60);
+    const seconds = String(remainingSeconds % 60).padStart(2, "0");
+    return `Expires in ${minutes}:${seconds}`;
+  },
+
+  pairingStatusLabel() {
+    if (this.pairingStatusLoading && this.pairingStatus.state === "not_checked") {
+      return "Checking server pairing availability…";
+    }
+    if (this.pairingStatus.state === "not_checked") {
+      return "Pairing status has not been checked. No browser control is enabled.";
+    }
+    if (this.pairingStatus.state === "repair_required") {
+      return "Pairing status needs repair. No browser control is enabled.";
+    }
+    if (this.pairingStatus.state === "paired") {
+      return "Browser pairing is saved. You do not need a new code when Chrome or Agent Zero restarts.";
+    }
+    if (!this.pairingStatus.serverPairingEnabled && this.pairingStatus.state !== "paired") {
+      if (this.pairingStatus.reasonCode === "expected_extension_id_not_configured") {
+        return "Pairing is waiting for the server's pinned Chrome extension ID.";
+      }
+      return "Pairing is disabled for this Agent Zero instance.";
+    }
+    if (this.pairingStatus.state === "pairing_pending") {
+      return this.pairingCodeAvailable()
+        ? "Waiting for the browser companion to use this code."
+        : "A pairing is already waiting in this WebUI session. Regenerate it to display a new code.";
+    }
+    return "No browser companion is paired.";
+  },
+
   async openHostBrowserSetup(browserFamily) {
     if (this.hostBrowserSetupOpening) return;
     const family = String(browserFamily || "").trim().toLowerCase();
@@ -406,7 +853,7 @@ export const store = createStore("browserConfig", {
     try {
       await callJsonApi(BROWSER_SETUP_API, { browser_family: family });
       const label = family === "edge" ? "Edge" : `${family[0].toUpperCase()}${family.slice(1)}`;
-      notificationStore.addFrontendToastOnly(
+      notifications.addFrontendToastOnly(
         "success",
         `${label} remote-debugging setup opened on the connected host.`,
         "",
@@ -414,7 +861,7 @@ export const store = createStore("browserConfig", {
       );
     } catch (error) {
       console.error("Failed to open host browser setup:", error);
-      notificationStore.addFrontendToastOnly(
+      notifications.addFrontendToastOnly(
         "error",
         "Connect or update Launcher or A0 CLI, enable host Browser access, and try again.",
         "Could not open browser setup",
@@ -465,6 +912,12 @@ export const store = createStore("browserConfig", {
   browserRuntimeStatusLabel() {
     if (this.config?.runtime_backend !== "host_required") {
       return "Docker browser runs inside Agent Zero; host-browser connection status does not affect it.";
+    }
+    if (this.isDevelopmentBrowserSelected()) {
+      return "This development connection is retired. Pair and select the production Chrome extension in Browser settings.";
+    }
+    if (this.isProductionBrowserSelected()) {
+      return "Chrome extension selected. Connection status is shown above; A0 CLI and remote debugging are not required.";
     }
     const label = this.hostBrowserConnectorLabel();
     if (label.startsWith("Connect through Launcher") || label.includes("unavailable")) {

--- a/plugins/_browser/webui/browser-site-requests-store.js
+++ b/plugins/_browser/webui/browser-site-requests-store.js
@@ -1,0 +1,128 @@
+import { createStore } from "/js/AlpineStore.js";
+import { callJsonApi } from "/js/api.js";
+
+const API = "/plugins/_a0_connector/browser_bridge_site_authority";
+const CONTRACT = "a0.browser-bridge.site-authority.v1";
+const PRODUCTION_PROFILE = Object.freeze({ api: API, contract: CONTRACT });
+const decisions = ["deny", "allow_once", "allow_turn"];
+const firstOpenDecisions = [...decisions, "allow_site"];
+const identifier = (value) => typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/.test(value);
+
+function envelope(value, profile) {
+  if (value?.contract !== profile.contract || value.authority_version !== 1
+    || value.browser_control_ready !== false) throw new Error("Invalid site authority");
+  return value;
+}
+
+function parseRequests(value, contextId, profile) {
+  const response = envelope(value, profile);
+  if (!Array.isArray(response.challenges) || response.challenges.length > 128) throw new Error("Invalid site requests");
+  const requests = response.challenges.map((request) => {
+    if (!identifier(request?.challenge_id) || !["navigate", "open"].includes(request.action_class)
+      || JSON.stringify(request.options) !== JSON.stringify(request.action_class === "open" ? firstOpenDecisions : decisions)
+      || !Number.isSafeInteger(request.expires_at_ms) || request.expires_at_ms < 1
+      || typeof request.origin !== "string" || request.origin.length > 2048) throw new Error("Invalid site request");
+    const url = new URL(request.origin);
+    if (!["https:", "http:"].includes(url.protocol) || url.origin !== request.origin) throw new Error("Invalid site origin");
+    // Never render a page-supplied action description or HTML as permission UI.
+    return { id: request.challenge_id, origin: request.origin, expires: request.expires_at_ms, contextId,
+      canRemember: request.action_class === "open" };
+  });
+  if (new Set(requests.map((request) => request.id)).size !== requests.length) throw new Error("Duplicate site request");
+  return requests;
+}
+
+function createRequestsModel({ api, selection = () => "", now = Date.now, schedule = setTimeout, unschedule = clearTimeout }, profile) {
+  return {
+    active: false, generation: 0, listSequence: 0, timer: null, loading: false, busyId: "",
+    requests: [], state: "not_checked", stateContextId: "", notice: "", noticeContextId: "", noticeExpires: 0, decisionUnconfirmed: false, clock: 0,
+
+    async mount() {
+      this.cleanup();
+      this.active = true;
+      await this.refresh();
+    },
+
+    cleanup() {
+      this.active = false; this.generation += 1; this.listSequence += 1;
+      if (this.timer !== null) unschedule(this.timer);
+      this.timer = null; this.requests = []; this.loading = false; this.busyId = "";
+      this.state = "not_checked"; this.stateContextId = ""; this.notice = ""; this.noticeContextId = ""; this.noticeExpires = 0; this.decisionUnconfirmed = false;
+    },
+
+    current(generation) { return this.active && this.generation === generation; },
+    visibleNotice() {
+      const time = Math.max(this.clock, now());
+      return this.active && this.noticeContextId === selection() && this.noticeExpires > time ? this.notice : "";
+    },
+    hasUnconfirmedDecision() { return this.decisionUnconfirmed && Boolean(this.visibleNotice()); },
+    unavailableHere() { return this.state === "unavailable" && this.stateContextId === selection(); },
+    visibleRequests() { return this.requests.filter((request) => request.contextId === selection() && request.expires > Math.max(this.clock, now())); },
+    canDecide(request) {
+      return this.active && !this.busyId && this.state === "loaded"
+        && request.contextId === selection() && this.requests.some((item) => item.id === request.id) && request.expires > now();
+    },
+
+    async refresh() {
+      if (!this.active || this.loading) return;
+      if (this.timer !== null) unschedule(this.timer);
+      this.timer = null;
+      const generation = this.generation;
+      const sequence = ++this.listSequence;
+      const contextId = selection();
+      this.loading = true; this.clock = now();
+      try {
+        const requests = identifier(contextId) ? parseRequests(await api(profile.api, { action: "list", context_id: contextId }), contextId, profile) : [];
+        if (!this.current(generation) || sequence !== this.listSequence || contextId !== selection()) return;
+        this.requests = requests.filter((request) => request.expires > now());
+        this.state = "loaded"; this.stateContextId = contextId;
+      } catch {
+        if (!this.current(generation) || sequence !== this.listSequence || contextId !== selection()) return;
+        // A failed poll is not evidence that a previously listed request was
+        // withdrawn. Keep its safe projection visible, but canDecide fails shut.
+        this.requests = this.requests.filter((request) => request.contextId === contextId && request.expires > now());
+        this.state = "unavailable"; this.stateContextId = contextId;
+      } finally {
+        if (this.current(generation)) {
+          this.loading = false; this.clock = now();
+          this.timer = schedule(() => { void this.refresh(); }, this.state === "unavailable" ? 10_000 : 2_000);
+        }
+      }
+    },
+
+    async decide(request, decision) {
+      if (!(request.canRemember ? firstOpenDecisions : decisions).includes(decision) || !this.canDecide(request)) return;
+      const generation = this.generation;
+      this.listSequence += 1;
+      this.busyId = request.id; this.notice = ""; this.decisionUnconfirmed = false;
+      this.noticeContextId = request.contextId; this.noticeExpires = request.expires;
+      try {
+        const response = envelope(await api(profile.api, { action: "decide", challenge_id: request.id, decision }), profile);
+        if (!this.current(generation)) return;
+        if (response.challenge_id !== request.id || response.decision !== decision
+          || !identifier(response.control_id) || response.status !== "accepted"
+          || !Number.isSafeInteger(response.expires_at_ms)) throw new Error("Invalid decision acknowledgement");
+        this.listSequence += 1;
+        this.requests = this.requests.filter((item) => item.id !== request.id);
+        this.notice = "Decision recorded. The browser will recheck access before continuing.";
+        this.noticeExpires = Math.min(request.expires, now() + 3_000);
+      } catch {
+        if (this.current(generation)) {
+          this.listSequence += 1;
+          this.requests = this.requests.filter((item) => item.id !== request.id);
+          this.decisionUnconfirmed = true;
+          this.notice = "This request could not be confirmed. Refresh to check whether it is still available.";
+        }
+      } finally {
+        if (this.current(generation)) this.busyId = "";
+      }
+    },
+  };
+}
+
+export function createSiteRequestsModel(dependencies) { return createRequestsModel(dependencies, PRODUCTION_PROFILE); }
+
+export const store = createStore("browserSiteRequests", createSiteRequestsModel({
+  api: callJsonApi,
+  selection: () => globalThis.Alpine?.store("chats")?.selected || "",
+}));

--- a/plugins/_browser/webui/browser-site-requests.html
+++ b/plugins/_browser/webui/browser-site-requests.html
@@ -1,0 +1,80 @@
+<html>
+<head>
+  <script type="module">
+    import { store } from "/plugins/_browser/webui/browser-site-requests-store.js";
+  </script>
+</head>
+<body>
+  <!-- Compact consent strip; secondary scopes stay discoverable without
+       competing with the explicit remembered-site choice. -->
+  <section class="browser-site-requests" x-data x-init="$store.browserSiteRequests.mount()"
+    x-destroy="$store.browserSiteRequests.cleanup()" aria-label="Browser site requests" x-cloak
+    x-show="$store.browserSiteRequests.visibleRequests().length || $store.browserSiteRequests.visibleNotice()">
+    <template x-for="request in $store.browserSiteRequests.visibleRequests()" :key="request.id">
+      <div class="browser-site-request" :aria-busy="$store.browserSiteRequests.busyId === request.id">
+        <div class="browser-site-request-main">
+          <x-icon class="browser-site-request-icon" name="language" aria-hidden="true"></x-icon>
+          <div class="browser-site-request-copy">
+            <p class="browser-site-request-origin" x-text="request.origin"></p>
+            <p class="browser-site-request-caption" x-text="request.canRemember ? 'Read and navigate. Remember for future chats.' : 'Allow navigation to this site?' "></p>
+          </div>
+          <div class="browser-site-request-actions">
+          <button type="button" class="button confirm" x-show="request.canRemember"
+            :disabled="!$store.browserSiteRequests.canDecide(request) || request.expires &lt;= $store.browserSiteRequests.clock"
+            @click="$store.browserSiteRequests.decide(request, 'allow_site')">Always allow site</button>
+          <button type="button" class="button confirm" x-show="!request.canRemember"
+            :disabled="!$store.browserSiteRequests.canDecide(request) || request.expires &lt;= $store.browserSiteRequests.clock"
+            @click="$store.browserSiteRequests.decide(request, 'allow_once')">Allow once</button>
+          <button type="button" class="text-button" :disabled="!$store.browserSiteRequests.canDecide(request) || request.expires &lt;= $store.browserSiteRequests.clock"
+            @click="$store.browserSiteRequests.decide(request, 'deny')">Deny</button>
+          </div>
+        </div>
+        <details class="browser-site-request-options">
+          <summary>More options</summary>
+          <div class="browser-site-request-secondary">
+            <button type="button" class="button" x-show="request.canRemember"
+              :disabled="!$store.browserSiteRequests.canDecide(request) || request.expires &lt;= $store.browserSiteRequests.clock"
+              @click="$store.browserSiteRequests.decide(request, 'allow_once')">Allow once</button>
+            <button type="button" class="button" :disabled="!$store.browserSiteRequests.canDecide(request) || request.expires &lt;= $store.browserSiteRequests.clock"
+              @click="$store.browserSiteRequests.decide(request, 'allow_turn')">Allow this turn</button>
+          </div>
+          <p class="browser-site-request-help">Purchases, submissions, and other consequential actions need separate approval.</p>
+          <p class="browser-site-request-help" x-show="request.canRemember">Saved access applies only to this exact site in this Chrome browser. Remove it in Browser settings.</p>
+        </details>
+      </div>
+    </template>
+    <p class="browser-site-request-help" role="status" x-show="$store.browserSiteRequests.visibleNotice()">
+      <span x-text="$store.browserSiteRequests.visibleNotice()"></span>
+      <button type="button" class="text-button" x-show="$store.browserSiteRequests.hasUnconfirmedDecision()" @click="$store.browserSiteRequests.refresh()"
+        :disabled="$store.browserSiteRequests.loading">Check status</button>
+    </p>
+  </section>
+  <style>
+    .browser-site-requests { flex: 0 0 auto; max-height: min(40vh, 320px); overflow: auto; color: var(--color-text); scrollbar-color: var(--color-border) transparent; }
+    .browser-site-requests ::selection { background: var(--color-primary); color: var(--color-background); }
+    .browser-site-request { padding: 12px; border-bottom: 1px solid var(--color-border); }
+    .browser-site-request-main { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+    .browser-site-request-icon { flex: 0 0 auto; font-size: 20px; color: var(--color-text-muted); }
+    .browser-site-request-copy { flex: 1 1 180px; min-width: 0; }
+    .browser-site-request p { margin: 0; }
+    .browser-site-request-origin { overflow-wrap: anywhere; font-size: .875rem; line-height: 1.4; font-weight: 500; }
+    .browser-site-request-caption { color: var(--color-text-muted); font-size: .75rem; line-height: 1.5; }
+    .browser-site-request-actions, .browser-site-request-secondary { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .browser-site-requests .button { min-height: 36px; padding: 6px 12px; font-size: .8125rem; }
+    .browser-site-requests .text-button { min-height: 36px; font-size: .8125rem; }
+    .browser-site-request-options { margin: 4px 0 0 32px; font-size: .75rem; color: var(--color-text-muted); }
+    .browser-site-request-options summary { width: fit-content; padding: 4px 0; cursor: pointer; border-radius: 3px; }
+    .browser-site-request-options summary:hover { color: var(--color-text); }
+    .browser-site-request-secondary { padding: 8px 0; }
+    .browser-site-request .browser-site-request-help { max-width: 72ch; margin-top: 4px; font-size: .75rem; line-height: 1.5; }
+    .browser-site-requests > .browser-site-request-help { margin: 8px 12px; font-size: .75rem; }
+    .browser-site-requests :is(button, summary):focus-visible { outline: 2px solid var(--color-highlight); outline-offset: 2px; }
+    .browser-site-requests button:disabled { opacity: .5; cursor: not-allowed; }
+    @media (max-width: 480px) {
+      .browser-site-request-actions { margin-left: 32px; flex-basis: 100%; }
+      .browser-site-requests :is(button, summary) { min-height: 44px; }
+      .browser-site-request-options summary { display: flex; align-items: center; }
+    }
+  </style>
+</body>
+</html>

--- a/plugins/_browser/webui/config.html
+++ b/plugins/_browser/webui/config.html
@@ -3,6 +3,9 @@
   <title>Browser Settings</title>
   <script type="module">
     import { store } from "/plugins/_browser/webui/browser-config-store.js";
+    import { store as bridgeAccess } from "/plugins/_browser/webui/browser-bridge-access-store.js";
+    import { store as bridgeSelection } from "/plugins/_browser/webui/browser-bridge-selection-store.js";
+    import { store as bridgeSetup } from "/plugins/_browser/webui/browser-bridge-setup-store.js";
   </script>
 </head>
 
@@ -11,21 +14,251 @@
     <template x-if="$store.browserConfig && config">
       <div
         class="browser-config-sections"
-        x-init="$store.browserConfig.init(config)"
+        x-init="$store.browserConfig.init(config); $store.browserBridgeSetup.mount()"
         x-effect="$store.browserConfig.bindConfig(config)"
-        x-destroy="$store.browserConfig.cleanup()"
+        x-destroy="$store.browserConfig.cleanup(); $store.browserBridgeSetup.cleanup()"
       >
-        <div class="browser-config-card">
-          <div class="section-title">Browser Runtime</div>
-          <div class="section-description">
-            Choose the internal Docker browser or a host browser connected through Launcher or A0 CLI.
+        <div
+          class="browser-config-card browser-pairing-card"
+          aria-labelledby="browser-pairing-title"
+          :aria-busy="$store.browserConfig.pairingActionLoading || $store.browserConfig.pairingStatusLoading"
+        >
+          <div class="browser-pairing-heading">
+            <div>
+              <div id="browser-pairing-title" class="section-title">Chrome extension</div>
+              <div class="section-description">
+                Use Chrome on your computer, including when Agent Zero runs in Docker. Connect it once as your default browser, then approve the sites it can use.
+              </div>
+            </div>
+
           </div>
 
+          <div class="browser-config-note" role="status" aria-live="polite">
+            <x-icon
+              :class="{ spinning: $store.browserConfig.pairingStatusLoading }"
+              :name="$store.browserConfig.pairingStatusLoading ? 'progress_activity' : 'link'"
+            ></x-icon>
+            <span x-text="$store.browserConfig.pairingStatusLabel()"></span>
+          </div>
+
+          <details class="browser-setup-steps" :open="$store.browserConfig.pairingStatus.state !== 'paired'">
+            <summary x-text="$store.browserConfig.pairingStatus.state === 'paired' ? 'Connect another browser' : 'Connect Chrome once'"></summary>
+            <ol class="browser-setup-list">
+              <li>
+                <span>Install the Agent Zero Chrome extension.</span>
+                <a class="browser-pairing-button" x-show="$store.browserBridgeSetup.setup?.extension_url"
+                  :href="$store.browserBridgeSetup.setup?.extension_url" target="_blank" rel="noopener noreferrer">Open Chrome Web Store</a>
+              </li>
+              <li>
+                <span>Install the companion on the computer running Chrome.</span>
+                <label class="browser-config-field">
+                  <span class="browser-config-field-label">Your computer</span>
+                  <select x-model="$store.browserBridgeSetup.platform">
+                    <option value="">Choose an operating system</option>
+                    <option value="macos">macOS</option><option value="windows">Windows</option><option value="linux">Linux</option>
+                  </select>
+                </label>
+                <p class="browser-config-field-help" role="status" x-text="$store.browserBridgeSetup.availabilityText()"></p>
+                <template x-for="installer in $store.browserBridgeSetup.installers()" :key="installer.platform + ':' + installer.arch">
+                  <a class="browser-pairing-button" :href="installer.url" target="_blank" rel="noopener noreferrer"
+                    x-text="$store.browserBridgeSetup.installerLabel(installer)"></a>
+                </template>
+                <p class="browser-config-field-help" x-show="$store.browserBridgeSetup.installers().length">Publisher-provided downloads. The companion installer verifies the signed release on your computer before installation. Never install it inside Docker.</p>
+              </li>
+              <li>Open the extension's Settings, enter this Agent Zero address and the pairing code below, then choose Pair browser. Select Use this Chrome browser below once; Agent Zero remembers it across chats.</li>
+            </ol>
+
           <label class="browser-config-field">
+            <span class="browser-config-field-label">Browser name</span>
+            <input
+              type="text"
+              maxlength="192"
+              autocomplete="off"
+              spellcheck="false"
+              x-model="$store.browserConfig.pairingDisplayName"
+              :disabled="$store.browserConfig.pairingActionLoading"
+            />
+            <span class="browser-config-field-help">
+              Choose a name you will recognize, such as “My laptop”.
+            </span>
+          </label>
+
+          <template x-if="$store.browserConfig.pairingCodeAvailable()">
+            <div class="browser-pairing-code-card">
+              <div class="browser-pairing-code-heading">
+                <span>Single-use pairing code</span>
+                <span x-text="$store.browserConfig.pairingExpiryLabel()"></span>
+              </div>
+              <code
+                class="browser-pairing-code"
+                tabindex="0"
+                aria-label="Single-use browser companion pairing code"
+                x-text="$store.browserConfig.pairingCode"
+              ></code>
+              <div class="browser-config-field-help">
+                Anyone with this code can pair during its five-minute lifetime. Enter it only in the Agent Zero browser companion. It cannot be shown again after this panel closes.
+              </div>
+              <div class="browser-pairing-server" x-show="$store.browserConfig.pairingServerBaseUrl">
+                <span>Agent Zero</span>
+                <span x-text="$store.browserConfig.pairingServerBaseUrl"></span>
+              </div>
+              <div class="browser-pairing-actions">
+                <button
+                  type="button"
+                  class="browser-pairing-button browser-pairing-button-primary"
+                  @click="$store.browserConfig.copyBrowserBridgePairingCode()"
+                >
+                  <x-icon name="content_copy"></x-icon>
+                  <span>Copy code</span>
+                </button>
+                <button
+                  type="button"
+                  class="browser-pairing-button"
+                  :disabled="!$store.browserConfig.canCreateBrowserBridgePairing()"
+                  @click="$store.browserConfig.createBrowserBridgePairing()"
+                >
+                  <x-icon name="refresh"></x-icon>
+                  <span>Regenerate</span>
+                </button>
+                <button
+                  type="button"
+                  class="browser-pairing-button browser-pairing-button-danger"
+                  :disabled="$store.browserConfig.pairingActionLoading"
+                  @click="$store.browserConfig.cancelBrowserBridgePairing()"
+                >
+                  <x-icon name="cancel"></x-icon>
+                  <span>Cancel</span>
+                </button>
+              </div>
+            </div>
+          </template>
+
+          <div class="browser-pairing-actions" x-show="!$store.browserConfig.pairingCodeAvailable()">
+            <button
+              type="button"
+              class="browser-pairing-button browser-pairing-button-primary"
+              :disabled="!$store.browserConfig.canCreateBrowserBridgePairing()"
+              @click="$store.browserConfig.createBrowserBridgePairing()"
+            >
+              <x-icon :name="$store.browserConfig.pairingActionLoading ? 'progress_activity' : 'key'"></x-icon>
+              <span x-text="$store.browserConfig.pairingPrimaryActionLabel()"></span>
+            </button>
+            <button
+              type="button"
+              class="browser-pairing-button browser-pairing-button-danger"
+              x-show="$store.browserConfig.pairingStatus.state === 'pairing_pending' && $store.browserConfig.pairingStatus.pairingId"
+              :disabled="$store.browserConfig.pairingActionLoading"
+              @click="$store.browserConfig.cancelBrowserBridgePairing()"
+            >
+              <x-icon name="cancel"></x-icon>
+              <span>Cancel pending code</span>
+            </button>
+          </div>
+
+          <div class="browser-config-warning">
+            <x-icon name="computer"></x-icon>
+            <span>
+              Install the companion on the same computer as Chrome, not inside Docker. Your saved pairing stays on that computer; only revoking access or resetting its profile requires pairing again.
+            </span>
+          </div>
+          </details>
+          <template x-if="$store.browserBridgeAccess">
+            <section class="browser-bridge-access" aria-labelledby="browser-access-title"
+              x-init="$store.browserBridgeAccess.mount(); $store.browserBridgeSelection.mount(context)"
+              x-destroy="$store.browserBridgeAccess.cleanup(); $store.browserBridgeSelection.cleanup()"
+              :aria-busy="$store.browserBridgeAccess.loading || $store.browserBridgeAccess.busy">
+              <div class="browser-pairing-heading">
+                <h3 id="browser-access-title">Paired browsers &amp; site access</h3>
+                <button type="button" class="browser-pairing-button" @click="$store.browserConfig.refreshProductionBrowserStatus()"
+                  :disabled="$store.browserBridgeAccess.loading || $store.browserBridgeAccess.busy">
+                  <x-icon name="refresh"></x-icon><span>Check connection</span>
+                </button>
+              </div>
+              <p class="browser-config-field-help" role="status" x-show="$store.browserBridgeAccess.inventoryState === 'not_checked'">Checking paired browsers…</p>
+              <p class="browser-config-field-help" role="status" x-show="$store.browserBridgeAccess.inventoryState === 'unavailable'">Browser access could not be checked. Refresh to retry.</p>
+              <p class="browser-config-field-help" x-show="$store.browserBridgeAccess.inventoryState === 'loaded' &amp;&amp; !$store.browserBridgeAccess.bridges.length">No browsers paired yet. Use the pairing code above to connect your browser computer.</p>
+              <template x-if="$store.browserBridgeAccess.bridges.length">
+                <div>
+                  <label class="browser-config-field">
+                    <span class="browser-config-field-label">Paired browser</span>
+                    <select :value="$store.browserBridgeAccess.selectedId" @change="$store.browserBridgeAccess.selectBridge($event.target.value)"
+                      :disabled="$store.browserBridgeAccess.busy || $store.browserBridgeAccess.loading">
+                      <template x-for="bridge in $store.browserBridgeAccess.bridges" :key="bridge.id">
+                        <option :value="bridge.id" x-text="bridge.name + (bridge.state === 'revoked' ? ' — revoked' : '')"></option>
+                      </template>
+                    </select>
+                  </label>
+                  <p class="browser-config-field-help" x-show="$store.browserBridgeAccess.selectedBridge()?.state === 'revoked'">Access revoked. Pair this browser again to reconnect. Existing tabs are left open.</p>
+                  <template x-if="$store.browserBridgeAccess.selectedBridge()?.state === 'active'">
+                    <div>
+                      <p class="browser-config-field-help" role="status" x-text="$store.browserBridgeSelection.statusText()"></p>
+                      <p class="browser-config-field-help" x-show="$store.browserBridgeSelection.contextStatusText()" x-text="$store.browserBridgeSelection.contextStatusText()"></p>
+                      <div class="browser-pairing-actions">
+                        <button type="button" class="browser-pairing-button"
+                          @click="$store.browserBridgeSelection.useBrowser($store.browserBridgeAccess.selectedId)"
+                          :disabled="!$store.browserBridgeSelection.canSelect($store.browserBridgeAccess.selectedId)">
+                          <x-icon name="desktop_windows"></x-icon>
+                          <span x-text="$store.browserBridgeSelection.selectedDefault($store.browserBridgeAccess.selectedId) ? 'Default Chrome browser' : 'Use this Chrome browser'"></span>
+                        </button>
+                        <button type="button" class="browser-pairing-button" @click="$store.browserBridgeSelection.clear()"
+                          x-show="$store.browserBridgeSelection.defaultSelection?.selected"
+                          :disabled="$store.browserBridgeSelection.busy || $store.browserBridgeSelection.loading">Use internal browser</button>
+                      </div>
+                      <p class="browser-config-field-help">Saved permissions do not enable browser control or approve purchases, submissions, or other consequential actions. Chrome permissions are checked separately.</p>
+                      <div class="browser-config-switch-row">
+                        <span class="browser-config-switch-copy">
+                          <span class="browser-config-field-label">All websites</span>
+                          <span class="browser-config-field-help">Allow browsing once for this Chrome browser, across chats. Restricted pages and separate action approvals still apply.</span>
+                        </span>
+                        <button type="button" class="browser-pairing-button"
+                          :disabled="!$store.browserBridgeAccess.canManageSites() || $store.browserBridgeAccess.policyState !== 'loaded'"
+                          @click="$store.browserBridgeAccess.setAllWebsites($store.browserBridgeAccess.siteMode !== 'allow_all_websites')"
+                          x-text="$store.browserBridgeAccess.siteMode === 'allow_all_websites' ? 'Turn off all-websites access' : 'Allow all websites'"></button>
+                      </div>
+                      <p class="browser-config-field-help" x-show="$store.browserBridgeAccess.policyState === 'loaded' &amp;&amp; $store.browserBridgeAccess.siteMode === 'allow_all_websites'">All supported websites are allowed. Turning this off keeps the individually saved sites below.</p>
+                      <form class="browser-site-form" @submit.prevent="$store.browserBridgeAccess.allowSite()">
+                        <label class="browser-config-field">
+                          <span class="browser-config-field-label">Website address</span>
+                          <input type="url" placeholder="https://example.com" maxlength="2048" autocomplete="off" spellcheck="false"
+                            aria-describedby="browser-site-origin-help" x-model="$store.browserBridgeAccess.originDraft"
+                            :disabled="$store.browserBridgeAccess.busy" />
+                          <span id="browser-site-origin-help" class="browser-config-field-help">Enter a website address such as https://example.com, without a page path.</span>
+                        </label>
+                        <button type="submit" class="browser-pairing-button" :disabled="!$store.browserBridgeAccess.canAllowSite()">Allow site</button>
+                      </form>
+                      <p class="browser-config-field-help" role="status" x-show="$store.browserBridgeAccess.policyState === 'loading'">Checking saved site permissions…</p>
+                      <p class="browser-config-field-help" role="status" x-show="$store.browserBridgeAccess.policyState === 'unavailable'">Site permissions could not be checked. Check connection to retry.</p>
+                      <p class="browser-config-field-help" x-show="$store.browserBridgeAccess.policyState === 'loaded' &amp;&amp; $store.browserBridgeAccess.siteMode !== 'allow_all_websites' &amp;&amp; !$store.browserBridgeAccess.grants.length">No sites allowed. Site access is denied unless you grant permission.</p>
+                      <ul class="browser-site-grants" aria-label="Allowed sites">
+                        <template x-for="grant in $store.browserBridgeAccess.grants" :key="grant.id">
+                          <li><span x-text="grant.origin"></span><button type="button" class="browser-pairing-button"
+                            :aria-label="'Remove permission for ' + grant.origin" :disabled="$store.browserBridgeAccess.busy"
+                            @click="$store.browserBridgeAccess.revokeSite(grant.origin)">Remove</button></li>
+                        </template>
+                      </ul>
+                      <button type="button" class="browser-pairing-button browser-pairing-button-danger"
+                        :disabled="!$store.browserBridgeAccess.canManageSites()" @click="$store.browserBridgeAccess.revokeBridge()">
+                        <x-icon name="link_off"></x-icon><span>Revoke browser access</span>
+                      </button>
+                    </div>
+                  </template>
+                </div>
+              </template>
+            </section>
+          </template>
+        </div>
+
+        <details class="browser-config-card browser-advanced-settings">
+          <summary class="section-title">Internal browser and advanced host connection</summary>
+          <div class="section-description">
+            The internal browser needs no Chrome setup. Launcher and A0 CLI host connections use the advanced browser setup below.
+          </div>
+
+          <label class="browser-config-field" x-show="!$store.browserConfig.isCompanionSelected()">
             <span class="browser-config-field-label">Browser location</span>
             <select x-model="$store.browserConfig.config.runtime_backend">
               <option value="container">Internal Docker browser</option>
-              <option value="host_required">Host browser on connected computer</option>
+              <option value="host_required">Advanced: Launcher or A0 CLI host browser</option>
             </select>
             <span
               class="browser-config-field-help"
@@ -35,9 +268,13 @@
             </span>
             <span
               class="browser-config-field-help"
-              x-show="$store.browserConfig.config.runtime_backend === 'host_required'"
+              x-show="$store.browserConfig.config.runtime_backend === 'host_required' &amp;&amp; !$store.browserConfig.isCompanionSelected()"
             >
               Uses Safari, Chrome, Edge, Brave, Opera, Vivaldi, or Chromium on a computer connected through Launcher or A0 CLI. The browser opens when the agent first needs it.
+            </span>
+            <span class="browser-config-field-help"
+              x-show="$store.browserConfig.isDevelopmentBrowserSelected()">
+              This old development connection is retired. Pair and select the production Chrome extension above; no access is transferred automatically.
             </span>
           </label>
 
@@ -100,7 +337,7 @@
 
           <label
             class="browser-config-field"
-            x-show="$store.browserConfig.config.runtime_backend === 'host_required'"
+            x-show="$store.browserConfig.config.runtime_backend === 'host_required' &amp;&amp; !$store.browserConfig.isCompanionSelected()"
           >
             <span class="browser-config-field-label">Host browser profile</span>
             <select x-model="$store.browserConfig.config.host_browser_profile_mode">
@@ -117,7 +354,7 @@
 
           <label
             class="browser-config-field"
-            x-show="$store.browserConfig.config.runtime_backend === 'host_required' && $store.browserConfig.config.host_browser_profile_mode !== 'agent'"
+            x-show="$store.browserConfig.config.runtime_backend === 'host_required' && !$store.browserConfig.isCompanionSelected() && $store.browserConfig.config.host_browser_profile_mode !== 'agent'"
           >
             <span class="browser-config-field-label">Host browser</span>
             <select
@@ -135,7 +372,7 @@
 
           <label
             class="browser-config-field"
-            x-show="$store.browserConfig.config.runtime_backend === 'host_required' && $store.browserConfig.config.host_browser_profile_mode !== 'agent' && $store.browserConfig.showCustomHostBrowserEndpoint()"
+            x-show="$store.browserConfig.config.runtime_backend === 'host_required' && !$store.browserConfig.isCompanionSelected() && $store.browserConfig.config.host_browser_profile_mode !== 'agent' && $store.browserConfig.showCustomHostBrowserEndpoint()"
           >
             <span class="browser-config-field-label">Custom endpoint</span>
             <input
@@ -151,7 +388,7 @@
 
           <div
             class="browser-config-guide"
-            x-show="$store.browserConfig.config.runtime_backend === 'host_required' && $store.browserConfig.config.host_browser_profile_mode !== 'agent'"
+            x-show="$store.browserConfig.config.runtime_backend === 'host_required' && !$store.browserConfig.isCompanionSelected() && $store.browserConfig.config.host_browser_profile_mode !== 'agent'"
           >
             <div class="browser-config-guide-heading">
               <x-icon name="tune"></x-icon>
@@ -229,7 +466,7 @@
 
           <div
             class="browser-config-warning"
-            x-show="$store.browserConfig.config.runtime_backend === 'host_required' && $store.browserConfig.config.host_browser_profile_mode !== 'agent'"
+            x-show="$store.browserConfig.config.runtime_backend === 'host_required' && !$store.browserConfig.isCompanionSelected() && $store.browserConfig.config.host_browser_profile_mode !== 'agent'"
           >
             <x-icon name="warning"></x-icon>
             <span>
@@ -255,10 +492,10 @@
             <x-icon :class="{ spinning: $store.browserConfig.hostBrowserStatusLoading }" :name="$store.browserConfig.hostBrowserStatusLoading ? 'progress_activity' : 'captive_portal'"></x-icon>
             <span x-text="$store.browserConfig.browserRuntimeStatusLabel()"></span>
           </div>
-        </div>
+        </details>
 
-        <div class="browser-config-card">
-          <div class="section-title">Browsing</div>
+        <details class="browser-config-card">
+          <summary class="section-title">Internal browser preferences</summary>
           <div class="section-description">
             Set how new Browser sessions start and how an already-open Browser surface follows agent activity.
           </div>
@@ -345,7 +582,7 @@
           <label class="browser-config-switch-row">
             <span class="browser-config-switch-copy">
               <span class="browser-config-field-label">Autofocus active page</span>
-              <span class="browser-config-field-help">Update the visible Browser surface for pages opened or changed by Browser tool results.</span>
+              <span class="browser-config-field-help">Follow the active page, including Agent Zero's Chrome tab during browser actions. Turn off to stay in your current tab. Reading pages and background updates never switch Chrome tabs.</span>
             </span>
             <span class="browser-config-toggle-with-label">
               <span class="browser-config-toggle-label" x-text="$store.browserConfig.autofocusLabel()"></span>
@@ -359,10 +596,10 @@
               </span>
             </span>
           </label>
-        </div>
+        </details>
 
-        <div class="browser-config-card">
-          <div class="section-title">Extensions</div>
+        <details class="browser-config-card">
+          <summary class="section-title">Internal browser add-ons</summary>
           <div class="section-description">
             Choose which installed Chrome extensions Browser loads.
           </div>
@@ -431,7 +668,7 @@
               Ready
             </span>
           </div>
-        </div>
+        </details>
       </div>
     </template>
   </div>
@@ -457,6 +694,19 @@
       flex-direction: column;
       gap: 6px;
     }
+
+    .browser-pairing-card { border: 0; padding: 0; }
+    details.browser-config-card { display: block; }
+    details.browser-config-card[open] > :not(summary) { margin-top: 14px; }
+    .browser-setup-steps > summary,
+    details.browser-config-card > summary { cursor: pointer; padding-block: 8px; }
+    .browser-setup-steps > summary:focus-visible,
+    details.browser-config-card > summary:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 3px; }
+    .browser-setup-steps > :not(summary) { margin-block: 14px; }
+    .browser-setup-list { display: grid; gap: 18px; padding-left: 24px; }
+    .browser-setup-list li { padding-left: 4px; line-height: 1.5; }
+    .browser-setup-list li > * { margin-top: 8px; }
+    .browser-setup-list .browser-pairing-button { max-width: 100%; white-space: normal; text-decoration: none; }
 
     .browser-config-field-label {
       color: var(--color-text);
@@ -494,6 +744,7 @@
     .browser-config-field input[type="text"],
     .browser-config-field input[type="password"],
     .browser-config-field input[type="number"],
+    .browser-config-field input[type="url"],
     .browser-config-field select {
       width: 100%;
       min-height: 36px;
@@ -700,6 +951,143 @@
       color: color-mix(in srgb, var(--color-text) 88%, #166534);
     }
 
+    .browser-config-note.browser-config-error {
+      background: color-mix(in srgb, #be123c 10%, var(--color-background));
+      color: color-mix(in srgb, var(--color-text) 88%, #9f1239);
+    }
+
+    .browser-bridge-access {
+      margin-top: 1.5rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--color-border);
+    }
+
+    .browser-bridge-access h3 { margin: 0; font-size: 1rem; }
+    .browser-site-form { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
+    .browser-site-form > label { flex: 1 1 16rem; min-width: 0; }
+    .browser-site-grants { list-style: none; padding: 0; margin: 1rem 0; }
+    .browser-site-grants li { display: flex; align-items: center; gap: 0.75rem; padding: 0.5rem 0; }
+    .browser-site-grants li > span { flex: 1; min-width: 0; overflow-wrap: anywhere; }
+    .browser-bridge-access input { caret-color: var(--color-primary); }
+    .browser-bridge-access ::selection { background: var(--color-primary); color: var(--color-background); }
+
+    .browser-pairing-heading,
+    .browser-pairing-code-heading,
+    .browser-pairing-server {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .browser-pairing-heading > div {
+      display: flex;
+      min-width: 0;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .browser-pairing-code-card {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      padding: 14px;
+      border: 1px solid color-mix(in srgb, var(--color-primary) 38%, var(--color-border));
+      border-radius: 10px;
+      background: color-mix(in srgb, var(--color-primary) 7%, var(--color-background));
+    }
+
+    .browser-pairing-code-heading {
+      color: var(--color-text-secondary);
+      font-size: 0.78rem;
+      font-weight: 650;
+    }
+
+    .browser-pairing-code {
+      display: block;
+      width: 100%;
+      padding: 12px;
+      overflow-wrap: anywhere;
+      border: 1px solid color-mix(in srgb, var(--color-border) 72%, transparent);
+      border-radius: 8px;
+      background: var(--color-input);
+      color: var(--color-text);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: clamp(0.82rem, 2.2vw, 1rem);
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      line-height: 1.45;
+      text-align: center;
+      user-select: all;
+    }
+
+    .browser-pairing-server {
+      color: var(--color-text-secondary);
+      font-size: 0.78rem;
+    }
+
+    .browser-pairing-server span:last-child {
+      overflow-wrap: anywhere;
+      color: var(--color-text);
+      text-align: right;
+    }
+
+    .browser-pairing-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .browser-pairing-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 7px;
+      min-height: 38px;
+      padding: 8px 12px;
+      border: 1px solid color-mix(in srgb, var(--color-border) 78%, transparent);
+      border-radius: 8px;
+      background: color-mix(in srgb, var(--color-panel) 88%, var(--color-background));
+      color: var(--color-text);
+      font: inherit;
+      font-size: 0.82rem;
+      font-weight: 650;
+      cursor: pointer;
+    }
+
+    .browser-pairing-button:hover:not(:disabled) {
+      border-color: color-mix(in srgb, var(--color-primary) 48%, var(--color-border));
+      background: color-mix(in srgb, var(--color-primary) 10%, var(--color-background));
+    }
+
+    .browser-pairing-button:focus-visible {
+      outline: 2px solid var(--color-primary);
+      outline-offset: 2px;
+    }
+
+    .browser-pairing-button:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+
+    .browser-pairing-button-primary {
+      border-color: color-mix(in srgb, var(--color-primary) 55%, var(--color-border));
+      background: var(--color-primary);
+      color: var(--color-primary-text, #fff);
+    }
+
+    .browser-pairing-button-primary:hover:not(:disabled) {
+      background: color-mix(in srgb, var(--color-primary) 86%, #000);
+    }
+
+    .browser-pairing-button-danger {
+      color: color-mix(in srgb, #be123c 78%, var(--color-text));
+    }
+
+    .browser-pairing-button .material-symbols-outlined {
+      font-size: 18px;
+    }
+
     .browser-config-guide {
       display: flex;
       flex-direction: column;
@@ -879,6 +1267,37 @@
       color: #1b5e20;
       border-color: rgba(27, 94, 32, 0.18);
       background: rgba(46, 125, 50, 0.12);
+    }
+
+    @media (max-width: 520px) {
+      .browser-pairing-heading,
+      .browser-pairing-code-heading,
+      .browser-pairing-server {
+        align-items: flex-start;
+        flex-direction: column;
+      }
+
+      .browser-pairing-server span:last-child {
+        text-align: left;
+      }
+
+      .browser-pairing-button {
+        flex: 1 1 100%;
+      }
+
+      .browser-bridge-access .browser-pairing-button {
+        min-height: 44px;
+      }
+
+      .browser-site-grants li {
+        align-items: stretch;
+        flex-direction: column;
+      }
+
+      .browser-site-grants .browser-pairing-button {
+        flex: 0 0 auto;
+        width: 100%;
+      }
     }
   </style>
 </body>

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,5 +1,12 @@
 # Tests DOX
 
+Legacy retirement tests use only the exact temporary prototype fixture and
+synthetic journals. Cover once-only bounded draining, no replay, payload purge,
+and legacy-only fail-closed guards without touching live tabs or credentials.
+Quarantine tests cover durable private backup before exact field removal,
+idempotence, user-attachment preservation, symlink refusal, real persistence
+hook dispatch, and bounded loaded-context-only sweep behavior.
+
 ## Purpose
 
 - Own pytest regression, security, integration, and contract tests.
@@ -9,6 +16,12 @@
 
 - Test files live directly under `tests/` and are named for the behavior or subsystem they cover.
 - Shared fixtures should be added only when multiple tests need them.
+- Browser setup, selection, access and pairing UI regressions share
+  `test_browser_bridge_setup_webui.py`; site/action consent UI shares
+  `test_browser_approval_inbox_webui.py`. Keep artifact transfer/materialization
+  in `test_browser_bridge_artifact_controller.py` and lifecycle composition in
+  `test_browser_extension_services.py`. Reuse `browser_bridge_test_support.py`
+  for Node runners and identical synthetic fixtures, not middleware security proofs.
 - Runtime artifacts created during tests should use pytest temporary directories or existing isolated test helpers.
 
 ## Local Contracts
@@ -17,10 +30,172 @@
 - Keep tests deterministic and isolated from existing chats, uploads, downloads, plugin state, and settings.
 - Prefer exercising public helper/API contracts over fragile implementation details when practical.
 - Security regression tests should assert the protected behavior directly.
+- Static connector discovery coverage is consolidated in
+  `test_browser_bridge_foundation_status.py`; do not repeat the same module
+  stubs and feature-list assertions in each pairing/policy/approval/metadata
+  suite. Keep their behavioral auth, schema, expiry and side-effect tests.
 - Launcher gateway tests must cover feature negotiation, authenticated and
   CSRF-protected control, acknowledgement timeout, identity lifecycle,
   context-bound CLI routing precedence, duplicate/multiple-host behavior,
   scope-driven availability, and emergency disconnect without a live host.
+- Browser extension bridge foundation tests must remain host-independent and
+  effect-free: use temporary legacy-plugin fixtures, assert redacted versioned
+  projections, preserve existing container/A0 CLI CDP behavior, and prove that
+  every reserved `extension:` selection fails before legacy or container
+  fallback while the runtime is unavailable.
+- MV3 runtime foundation tests must assert the exact frozen runtime, adapter,
+  and protocol identifiers while proving the projection stays disabled and
+  browser-host-only, with no lease/finalization validation claim. Test actual
+  binding, redaction and finalization behavior in the production lifecycle,
+  lease and broker suites, not parallel discovery-only model tests.
+- Browser bridge pairing tests must remain host-independent and use synthetic
+  in-memory records. Prove default rollout/config failure, 160-bit five-minute
+  creation, one active intent per authenticated session, no-store and CSRF,
+  exact extension/server/public-key binding, atomic single use, generic bounded
+  failures including duplicate JSON keys at every object depth, public-key-only
+  persistence, redacted status, and browser-host-only Docker semantics. Pairing
+  WebUI tests must prove the code stays transient in the open panel, cleanup and
+  cancel clear it, status cannot rehydrate it, copy is explicit, and UI requests
+  cannot supply server-owned identity. Pairing tests must also prove that
+  challenge/session and browser-control capabilities remain absent until their
+  complete security boundary exists.
+- Browser bridge challenge tests must use synthetic in-memory bridge records and
+  deterministic nonces/clocks. Prove 60-second expiry, exact request/proof
+  schemas, active-record and server binding, source-rate bounds, atomic consume
+  on both valid and invalid proof attempts, real Ed25519 verification over the
+  fixed JCS bytes, last-authenticated persistence, generic no-store endpoint
+  failures, and continued absence from capability discovery until scoped
+  WebSocket principal activation is complete.
+- Browser bridge site-policy tests must use synthetic durable state and active
+  pairing records. Prove exact HTTP(S)-origin canonicalization, rejection of
+  userinfo, paths, queries, fragments, wildcards, ambiguous numeric hosts, and
+  restricted schemes, plus default deny, bridge/subject/server isolation,
+  atomic idempotent allow, revoke, corruption failure, strict bounded bodies,
+  normal auth/CSRF, no-store responses, and continued non-advertisement of
+  Browser runtime and one-operation approvals.
+- Browser bridge approval tests must use synthetic current routes, active
+  pairing records, clocks, and identifiers. Prove exact binding across bridge,
+  subject, key/load generation, connector, context, browser session, turn,
+  action, operation, tab and document generation, parameter hash, target
+  fingerprint, origin, and action class; one winning user decision; one exact
+  receipt consumption; two-minute
+  expiry; bounded state; and denial on mismatch, cancellation, finalization,
+  disconnect, revocation, or expiry. The protected API must accept only a
+  challenge ID and explicit decision, reject binding injection and malformed or
+  duplicate-key bodies, require auth/CSRF, return no-store projections, and
+  remain non-activating with no permissive route-resolver fallback.
+- Browser bridge context tests must use synthetic principals, routes, data
+  sources, and log entries. Prove exact principal-object, SID, and load-generation
+  isolation; advertise-before-subscribe/read/message authority; current-route
+  rechecks after source calls; bounded UTF-8-safe message projection from only
+  the actual `input`, `user`, and `response` log types; classification-only
+  projection for other known log types; and complete removal of tool/browser
+  payloads, headings, kvps, scripts, selectors, paths, raw errors, snapshots,
+  and attachments. Preserve cursor, history pagination, and completion state,
+  reject nonadvancing pages, and keep the helper separate from legacy and live
+  runtime wiring.
+- Browser bridge runtime-registry tests must use synthetic immutable principals,
+  typed active-record verification and typed complete-runtime admission. Prove
+  exact hello shape and bounds, rejection of remote authority and unproven
+  capabilities, default-deny admission, current server-instance scoping,
+  fail-isolated cleanup after route removal, same-principal reconnect and
+  generation replacement, cross-principal/SID isolation, session capacity,
+  explicit context plus extension selection, and exact active-route operation
+  and control settlement. The restricted sender test must assert direct shared
+  manager emission with the expected principal and exact handler while rejecting
+  every non-operation/control event. Keep tests independent of the legacy
+  connector registry and do not imply production activation.
+- Browser bridge transport tests must prove only the exact process-owned
+  production profile is accepted. Reject retired development identities even
+  with complete scope sets; structural identity never supplies missing runtime
+  capabilities. Preserve production reconciliation and scoped-sender checks.
+- Browser bridge bootstrap/handler tests must prove the default application is
+  absent and hello-only, full immutable event sets require explicit server
+  binding, exact hello admission precedes any ready response, and the success
+  projection includes the complete fresh typed activation and authenticated
+  transport binding while omitting subject, raw instance claims, exec config,
+  and legacy metadata. Prove an unadmitted SID and a missing owner fail closed,
+  restricted events never enter legacy handlers, disconnect retires the exact
+  route, and an installed owner cannot be synchronously unbound or replaced;
+  exact async retirement must await cleanup before clearing API ownership. Keep
+  the admission evaluator synthetic; these tests do not establish production cutover.
+- Browser bridge message tests use synthetic durable state and delivery hooks.
+  Assert reservation-before-effect, accepted replay across reconnect without
+  duplicate execution, payload conflict, current authority before delivery,
+  and uncertain partial delivery or acceptance-write failure without retry.
+  Never start a real model, touch existing contexts, or persist message text in
+  idempotency fixtures.
+- Message and queue journal coverage must include a full original 2,048-record
+  store, the downgrade-fencing version marker, new individually indexed KVP
+  receipts, reconstruction, retained old
+  replay/conflict/uncertainty protection, corruption and failed reservation
+  writes. Use temporary KVP roots; retain the separate 32-live-item queue bound.
+  Injected stores must use the same KVP-shaped reads/writes and migration path
+  as production; do not maintain a test-only whole-journal implementation.
+- Server startup tests must enter multiple ASGI lifespans on the same runtime,
+  including startup-hook failure and plugin disablement. Each attempt owns
+  installation plus awaited cleanup; the legacy HTTP guard remains independent.
+- Browser queue tests use the real Core queue with synthetic contexts and
+  hash-only in-memory journals: prove owned-only projection, foreign-item
+  isolation, reservation-before-effect, changed-payload conflict, no duplicate
+  enqueue or delivery, and no retry after uncertain effects. Local approval
+  tests prove exact retained principal object, SID and load-generation matching
+  in the real site/action decision repositories, not only subject equality.
+- Browser bridge context-controller tests must exercise only synthetic routes,
+  context sources, message effects, and WebSocket managers. Prove exact native
+  acknowledgement shapes, cursor-preserving snapshot/live projection, strict
+  body and empty-placeholder handling, expected-principal/handler emission,
+  separate stable item and source-update cursors without mid-page skipping,
+  stream capacity, stale-route suppression, and principal/SID/generation-bound
+  unsubscribe/disconnect. A healthy explicit subscription must not silently
+  expire, and presentation cleanup must never cancel a simulated agent task.
+- Browser bridge critical-event tests must use synthetic current routes,
+  durable stores, callbacks, and WebSocket managers. Prove exact supported
+  event/data enums and bounds, reservation-before-callback, hash-only storage,
+  event-ID/sequence conflict rejection, callback-error replay, passive-created
+  lease behavior, gap-safe contiguous cursor advancement, crash-safe duplicate
+  ACK, current-generation replacement, and exact ACK transport. Finalization
+  observers must receive no usable control-result proof, and unsupported event
+  types, stale routes, malformed data, and permissive defaults stay fail-closed.
+- Browser bridge reconciliation tests must use synthetic fixed-profile
+  principals, provisional route checks, snapshots, transport and an atomic
+  promoter. Prove exact frozen request parity, full nested result validation,
+  synchronous promotion before future delivery, stale/forged/timeout denial,
+  and redacted-count-only retention. Embedded pending events are validation
+  input only: never invoke their callbacks, persist them, or ACK a cursor. Keep
+  production admission, runtime ownership, browser selection and live transport
+  out of these fixtures.
+- Browser bridge site-authority tests must use synthetic current operations,
+  leases, routes, turns, clocks, and control completions. Prove exact retained
+  origin/parameter/lease/document/fingerprint validation, server-generated safe
+  projection, explicit decision-only WebUI input, no grant before a matching
+  control result, operation-only scope, exact current-turn reuse with automatic
+  fresh-challenge resolution, lifecycle invalidation, bounded state, strict
+  bodies, auth/CSRF, no-store responses, and unavailable defaults. Critical
+  challenge registration must precede cursor advancement and persist only event
+  and payload hashes, never origin, summary, or binding values.
+- Browser bridge artifact-controller tests use synthetic exact routes, pending
+  operation bindings, receivers, clocks, and WebSocket managers. Prove exact
+  phase schemas and binding comparison, canonical base64 and size bounds,
+  progress/descriptor/abort acknowledgement shapes, exact expected-principal
+  emission, no guessed chunk replay, pathless completion, one bounded expiry
+  owner, and principal/SID/generation-only disconnect cleanup. Sender and
+  screenshot cases also cover upload bounds and safe materialization; do not
+  activate live handlers or transfer real user files.
+- Restricted WebSocket tests must prove authoritative proof presence with no
+  ambient credential rescue, origin-before-proof, exact handler binding,
+  immutable event sets, credential revalidation, and isolation from ordinary
+  user buckets, global handlers, broadcasts, diagnostics and reconnect buffers.
+  Exercise stale-SID replacement, generation-bound delayed delivery, duplicate
+  disconnect, partial activation rollback and raw-error canaries. The initial
+  connector adapter accepts hello only and must not activate legacy CLI tools
+  or advertise operational readiness. Keep tests synthetic and effect-free.
+- Browser companion release-metadata tests use only synthetic public catalogs.
+  They must prove default unavailability, the distinct non-install-ready
+  presentation contract, strict compatibility and the independent non-lowerable
+  server floor, complete signed artifact validation, canonical URL and
+  secret/path/extension-ID rejection, normal auth/CSRF, malformed/nonempty raw
+  request-body rejection, and the browser-host-only Docker boundary.
 
 ## Work Guidance
 

--- a/tests/browser_bridge_test_support.py
+++ b/tests/browser_bridge_test_support.py
@@ -1,0 +1,70 @@
+"""Shared synthetic bridge fixtures; never installs a runtime or grants access."""
+from copy import deepcopy
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+WEBUI = Path(__file__).resolve().parents[1] / "plugins/_browser/webui"
+
+
+def run_node(script):
+    if not shutil.which("node"):
+        import pytest
+        pytest.skip("Node required")
+    result = subprocess.run(["node", "--input-type=module"], input=script,
+                            text=True, capture_output=True, timeout=10)
+    assert result.returncode == 0, result.stderr
+
+
+def run_model(filename, script):
+    source = (WEBUI / filename).read_text().split("export const store =", 1)[0]
+    source = re.sub(r"^import .*;\n", "", source, flags=re.M)
+    source = source.replace("export function ", "function ")
+    source = source.replace("export async function ", "async function ")
+    run_node(source + "\n" + script)
+
+
+class MemoryPersistence:
+    def __init__(self):
+        self.value = None
+
+    def load(self):
+        return deepcopy(self.value)
+
+    def save(self, value):
+        self.value = deepcopy(value)
+
+
+class MemoryKeyValue:
+    """KVP-shaped storage: preserve the exact default sentinel on a miss."""
+    def __init__(self):
+        self.value = {}
+
+    def load(self, key, default=None):
+        return deepcopy(self.value[key]) if key in self.value else default
+
+    def save(self, key, value):
+        self.value[key] = deepcopy(value)
+
+
+class FakeApiHandler:
+    """Endpoint-unit-test base only; shared middleware security is tested separately."""
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    @classmethod
+    def requires_auth(cls):
+        return True
+
+    @classmethod
+    def requires_csrf(cls):
+        return cls.requires_auth()
+
+
+class FakeResponse:
+    def __init__(self, *, response, status, mimetype, headers):
+        self.response = response
+        self.status = status
+        self.mimetype = mimetype
+        self.headers = headers

--- a/tests/fixtures/browser-reconcile-v1.json
+++ b/tests/fixtures/browser-reconcile-v1.json
@@ -1,0 +1,283 @@
+{
+  "core_control": {
+    "method": "browser.reconcile",
+    "contract_version": 1,
+    "bridge_id": "bridge-dev-1",
+    "load_generation_id": "load-dev-1",
+    "control_id": "reconcile-1",
+    "expected_contexts": [
+      {
+        "context_id": "context-1",
+        "browser_session_id": "browser-session-1",
+        "active_turn_ids": ["turn-1"]
+      }
+    ],
+    "event_cursors": [
+      {
+        "load_generation_id": "load-dev-1",
+        "last_acked_event_sequence": 7
+      }
+    ],
+    "known_control_ids": ["finalize-older-1"]
+  },
+  "extension_request": {
+    "contract_version": 1,
+    "control_id": "reconcile-1",
+    "expected_contexts": [
+      {
+        "context_id": "context-1",
+        "browser_session_id": "browser-session-1",
+        "active_turn_ids": ["turn-1"]
+      }
+    ],
+    "event_cursors": [
+      {
+        "load_generation_id": "load-dev-1",
+        "last_acked_event_sequence": 7
+      }
+    ],
+    "known_control_ids": ["finalize-older-1"]
+  },
+  "extension_result": {
+    "contract_version": 1,
+    "control_id": "reconcile-1",
+    "install_instance_id": "install-dev-1",
+    "load_generation_id": "load-dev-1",
+    "leases": [
+      {
+        "lease_id": "lease-1",
+        "tab_handle": "tab-1",
+        "load_generation_id": "load-dev-1",
+        "context_id": "context-1",
+        "browser_session_id": "browser-session-1",
+        "turn_id": "turn-1",
+        "origin": "created",
+        "disposition": "ephemeral",
+        "state": "active",
+        "site_origin": "https://example.test",
+        "identity": {
+          "browser_instance_id": "browser-instance-1",
+          "provider_tab_id": 21,
+          "provider_window_id": 4,
+          "document_id": null,
+          "document_epoch": 0
+        },
+        "group_intent_id": "group-intent-1",
+        "provider_group_id": 8,
+        "finalization_control_id": null,
+        "user_intervened": false,
+        "user_takeover_reason": null,
+        "is_protected": false,
+        "is_ambiguous": false,
+        "unresolved_reconciliation": false,
+        "overlay_attached": true,
+        "debugger_attached": false,
+        "retention_reason": null,
+        "revision": 1
+      }
+    ],
+    "inflight_operations": [
+      {
+        "load_generation_id": "load-dev-1",
+        "action_id": "action-inflight-1",
+        "kind": "navigate",
+        "canonical_parameter_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "stage": "effect_started",
+        "created_at_ms": 1700000000000,
+        "updated_at_ms": 1700000000100
+      }
+    ],
+    "terminal_action_receipts": [
+      {
+        "load_generation_id": "load-dev-1",
+        "action_id": "action-terminal-1",
+        "kind": "open",
+        "canonical_parameter_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "stage": "succeeded",
+        "safe_receipt": {
+          "outcome": "applied",
+          "code": null,
+          "lease_handle_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "created_at_ms": 1700000000200,
+        "updated_at_ms": 1700000000300,
+        "acknowledged_at_ms": 1700000000400
+      }
+    ],
+    "pending_critical_events": [
+      {
+        "contract_version": 1,
+        "event_id": "event-8",
+        "load_generation_id": "load-dev-1",
+        "event_sequence": 8,
+        "delivery": "critical",
+        "event_type": "lease.changed",
+        "observed_at_ms": 1700000000500,
+        "context_id": "context-1",
+        "browser_session_id": "browser-session-1",
+        "turn_id": "turn-1",
+        "op_id": null,
+        "action_id": null,
+        "data": {
+          "lease_id_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "browser_id_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "state": "active",
+          "ownership": "created",
+          "disposition": "ephemeral",
+          "change": "created",
+          "reason_code": null
+        }
+      }
+    ],
+    "prior_generation_orphans": [
+      {
+        "load_generation_id": "load-dev-old-1",
+        "lease_handle_digest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "exact_identity_digest": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "browser_instance_id": "browser-instance-old-1",
+        "provider_tab_id": 13,
+        "provider_window_id": 3,
+        "provider_group_id": null,
+        "context_id": "context-old-1",
+        "browser_session_id": "browser-session-old-1",
+        "turn_id": "turn-old-1",
+        "origin": "created",
+        "disposition": "ephemeral",
+        "state": "orphan",
+        "url_identity": {
+          "origin": "https://old.example.test",
+          "path_digest": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        },
+        "user_intervened": false,
+        "finalization_control_id": null,
+        "retention_reason": "generation_mismatch",
+        "updated_at_ms": 1700000000600
+      }
+    ]
+  },
+  "core_control_result": {
+    "contract_version": 1,
+    "method": "browser.reconcile",
+    "bridge_id": "bridge-dev-1",
+    "load_generation_id": "load-dev-1",
+    "control_id": "reconcile-1",
+    "ok": true,
+    "result": {
+      "contract_version": 1,
+      "control_id": "reconcile-1",
+      "install_instance_id": "install-dev-1",
+      "load_generation_id": "load-dev-1",
+      "leases": [
+        {
+          "lease_id": "lease-1",
+          "tab_handle": "tab-1",
+          "load_generation_id": "load-dev-1",
+          "context_id": "context-1",
+          "browser_session_id": "browser-session-1",
+          "turn_id": "turn-1",
+          "origin": "created",
+          "disposition": "ephemeral",
+          "state": "active",
+          "site_origin": "https://example.test",
+          "identity": {
+            "browser_instance_id": "browser-instance-1",
+            "provider_tab_id": 21,
+            "provider_window_id": 4,
+            "document_id": null,
+            "document_epoch": 0
+          },
+          "group_intent_id": "group-intent-1",
+          "provider_group_id": 8,
+          "finalization_control_id": null,
+          "user_intervened": false,
+          "user_takeover_reason": null,
+          "is_protected": false,
+          "is_ambiguous": false,
+          "unresolved_reconciliation": false,
+          "overlay_attached": true,
+          "debugger_attached": false,
+          "retention_reason": null,
+          "revision": 1
+        }
+      ],
+      "inflight_operations": [
+        {
+          "load_generation_id": "load-dev-1",
+          "action_id": "action-inflight-1",
+          "kind": "navigate",
+          "canonical_parameter_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "stage": "effect_started",
+          "created_at_ms": 1700000000000,
+          "updated_at_ms": 1700000000100
+        }
+      ],
+      "terminal_action_receipts": [
+        {
+          "load_generation_id": "load-dev-1",
+          "action_id": "action-terminal-1",
+          "kind": "open",
+          "canonical_parameter_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "stage": "succeeded",
+          "safe_receipt": {
+            "outcome": "applied",
+            "code": null,
+            "lease_handle_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+          },
+          "created_at_ms": 1700000000200,
+          "updated_at_ms": 1700000000300,
+          "acknowledged_at_ms": 1700000000400
+        }
+      ],
+      "pending_critical_events": [
+        {
+          "contract_version": 1,
+          "event_id": "event-8",
+          "load_generation_id": "load-dev-1",
+          "event_sequence": 8,
+          "delivery": "critical",
+          "event_type": "lease.changed",
+          "observed_at_ms": 1700000000500,
+          "context_id": "context-1",
+          "browser_session_id": "browser-session-1",
+          "turn_id": "turn-1",
+          "op_id": null,
+          "action_id": null,
+          "data": {
+            "lease_id_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            "browser_id_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "state": "active",
+            "ownership": "created",
+            "disposition": "ephemeral",
+            "change": "created",
+            "reason_code": null
+          }
+        }
+      ],
+      "prior_generation_orphans": [
+        {
+          "load_generation_id": "load-dev-old-1",
+          "lease_handle_digest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "exact_identity_digest": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          "browser_instance_id": "browser-instance-old-1",
+          "provider_tab_id": 13,
+          "provider_window_id": 3,
+          "provider_group_id": null,
+          "context_id": "context-old-1",
+          "browser_session_id": "browser-session-old-1",
+          "turn_id": "turn-old-1",
+          "origin": "created",
+          "disposition": "ephemeral",
+          "state": "orphan",
+          "url_identity": {
+            "origin": "https://old.example.test",
+            "path_digest": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+          },
+          "user_intervened": false,
+          "finalization_control_id": null,
+          "retention_reason": "generation_mismatch",
+          "updated_at_ms": 1700000000600
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/browser_bridge_cutover_v1/confirmed_public.json
+++ b/tests/fixtures/browser_bridge_cutover_v1/confirmed_public.json
@@ -1,0 +1,10 @@
+{
+  "contract": "a0.browser-bridge.cutover.v1",
+  "inspected_marker_count": 5,
+  "manifest_matched": true,
+  "matched_marker_count": 5,
+  "reason_code": "legacy_bridge_detected",
+  "schema_version": 1,
+  "state": "confirmed"
+}
+

--- a/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/api/command_pull.py
+++ b/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/api/command_pull.py
@@ -1,0 +1,2 @@
+# Structural legacy fixture.
+

--- a/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/api/command_result.py
+++ b/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/api/command_result.py
@@ -1,0 +1,2 @@
+# Structural legacy fixture.
+

--- a/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/api/session_upsert.py
+++ b/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/api/session_upsert.py
@@ -1,0 +1,2 @@
+# Structural legacy fixture.
+

--- a/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/default_config.yaml
+++ b/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/default_config.yaml
@@ -1,0 +1,6 @@
+command_timeout_seconds: 30
+redelivery_seconds: 8
+stale_session_seconds: 600
+max_inspect_nodes: 40
+prompt_guidance: Legacy fixture only.
+

--- a/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/helpers/constants.py
+++ b/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/helpers/constants.py
@@ -1,0 +1,4 @@
+SOURCE_NAME = "chrome_extension"
+CTX_BROWSER_SESSION_ID = "chrome_browser_session_id"
+CTX_CHROME_CAPABILITIES = "chrome_extension_capabilities"
+

--- a/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/helpers/session_store.py
+++ b/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/helpers/session_store.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from threading import RLock
+from typing import Any
+
+from agent import AgentContext
+
+from usr.plugins.chrome_extension.helpers.constants import (
+    CTX_BROWSER_SESSION_ID,
+    CTX_CHROME_CAPABILITIES,
+    CTX_SOURCE,
+    SOURCE_NAME,
+)
+
+
+@dataclass
+class BrowserTabSummary:
+    tab_id: int
+    window_id: int | None = None
+    url: str = ""
+    title: str = ""
+    active: bool = False
+    focused: bool = False
+
+
+@dataclass
+class BridgeCommand:
+    command_id: str
+    browser_session_id: str
+    verb: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    target_tab_id: int | None = None
+    timeout_seconds: float = 30.0
+    status: str = "queued"
+    attempts: int = 0
+    created_at: float = field(default_factory=time.time)
+    dispatched_at: float | None = None
+    completed_at: float | None = None
+    result: dict[str, Any] | None = None
+    error: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        return data
+
+
+@dataclass
+class BrowserSession:
+    browser_session_id: str
+    context_id: str = ""
+    source: str = SOURCE_NAME
+    active_tab_id: int | None = None
+    capabilities: dict[str, Any] = field(default_factory=dict)
+    tabs: dict[int, BrowserTabSummary] = field(default_factory=dict)
+    queue: list[str] = field(default_factory=list)
+    commands: dict[str, BridgeCommand] = field(default_factory=dict)
+    last_seen: float = field(default_factory=time.time)
+    created_at: float = field(default_factory=time.time)
+
+    def snapshot(self, *, include_commands: bool = False) -> dict[str, Any]:
+        tabs = [asdict(tab) for tab in self.tabs.values()]
+        tabs.sort(key=lambda item: (not item.get("focused", False), not item.get("active", False), item.get("tab_id", 0)))
+        data = {
+            "browser_session_id": self.browser_session_id,
+            "context_id": self.context_id,
+            "source": self.source,
+            "active_tab_id": self.active_tab_id,
+            "capabilities": self.capabilities,
+            "tabs": tabs,
+            "last_seen": self.last_seen,
+            "created_at": self.created_at,
+            "pending_commands": sum(
+                1 for command_id in self.queue if self.commands.get(command_id) and self.commands[command_id].status in {"queued", "dispatched"}
+            ),
+        }
+        if include_commands:
+            data["commands"] = [self.commands[command_id].to_dict() for command_id in self.queue if command_id in self.commands]
+        return data
+
+
+_lock = RLock()
+_sessions: dict[str, BrowserSession] = {}
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_tab(raw: dict[str, Any]) -> BrowserTabSummary | None:
+    if not isinstance(raw, dict):
+        return None
+    tab_id = _coerce_int(raw.get("tab_id", raw.get("id")))
+    if tab_id is None:
+        return None
+    return BrowserTabSummary(
+        tab_id=tab_id,
+        window_id=_coerce_int(raw.get("window_id", raw.get("windowId"))),
+        url=str(raw.get("url", "") or ""),
+        title=str(raw.get("title", "") or ""),
+        active=bool(raw.get("active", False)),
+        focused=bool(raw.get("focused", False)),
+    )
+
+
+def _cleanup_locked(stale_after_seconds: float) -> None:
+    now = time.time()
+    stale_session_ids = [
+        session_id
+        for session_id, session in _sessions.items()
+        if stale_after_seconds > 0 and (now - session.last_seen) > stale_after_seconds
+    ]
+    for session_id in stale_session_ids:
+        del _sessions[session_id]
+
+
+def _bind_context(context_id: str, browser_session_id: str, capabilities: dict[str, Any] | None = None) -> None:
+    context = AgentContext.use(context_id) if context_id else None
+    if not context:
+        return
+    context.data[CTX_SOURCE] = SOURCE_NAME
+    context.data[CTX_BROWSER_SESSION_ID] = browser_session_id
+    context.data[CTX_CHROME_CAPABILITIES] = capabilities or {}
+
+
+def get_context_session_id(context_id: str) -> str:
+    if not context_id:
+        return ""
+    context = AgentContext.use(context_id)
+    if not context:
+        return ""
+    return str(context.data.get(CTX_BROWSER_SESSION_ID, "") or "")
+
+
+def bind_context_to_session(context_id: str, browser_session_id: str, capabilities: dict[str, Any] | None = None) -> None:
+    with _lock:
+        session = _sessions.get(browser_session_id)
+        if session:
+            session.context_id = context_id
+            if capabilities is not None:
+                session.capabilities = dict(capabilities)
+        _bind_context(context_id, browser_session_id, capabilities)
+
+
+def upsert_session(
+    browser_session_id: str,
+    *,
+    context_id: str = "",
+    active_tab_id: int | None = None,
+    tabs: list[dict[str, Any]] | None = None,
+    capabilities: dict[str, Any] | None = None,
+    stale_after_seconds: float = 600.0,
+) -> dict[str, Any]:
+    if not browser_session_id:
+        raise ValueError("browser_session_id is required")
+
+    with _lock:
+        _cleanup_locked(stale_after_seconds)
+        session = _sessions.get(browser_session_id)
+        if not session:
+            session = BrowserSession(browser_session_id=browser_session_id)
+            _sessions[browser_session_id] = session
+
+        session.last_seen = time.time()
+        if context_id:
+            session.context_id = context_id
+        if capabilities is not None:
+            session.capabilities = dict(capabilities)
+        if active_tab_id is not None:
+            session.active_tab_id = active_tab_id
+        if tabs is not None:
+            normalized_tabs = {}
+            for raw_tab in tabs:
+                tab = _normalize_tab(raw_tab)
+                if tab:
+                    normalized_tabs[tab.tab_id] = tab
+            session.tabs = normalized_tabs
+            if session.active_tab_id is None:
+                active_tabs = [tab.tab_id for tab in normalized_tabs.values() if tab.active]
+                if active_tabs:
+                    session.active_tab_id = active_tabs[0]
+
+        if session.context_id:
+            _bind_context(session.context_id, session.browser_session_id, session.capabilities)
+
+        return session.snapshot(include_commands=False)
+
+
+def list_sessions(*, stale_after_seconds: float = 600.0, include_commands: bool = False) -> list[dict[str, Any]]:
+    with _lock:
+        _cleanup_locked(stale_after_seconds)
+        sessions = [session.snapshot(include_commands=include_commands) for session in _sessions.values()]
+    sessions.sort(key=lambda item: item.get("last_seen", 0), reverse=True)
+    return sessions
+
+
+def get_session(browser_session_id: str, *, stale_after_seconds: float = 600.0, include_commands: bool = False) -> dict[str, Any] | None:
+    with _lock:
+        _cleanup_locked(stale_after_seconds)
+        session = _sessions.get(browser_session_id)
+        return session.snapshot(include_commands=include_commands) if session else None
+
+
+def get_session_or_context(browser_session_id: str = "", context_id: str = "", *, stale_after_seconds: float = 600.0) -> BrowserSession | None:
+    with _lock:
+        _cleanup_locked(stale_after_seconds)
+        if browser_session_id:
+            return _sessions.get(browser_session_id)
+        if context_id:
+            bound_session_id = get_context_session_id(context_id)
+            if bound_session_id:
+                return _sessions.get(bound_session_id)
+        return None
+
+
+def enqueue_command(
+    browser_session_id: str,
+    verb: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    target_tab_id: int | None = None,
+    timeout_seconds: float = 30.0,
+) -> dict[str, Any]:
+    with _lock:
+        session = _sessions.get(browser_session_id)
+        if not session:
+            raise KeyError(f"browser session '{browser_session_id}' is not connected")
+
+        command = BridgeCommand(
+            command_id=str(uuid.uuid4()),
+            browser_session_id=browser_session_id,
+            verb=verb,
+            payload=dict(payload or {}),
+            target_tab_id=target_tab_id,
+            timeout_seconds=timeout_seconds,
+        )
+        session.commands[command.command_id] = command
+        session.queue.append(command.command_id)
+        session.last_seen = time.time()
+        return command.to_dict()
+
+
+def pull_next_command(
+    browser_session_id: str,
+    *,
+    redelivery_seconds: float = 8.0,
+    stale_after_seconds: float = 600.0,
+) -> dict[str, Any] | None:
+    with _lock:
+        _cleanup_locked(stale_after_seconds)
+        session = _sessions.get(browser_session_id)
+        if not session:
+            return None
+
+        now = time.time()
+        for command_id in list(session.queue):
+            command = session.commands.get(command_id)
+            if not command:
+                continue
+
+            expired = (now - command.created_at) > max(command.timeout_seconds, 1)
+            if expired and command.status not in {"completed", "failed"}:
+                command.status = "failed"
+                command.completed_at = now
+                command.error = "Command timed out before the extension returned a result."
+                continue
+
+            if command.status == "queued" or (
+                command.status == "dispatched"
+                and command.dispatched_at is not None
+                and (now - command.dispatched_at) >= redelivery_seconds
+            ):
+                command.status = "dispatched"
+                command.dispatched_at = now
+                command.attempts += 1
+                session.last_seen = now
+                return command.to_dict()
+
+        return None
+
+
+def store_command_result(
+    browser_session_id: str,
+    command_id: str,
+    *,
+    status: str,
+    result: dict[str, Any] | None = None,
+    error: str = "",
+    active_tab_id: int | None = None,
+    tabs: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    with _lock:
+        session = _sessions.get(browser_session_id)
+        if not session:
+            raise KeyError(f"browser session '{browser_session_id}' is not connected")
+
+        command = session.commands.get(command_id)
+        if not command:
+            raise KeyError(f"command '{command_id}' was not found")
+
+        now = time.time()
+        command.status = status
+        command.completed_at = now
+        command.result = dict(result or {})
+        command.error = error
+        session.last_seen = now
+
+        if active_tab_id is not None:
+            session.active_tab_id = active_tab_id
+        if tabs is not None:
+            normalized_tabs = {}
+            for raw_tab in tabs:
+                tab = _normalize_tab(raw_tab)
+                if tab:
+                    normalized_tabs[tab.tab_id] = tab
+            if normalized_tabs:
+                session.tabs = normalized_tabs
+        if command_id in session.queue and command.status in {"completed", "failed"}:
+            session.queue.remove(command_id)
+
+        return command.to_dict()
+
+
+async def wait_for_command_result(
+    browser_session_id: str,
+    command_id: str,
+    *,
+    timeout_seconds: float,
+    poll_interval: float = 0.2,
+) -> dict[str, Any]:
+    started = time.time()
+    while True:
+        with _lock:
+            session = _sessions.get(browser_session_id)
+            command = session.commands.get(command_id) if session else None
+            if not session or not command:
+                raise RuntimeError("Chrome bridge command could not be found.")
+            if command.status in {"completed", "failed"}:
+                return command.to_dict()
+
+        if (time.time() - started) >= timeout_seconds:
+            with _lock:
+                session = _sessions.get(browser_session_id)
+                command = session.commands.get(command_id) if session else None
+                if command and command.status not in {"completed", "failed"}:
+                    command.status = "failed"
+                    command.completed_at = time.time()
+                    command.error = "Timed out while waiting for the Chrome extension to finish the command."
+                    if command_id in session.queue:
+                        session.queue.remove(command_id)
+                    return command.to_dict()
+            raise RuntimeError("Chrome bridge command timed out.")
+
+        await asyncio.sleep(poll_interval)

--- a/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/plugin.yaml
+++ b/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/plugin.yaml
@@ -1,0 +1,4 @@
+name: chrome_extension
+title: Chrome Extension Integration
+version: 1.0.0
+

--- a/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/prompts/agent.system.tool.chrome_bridge.md
+++ b/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/prompts/agent.system.tool.chrome_bridge.md
@@ -1,0 +1,2 @@
+Legacy fixture tool prompt.
+

--- a/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/prompts/fw.chrome.system_context.md
+++ b/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/prompts/fw.chrome.system_context.md
@@ -1,0 +1,2 @@
+Legacy fixture system context.
+

--- a/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/tools/chrome_bridge.py
+++ b/tests/fixtures/browser_bridge_cutover_v1/legacy_exact/tools/chrome_bridge.py
@@ -1,0 +1,4 @@
+class ChromeBridge:
+    def execute(self):
+        return enqueue_command()
+

--- a/tests/fixtures/context-queue-approval-v1.json
+++ b/tests/fixtures/context-queue-approval-v1.json
@@ -1,0 +1,79 @@
+{
+  "contract": "a0.browser-bridge.context-queue-approval.v1",
+  "queue_add": {
+    "native_method": "context.queue_add",
+    "connector_event": "connector_message_queue_add",
+    "params": {
+      "contract_version": 1,
+      "context_id": "context-A",
+      "client_message_id": "message-A",
+      "text": "private queue text"
+    }
+  },
+  "queue_item": {
+    "native_methods": [
+      "context.queue_remove",
+      "context.queue_send"
+    ],
+    "connector_events": [
+      "connector_message_queue_remove",
+      "connector_message_queue_send"
+    ],
+    "params": {
+      "contract_version": 1,
+      "context_id": "context-A",
+      "item_id": "queue-A"
+    }
+  },
+  "action_approval": {
+    "native_method": "browser.approval_decision",
+    "connector_event": "connector_browser_approval_decision",
+    "params": {
+      "contract_version": 1,
+      "challenge_id": "challenge-A",
+      "kind": "action",
+      "decision": "approve_once"
+    },
+    "result": {
+      "contract_version": 1,
+      "challenge_id": "challenge-A",
+      "decision": "approved",
+      "control_id": "control-A",
+      "status": "accepted"
+    }
+  },
+  "site_approval": {
+    "native_method": "browser.approval_decision",
+    "connector_event": "connector_browser_approval_decision",
+    "params": {
+      "contract_version": 1,
+      "challenge_id": "challenge-A",
+      "kind": "site",
+      "decision": "allow_once"
+    },
+    "result": {
+      "contract_version": 1,
+      "challenge_id": "challenge-A",
+      "decision": "allow_once",
+      "control_id": "control-A",
+      "status": "accepted",
+      "expires_at_ms": 1800000000000
+    }
+  },
+  "queue_notification": {
+    "native_method": "context.queue_updated",
+    "connector_event": "connector_message_queue_updated",
+    "params": {
+      "contract_version": 1,
+      "context_id": "context-A",
+      "message_queue": [
+        {
+          "id": "queue-A",
+          "text": "Preview",
+          "attachments": [],
+          "attachment_count": 0
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/credential-control-v1.json
+++ b/tests/fixtures/credential-control-v1.json
@@ -1,0 +1,16 @@
+{
+  "contract_version": 1,
+  "native_params": { "contract_version": 1 },
+  "rotate": {
+    "request": { "contract_version": 1, "action": "rotate", "rotation_id": "rotation-1", "public_key": { "algorithm": "Ed25519", "encoding": "raw-base64url", "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" } },
+    "response": { "contract_version": 1, "action": "rotate", "rotation_id": "rotation-1", "key_generation": 1, "status": "pending", "expires_at_ms": 1000 }
+  },
+  "status": {
+    "request": { "contract_version": 1, "action": "status", "rotation_id": "rotation-1" },
+    "response": { "contract_version": 1, "action": "status", "rotation_id": "rotation-1", "key_generation": 2, "status": "active", "expires_at_ms": null }
+  },
+  "revoke": {
+    "request": { "contract_version": 1, "action": "revoke" },
+    "response": { "contract_version": 1, "action": "revoke", "rotation_id": null, "key_generation": 2, "status": "revoked", "expires_at_ms": null }
+  }
+}

--- a/tests/test_browser_agent_regressions.py
+++ b/tests/test_browser_agent_regressions.py
@@ -4930,3 +4930,34 @@ def test_legacy_browser_dependency_is_removed():
     assert ("browser" + "-use") not in (PROJECT_ROOT / "requirements.txt").read_text(
         encoding="utf-8"
     )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("code", ["ORIGIN_BLOCKED", "APPROVAL_REQUIRED", "APPROVAL_DENIED", "APPROVAL_EXPIRED"])
+async def test_extension_permission_failure_does_not_suggest_tool_workaround(monkeypatch, code):
+    class DeniedRuntime:
+        async def call(self, *_args, **_kwargs):
+            raise browser_tool_module.ExtensionBrowserError(code)
+
+    async def get_denied_runtime(*_args, **_kwargs):
+        return DeniedRuntime()
+
+    monkeypatch.setattr(browser_tool_module, "get_runtime", get_denied_runtime)
+    monkeypatch.setattr(browser_tool_module, "activate_browser_model", lambda _agent: None)
+    tool = browser_tool_module.Browser(
+        agent=SimpleNamespace(context=SimpleNamespace(id="ctx")), name="browser",
+        method=None, args={}, message="", loop_data=None,
+    )
+    result = await tool.execute(action="open", url="https://example.com/private-query")
+    assert code in result.message
+    assert "do not bypass it" in result.message
+    assert "Do not retry a denied request" in result.message
+    assert "private-query" not in result.message
+    assert result.break_loop is False  # Let the agent explain the blocker.
+
+
+def test_extension_prompt_requires_site_consent_without_alternate_tool_bypass():
+    prompt = (PROJECT_ROOT / "plugins/_browser/prompts/agent.system.tool.browser.md").read_text()
+    assert "never work around it" in prompt
+    assert "browser permission failure is not authorization to switch tools" in prompt
+    assert "Chrome extension does not need remote debugging" in prompt

--- a/tests/test_browser_approval_inbox_webui.py
+++ b/tests/test_browser_approval_inbox_webui.py
@@ -1,0 +1,183 @@
+import shutil
+import pytest
+from pathlib import Path
+from browser_bridge_test_support import run_model
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+WEBUI = ROOT / "plugins/_browser/webui"
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="Node required")
+@pytest.mark.parametrize("lane", ["site", "action"])
+def test_pending_consent_survives_failed_poll_disabled_until_revalidated(lane):
+    action = lane == "action"
+    factory = "createActionRequestsModel" if action else "createSiteRequestsModel"
+    contract = "approval" if action else "site-authority"
+    script = f'''
+import assert from "node:assert/strict";
+const base={{contract:"a0.browser-bridge.{contract}.v1",{('approval_version' if action else 'authority_version')}:1,browser_control_ready:false}};
+const request={{challenge_id:"request-1",origin:"https://example.com",expires_at_ms:2000,
+ action_class:"{'unknown' if action else 'navigate'}",summary:"Do not render",{('action:"click",' if action else '')}
+ options:{'["decline","approve_once"]' if action else '["deny","allow_once","allow_turn"]'}}};
+let failed=false,empty=true,time=1000,chat="chat-1";const calls=[];
+const model={factory}({{selection:()=>{'({contextId:chat})' if action else 'chat'},now:()=>time,schedule:()=>1,unschedule:()=>{{}},
+ api:async(endpoint,body)=>{{calls.push(body);if(failed)throw Error("offline");return {{...base,challenges:empty?[]:[request]}};}}}});
+await model.mount();assert.equal(model.visibleRequests().length,0);
+empty=false;await model.refresh();assert.equal(model.canDecide(model.requests[0]),true);
+failed=true;await model.refresh();assert.equal(model.visibleRequests().length,1);
+assert.equal(model.canDecide(model.requests[0]),false);
+const count=calls.length;await model.decide(model.requests[0],"{'approve_once' if action else 'allow_once'}");assert.equal(calls.length,count);
+chat="chat-2";assert.equal(model.visibleRequests().length,0);assert.equal(model.unavailableHere(),false);
+chat="chat-1";time=2001;assert.equal(model.visibleRequests().length,0);
+time=1000;failed=false;await model.refresh();assert.equal(model.canDecide(model.requests[0]),true);
+empty=true;await model.refresh();assert.equal(model.visibleRequests().length,0);model.cleanup();
+'''
+    run_model("browser-action-requests-store.js" if action else "browser-site-requests-store.js", script)
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="Node required")
+def test_one_notification_without_composer_recovery_for_both_lanes():
+    run_model("browser-approval-inbox-store.js", r'''
+import assert from "node:assert/strict";
+let failed=false,chat="chat-1",refreshes=0;const notices=[];
+const stores=Array.from({length:2},()=>({active:true,unavailableHere:()=>failed,refresh:async()=>{refreshes++;}}));
+const model=createApprovalInboxModel({stores:()=>stores,selection:()=>chat,notify:message=>notices.push(message)});
+model.observe();assert.equal(model.unavailable(),false);assert.equal(notices.length,0);
+failed=true;model.observe();model.observe();assert.equal(notices.length,1);
+assert.equal(model.retry,undefined);assert.equal(refreshes,0);model.observe();assert.equal(notices.length,1);
+assert.match(notices[0],/check again automatically/);assert.doesNotMatch(notices[0],/Use Check|try again/);
+chat="chat-2";model.observe();assert.equal(notices.length,2);
+failed=false;model.observe();failed=true;model.observe();assert.equal(notices.length,3);
+stores.forEach(store=>store.active=false);assert.equal(model.unavailable(),false);
+''')
+    for name in ["browser-site-requests.html", "browser-action-requests.html"]:
+        template = (WEBUI / name).read_text()
+        assert "unavailableHere()" not in template
+        assert "visibleRequests().length" in template
+        assert "x-cloak" in template
+        assert "canDecide(request)" in template
+    composer = (ROOT / "plugins/_browser/extensions/webui/chat-input-start/browser-approvals.html").read_text()
+    assert "browserApprovalInbox.retry()" not in composer
+    assert "browser-approval-recovery" not in composer
+    assert "Check browser requests" not in composer
+    coordinator = (WEBUI / "browser-approval-inbox-store.js").read_text()
+    assert "notifications.addOrUpdateNotification(" in coordinator
+    assert "notifications.updateUnreadCount()" in coordinator
+    assert "notifications.frontendNotification(" not in coordinator
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="Node required")
+def test_action_ui_sends_only_explicit_choice_and_never_retries_uncertainty():
+    script = r'''
+import assert from "node:assert/strict";
+const base={contract:"a0.browser-bridge.approval.v1",approval_version:1,browser_control_ready:false};
+const challenge={challenge_id:"action-1",action:"click",origin:"https://example.com",action_class:"unknown",options:["decline","approve_once"],expires_at_ms:2000,summary:"Do not render <script>"};
+const calls=[],timers=new Map();let time=1000,next=0,uncertain=false,pending=null;
+let selected={contextId:"context-1"};
+const model=createActionRequestsModel({selection:()=>selected,now:()=>time,schedule:fn=>{timers.set(++next,fn);return next;},unschedule:id=>timers.delete(id),api:async(_endpoint,body)=>{
+  calls.push(body);
+  if(body.action==="list")return {...base,challenges:[challenge]};
+  if(uncertain)throw new Error("unknown response");
+  return {...base,challenge_id:body.challenge_id,decision:body.choice==="approve_once"?"approved":"declined",control_id:"control-1",status:"accepted"};
+}});
+await model.mount();assert.equal(model.requests[0].summary,undefined);
+assert.deepEqual(calls[0],{action:"list",context_id:"context-1"});
+selected={...selected,contextId:"other-context"};assert.equal(model.visibleRequests().length,0);assert.equal(model.canDecide(model.requests[0]),false);
+selected={contextId:"context-1"};
+await model.decide(model.requests[0],"approve_once");
+assert.deepEqual(calls.at(-1),{challenge_id:"action-1",choice:"approve_once"});assert.equal(model.requests.length,0);
+assert.match(model.visibleNotice(),/Approval recorded/);
+time=3999;assert.notEqual(model.visibleNotice(),"");time=4000;assert.equal(model.visibleNotice(),"");time=1000;
+await model.refresh();time=2001;const count=calls.length;
+await model.decide(model.requests[0],"approve_once");assert.equal(calls.length,count);
+time=1000;await model.refresh();uncertain=true;await model.decide(model.requests[0],"decline");
+assert.equal(model.decisionUnconfirmed,true);assert.equal(model.requests.length,0);
+assert.equal(model.hasUnconfirmedDecision(),true);selected={contextId:"context-2"};assert.equal(model.visibleNotice(),"");assert.equal(model.hasUnconfirmedDecision(),false);selected={contextId:"context-1"};assert.equal(model.hasUnconfirmedDecision(),true);
+time=2001;assert.equal(model.visibleNotice(),"");assert.equal(model.hasUnconfirmedDecision(),false);time=1000;
+// The expiry check legitimately pruned the quarantine; create a new uncertain
+// decision to keep exercising no-replay through refresh and close/reopen.
+await model.refresh();await model.decide(model.requests[0],"decline");
+const mutations=calls.filter(body=>body.choice).length;
+await model.refresh();assert.equal(calls.filter(body=>body.choice).length,mutations);
+assert.equal(model.visibleRequests().length,0);assert.equal(model.canDecide(model.requests[0]),false);
+await model.decide(model.requests[0],"approve_once");assert.equal(calls.filter(body=>body.choice).length,mutations);
+model.cleanup();assert.equal(timers.size,0);assert.equal(model.notice,"");
+await model.mount();assert.equal(model.visibleRequests().length,0);assert.equal(model.canDecide(model.requests[0]),false);model.cleanup();
+const late=createActionRequestsModel({selection:()=>selected,schedule:()=>1,unschedule:()=>{},api:()=>new Promise(resolve=>pending=resolve)});
+const mounted=late.mount();late.cleanup();pending({...base,challenges:[challenge]});await mounted;
+assert.equal(late.requests.length,0);assert.equal(late.loading,false);
+const typing=createActionRequestsModel({selection:()=>selected,now:()=>1000,schedule:()=>1,unschedule:()=>{},api:async()=>({...base,challenges:[{...challenge,action:"type",action_class:"sensitive_input",text:"never display",data_classification:{text_sha256:"secret"}}]})});
+await typing.mount();assert.equal(typing.requests[0].action,"type");assert.equal(typing.requests[0].text,undefined);assert.equal(typing.requests[0].data_classification,undefined);typing.cleanup();
+const upload=createActionRequestsModel({selection:()=>selected,now:()=>1000,schedule:()=>1,unschedule:()=>{},api:async()=>({...base,challenges:[{...challenge,action:"upload_file",action_class:"external_side_effect",path:"/never/project",artifact_id:"never-project"}]})});
+await upload.mount();assert.equal(upload.requests[0].action,"upload_file");assert.equal(upload.requests[0].path,undefined);assert.equal(upload.requests[0].artifact_id,undefined);upload.cleanup();
+'''
+    run_model("browser-action-requests-store.js", script)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_site_prompt_keeps_scope_explicit_and_secondary_choices_disclosed():
+    html = (ROOT / "plugins/_browser/webui/browser-site-requests.html").read_text()
+    main, details = html.split('<details class="browser-site-request-options">', 1)
+    assert 'x-text="request.origin"' in main
+    assert "Remember for future chats." in main
+    assert "Always allow site" in main and "Deny</button>" in main
+    assert '<summary>More options</summary>' in details
+    assert "Allow once" in details and "Allow this turn" in details
+    assert "consequential actions need separate approval" in details
+    assert 'class="button confirm"' in main
+    assert "Check status" in details and "Refresh requests" not in html
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="Node required")
+def test_site_requests_are_decision_only_expiring_and_fenced_after_cleanup():
+    script = r'''
+import assert from "node:assert/strict";
+const contract="a0.browser-bridge.site-authority.v1";
+const responseBase={contract,authority_version:1,browser_control_ready:false};
+const challenge={challenge_id:"challenge-1",origin:"https://next.example",action_class:"navigate",summary:"Never render this <img>",options:["deny","allow_once","allow_turn"],expires_at_ms:2000};
+assert.equal(parseRequests({...responseBase,challenges:[{...challenge,action_class:"open",options:firstOpenDecisions}]},"context-1",PRODUCTION_PROFILE)[0].canRemember,true);
+assert.throws(()=>parseRequests({...responseBase,challenges:[{...challenge,options:firstOpenDecisions}]},"context-1",PRODUCTION_PROFILE));
+assert.throws(()=>parseRequests({...responseBase,contract:"a0.browser-bridge.development-site-authority.v1",challenges:[challenge]},"context-1",PRODUCTION_PROFILE), /Invalid site authority/);
+const calls=[],timers=new Map(); let time=1000, next=0, pending=null, defer=false;
+let selectedContext="context-1";
+const model=createSiteRequestsModel({selection:()=>selectedContext,now:()=>time,schedule:(fn)=>{timers.set(++next,fn);return next;},unschedule:id=>timers.delete(id),api:async(endpoint,body)=>{
+  calls.push(body);
+  if(defer) return await new Promise(resolve=>{pending=resolve;});
+  if(body.action==="list") return {...responseBase,challenges:[challenge]};
+  return {...responseBase,challenge_id:body.challenge_id,decision:body.decision,control_id:"control-1",status:"accepted",expires_at_ms:2000};
+}});
+await model.mount();
+assert.equal(model.requests[0].origin,"https://next.example");
+assert.equal(model.requests[0].summary,undefined);
+assert.deepEqual(calls[0],{action:"list",context_id:"context-1"});
+selectedContext="context-2";assert.equal(model.visibleRequests().length,0);assert.equal(model.canDecide(model.requests[0]),false);selectedContext="context-1";
+assert.equal(timers.size,1);
+await model.decide(model.requests[0],"allow_once");
+assert.deepEqual(calls.at(-1),{action:"decide",challenge_id:"challenge-1",decision:"allow_once"});
+assert.equal(model.requests.length,0);
+assert.notEqual(model.visibleNotice(),"");selectedContext="context-2";assert.equal(model.visibleNotice(),"");selectedContext="context-1";
+await model.refresh();time=2001;
+assert.equal(model.visibleNotice(),"");assert.equal(model.hasUnconfirmedDecision(),false);
+const count=calls.length;await model.decide(model.requests[0],"allow_turn");assert.equal(calls.length,count);
+time=1000;defer=true;
+const old=model.refresh();model.cleanup();pending({...responseBase,challenges:[challenge]});await old;
+assert.deepEqual(model.requests,[]);assert.equal(timers.size,0);assert.equal(model.loading,false);
+defer=false;await model.mount();
+defer=true;const decision=model.decide(model.requests[0],"deny");model.cleanup();
+pending({...responseBase,challenge_id:"challenge-1",decision:"deny",control_id:"control-2",status:"accepted",expires_at_ms:2000});await decision;
+assert.equal(model.notice,"");assert.equal(model.busyId,"");assert.equal(timers.size,0);
+defer=false;time=1000;challenge.action_class="open";challenge.options=firstOpenDecisions;challenge.expires_at_ms=120000;
+await model.mount();await model.decide(model.requests[0],"allow_site");
+assert.equal(calls.at(-1).decision,"allow_site");assert.equal(model.noticeExpires,4000);
+time=4001;assert.equal(model.visibleNotice(),"");
+await model.refresh();const savedApi=model.noticeExpires;
+defer=true;const uncertain=model.decide(model.requests[0],"allow_site");pending({});await uncertain;
+assert.equal(model.decisionUnconfirmed,true);assert.equal(model.noticeExpires,120000);
+model.cleanup();
+'''
+    run_model("browser-site-requests-store.js", script)

--- a/tests/test_browser_bridge_action_authority.py
+++ b/tests/test_browser_bridge_action_authority.py
@@ -1,0 +1,860 @@
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from dataclasses import replace
+import hashlib
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_action_authority import (
+    ACTION_AUTHORITY_CONTRACT,
+    ActionDocumentBinding,
+    BrowserBridgeActionAuthority,
+    BrowserBridgeActionAuthorityUnavailable,
+)
+from plugins._a0_connector.helpers.browser_bridge_approval import (
+    BrowserActionDataClassification,
+    BrowserBridgeApprovalRepository,
+    NO_ACTION_DATA_CLASSIFICATION,
+)
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    BrowserBridgeContextRoute,
+)
+from plugins._a0_connector.helpers.browser_bridge_events import (
+    BROWSER_EVENT,
+    BROWSER_EVENT_ACK,
+    RESTRICTED_HANDLER_ID,
+    ActionChallengeNotice,
+    BrowserBridgeCriticalEventReceiver,
+    TYPE_CHALLENGE_SUMMARY,
+    UPLOAD_CHALLENGE_SUMMARY,
+)
+from plugins._a0_connector.helpers.browser_bridge_operations import (
+    CONTROL_EVENT,
+    BridgeAuthorization,
+    BrokerCompletion,
+    BrowserBridgeBrokerError,
+    BrowserBridgeOperationBroker,
+    ControlBinding,
+    ControlTicket,
+    OperationBinding,
+    OperationTicket,
+)
+
+
+NOW_MS = 1_788_492_400_000
+ORIGIN = "https://example.com"
+LEASE_ID = "lease-A"
+TAB_HANDLE = "tab-A"
+DOCUMENT_ID = "document-A"
+REF = "a0t1.generation-A.tab-A.1"
+TYPE_TEXT = "sensitive café text"
+TYPE_TEXT_SHA256 = hashlib.sha256(TYPE_TEXT.encode("utf-8")).hexdigest()
+
+
+def _principal() -> WsPrincipal:
+    return WsPrincipal(
+        principal_type="browser_bridge",
+        principal_id="bridge-A",
+        subject_id="single_user",
+        scopes=frozenset(
+            {"browser.operate", "browser.control", "browser.approval"}
+        ),
+        handler_path="plugins/_a0_connector/ws_connector",
+        handler_id=RESTRICTED_HANDLER_ID,
+        inbound_events=frozenset({BROWSER_EVENT}),
+        outbound_events=frozenset(
+            {BROWSER_EVENT_ACK, "connector_browser_op", CONTROL_EVENT}
+        ),
+        key_generation=3,
+    )
+
+
+def _operation(
+    loop: asyncio.AbstractEventLoop,
+    principal: WsPrincipal,
+    *,
+    action: str = "click",
+) -> OperationTicket:
+    binding = OperationBinding(
+        principal=principal,
+        connector_sid="sid-A",
+        load_generation_id="generation-A",
+        context_id="context-A",
+        browser_session_id="browser-session-A",
+        turn_id="turn-A",
+        action_id="action-A",
+        op_id="op-A",
+    )
+    expected_action_class = (
+        "sensitive_input" if action == "type" else "unknown"
+    )
+    args = {
+        "ref": REF,
+        **(
+            {"text": TYPE_TEXT, "text_sha256": TYPE_TEXT_SHA256}
+            if action == "type"
+            else {}
+        ),
+        "expected_action_class": expected_action_class,
+    }
+    display = {"cursor": True, "foreground": False}
+    canonical = {
+        "action": action,
+        "target": {"tabHandle": TAB_HANDLE},
+        "context_id": binding.context_id,
+        "browser_session_id": binding.browser_session_id,
+        "turn_id": binding.turn_id,
+        "args": args,
+        "display": display,
+    }
+    parameter_hash = hashlib.sha256(
+        json.dumps(
+            canonical,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+    return OperationTicket(
+        binding=binding,
+        deadline_ms=NOW_MS + 90_000,
+        effect="mutating",
+        _future=loop.create_future(),
+        action=action,
+        target_tab_handle=TAB_HANDLE,
+        target_ref=REF,
+        expected_action_class=expected_action_class,
+        text_sha256=TYPE_TEXT_SHA256 if action == "type" else None,
+        canonical_parameter_hash=parameter_hash,
+    )
+
+
+def _notice(operation: OperationTicket, **changes: Any) -> ActionChallengeNotice:
+    values = {
+        "principal": operation.binding.principal,
+        "connector_sid": operation.binding.connector_sid,
+        "load_generation_id": operation.binding.load_generation_id,
+        "context_id": operation.binding.context_id,
+        "browser_session_id": operation.binding.browser_session_id,
+        "turn_id": operation.binding.turn_id,
+        "action_id": operation.binding.action_id,
+        "op_id": operation.binding.op_id,
+        "challenge_id": "challenge-A",
+        "origin": ORIGIN,
+        "action_class": operation.expected_action_class,
+        "canonical_parameter_hash": operation.canonical_parameter_hash,
+        "target_fingerprint": "b" * 64,
+        "lease_id_digest": hashlib.sha256(LEASE_ID.encode()).hexdigest(),
+        "browser_id_digest": hashlib.sha256(TAB_HANDLE.encode()).hexdigest(),
+        "document_id": DOCUMENT_ID,
+        "document_epoch": 1,
+        "summary": (
+            TYPE_CHALLENGE_SUMMARY
+            if operation.action == "type"
+            else "Untrusted extension wording is never shown."
+        ),
+        "data_classification": (
+            BrowserActionDataClassification(
+                "text", "sensitive", operation.text_sha256
+            )
+            if operation.action == "type"
+            else NO_ACTION_DATA_CLASSIFICATION
+        ),
+        "expires_at_ms": NOW_MS + 60_000,
+    }
+    values.update(changes)
+    return ActionChallengeNotice(**values)
+
+
+class _Harness:
+    def __init__(self, operation: OperationTicket) -> None:
+        self.operation = operation
+        self.selection_allowed = True
+        self.operations = {operation.binding.op_id: operation}
+        self.lease = SimpleNamespace(
+            binding=operation.binding,
+            lease_id=LEASE_ID,
+            tab_handle=TAB_HANDLE,
+            origin=ORIGIN,
+        )
+        self.document = ActionDocumentBinding(DOCUMENT_ID, 1, frozenset({REF}))
+        self.current_route = BrowserBridgeContextRoute(
+            operation.binding.principal,
+            operation.binding.connector_sid,
+            operation.binding.load_generation_id,
+        )
+        self.resolutions: list[dict[str, Any]] = []
+        self.control_ids = iter(("control-A", "control-B"))
+        self.grant_ids = iter(("grant-A", "grant-B"))
+        self.approvals = BrowserBridgeApprovalRepository(
+            route_authorizer=lambda route: self.authority.approval_route_current(
+                route
+            ),
+            active_record_loader=self.active_record,
+            server_instance_id_loader=lambda: "server-A",
+            clock_ms=lambda: NOW_MS,
+            receipt_id_factory=lambda: "receipt-A",
+        )
+        self.authority = BrowserBridgeActionAuthority(
+            current_operation=self.current_operation,
+            remaining_operation_ms=lambda _operation: 90_000,
+            lease_for=self.lease_for,
+            document_for=self.document_for,
+            route_verifier=self.route_verifier,
+            turn_current=lambda binding: self.current_operation(
+                principal=binding.principal,
+                connector_sid=binding.connector_sid,
+                load_generation_id=binding.load_generation_id,
+                op_id=binding.op_id,
+            )
+            is operation,
+            selection_current=self.selection_current,
+            begin_resolution=self.begin_resolution,
+            wait_control=self.wait_control,
+            server_instance_id=lambda: "server-A",
+            approval_repository=self.approvals,
+            clock_ms=lambda: NOW_MS,
+            control_id_factory=lambda: next(self.control_ids),
+            grant_id_factory=lambda: next(self.grant_ids),
+        )
+
+    def selection_current(self, context_id: str, bridge_id: str) -> bool:
+        return bool(
+            self.selection_allowed
+            and context_id == self.operation.binding.context_id
+            and bridge_id == self.operation.binding.bridge_id
+        )
+
+    def active_record(self, server_id: str, bridge_id: str) -> dict[str, Any] | None:
+        principal = self.operation.binding.principal
+        if server_id != "server-A" or bridge_id != principal.principal_id:
+            return None
+        return {
+            "state": "active",
+            "server_instance_id": server_id,
+            "bridge_id": bridge_id,
+            "subject_id": principal.subject_id,
+            "key_generation": principal.key_generation,
+            "scopes": sorted(principal.scopes),
+        }
+
+    def current_operation(self, **kwargs: Any) -> OperationTicket | None:
+        operation = self.operations.get(kwargs["op_id"])
+        if operation is None:
+            return None
+        binding = operation.binding
+        return operation if (
+            binding.principal is kwargs["principal"]
+            and binding.connector_sid == kwargs["connector_sid"]
+            and binding.load_generation_id == kwargs["load_generation_id"]
+        ) else None
+
+    def lease_for(self, binding: OperationBinding, handle: str) -> Any | None:
+        return self.lease if (
+            binding is self.operation.binding and handle == TAB_HANDLE
+        ) else None
+
+    def document_for(
+        self, binding: OperationBinding, handle: str
+    ) -> ActionDocumentBinding | None:
+        return self.document if (
+            binding is self.operation.binding and handle == TAB_HANDLE
+        ) else None
+
+    def route_verifier(self, route: BrowserBridgeContextRoute) -> bool:
+        return (
+            route.principal is self.current_route.principal
+            and route.connector_sid == self.current_route.connector_sid
+            and route.load_generation_id == self.current_route.load_generation_id
+        )
+
+    async def begin_resolution(
+        self, operation: OperationTicket, **kwargs: Any
+    ) -> ControlTicket:
+        assert operation is self.operation
+        assert self.approvals.pending_receipt_count == 0
+        assert kwargs["authorization_current"]() is True
+        self.resolutions.append(deepcopy(kwargs))
+        binding = operation.binding
+        return ControlTicket(
+            binding=ControlBinding(
+                binding.principal,
+                binding.connector_sid,
+                binding.load_generation_id,
+                binding.context_id,
+                binding.browser_session_id,
+                binding.turn_id,
+                kwargs["control_id"],
+                "browser.resolve_challenge",
+                binding.op_id,
+                binding.action_id,
+            ),
+            deadline_ms=NOW_MS + kwargs["timeout_ms"],
+            _future=asyncio.get_running_loop().create_future(),
+        )
+
+    async def wait_control(self, ticket: ControlTicket) -> BrokerCompletion:
+        resolution = self.resolutions[-1]["resolution"]
+        return BrokerCompletion(
+            ok=True,
+            result={
+                "contract_version": 1,
+                "control_id": ticket.binding.control_id,
+                "challenge_id": resolution["challenge_id"],
+                "status": "resolved",
+                "decision": resolution["decision"],
+            },
+        )
+
+
+def test_exact_action_challenge_and_receipt_are_bound_once() -> None:
+    async def scenario() -> None:
+        operation = _operation(asyncio.get_running_loop(), _principal())
+        harness = _Harness(operation)
+        assert harness.authority.ready_for(operation.binding) is True
+        challenge = harness.authority.register_challenge(_notice(operation))
+        assert challenge.as_public_dict() == {
+            "challenge_id": "challenge-A",
+            "action": "click",
+            "origin": ORIGIN,
+            "action_class": "unknown",
+            "options": ["decline", "approve_once"],
+            "expires_at_ms": NOW_MS + 60_000,
+        }
+        assert harness.authority.list_pending(
+            subject_id="single_user",
+            context_id="context-A",
+            bridge_id="bridge-A",
+        ) == (challenge.as_public_dict(),)
+        assert harness.authority.list_pending(
+            subject_id="single_user",
+            context_id="context-B",
+            bridge_id="bridge-A",
+        ) == ()
+        decision = await harness.authority.decide(
+            subject_id="single_user",
+            challenge_id="challenge-A",
+            choice="approve_once",
+        )
+        assert decision.as_public_dict() == {
+            "challenge_id": "challenge-A",
+            "decision": "approved",
+            "control_id": "control-A",
+            "status": "accepted",
+        }
+        assert harness.approvals.pending_receipt_count == 1
+        replay = await harness.authority.decide(
+            subject_id="single_user",
+            challenge_id="challenge-A",
+            choice="approve_once",
+        )
+        assert replay is decision
+        with pytest.raises(BrowserBridgeActionAuthorityUnavailable):
+            await harness.authority.decide(
+                subject_id="single_user",
+                challenge_id="challenge-A",
+                choice="decline",
+            )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert harness.approvals.pending_receipt_count == 0
+        resolution = harness.resolutions[0]["resolution"]
+        assert resolution == {
+            "challenge_id": "challenge-A",
+            "tab_handle": TAB_HANDLE,
+            "document_id": DOCUMENT_ID,
+            "document_epoch": 1,
+            "canonical_parameter_hash": operation.canonical_parameter_hash,
+            "target_fingerprint": "b" * 64,
+            "origin": ORIGIN,
+            "action_class": "unknown",
+            "data_classification": "none",
+            "decision": "approve_once",
+            "grant": {
+                "action_grant_id": "grant-A",
+                "scope": "operation",
+                "origin": ORIGIN,
+                "action_class": "unknown",
+                "canonical_parameter_hash": operation.canonical_parameter_hash,
+                "target_fingerprint": "b" * 64,
+                "data_classification": "none",
+                "expires_at_ms": NOW_MS + 60_000,
+            },
+        }
+        await harness.authority.close()
+
+    asyncio.run(scenario())
+
+
+def test_upload_challenge_requires_fixed_warning_and_exact_artifact_parameter_hash() -> None:
+    from plugins._a0_connector.helpers.browser_bridge_operations import _operation_parameter_hash
+
+    async def scenario() -> None:
+        operation = replace(_operation(asyncio.get_running_loop(), _principal()),
+                            action="upload_file", expected_action_class="external_side_effect")
+        args = {"ref": REF, "expected_action_class": "external_side_effect", "artifact_id": "input-A",
+                "mime_type": "text/plain", "byte_count": 3, "sha256": "sha256:" + "a" * 64}
+        digest = _operation_parameter_hash(operation.binding, "upload_file", {"tab_handle": TAB_HANDLE}, args,
+                                           {"cursor": True, "foreground": False})
+        assert digest is not None
+        assert _operation_parameter_hash(operation.binding, "upload_file", {"tab_handle": TAB_HANDLE},
+                                         {**args, "path": "/private/secret"}, {}) is None
+        changed = _operation_parameter_hash(operation.binding, "upload_file", {"tab_handle": TAB_HANDLE},
+                                             {**args, "sha256": "sha256:" + "b" * 64}, {"cursor": True, "foreground": False})
+        assert changed != digest
+        operation = replace(operation, canonical_parameter_hash=digest)
+        harness = _Harness(operation)
+        with pytest.raises(BrowserBridgeActionAuthorityUnavailable):
+            harness.authority.register_challenge(_notice(operation))
+        challenge = harness.authority.register_challenge(_notice(operation, summary=UPLOAD_CHALLENGE_SUMMARY))
+        assert challenge.as_public_dict()["action"] == "upload_file"
+        assert challenge.data_classification == NO_ACTION_DATA_CLASSIFICATION
+        await harness.authority.decide(subject_id="single_user", challenge_id="challenge-A", choice="approve_once")
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        resolution = harness.resolutions[0]["resolution"]
+        assert resolution["action_class"] == "external_side_effect"
+        assert resolution["data_classification"] == "none"
+        assert resolution["canonical_parameter_hash"] == digest
+        await harness.authority.close()
+
+    asyncio.run(scenario())
+
+
+def test_type_challenge_binds_tagged_digest_without_retaining_text() -> None:
+    async def scenario() -> None:
+        operation = _operation(
+            asyncio.get_running_loop(), _principal(), action="type"
+        )
+        harness = _Harness(operation)
+        wrong = BrowserActionDataClassification(
+            "text", "sensitive", "c" * 64
+        )
+        with pytest.raises(BrowserBridgeActionAuthorityUnavailable):
+            harness.authority.register_challenge(
+                _notice(operation, data_classification=wrong)
+            )
+        challenge = harness.authority.register_challenge(_notice(operation))
+        assert challenge.as_public_dict() == {
+            "challenge_id": "challenge-A",
+            "action": "type",
+            "origin": ORIGIN,
+            "action_class": "sensitive_input",
+            "options": ["decline", "approve_once"],
+            "expires_at_ms": NOW_MS + 60_000,
+        }
+        assert challenge.data_classification.as_wire_value() == {
+            "kind": "text",
+            "sensitivity": "sensitive",
+            "text_sha256": TYPE_TEXT_SHA256,
+        }
+        assert TYPE_TEXT not in repr(operation)
+        assert TYPE_TEXT not in repr(challenge)
+        await harness.authority.decide(
+            subject_id="single_user",
+            challenge_id="challenge-A",
+            choice="approve_once",
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        resolution = harness.resolutions[0]["resolution"]
+        assert resolution["data_classification"] == {
+            "kind": "text",
+            "sensitivity": "sensitive",
+            "text_sha256": TYPE_TEXT_SHA256,
+        }
+        assert resolution["grant"]["data_classification"] == (
+            resolution["data_classification"]
+        )
+        assert TYPE_TEXT not in json.dumps(resolution, sort_keys=True)
+        await harness.authority.close()
+
+    asyncio.run(scenario())
+
+
+def test_action_registration_rechecks_document_ref_lease_and_hash() -> None:
+    async def scenario() -> None:
+        operation = _operation(asyncio.get_running_loop(), _principal())
+        harness = _Harness(operation)
+        harness.document = ActionDocumentBinding(
+            DOCUMENT_ID, 1, frozenset({"different-ref"})
+        )
+        with pytest.raises(BrowserBridgeActionAuthorityUnavailable):
+            harness.authority.register_challenge(_notice(operation))
+        harness.document = ActionDocumentBinding(DOCUMENT_ID, 1, frozenset({REF}))
+        with pytest.raises(BrowserBridgeActionAuthorityUnavailable):
+            harness.authority.register_challenge(
+                _notice(operation, canonical_parameter_hash="c" * 64)
+            )
+        harness.lease.origin = "https://different.example"
+        with pytest.raises(BrowserBridgeActionAuthorityUnavailable):
+            harness.authority.register_challenge(_notice(operation))
+        await harness.authority.close()
+
+    asyncio.run(scenario())
+
+
+def test_action_decision_is_withdrawn_when_server_selection_changes() -> None:
+    async def scenario() -> None:
+        operation = _operation(asyncio.get_running_loop(), _principal())
+        harness = _Harness(operation)
+        harness.authority.register_challenge(_notice(operation))
+        harness.selection_allowed = False
+        with pytest.raises(BrowserBridgeActionAuthorityUnavailable):
+            await harness.authority.decide(
+                subject_id="single_user",
+                challenge_id="challenge-A",
+                choice="approve_once",
+            )
+        assert harness.resolutions == []
+        await harness.authority.close()
+
+        queued = _Harness(
+            _operation(asyncio.get_running_loop(), _principal())
+        )
+        queued.authority.register_challenge(_notice(queued.operation))
+        await queued.authority.decide(
+            subject_id="single_user",
+            challenge_id="challenge-A",
+            choice="approve_once",
+        )
+        queued.selection_allowed = False
+        await asyncio.sleep(0)
+        assert queued.resolutions == []
+        with pytest.raises(BrowserBridgeActionAuthorityUnavailable):
+            await queued.authority.decide(
+                subject_id="single_user",
+                challenge_id="challenge-A",
+                choice="approve_once",
+            )
+        await queued.authority.close()
+
+    asyncio.run(scenario())
+
+
+class _Manager:
+    def __init__(self) -> None:
+        self.emits: list[tuple[Any, ...]] = []
+
+    async def emit_to(self, *args: Any, **kwargs: Any) -> None:
+        self.emits.append((*args, kwargs))
+
+
+def _event(notice: ActionChallengeNotice) -> dict[str, Any]:
+    return {
+        "contract_version": 1,
+        "event_id": "event-A",
+        "load_generation_id": notice.load_generation_id,
+        "event_sequence": 1,
+        "delivery": "critical",
+        "event_type": "challenge.required",
+        "observed_at_ms": NOW_MS,
+        "context_id": notice.context_id,
+        "browser_session_id": notice.browser_session_id,
+        "turn_id": notice.turn_id,
+        "op_id": notice.op_id,
+        "action_id": notice.action_id,
+        "data": {
+            "challenge_id": notice.challenge_id,
+            "kind": "action",
+            "origin": notice.origin,
+            "action_class": notice.action_class,
+            "canonical_parameter_hash": notice.canonical_parameter_hash,
+            "target_fingerprint": notice.target_fingerprint,
+            "lease_id_digest": notice.lease_id_digest,
+            "browser_id_digest": notice.browser_id_digest,
+            "document_id": notice.document_id,
+            "document_epoch": notice.document_epoch,
+            "summary": notice.summary,
+            "options": ["decline", "approve_once"],
+            "data_classification": notice.data_classification.as_wire_value(),
+            "expires_at_ms": notice.expires_at_ms,
+        },
+    }
+
+
+def test_critical_action_event_registers_before_hash_only_receipt() -> None:
+    async def scenario() -> None:
+        operation = _operation(
+            asyncio.get_running_loop(), _principal(), action="type"
+        )
+        harness = _Harness(operation)
+        stores: list[dict[str, Any]] = []
+        manager = _Manager()
+        receiver = BrowserBridgeCriticalEventReceiver(
+            manager=manager,
+            server_instance_id=lambda: "server-A",
+            current_route_verifier=harness.route_verifier,
+            register_action_challenge=harness.authority.register_event,
+            load=lambda: stores[-1] if stores else None,
+            save=lambda state: stores.append(deepcopy(state)),
+        )
+        result = await receiver.receive(harness.current_route, _event(_notice(operation)))
+        assert result == {
+            "contract_version": 1,
+            "event_id": "event-A",
+            "status": "accepted",
+        }
+        assert harness.authority.pending_count == 1
+        serialized = json.dumps(stores[-1], sort_keys=True)
+        for secret in (
+            ORIGIN,
+            "challenge-A",
+            DOCUMENT_ID,
+            TYPE_TEXT,
+            TYPE_TEXT_SHA256,
+        ):
+            assert secret not in serialized
+        assert manager.emits[-1][2] == BROWSER_EVENT_ACK
+        await harness.authority.close()
+
+    asyncio.run(scenario())
+
+
+def test_action_broker_hash_and_exact_resolution_schema() -> None:
+    async def scenario() -> None:
+        sent: list[tuple[Any, ...]] = []
+        principal = _principal()
+        binding = OperationBinding(
+            principal,
+            "sid-A",
+            "generation-A",
+            "context-A",
+            "browser-session-A",
+            "turn-A",
+            "action-A",
+            "op-A",
+        )
+
+        async def sender(*args: Any) -> None:
+            sent.append(args)
+
+        def authorize(candidate: Any) -> BridgeAuthorization:
+            return BridgeAuthorization(
+                candidate.principal,
+                candidate.connector_sid,
+                candidate.load_generation_id,
+                1,
+                frozenset(
+                    {"browser_extension_bridge_v1", "connector_browser_control"}
+                ),
+                frozenset(
+                    {
+                        "click",
+                        "type",
+                        "semantic_dom_v1",
+                        "cursor_v1",
+                        "trusted_input_v1",
+                    }
+                ),
+                frozenset(),
+            )
+
+        broker = BrowserBridgeOperationBroker(sender=sender, authorizer=authorize)
+        ticket = await broker.begin_operation(
+            binding,
+            action="click",
+            target={"tab_handle": TAB_HANDLE},
+            args={"ref": REF, "expected_action_class": "unknown"},
+            timeout_ms=30_000,
+            required_capabilities=[
+                "click",
+                "semantic_dom_v1",
+                "cursor_v1",
+                "trusted_input_v1",
+            ],
+            policy={"origin_grant_id": "origin-grant", "action_grant_id": None},
+            display={"cursor": True, "foreground": False},
+        )
+        assert ticket.target_ref == REF
+        resolution = {
+            "challenge_id": "challenge-A",
+            "tab_handle": TAB_HANDLE,
+            "document_id": DOCUMENT_ID,
+            "document_epoch": 1,
+            "canonical_parameter_hash": ticket.canonical_parameter_hash,
+            "target_fingerprint": "b" * 64,
+            "origin": ORIGIN,
+            "action_class": "unknown",
+            "data_classification": "none",
+            "decision": "decline",
+            "grant": None,
+        }
+        await broker.begin_action_resolution(
+            ticket,
+            control_id="control-A",
+            resolution=resolution,
+            authorization_current=lambda: True,
+        )
+        await asyncio.sleep(0)
+        control = next(item[2] for item in sent if item[1] == CONTROL_EVENT)
+        assert set(control) == {
+            "method",
+            "contract_version",
+            "bridge_id",
+            "load_generation_id",
+            "control_id",
+            "context_id",
+            "browser_session_id",
+            "turn_id",
+            "op_id",
+            "action_id",
+            *resolution,
+        }
+        type_binding = OperationBinding(
+            principal,
+            "sid-A",
+            "generation-A",
+            "context-A",
+            "browser-session-A",
+            "turn-A",
+            "action-B",
+            "op-B",
+        )
+        type_args = {
+            "ref": REF,
+            "text": TYPE_TEXT,
+            "text_sha256": TYPE_TEXT_SHA256,
+            "expected_action_class": "sensitive_input",
+        }
+        with pytest.raises(BrowserBridgeBrokerError):
+            await broker.begin_operation(
+                type_binding,
+                action="type",
+                target={"tab_handle": TAB_HANDLE},
+                args={**type_args, "text_sha256": "c" * 64},
+                timeout_ms=30_000,
+                required_capabilities=["type", "trusted_input_v1"],
+                display={"cursor": True, "foreground": False},
+            )
+        type_ticket = await broker.begin_operation(
+            type_binding,
+            action="type",
+            target={"tab_handle": TAB_HANDLE},
+            args=type_args,
+            timeout_ms=30_000,
+            required_capabilities=["type", "trusted_input_v1"],
+            display={"cursor": True, "foreground": False},
+        )
+        assert type_ticket.target_ref == REF
+        assert type_ticket.expected_action_class == "sensitive_input"
+        assert type_ticket.text_sha256 == TYPE_TEXT_SHA256
+        assert TYPE_TEXT not in repr(type_ticket)
+        type_classification = {
+            "kind": "text",
+            "sensitivity": "sensitive",
+            "text_sha256": TYPE_TEXT_SHA256,
+        }
+        await broker.begin_action_resolution(
+            type_ticket,
+            control_id="control-B",
+            resolution={
+                "challenge_id": "challenge-B",
+                "tab_handle": TAB_HANDLE,
+                "document_id": DOCUMENT_ID,
+                "document_epoch": 1,
+                "canonical_parameter_hash": type_ticket.canonical_parameter_hash,
+                "target_fingerprint": "c" * 64,
+                "origin": ORIGIN,
+                "action_class": "sensitive_input",
+                "data_classification": type_classification,
+                "decision": "decline",
+                "grant": None,
+            },
+            authorization_current=lambda: True,
+        )
+        await asyncio.sleep(0)
+        type_control = next(
+            item[2]
+            for item in sent
+            if item[1] == CONTROL_EVENT and item[2]["control_id"] == "control-B"
+        )
+        assert type_control["data_classification"] == type_classification
+        broker.disconnect(
+            principal=principal,
+            connector_sid="sid-A",
+            load_generation_id="generation-A",
+        )
+
+    asyncio.run(scenario())
+
+
+def test_protected_action_api_is_decision_only_and_default_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugins._a0_connector.api import browser_bridge_approval as endpoint
+
+    async def scenario() -> None:
+        operation = _operation(asyncio.get_running_loop(), _principal())
+        harness = _Harness(operation)
+        harness.authority.register_challenge(_notice(operation))
+        monkeypatch.setattr(endpoint, "selected_bridge", lambda _context: None)
+        monkeypatch.setattr(
+            endpoint,
+            "get_browser_bridge_action_authority",
+            lambda: pytest.fail("unselected context resolved action authority"),
+        )
+        empty = await endpoint.BrowserBridgeApproval(None, None).process(
+            {"action": "list", "context_id": "context-missing"},
+            request=None,
+        )
+        assert json.loads(empty.get_data(as_text=True))["challenges"] == []
+        monkeypatch.setattr(
+            endpoint,
+            "selected_bridge",
+            lambda context: "bridge-A" if context == "context-A" else None,
+        )
+        monkeypatch.setattr(
+            endpoint,
+            "get_browser_bridge_action_authority",
+            lambda: harness.authority,
+        )
+        handler = endpoint.BrowserBridgeApproval(None, None)
+        listing = await handler.process(
+            {"action": "list", "context_id": "context-A"}, request=None
+        )
+        listed = json.loads(listing.get_data(as_text=True))
+        assert listing.headers["Cache-Control"] == "no-store"
+        assert listed == {
+            "contract": ACTION_AUTHORITY_CONTRACT,
+            "approval_version": 1,
+            "browser_control_ready": False,
+            "challenges": [
+                harness.authority.list_pending(
+                    subject_id="single_user",
+                    context_id="context-A",
+                    bridge_id="bridge-A",
+                )[0]
+            ],
+        }
+        rejected = await handler.process(
+            {
+                "challenge_id": "challenge-A",
+                "choice": "approve_once",
+                "target_fingerprint": "c" * 64,
+            },
+            request=None,
+        )
+        assert rejected.status_code == 400
+        response = await handler.process(
+            {"challenge_id": "challenge-A", "choice": "decline"},
+            request=None,
+        )
+        assert json.loads(response.get_data(as_text=True)) == {
+            "contract": ACTION_AUTHORITY_CONTRACT,
+            "approval_version": 1,
+            "browser_control_ready": False,
+            "challenge_id": "challenge-A",
+            "decision": "declined",
+            "control_id": "control-A",
+            "status": "accepted",
+        }
+        await harness.authority.close()
+
+    asyncio.run(scenario())

--- a/tests/test_browser_bridge_application.py
+++ b/tests/test_browser_bridge_application.py
@@ -1,0 +1,279 @@
+import asyncio
+import base64
+import hashlib
+import json
+import time
+import pytest
+from types import SimpleNamespace
+from plugins._a0_connector.helpers.browser_bridge_application import BrowserBridgeApplication
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    BrowserContextSourceSummary,
+    BrowserContextSourcePage,
+)
+from plugins._a0_connector.helpers.browser_bridge_runtime import BrowserBridgeRuntimeDenied
+from plugins._browser.helpers.extension_sessions import ExtensionSessionLifecycle, ExtensionSessionRegistry
+from plugins._a0_connector.helpers.browser_bridge_operations import OperationBinding, SettlementStatus
+from plugins._a0_connector.helpers.browser_bridge_artifact_controller import (
+    BrowserBridgeArtifactControllerDenied,
+)
+from plugins._a0_connector.helpers.browser_bridge_artifacts import ArtifactBinding
+from plugins._a0_connector.helpers.browser_bridge_queue import BrowserBridgeQueueError
+from test_browser_bridge_runtime_foundation import (
+    _principal,
+    _active,
+    _admission,
+    _hello,
+    _reconcile_registered,
+)
+from browser_bridge_test_support import MemoryPersistence as Memory
+from browser_bridge_test_support import MemoryKeyValue
+
+
+class Source:
+    def list_contexts(self, **_kwargs):
+        return [BrowserContextSourceSummary("context-A", "Task", "chat", "running", 1, 2)]
+
+    def context_exists(self, *, context_id, **_kwargs):
+        return context_id == "context-A"
+
+    def read_context(self, *, history, history_before, **_kwargs):
+        return BrowserContextSourcePage(entries=(), last_sequence=0, complete=False,
+                                       history_before=0 if history == "tail" else None,
+                                       has_more_history=False if history == "tail" else None)
+
+
+def test_application_composes_exact_context_message_artifact_and_route_teardown(tmp_path):
+    async def scenario():
+        emitted = []
+
+        class Manager:
+            async def emit_to(self, *args, **kwargs):
+                emitted.append((args, kwargs))
+
+        messages, events, sessions = MemoryKeyValue(), Memory(), Memory()
+        queues = MemoryKeyValue()
+        delivered = []
+        principal = _principal()
+        app = BrowserBridgeApplication(
+            manager=Manager(), server_instance_id=lambda: "server-A",
+            lifecycle=ExtensionSessionLifecycle(registry=ExtensionSessionRegistry(persistence=sessions)),
+            active_principal_verifier=_active, admission_evaluator=_admission,
+            context_authorizer=lambda _route, context: context == "context-A",
+            context_data_source=Source(), message_load=messages.load, message_save=messages.save,
+            message_deliver=lambda *args: delivered.append(args), event_load=events.load, event_save=events.save,
+            artifact_spool_parent=tmp_path,
+            queue_context_get=lambda context: SimpleNamespace(get_data=lambda key: None),
+            queue_load=queues.load, queue_save=queues.save,
+            queue_mark_dirty=lambda context: None,
+            selection_current=lambda context, bridge: context == "context-A" and bridge == principal.principal_id,
+        )
+        with pytest.raises(BrowserBridgeRuntimeDenied):
+            await app.dispatch(principal, "sid-A", "connector_context_list", {"contract_version": 1})
+        hello = _hello(principal)
+        hello["host_browser"]["capabilities"]["actions"].append("screenshot")
+        route = app.registry.register_hello(principal=principal, connector_sid="sid-A", data=hello)
+        await _reconcile_registered(app.registry, route)
+        listing = await app.dispatch(principal, "sid-A", "connector_context_list", {"contract_version": 1})
+        assert listing["contexts"][0]["context_id"] == "context-A"
+        await app.dispatch(principal, "sid-A", "connector_subscribe_context", {
+            "contract_version": 1, "context_id": "context-A", "history": "tail",
+        })
+        assert emitted[0][1]["expected_principal"] is principal
+        assert app.contexts.stream_count == 1
+        message = {"contract_version": 1, "context_id": "context-A", "client_message_id": "message-1", "text": "Hello"}
+        await app.dispatch(principal, "sid-A", "connector_send_message", message)
+        await app.dispatch(principal, "sid-A", "connector_send_message", message)
+        assert delivered == [("context-A", "Hello", "message-1")]
+        session, turn = app.browser.lifecycle.registry.begin_turn(
+            context_id="context-A", browser_id="extension:bridge-A", bridge_id="bridge-A",
+        )
+        operation = OperationBinding(principal, "sid-A", "generation-A", "context-A",
+                                     session.browser_session_id, turn.turn_id, "action-image", "op-image")
+        app.browser.leases.observe_open(operation, {
+            "lease_id": "lease-nav", "tab_handle": "tab-nav", "browser_id": "tab-nav",
+            "origin": "https://source.example", "disposition": "ephemeral",
+        }, "https://source.example")
+        navigation_binding = OperationBinding(principal, "sid-A", "generation-A", "context-A",
+                                              session.browser_session_id, turn.turn_id, "action-nav", "op-nav")
+        navigation = await app.registry.broker.begin_operation(
+            navigation_binding, action="navigate", target={"tab_handle": "tab-nav"}, args={"url": "https://next.example/"},
+            timeout_ms=30_000, required_capabilities=["navigate"], policy={"origin_grant_id": "source-grant"},
+            display={"cursor": False, "foreground": False},
+        )
+        fingerprint = {"action_class": "navigate", "browser_id_digest": hashlib.sha256(b"tab-nav").hexdigest(),
+                       "lease_id_digest": hashlib.sha256(b"lease-nav").hexdigest(), "document_id": None,
+                       "document_epoch": 0, "load_generation_id": "generation-A", "origin": "https://next.example"}
+        now = time.time_ns() // 1_000_000
+        event = {"contract_version": 1, "event_id": "event-site", "load_generation_id": "generation-A",
+                 "event_sequence": 1, "delivery": "critical", "event_type": "challenge.required", "observed_at_ms": now,
+                 "context_id": "context-A", "browser_session_id": session.browser_session_id, "turn_id": turn.turn_id,
+                 "op_id": "op-nav", "action_id": "action-nav", "data": {
+                     **{key: value for key, value in fingerprint.items() if key != "load_generation_id"},
+                     "challenge_id": "challenge-nav", "kind": "site", "canonical_parameter_hash": navigation.canonical_parameter_hash,
+                     "target_fingerprint": hashlib.sha256(json.dumps(fingerprint, sort_keys=True, separators=(",", ":")).encode()).hexdigest(),
+                     "summary": "Allow Agent Zero to work on next.example?", "options": ["deny", "allow_once", "allow_turn"],
+                     "expires_at_ms": now + 20_000,
+                 }}
+        await app.dispatch(principal, "sid-A", "connector_browser_event", event)
+        assert app.sites.list_pending(subject_id=principal.subject_id)[0]["origin"] == "https://next.example"
+        decision = await app.sites.decide(subject_id=principal.subject_id, challenge_id="challenge-nav", decision="allow_turn")
+        assert await app.sites.decide(subject_id=principal.subject_id, challenge_id="challenge-nav", decision="allow_turn") is decision
+        for _ in range(3):
+            await asyncio.sleep(0)
+        control = next(args[3] for args, _kwargs in emitted if args[2] == "connector_browser_control")
+        assert control["canonical_parameter_hash"] == navigation.canonical_parameter_hash
+        assert control["grant"]["scope"] == "turn"
+        control_response = {key: control[key] for key in (
+            "contract_version", "method", "bridge_id", "load_generation_id", "context_id", "browser_session_id",
+            "turn_id", "control_id", "op_id", "action_id",
+        )}
+        control_response.update(ok=True, result={"contract_version": 1, "control_id": decision.control_id,
+                                                "challenge_id": "challenge-nav", "status": "resolved", "decision": "allow_turn"})
+        assert (await app.dispatch(principal, "sid-A", "connector_browser_control_result", control_response))["status"] == SettlementStatus.SETTLED
+        for _ in range(8):
+            if app.sites.turn_grant_for(navigation_binding, origin="https://next.example") is not None:
+                break
+            await asyncio.sleep(0)
+        assert app.sites.turn_grant_for(navigation_binding, origin="https://next.example") is not None
+        ticket = await app.registry.broker.begin_operation(
+            operation, action="screenshot", target={"tab_handle": "tab-image"}, args={},
+            timeout_ms=5_000, required_capabilities=["screenshot"], policy={"origin_grant_id": "site-grant"},
+            display={"cursor": False, "foreground": False},
+        )
+        artifact = ArtifactBinding(principal, "sid-A", "generation-A", "bridge-A", "context-A",
+                                   session.browser_session_id, turn.turn_id, "action-image", "op-image",
+                                   "artifact-image", "output", "screenshot")
+        common = {name: getattr(artifact, name) for name in (
+            "contract_version", "bridge_id", "load_generation_id", "context_id", "browser_session_id",
+            "turn_id", "action_id", "op_id", "artifact_id", "direction", "purpose",
+        )}
+        data = b"synthetic artifact bytes"
+        begin = {**common, "phase": "begin", "byte_count": len(data), "mime_type": "image/png", "sha256": "sha256:" + hashlib.sha256(data).hexdigest()}
+        with pytest.raises(BrowserBridgeArtifactControllerDenied):
+            await app.dispatch(principal, "sid-A", "connector_browser_artifact_chunk", {**begin, "action_id": "wrong-action"})
+        await app.dispatch(principal, "sid-A", "connector_browser_artifact_chunk", begin)
+        await app.dispatch(principal, "sid-A", "connector_browser_artifact_chunk", {
+            **common, "phase": "chunk", "chunk_index": 0, "data_base64": base64.b64encode(data).decode(),
+        })
+        ended = await app.dispatch(principal, "sid-A", "connector_browser_artifact_chunk", {**common, "phase": "end"})
+        assert ended["status"] == "complete"
+        response = {name: getattr(operation, name) for name in (
+            "bridge_id", "load_generation_id", "context_id", "browser_session_id", "turn_id", "action_id", "op_id",
+        )}
+        response.update(contract_version=1, ok=True, result={}, receipts=[], artifacts=[])
+        assert (await app.dispatch(principal, "sid-A", "connector_browser_op_result", response))["status"] == SettlementStatus.SETTLED
+        assert (await app.registry.broker.wait_operation(ticket)).ok
+        # Verified output can be consumed once after the op settles, but only
+        # while the independently retained exact turn and route remain active.
+        assert app.artifact_receiver.consume(artifact, lambda stream, _descriptor: stream.read()) == data
+        with pytest.raises(BrowserBridgeArtifactControllerDenied):
+            await app.dispatch(principal, "sid-A", "connector_browser_artifact_chunk", {**begin, "artifact_id": "late-artifact"})
+        with pytest.raises(BrowserBridgeQueueError):
+            await app.dispatch(principal, "sid-A", "connector_message_queue_add", {"contract_version": 1})
+        assert await app.disconnect(principal, "sid-A")
+        assert app.contexts.stream_count == 0 and app.registry.session_count == 0
+        assert not await app.disconnect(principal, "sid-A")
+        await app.close()
+        assert not list(tmp_path.iterdir())
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("action", ["click", "type"])
+def test_application_binds_action_approval_to_inspected_document_and_once_control(tmp_path, action):
+    async def scenario():
+        emitted = []
+        class Manager:
+            async def emit_to(self, *args, **kwargs):
+                emitted.append((args, kwargs))
+        principal = _principal()
+        messages, events, sessions = MemoryKeyValue(), Memory(), Memory()
+        app = BrowserBridgeApplication(
+            manager=Manager(), server_instance_id=lambda: "server-A",
+            lifecycle=ExtensionSessionLifecycle(registry=ExtensionSessionRegistry(persistence=sessions)),
+            active_principal_verifier=_active, admission_evaluator=_admission,
+            context_authorizer=lambda _route, context: context == "context-A", context_data_source=Source(),
+            message_load=messages.load, message_save=messages.save, message_deliver=lambda *_args: None,
+            event_load=events.load, event_save=events.save, artifact_spool_parent=tmp_path,
+            selection_current=lambda context, bridge: context == "context-A" and bridge == principal.principal_id,
+            approval_record_loader=lambda server, bridge: {
+                "state": "active", "server_instance_id": server, "bridge_id": bridge,
+                "subject_id": principal.subject_id, "key_generation": principal.key_generation,
+                "scopes": sorted(principal.scopes),
+            },
+        )
+        hello = _hello(principal)
+        hello["host_browser"]["capabilities"]["actions"].append(action)
+        route = app.registry.register_hello(principal=principal, connector_sid="sid-A", data=hello)
+        await _reconcile_registered(app.registry, route)
+        session, turn = app.browser.lifecycle.registry.begin_turn(
+            context_id="context-A", browser_id="extension:bridge-A", bridge_id="bridge-A",
+        )
+        binding = OperationBinding(principal, "sid-A", "generation-A", "context-A",
+                                   session.browser_session_id, turn.turn_id, "action-click", "op-click")
+        app.browser.leases.observe_open(binding, {
+            "lease_id": "lease-click", "browser_id": "tab-click", "tab_handle": "tab-click",
+            "origin": "https://example.com", "disposition": "ephemeral",
+        }, "https://example.com")
+        app.browser.leases.observe_content(binding, "tab-click", {
+            "lease_id": "lease-click", "browser_id": "tab-click", "tab_handle": "tab-click",
+            "document_id": "document-click", "document_epoch": "1", "title": "Synthetic", "text": "",
+            "nodes": [{"ref": "doc:1:click", "role": "button", "name": "Synthetic control"}], "truncated": False,
+        })
+        action_class = "sensitive_input" if action == "type" else "unknown"
+        params = {"ref": "doc:1:click", "expected_action_class": action_class}
+        classification = "none"
+        if action == "type":
+            digest = hashlib.sha256(b"synthetic private input").hexdigest()
+            params.update(text="synthetic private input", text_sha256=digest)
+            classification = {"kind": "text", "sensitivity": "sensitive", "text_sha256": digest}
+        ticket = await app.registry.broker.begin_operation(
+            binding, action=action, target={"tab_handle": "tab-click"},
+            args=params, timeout_ms=30_000,
+            required_capabilities=[action], policy={"origin_grant_id": "origin-grant", "action_grant_id": None},
+            display={"cursor": True, "foreground": False},
+        )
+        now = time.time_ns() // 1_000_000
+        event = {"contract_version": 1, "event_id": "event-action", "load_generation_id": "generation-A",
+                 "event_sequence": 1, "delivery": "critical", "event_type": "challenge.required", "observed_at_ms": now,
+                 "context_id": "context-A", "browser_session_id": session.browser_session_id, "turn_id": turn.turn_id,
+                 "op_id": "op-click", "action_id": "action-click", "data": {
+                     "challenge_id": "challenge-click", "kind": "action", "origin": "https://example.com",
+                     "action_class": action_class, "canonical_parameter_hash": ticket.canonical_parameter_hash,
+                     "target_fingerprint": hashlib.sha256(b"synthetic exact target").hexdigest(),
+                     "lease_id_digest": hashlib.sha256(b"lease-click").hexdigest(),
+                     "browser_id_digest": hashlib.sha256(b"tab-click").hexdigest(),
+                     "document_id": "document-click", "document_epoch": 1,
+                     "summary": "Allow Agent Zero to type into the highlighted field?" if action == "type" else "Confirm this browser action",
+                     "options": ["decline", "approve_once"], "data_classification": classification, "expires_at_ms": now + 20_000,
+                 }}
+        await app.dispatch(principal, "sid-A", "connector_browser_event", event)
+        listing = app.actions.list_pending(subject_id=principal.subject_id)
+        assert listing[0]["challenge_id"] == "challenge-click" and listing[0]["origin"] == "https://example.com"
+        assert listing[0]["action"] == action
+        assert "synthetic private input" not in json.dumps(listing) + json.dumps(events.value)
+        decision = await app.actions.decide(subject_id=principal.subject_id, challenge_id="challenge-click", choice="approve_once")
+        assert await app.actions.decide(subject_id=principal.subject_id, challenge_id="challenge-click", choice="approve_once") is decision
+        for _ in range(8):
+            await asyncio.sleep(0)
+            if any(args[2] == "connector_browser_control" for args, _kwargs in emitted):
+                break
+        controls = [args[3] for args, _kwargs in emitted if args[2] == "connector_browser_control"]
+        assert len(controls) == 1
+        control = controls[0]
+        assert control["grant"]["scope"] == "operation" and control["grant"]["canonical_parameter_hash"] == ticket.canonical_parameter_hash
+        assert control["document_id"] == "document-click" and control["grant"]["expires_at_ms"] <= event["data"]["expires_at_ms"]
+        assert control["data_classification"] == classification == control["grant"]["data_classification"]
+        response = {key: control[key] for key in (
+            "contract_version", "method", "bridge_id", "load_generation_id", "context_id", "browser_session_id",
+            "turn_id", "control_id", "op_id", "action_id",
+        )}
+        response.update(ok=True, result={"contract_version": 1, "control_id": decision.control_id,
+                                        "challenge_id": "challenge-click", "status": "resolved", "decision": "approve_once"})
+        assert (await app.dispatch(principal, "sid-A", "connector_browser_control_result", response))["status"] == SettlementStatus.SETTLED
+        await app.disconnect(principal, "sid-A")
+        assert not app.actions.list_pending(subject_id=principal.subject_id)
+        await app.close()
+        assert not list(tmp_path.iterdir())
+
+    asyncio.run(scenario())

--- a/tests/test_browser_bridge_approval_foundation.py
+++ b/tests/test_browser_bridge_approval_foundation.py
@@ -1,0 +1,616 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+import io
+import importlib
+import json
+import threading
+from typing import Any
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_approval import (
+    BROWSER_BRIDGE_APPROVAL_CONTRACT,
+    MAX_APPROVAL_TTL_MS,
+    ApprovalConsumeStatus,
+    ApprovalDecisionStatus,
+    BrowserActionDataClassification,
+    BrowserApprovalBinding,
+    BrowserApprovalRoute,
+    BrowserBridgeApprovalError,
+    BrowserBridgeApprovalRepository,
+    BrowserBridgeApprovalUnavailable,
+    NO_ACTION_DATA_CLASSIFICATION,
+    parse_action_data_classification,
+)
+
+
+SERVER_ID = "server-instance-A"
+BRIDGE_ID = "22222222-2222-4222-8222-222222222222"
+SUBJECT_ID = "single_user"
+PARAMETER_HASH = "a" * 64
+TARGET_FINGERPRINT = "b" * 64
+
+
+def _principal() -> WsPrincipal:
+    return WsPrincipal(
+        principal_type="browser_bridge",
+        principal_id=BRIDGE_ID,
+        subject_id=SUBJECT_ID,
+        scopes=frozenset({"browser.approval", "browser.control"}),
+        handler_path="plugins/_a0_connector/ws_connector",
+        handler_id="ws_connector.WsConnector",
+        inbound_events=frozenset({"connector_browser_approval_decision"}),
+        outbound_events=frozenset({"connector_browser_control"}),
+        key_generation=1,
+    )
+
+
+def _route(
+    *,
+    principal: WsPrincipal | None = None,
+    action_id: str = "action-A",
+    op_id: str = "op-A",
+) -> BrowserApprovalRoute:
+    return BrowserApprovalRoute(
+        server_instance_id=SERVER_ID,
+        principal=principal or _principal(),
+        connector_sid="sid-A",
+        load_generation_id="generation-A",
+        context_id="context-A",
+        browser_session_id="session-A",
+        turn_id="turn-A",
+        action_id=action_id,
+        op_id=op_id,
+        tab_handle="tab-A",
+        document_id="document-A",
+        document_epoch=1,
+    )
+
+
+def _binding(
+    *,
+    route: BrowserApprovalRoute | None = None,
+    parameter_hash: str = PARAMETER_HASH,
+    target_fingerprint: str = TARGET_FINGERPRINT,
+    origin: str = "https://example.com",
+    action_class: str = "external_side_effect",
+    data_classification: BrowserActionDataClassification = (
+        NO_ACTION_DATA_CLASSIFICATION
+    ),
+) -> BrowserApprovalBinding:
+    return BrowserApprovalBinding(
+        route=route or _route(),
+        canonical_parameter_hash=parameter_hash,
+        target_fingerprint=target_fingerprint,
+        origin=origin,
+        action_class=action_class,
+        data_classification=data_classification,
+    )
+
+
+def _repository(
+    *,
+    route_authorizer=None,
+    record_active: list[bool] | None = None,
+    max_pending_challenges: int = 128,
+    max_pending_receipts: int = 128,
+) -> tuple[BrowserBridgeApprovalRepository, list[int]]:
+    now = [1_788_492_400_000]
+    active = record_active or [True]
+
+    def active_record(server_id: str, bridge_id: str) -> dict[str, Any] | None:
+        if not active[0] or server_id != SERVER_ID or bridge_id != BRIDGE_ID:
+            return None
+        return {
+            "state": "active",
+            "server_instance_id": SERVER_ID,
+            "bridge_id": BRIDGE_ID,
+            "subject_id": SUBJECT_ID,
+            "key_generation": 1,
+            "scopes": ["browser.approval", "browser.control"],
+        }
+
+    receipts = iter(f"receipt-{index}" for index in range(1, 20))
+    return (
+        BrowserBridgeApprovalRepository(
+            route_authorizer=route_authorizer or (lambda _route: True),
+            active_record_loader=active_record,
+            server_instance_id_loader=lambda: SERVER_ID,
+            clock_ms=lambda: now[0],
+            receipt_id_factory=lambda: next(receipts),
+            max_pending_challenges=max_pending_challenges,
+            max_pending_receipts=max_pending_receipts,
+        ),
+        now,
+    )
+
+
+def test_binding_accepts_only_consequential_exact_redacted_values() -> None:
+    binding = _binding(origin="HTTPS://Example.COM:443/")
+    assert binding.origin == "https://example.com"
+    assert set(binding.__slots__) == {
+        "route",
+        "canonical_parameter_hash",
+        "target_fingerprint",
+        "origin",
+        "action_class",
+        "data_classification",
+    }
+    for field_name, value in (
+        ("parameter_hash", "A" * 64),
+        ("target_fingerprint", "short"),
+        ("origin", "https://example.com/path"),
+        ("action_class", "observe"),
+    ):
+        kwargs = {field_name: value}
+        with pytest.raises(BrowserBridgeApprovalError):
+            _binding(**kwargs)
+
+    text_classification = parse_action_data_classification(
+        {
+            "kind": "text",
+            "sensitivity": "sensitive",
+            "text_sha256": "c" * 64,
+        }
+    )
+    assert hash(text_classification)
+    assert text_classification.as_wire_value()["text_sha256"] == "c" * 64
+    typed = _binding(
+        action_class="sensitive_input",
+        data_classification=text_classification,
+    )
+    assert typed.data_classification == text_classification
+    with pytest.raises(BrowserBridgeApprovalError):
+        _binding(data_classification=text_classification)
+    for invalid in (
+        {"kind": "text", "sensitivity": "sensitive", "text_sha256": "C" * 64},
+        {
+            "kind": "text",
+            "sensitivity": "sensitive",
+            "text_sha256": "c" * 64,
+            "length": 1,
+        },
+        {"kind": "text", "sensitivity": "public", "text_sha256": "c" * 64},
+    ):
+        with pytest.raises(BrowserBridgeApprovalError):
+            parse_action_data_classification(invalid)
+
+
+def test_repository_default_route_authority_is_fail_closed() -> None:
+    repository = BrowserBridgeApprovalRepository(
+        active_record_loader=lambda _server, _bridge: {},
+        server_instance_id_loader=lambda: SERVER_ID,
+    )
+    with pytest.raises(BrowserBridgeApprovalUnavailable):
+        repository.register_challenge(
+            "challenge-A",
+            _binding(),
+            timeout_ms=1_000,
+        )
+
+
+def test_repository_rejects_route_for_a_noncurrent_server_instance() -> None:
+    repository = BrowserBridgeApprovalRepository(
+        route_authorizer=lambda _route: True,
+        active_record_loader=lambda _server, _bridge: {
+            "state": "active",
+            "server_instance_id": SERVER_ID,
+            "bridge_id": BRIDGE_ID,
+            "subject_id": SUBJECT_ID,
+            "key_generation": 1,
+            "scopes": ["browser.approval", "browser.control"],
+        },
+        server_instance_id_loader=lambda: "replacement-server-instance",
+    )
+    with pytest.raises(BrowserBridgeApprovalUnavailable):
+        repository.register_challenge(
+            "challenge-A",
+            _binding(),
+            timeout_ms=1_000,
+        )
+
+
+def test_approval_is_exact_expiring_and_consumed_once() -> None:
+    repository, now = _repository()
+    binding = _binding()
+    challenge = repository.register_challenge(
+        "challenge-A",
+        binding,
+        timeout_ms=30_000,
+    )
+    assert challenge.expires_at_ms == now[0] + 30_000
+    assert repository.register_challenge(
+        "challenge-A",
+        binding,
+        timeout_ms=1,
+    ) is challenge
+
+    decision = repository.decide(
+        "challenge-A",
+        choice="approve_once",
+        current_route=binding.route,
+        surface="webui",
+    )
+    assert decision.status == ApprovalDecisionStatus.APPROVED
+    assert decision.receipt is not None
+    assert decision.receipt.approving_surface == "webui"
+    assert decision.receipt.expires_at_ms == now[0] + MAX_APPROVAL_TTL_MS
+    assert repository.pending_challenge_count == 0
+    assert repository.pending_receipt_count == 1
+    assert repository.consume(
+        decision.receipt.receipt_id,
+        binding=binding,
+    ) == ApprovalConsumeStatus.CONSUMED
+    assert repository.consume(
+        decision.receipt.receipt_id,
+        binding=binding,
+    ) == ApprovalConsumeStatus.ALREADY_CONSUMED
+    assert repository.decide(
+        "challenge-A",
+        choice="decline",
+        current_route=binding.route,
+        surface="side_panel",
+    ).status == ApprovalDecisionStatus.ALREADY_RESOLVED
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        "principal",
+        "connector_sid",
+        "load_generation_id",
+        "context_id",
+        "browser_session_id",
+        "turn_id",
+        "action_id",
+        "op_id",
+        "tab_handle",
+        "document_id",
+        "document_epoch",
+    ],
+)
+def test_decision_route_mismatch_atomically_denies_challenge(changed: str) -> None:
+    repository, _now = _repository()
+    binding = _binding()
+    repository.register_challenge("challenge-A", binding, timeout_ms=30_000)
+    replacement: Any
+    if changed == "principal":
+        replacement = _principal()
+    elif changed == "document_epoch":
+        replacement = 2
+    else:
+        replacement = f"other-{changed}"
+    mismatched = replace(binding.route, **{changed: replacement})
+
+    denied = repository.decide(
+        "challenge-A",
+        choice="approve_once",
+        current_route=mismatched,
+        surface="webui",
+    )
+    assert denied.status == ApprovalDecisionStatus.INVALIDATED
+    assert repository.pending_challenge_count == 0
+    assert repository.decide(
+        "challenge-A",
+        choice="approve_once",
+        current_route=binding.route,
+        surface="webui",
+    ).status == ApprovalDecisionStatus.ALREADY_RESOLVED
+
+
+@pytest.mark.parametrize(
+    ("field_name", "replacement"),
+    [
+        ("canonical_parameter_hash", "c" * 64),
+        ("target_fingerprint", "d" * 64),
+        ("origin", "https://other.example"),
+        ("action_class", "sensitive_input"),
+    ],
+)
+def test_receipt_binding_mismatch_destroys_authority(
+    field_name: str,
+    replacement: str,
+) -> None:
+    repository, _now = _repository()
+    binding = _binding()
+    repository.register_challenge("challenge-A", binding, timeout_ms=30_000)
+    decision = repository.decide(
+        "challenge-A",
+        choice="approve_once",
+        current_route=binding.route,
+        surface="side_panel",
+    )
+    assert decision.receipt is not None
+    mismatched = replace(binding, **{field_name: replacement})
+    assert repository.consume(
+        decision.receipt.receipt_id,
+        binding=mismatched,
+    ) == ApprovalConsumeStatus.INVALIDATED
+    assert repository.consume(
+        decision.receipt.receipt_id,
+        binding=binding,
+    ) == ApprovalConsumeStatus.INVALIDATED
+
+
+def test_receipt_binds_the_complete_type_data_classification() -> None:
+    repository, _now = _repository()
+    classification = BrowserActionDataClassification(
+        "text", "sensitive", "c" * 64
+    )
+    binding = _binding(
+        action_class="sensitive_input",
+        data_classification=classification,
+    )
+    repository.register_challenge("challenge-A", binding, timeout_ms=30_000)
+    decision = repository.decide(
+        "challenge-A",
+        choice="approve_once",
+        current_route=binding.route,
+        surface="webui",
+    )
+    assert decision.receipt is not None
+    assert repository.consume(
+        decision.receipt.receipt_id,
+        binding=replace(
+            binding, data_classification=NO_ACTION_DATA_CLASSIFICATION
+        ),
+    ) == ApprovalConsumeStatus.INVALIDATED
+
+
+def test_expiry_active_record_and_route_authority_deny() -> None:
+    active = [True]
+    current = [True]
+    repository, now = _repository(
+        route_authorizer=lambda _route: current[0],
+        record_active=active,
+    )
+    binding = _binding()
+    with pytest.raises(BrowserBridgeApprovalError):
+        repository.register_challenge(
+            "challenge-too-long",
+            binding,
+            timeout_ms=MAX_APPROVAL_TTL_MS + 1,
+        )
+    repository.register_challenge("challenge-expiring", binding, timeout_ms=10)
+    now[0] += 10
+    assert repository.decide(
+        "challenge-expiring",
+        choice="approve_once",
+        current_route=binding.route,
+        surface="webui",
+    ).status == ApprovalDecisionStatus.EXPIRED
+
+    current[0] = False
+    with pytest.raises(BrowserBridgeApprovalUnavailable):
+        repository.register_challenge(
+            "challenge-stale-route",
+            replace(binding, route=_route(action_id="action-B", op_id="op-B")),
+            timeout_ms=10,
+        )
+    current[0] = True
+    active[0] = False
+    with pytest.raises(BrowserBridgeApprovalUnavailable):
+        repository.register_challenge(
+            "challenge-revoked",
+            replace(binding, route=_route(action_id="action-C", op_id="op-C")),
+            timeout_ms=10,
+        )
+
+
+def test_receipt_expires_and_live_credential_revocation_blocks_consumption() -> None:
+    active = [True]
+    repository, now = _repository(record_active=active)
+    binding_a = _binding()
+    repository.register_challenge("challenge-A", binding_a, timeout_ms=30_000)
+    approved_a = repository.decide(
+        "challenge-A",
+        choice="approve_once",
+        current_route=binding_a.route,
+        surface="webui",
+    )
+    assert approved_a.receipt is not None
+    now[0] += MAX_APPROVAL_TTL_MS
+    assert repository.consume(
+        approved_a.receipt.receipt_id,
+        binding=binding_a,
+    ) == ApprovalConsumeStatus.EXPIRED
+
+    binding_b = _binding(route=_route(action_id="action-B", op_id="op-B"))
+    repository.register_challenge("challenge-B", binding_b, timeout_ms=30_000)
+    approved_b = repository.decide(
+        "challenge-B",
+        choice="approve_once",
+        current_route=binding_b.route,
+        surface="webui",
+    )
+    assert approved_b.receipt is not None
+    active[0] = False
+    assert repository.consume(
+        approved_b.receipt.receipt_id,
+        binding=binding_b,
+    ) == ApprovalConsumeStatus.INVALIDATED
+
+
+def test_lifecycle_invalidation_covers_cancel_turn_disconnect_and_revoke() -> None:
+    repository, _now = _repository()
+    route_a = _route(action_id="action-A", op_id="op-A")
+    route_b = replace(route_a, action_id="action-B", op_id="op-B")
+    binding_a = _binding(route=route_a)
+    binding_b = _binding(route=route_b, target_fingerprint="c" * 64)
+
+    repository.register_challenge("challenge-A", binding_a, timeout_ms=30_000)
+    assert repository.cancel_operation(route_a).challenges == 1
+
+    repository.register_challenge("challenge-B", binding_b, timeout_ms=30_000)
+    approved = repository.decide(
+        "challenge-B",
+        choice="approve_once",
+        current_route=route_b,
+        surface="webui",
+    )
+    repository.register_challenge("challenge-A2", binding_a, timeout_ms=30_000)
+    summary = repository.finalize_turn(route_a)
+    assert summary.challenges == 1
+    assert summary.receipts == 1
+    assert approved.receipt is not None
+    assert repository.consume(
+        approved.receipt.receipt_id,
+        binding=binding_b,
+    ) == ApprovalConsumeStatus.INVALIDATED
+
+    route_c = replace(route_a, turn_id="turn-C", action_id="action-C", op_id="op-C")
+    binding_c = _binding(route=route_c, target_fingerprint="d" * 64)
+    repository.register_challenge("challenge-C", binding_c, timeout_ms=30_000)
+    assert repository.disconnect(
+        principal=route_c.principal,
+        connector_sid=route_c.connector_sid,
+        load_generation_id=route_c.load_generation_id,
+    ).challenges == 1
+
+    route_d = replace(route_a, turn_id="turn-D", action_id="action-D", op_id="op-D")
+    binding_d = _binding(route=route_d, target_fingerprint="e" * 64)
+    repository.register_challenge("challenge-D", binding_d, timeout_ms=30_000)
+    assert repository.revoke_bridge(
+        server_instance_id=SERVER_ID,
+        bridge_id=BRIDGE_ID,
+        subject_id=SUBJECT_ID,
+    ).challenges == 1
+
+
+def test_registry_bounds_and_first_concurrent_decision_win() -> None:
+    repository, _now = _repository(max_pending_challenges=1)
+    binding = _binding()
+    repository.register_challenge("challenge-A", binding, timeout_ms=30_000)
+    with pytest.raises(BrowserBridgeApprovalUnavailable):
+        repository.register_challenge(
+            "challenge-B",
+            _binding(route=_route(action_id="action-B", op_id="op-B")),
+            timeout_ms=30_000,
+        )
+
+    results = []
+
+    def decide() -> None:
+        results.append(
+            repository.decide(
+                "challenge-A",
+                choice="approve_once",
+                current_route=binding.route,
+                surface="webui",
+            ).status
+        )
+
+    threads = [threading.Thread(target=decide) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert results.count(ApprovalDecisionStatus.APPROVED) == 1
+    assert results.count(ApprovalDecisionStatus.ALREADY_RESOLVED) == 7
+    assert repository.pending_receipt_count == 1
+
+
+def test_uncomposed_approval_api_is_protected_no_store_and_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugins._a0_connector.api import browser_bridge_approval as endpoint
+
+    handler = endpoint.BrowserBridgeApproval(None, None)
+    response = asyncio.run(
+        handler.process(
+            {"challenge_id": "challenge-A", "choice": "approve_once"},
+            request=None,
+        )
+    )
+    payload = json.loads(response.get_data(as_text=True))
+    assert handler.requires_auth() is True
+    assert handler.requires_csrf() is True
+    assert response.status_code == 409
+    assert response.headers["Cache-Control"] == "no-store"
+    assert payload["contract"] == BROWSER_BRIDGE_APPROVAL_CONTRACT
+    assert set(payload) == {
+        "contract",
+        "approval_version",
+        "browser_control_ready",
+        "error",
+    }
+
+
+def test_bridge_decision_apis_reject_non_string_enums_before_state_access():
+    endpoints = (
+        ("approval", "BrowserBridgeApproval", "choice", {"challenge_id": "challenge-A"}),
+        ("policy", "BrowserBridgePolicy", "action", {}),
+        ("bridges", "BrowserBridgeBridges", "action", {}),
+        ("selection", "BrowserBridgeSelection", "action", {}),
+    )
+    for suffix, class_name, field, base in endpoints:
+        endpoint = importlib.import_module(f"plugins._a0_connector.api.browser_bridge_{suffix}")
+        handler = getattr(endpoint, class_name)(None, None)
+        for malformed in ([], {}, None, True, 1):
+            raw = json.dumps({**base, field: malformed}).encode()
+            request = type("Request", (), {"content_length": len(raw), "is_json": True,
+                                           "stream": io.BytesIO(raw)})()
+            response = asyncio.run(handler.handle_request(request))
+            assert response.status_code == 400
+            assert response.headers["Cache-Control"] == "no-store"
+
+
+def test_approval_api_rejects_binding_injection_duplicate_and_oversized_bodies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugins._a0_connector.api import browser_bridge_approval as endpoint
+
+    authority_calls = []
+
+    class Authority:
+        async def decide(self, **kwargs):
+            authority_calls.append(kwargs)
+
+    monkeypatch.setattr(
+        endpoint,
+        "get_browser_bridge_action_authority",
+        lambda: Authority(),
+    )
+    handler = endpoint.BrowserBridgeApproval(None, None)
+
+    injected = asyncio.run(
+        handler.process(
+            {
+                "challenge_id": "challenge-A",
+                "choice": "approve_once",
+                "origin": "https://evil.example",
+            },
+            request=None,
+        )
+    )
+    assert injected.status_code == 400
+    assert authority_calls == []
+    raw = b'{"challenge_id":"challenge-A","choice":"approve_once","choice":"decline"}'
+    request = type(
+        "Request",
+        (),
+        {
+            "content_length": len(raw),
+            "is_json": True,
+            "stream": io.BytesIO(raw),
+        },
+    )()
+    duplicate = asyncio.run(handler.handle_request(request))
+    assert duplicate.status_code == 400
+    assert authority_calls == []
+
+    oversized = type(
+        "Request",
+        (),
+        {
+            "content_length": endpoint.MAX_APPROVAL_REQUEST_BYTES + 1,
+            "is_json": True,
+            "stream": io.BytesIO(b"{}"),
+        },
+    )()
+    too_large = asyncio.run(handler.handle_request(oversized))
+    assert too_large.status_code == 400
+    assert authority_calls == []

--- a/tests/test_browser_bridge_artifact_controller.py
+++ b/tests/test_browser_bridge_artifact_controller.py
@@ -1,0 +1,544 @@
+from __future__ import annotations
+import asyncio
+import base64
+import hashlib
+import pytest
+import io
+from dataclasses import replace
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_artifact_controller import (
+    ARTIFACT_ACK_EVENT,
+    ARTIFACT_CHUNK_EVENT,
+    RESTRICTED_HANDLER_ID,
+    ArtifactBindingLookup,
+    BrowserBridgeArtifactController,
+    BrowserBridgeArtifactControllerDenied,
+    BrowserBridgeArtifactControllerError,
+)
+from plugins._a0_connector.helpers.browser_bridge_artifacts import (
+    MAX_CHUNK_BYTES,
+    ArtifactBinding,
+    BrowserBridgeArtifactReceiver,
+    BrowserBridgeArtifactError,
+)
+from plugins._a0_connector.helpers.browser_bridge_context import BrowserBridgeContextRoute
+from types import SimpleNamespace
+from PIL import Image
+from plugins._a0_connector.helpers.browser_bridge_operations import OperationBinding, BrokerCompletion
+from plugins._browser.helpers.extension_artifacts import (
+    ExtensionScreenshotMaterializer,
+    ExtensionArtifactError,
+)
+from plugins._browser.helpers.extension_runtime import encode_extension_call, ExtensionBrowserError
+from plugins._a0_connector.helpers.browser_bridge_artifact_sender import (
+    BrowserBridgeArtifactSender,
+    BrowserBridgeArtifactSendError,
+)
+from test_browser_bridge_runtime_foundation import _principal as _runtime_principal
+
+
+class _Manager:
+    def __init__(self) -> None:
+        self.emissions = []
+
+    async def emit_to(self, *args, **kwargs):
+        self.emissions.append((args, kwargs))
+
+
+def _principal(*, bridge_id: str = "bridge-1") -> WsPrincipal:
+    return WsPrincipal(
+        principal_type="browser_bridge",
+        principal_id=bridge_id,
+        subject_id="subject-1",
+        scopes=frozenset({"bridge.connect", "browser.artifact"}),
+        handler_path="plugins/_a0_connector/ws_connector",
+        handler_id=RESTRICTED_HANDLER_ID,
+        inbound_events=frozenset({ARTIFACT_CHUNK_EVENT}),
+        outbound_events=frozenset({ARTIFACT_ACK_EVENT}),
+        key_generation=4,
+    )
+
+
+def _route(principal: WsPrincipal | None = None, *, sid: str = "sid-1"):
+    return BrowserBridgeContextRoute(
+        principal=principal or _principal(),
+        connector_sid=sid,
+        load_generation_id="load-1",
+    )
+
+
+def _binding(route: BrowserBridgeContextRoute, **changes) -> ArtifactBinding:
+    values = {
+        "principal": route.principal,
+        "connector_sid": route.connector_sid,
+        "load_generation_id": route.load_generation_id,
+        "bridge_id": route.principal.principal_id,
+        "context_id": "context-1",
+        "browser_session_id": "session-1",
+        "turn_id": "turn-1",
+        "action_id": "action-1",
+        "op_id": "op-1",
+        "artifact_id": "artifact-1",
+        "direction": "output",
+        "purpose": "screenshot",
+    }
+    values.update(changes)
+    return ArtifactBinding(**values)
+
+
+def _frame(binding: ArtifactBinding, phase: str, **fields):
+    return {
+        "contract_version": 1,
+        "phase": phase,
+        "bridge_id": binding.bridge_id,
+        "load_generation_id": binding.load_generation_id,
+        "context_id": binding.context_id,
+        "browser_session_id": binding.browser_session_id,
+        "turn_id": binding.turn_id,
+        "action_id": binding.action_id,
+        "op_id": binding.op_id,
+        "artifact_id": binding.artifact_id,
+        "direction": binding.direction,
+        "purpose": binding.purpose,
+        **fields,
+    }
+
+
+def _digest(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+def _resolver(binding: ArtifactBinding):
+    def resolve(lookup: ArtifactBindingLookup):
+        assert lookup.op_id == binding.op_id
+        return binding
+
+    return resolve
+
+
+def test_output_transfer_emits_exact_progress_and_pathless_descriptor(tmp_path):
+    async def run():
+        route = _route()
+        binding = _binding(route)
+        payload = b"bounded screenshot"
+        manager = _Manager()
+        receiver = BrowserBridgeArtifactReceiver(
+            spool_parent=tmp_path,
+            authorizer=lambda candidate: candidate == binding,
+        )
+        controller = BrowserBridgeArtifactController(
+            receiver=receiver,
+            binding_resolver=_resolver(binding),
+            manager=manager,
+        )
+        try:
+            begin = await controller.receive(
+                route,
+                _frame(
+                    binding,
+                    "begin",
+                    byte_count=len(payload),
+                    sha256=_digest(payload),
+                    mime_type="image/png",
+                ),
+            )
+            chunk = await controller.receive(
+                route,
+                _frame(
+                    binding,
+                    "chunk",
+                    chunk_index=0,
+                    data_base64=base64.b64encode(payload).decode("ascii"),
+                ),
+            )
+            end = await controller.receive(route, _frame(binding, "end"))
+
+            common = {
+                "contract_version": 1,
+                "bridge_id": "bridge-1",
+                "load_generation_id": "load-1",
+                "context_id": "context-1",
+                "browser_session_id": "session-1",
+                "turn_id": "turn-1",
+                "action_id": "action-1",
+                "op_id": "op-1",
+                "artifact_id": "artifact-1",
+                "direction": "output",
+                "purpose": "screenshot",
+            }
+            assert begin == {
+                **common,
+                "phase": "begin",
+                "status": "accepted",
+                "next_chunk_index": 0,
+                "received_bytes": 0,
+            }
+            assert chunk == {
+                **common,
+                "phase": "chunk",
+                "status": "accepted",
+                "next_chunk_index": 1,
+                "received_bytes": len(payload),
+            }
+            assert end == {
+                **common,
+                "phase": "end",
+                "status": "complete",
+                "descriptor": {
+                    "artifact_id": "artifact-1",
+                    "mime_type": "image/png",
+                    "byte_count": len(payload),
+                    "sha256": _digest(payload),
+                    "purpose": "screenshot",
+                },
+            }
+            assert "path" not in repr(end)
+            assert len(manager.emissions) == 3
+            for (namespace, sid, event, payload), kwargs in manager.emissions:
+                assert (namespace, sid, event) == (
+                    "/ws",
+                    "sid-1",
+                    ARTIFACT_ACK_EVENT,
+                )
+                assert payload["contract_version"] == 1
+                assert kwargs["handler_id"] == RESTRICTED_HANDLER_ID
+                assert kwargs["expected_principal"] is route.principal
+        finally:
+            await controller.close()
+
+    asyncio.run(run())
+
+
+def test_screenshot_materializes_only_exact_verified_image_once(tmp_path):
+    artifact = _binding(_route())
+    binding = OperationBinding(artifact.principal, artifact.connector_sid, artifact.load_generation_id,
+                               artifact.context_id, artifact.browser_session_id, artifact.turn_id,
+                               artifact.action_id, artifact.op_id)
+    output = io.BytesIO()
+    Image.new("RGB", (2, 2), (240, 240, 240)).save(output, format="JPEG", quality=62)
+    payload = output.getvalue()
+    receiver = BrowserBridgeArtifactReceiver(spool_parent=tmp_path, authorizer=lambda _: True)
+    descriptor = {"artifact_id": artifact.artifact_id, "mime_type": "image/jpeg", "byte_count": len(payload),
+                  "sha256": "sha256:" + hashlib.sha256(payload).hexdigest(), "purpose": "screenshot"}
+    receiver.begin(artifact, byte_count=len(payload), sha256=descriptor["sha256"], mime_type="image/jpeg")
+    receiver.append(artifact, chunk_index=0, data=payload)
+    receiver.complete(artifact)
+    lease = SimpleNamespace(lease_id="lease-1", origin="https://example.com")
+    written = []
+
+    def save(**kwargs):
+        written.append(kwargs)
+        return SimpleNamespace(path="/owned-chat/screenshot.jpg", a0_path="/a0/usr/chats/context/screenshot.jpg")
+
+    materialize = ExtensionScreenshotMaterializer(receiver=receiver, lease_for=lambda *_: lease, current=lambda _: True, save_image=save)
+    call = encode_extension_call("screenshot_file", ("tab-1",), {"quality": 62, "full_page": False, "path": ""})
+    assert call.action == "screenshot" and call.args == {"format": "jpeg", "quality": 62}
+    result = {"lease_id": "lease-1", "browser_id": "tab-1", "tab_handle": "tab-1", "artifact_id": artifact.artifact_id}
+    with pytest.raises(ExtensionArtifactError):
+        materialize(binding, call, BrokerCompletion(ok=True, result={**result, "path": "/peer/path"}, artifacts=(descriptor,)))
+    response = materialize(binding, call, BrokerCompletion(ok=True, result=result, artifacts=(descriptor,)))
+    assert response["chat_scoped"] is True and response["mime"] == "image/jpeg"
+    assert written[0]["context_id"] == binding.context_id and written[0]["payload"] == payload
+    assert "image" not in response and "artifact_id" not in response
+    with pytest.raises(BrowserBridgeArtifactError):
+        materialize(binding, call, BrokerCompletion(ok=True, result=result, artifacts=(descriptor,)))
+    for options in ({"full_page": True}, {"path": "/tmp/chosen"}, {"quality": True}, {"quality": 96}):
+        with pytest.raises(ExtensionBrowserError):
+            encode_extension_call("screenshot_file", ("tab-1",), options)
+    receiver.close()
+    assert not list(tmp_path.iterdir())
+
+
+def _input_binding():
+    return ArtifactBinding(_runtime_principal(), "sid-A", "generation-A", "bridge-A", "context-A", "session-A", "turn-A", "action-A", "op-A", "artifact-A", "input", "upload_file")
+
+
+def test_input_sender_orders_chunks_and_exact_digest_ack_without_reuse():
+    async def scenario():
+        binding = _input_binding()
+        route = BrowserBridgeContextRoute(binding.principal, binding.connector_sid, binding.load_generation_id)
+        frames = []
+        descriptor = None
+        received = 0
+        async def emit(_namespace, sid, event, frame, **kwargs):
+            nonlocal descriptor, received
+            assert kwargs["expected_principal"] is binding.principal
+            assert sid == binding.connector_sid and event == "connector_browser_artifact_chunk"
+            frames.append(frame)
+            common = {key: frame[key] for key in (
+                "contract_version", "phase", "bridge_id", "load_generation_id", "context_id",
+                "browser_session_id", "turn_id", "action_id", "op_id", "artifact_id", "direction", "purpose",
+            )}
+            if frame["phase"] == "begin":
+                descriptor = {"artifact_id": binding.artifact_id, "purpose": "upload_file", **{key: frame[key] for key in ("mime_type", "byte_count", "sha256")}}
+                ack = common | {"status": "accepted", "next_chunk_index": 0, "received_bytes": 0}
+            elif frame["phase"] == "chunk":
+                import base64
+                received += len(base64.b64decode(frame["data_base64"]))
+                ack = common | {"status": "accepted", "next_chunk_index": frame["chunk_index"] + 1, "received_bytes": received}
+            else:
+                ack = common | {"status": "complete", "descriptor": descriptor}
+            await sender.receive_ack(route, ack)
+        sender = BrowserBridgeArtifactSender(manager=SimpleNamespace(emit_to=emit), authorizer=lambda value: value is binding)
+        result = await sender.send(binding, data=b"x" * (MAX_CHUNK_BYTES + 1), mime_type="text/plain")
+        assert result.byte_count == MAX_CHUNK_BYTES + 1
+        assert [frame["phase"] for frame in frames] == ["begin", "chunk", "chunk", "end"]
+        with pytest.raises(BrowserBridgeArtifactSendError):
+            await sender.send(binding, data=b"x", mime_type="text/plain")
+        await sender.close()
+    asyncio.run(scenario())
+
+
+def test_input_sender_cross_route_ack_and_retirement_cannot_complete():
+    async def scenario():
+        binding = _input_binding()
+        emitted = asyncio.Event()
+        async def emit(*args, **kwargs):
+            emitted.set()
+        sender = BrowserBridgeArtifactSender(manager=SimpleNamespace(emit_to=emit), authorizer=lambda value: True)
+        waiting = asyncio.create_task(sender.send(binding, data=b"private", mime_type="text/plain"))
+        await emitted.wait()
+        pending = sender._pending[binding.artifact_id]
+        wrong = BrowserBridgeContextRoute(binding.principal, "sid-other", binding.load_generation_id)
+        with pytest.raises(BrowserBridgeArtifactSendError):
+            await sender.receive_ack(wrong, pending.expected)
+        assert not pending.future.done()
+        sender.retire(principal=binding.principal, connector_sid=binding.connector_sid, load_generation_id=binding.load_generation_id)
+        with pytest.raises(asyncio.CancelledError):
+            await waiting
+        await sender.close()
+        assert not sender._tasks
+    asyncio.run(scenario())
+
+
+def test_input_sender_denies_without_current_consent_before_emitting():
+    async def scenario():
+        async def emit(*args, **kwargs):
+            raise AssertionError("denied transfer emitted bytes")
+        sender = BrowserBridgeArtifactSender(manager=SimpleNamespace(emit_to=emit), authorizer=lambda value: False)
+        with pytest.raises(BrowserBridgeArtifactSendError):
+            await sender.send(_input_binding(), data=b"private", mime_type="text/plain")
+    asyncio.run(scenario())
+
+
+def test_frame_and_resolved_binding_are_exact_and_input_stays_disabled(tmp_path):
+    async def run():
+        route = _route()
+        binding = _binding(route)
+        receiver = BrowserBridgeArtifactReceiver(
+            spool_parent=tmp_path, authorizer=lambda _candidate: True
+        )
+        manager = _Manager()
+        controller = BrowserBridgeArtifactController(
+            receiver=receiver,
+            binding_resolver=lambda _lookup: replace(
+                binding, browser_session_id="wrong-session"
+            ),
+            manager=manager,
+        )
+        try:
+            with pytest.raises(BrowserBridgeArtifactControllerDenied) as error:
+                await controller.receive(
+                    route,
+                    _frame(
+                        binding,
+                        "begin",
+                        byte_count=0,
+                        sha256=_digest(b""),
+                        mime_type="image/png",
+                    ),
+                )
+            assert error.value.code == "ARTIFACT_BINDING_UNAVAILABLE"
+            assert receiver.active_count == 0
+            assert manager.emissions == []
+
+            input_frame = _frame(
+                binding,
+                "begin",
+                byte_count=0,
+                sha256=_digest(b""),
+                mime_type="image/png",
+            )
+            input_frame.update(direction="input", purpose="upload_file")
+            with pytest.raises(BrowserBridgeArtifactControllerDenied) as error:
+                await controller.receive(route, input_frame)
+            assert error.value.code == "ARTIFACT_DIRECTION_UNAVAILABLE"
+
+            invalid = _frame(
+                binding,
+                "chunk",
+                chunk_index=0,
+                data_base64="YQ",  # Valid bytes, but non-canonical unpadded form.
+            )
+            with pytest.raises(BrowserBridgeArtifactControllerError) as error:
+                await controller.receive(route, invalid)
+            assert error.value.code == "INVALID_CHUNK_BASE64"
+
+            oversized = _frame(
+                binding,
+                "chunk",
+                chunk_index=0,
+                data_base64=base64.b64encode(
+                    b"x" * (MAX_CHUNK_BYTES + 1)
+                ).decode("ascii"),
+            )
+            with pytest.raises(BrowserBridgeArtifactControllerError) as error:
+                await controller.receive(route, oversized)
+            assert error.value.code == "CHUNK_SIZE_INVALID"
+            assert manager.emissions == []
+        finally:
+            await controller.close()
+
+    asyncio.run(run())
+
+
+def test_sender_abort_is_exact_and_idempotently_acknowledged(tmp_path):
+    async def run():
+        route = _route()
+        binding = _binding(route)
+        manager = _Manager()
+        receiver = BrowserBridgeArtifactReceiver(
+            spool_parent=tmp_path, authorizer=lambda candidate: candidate == binding
+        )
+        controller = BrowserBridgeArtifactController(
+            receiver=receiver,
+            binding_resolver=_resolver(binding),
+            manager=manager,
+        )
+        try:
+            await controller.receive(
+                route,
+                _frame(
+                    binding,
+                    "begin",
+                    byte_count=1,
+                    sha256=_digest(b"x"),
+                    mime_type="image/png",
+                ),
+            )
+            request = _frame(binding, "abort", reason_code="CANCELED")
+            first = await controller.receive(route, request)
+            second = await controller.receive(route, request)
+            assert first == second
+            assert first["phase"] == "abort"
+            assert first["status"] == "aborted"
+            assert first["reason_code"] == "CANCELED"
+            assert receiver.active_count == 0
+        finally:
+            await controller.close()
+
+    asyncio.run(run())
+
+
+def test_receiver_failure_emits_typed_abort_and_does_not_guess_chunk_duplicate(
+    tmp_path,
+):
+    async def run():
+        route = _route()
+        binding = _binding(route)
+        manager = _Manager()
+        receiver = BrowserBridgeArtifactReceiver(
+            spool_parent=tmp_path, authorizer=lambda candidate: candidate == binding
+        )
+        controller = BrowserBridgeArtifactController(
+            receiver=receiver,
+            binding_resolver=_resolver(binding),
+            manager=manager,
+        )
+        try:
+            begin_frame = _frame(
+                binding,
+                "begin",
+                byte_count=3,
+                sha256=_digest(b"abc"),
+                mime_type="image/png",
+            )
+            assert (
+                await controller.receive(route, begin_frame)
+            )["status"] == "accepted"
+            assert (
+                await controller.receive(route, begin_frame)
+            )["status"] == "duplicate"
+
+            aborted = await controller.receive(
+                route,
+                _frame(
+                    binding,
+                    "chunk",
+                    chunk_index=1,
+                    data_base64=base64.b64encode(b"abc").decode("ascii"),
+                ),
+            )
+            assert aborted["status"] == "aborted"
+            assert aborted["phase"] == "chunk"
+            assert aborted["reason_code"] == "CHUNK_OUT_OF_ORDER"
+            assert receiver.active_count == 0
+            assert manager.emissions[-1][0][3] == aborted
+        finally:
+            await controller.close()
+
+    asyncio.run(run())
+
+
+def test_background_expiry_and_disconnect_clean_only_owned_route(tmp_path):
+    async def run():
+        now = [1_000]
+        first_route = _route()
+        second_route = _route(_principal(bridge_id="bridge-2"), sid="sid-2")
+        first = _binding(first_route, artifact_id="artifact-1")
+        second = _binding(
+            second_route,
+            bridge_id="bridge-2",
+            connector_sid="sid-2",
+            artifact_id="artifact-2",
+            op_id="op-2",
+        )
+        bindings = {first.artifact_id: first, second.artifact_id: second}
+        receiver = BrowserBridgeArtifactReceiver(
+            spool_parent=tmp_path,
+            authorizer=lambda candidate: candidate in bindings.values(),
+            clock_ms=lambda: now[0],
+            ttl_ms=20,
+        )
+        manager = _Manager()
+        controller = BrowserBridgeArtifactController(
+            receiver=receiver,
+            binding_resolver=lambda lookup: bindings.get(lookup.artifact_id),
+            manager=manager,
+            expiry_interval_seconds=0.01,
+        )
+        begin_fields = {
+            "byte_count": 1,
+            "sha256": _digest(b"x"),
+            "mime_type": "image/png",
+        }
+        try:
+            await controller.receive(
+                first_route, _frame(first, "begin", **begin_fields)
+            )
+            await controller.receive(
+                second_route, _frame(second, "begin", **begin_fields)
+            )
+            assert receiver.active_count == 2
+            assert controller.expiry_task_active is True
+
+            summary = await controller.disconnect(
+                principal=first_route.principal,
+                connector_sid=first_route.connector_sid,
+                load_generation_id=first_route.load_generation_id,
+            )
+            assert summary.artifacts == 1
+            assert receiver.active_count == 1
+            assert controller.expiry_task_active is True
+
+            now[0] = 1_021
+            for _ in range(20):
+                if receiver.active_count == 0:
+                    break
+                await asyncio.sleep(0.01)
+            assert receiver.active_count == 0
+            assert controller.expiry_task_active is False
+        finally:
+            await controller.close()
+
+    asyncio.run(run())

--- a/tests/test_browser_bridge_artifacts_foundation.py
+++ b/tests/test_browser_bridge_artifacts_foundation.py
@@ -1,0 +1,545 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import hashlib
+import os
+from pathlib import Path
+import stat
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_artifacts import (
+    ARTIFACT_CHUNK_EVENT,
+    MAX_ARTIFACT_BYTES,
+    MAX_CHUNK_BYTES,
+    ArtifactBinding,
+    BrowserBridgeArtifactError,
+    BrowserBridgeArtifactReceiver,
+)
+
+
+def _principal(*, bridge_id="bridge-1", key_generation=3):
+    return WsPrincipal(
+        principal_type="browser_bridge",
+        principal_id=bridge_id,
+        subject_id="single_user",
+        scopes=frozenset({"bridge.connect", "browser.artifact"}),
+        handler_path="plugins/_a0_connector/ws_connector",
+        handler_id="ws_connector.WsConnector",
+        inbound_events=frozenset({ARTIFACT_CHUNK_EVENT}),
+        outbound_events=frozenset({ARTIFACT_CHUNK_EVENT}),
+        key_generation=key_generation,
+    )
+
+
+def _binding(principal=None, **changes):
+    principal = principal or _principal()
+    values = {
+        "principal": principal,
+        "connector_sid": "sid-1",
+        "load_generation_id": "load-generation-1",
+        "bridge_id": principal.principal_id,
+        "context_id": "context-1",
+        "browser_session_id": "session-1",
+        "turn_id": "turn-1",
+        "action_id": "action-1",
+        "op_id": "op-1",
+        "artifact_id": "artifact-1",
+        "direction": "output",
+        "purpose": "screenshot",
+    }
+    values.update(changes)
+    return ArtifactBinding(**values)
+
+
+def _digest(data: bytes) -> str:
+    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
+def _spool_files(parent: Path) -> list[Path]:
+    return [entry for child in parent.iterdir() for entry in child.iterdir()]
+
+
+def test_default_authorizer_denies_before_spool_creation(tmp_path):
+    receiver = BrowserBridgeArtifactReceiver(spool_parent=tmp_path)
+    try:
+        with pytest.raises(BrowserBridgeArtifactError) as exc:
+            receiver.begin(
+                _binding(),
+                byte_count=3,
+                sha256=_digest(b"abc"),
+                mime_type="image/png",
+            )
+        assert exc.value.code == "SCOPE_DENIED"
+        assert receiver.active_count == 0
+        assert receiver.reserved_bytes == 0
+        assert _spool_files(tmp_path) == []
+    finally:
+        receiver.close()
+
+
+def test_private_spool_verifies_and_is_consumed_once_without_path_descriptor(tmp_path):
+    binding = _binding()
+    payload = b"verified screenshot bytes"
+    receiver = BrowserBridgeArtifactReceiver(
+        spool_parent=tmp_path,
+        authorizer=lambda candidate: candidate.principal is binding.principal,
+    )
+    root = next(tmp_path.iterdir())
+    try:
+        progress = receiver.begin(
+            binding,
+            byte_count=len(payload),
+            sha256=_digest(payload),
+            mime_type="image/png",
+        )
+        assert progress.status == "accepted"
+        assert progress.next_chunk_index == 0
+        assert stat.S_IMODE(os.lstat(root).st_mode) == 0o700
+        spool = _spool_files(tmp_path)
+        assert len(spool) == 1
+        assert binding.artifact_id not in spool[0].name
+        assert stat.S_IMODE(os.lstat(spool[0]).st_mode) == 0o600
+
+        receiver.append(binding, chunk_index=0, data=payload[:9])
+        progress = receiver.append(binding, chunk_index=1, data=payload[9:])
+        assert progress.received_bytes == len(payload)
+        assert progress.next_chunk_index == 2
+        descriptor = receiver.complete(binding)
+        assert descriptor.as_dict() == {
+            "artifact_id": "artifact-1",
+            "mime_type": "image/png",
+            "byte_count": len(payload),
+            "sha256": _digest(payload),
+            "purpose": "screenshot",
+        }
+        assert not hasattr(descriptor, "path")
+        assert str(root) not in repr(descriptor)
+
+        consumed = receiver.consume(
+            binding,
+            lambda stream, received: (stream.read(), received.as_dict()),
+        )
+        assert consumed == (payload, descriptor.as_dict())
+        assert receiver.active_count == 0
+        assert receiver.reserved_bytes == 0
+        assert _spool_files(tmp_path) == []
+        with pytest.raises(BrowserBridgeArtifactError) as exc:
+            receiver.consume(binding, lambda stream, _descriptor: stream.read())
+        assert exc.value.code == "ARTIFACT_TERMINAL"
+    finally:
+        receiver.close()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_cross_binding_frames_reject_without_deleting_legitimate_transfer(tmp_path):
+    binding = _binding()
+    receiver = BrowserBridgeArtifactReceiver(
+        spool_parent=tmp_path, authorizer=lambda _candidate: True
+    )
+    receiver.begin(
+        binding, byte_count=3, sha256=_digest(b"abc"), mime_type="image/png"
+    )
+    clone = _principal()
+    mutations = (
+        replace(binding, principal=clone),
+        replace(binding, connector_sid="sid-other"),
+        replace(binding, load_generation_id="load-other"),
+        replace(binding, bridge_id="bridge-other", principal=_principal(bridge_id="bridge-other")),
+        replace(binding, context_id="context-other"),
+        replace(binding, browser_session_id="session-other"),
+        replace(binding, turn_id="turn-other"),
+        replace(binding, action_id="action-other"),
+        replace(binding, op_id="op-other"),
+        replace(binding, purpose="download"),
+        replace(binding, direction="input", purpose="upload_file"),
+    )
+    try:
+        for candidate in mutations:
+            with pytest.raises(BrowserBridgeArtifactError) as exc:
+                receiver.append(candidate, chunk_index=0, data=b"abc")
+            assert exc.value.code == "SCOPE_DENIED"
+            assert exc.value.aborted is False
+            assert receiver.active_count == 1
+        receiver.append(binding, chunk_index=0, data=b"abc")
+        assert receiver.complete(binding).byte_count == 3
+    finally:
+        receiver.close()
+
+
+@pytest.mark.parametrize(
+    ("failure", "code"),
+    (
+        (
+            lambda receiver, binding: receiver.append(
+                binding, chunk_index=1, data=b"abc"
+            ),
+            "CHUNK_OUT_OF_ORDER",
+        ),
+        (
+            lambda receiver, binding: receiver.append(
+                binding, chunk_index=0, data=b"x" * (MAX_CHUNK_BYTES + 1)
+            ),
+            "CHUNK_SIZE_INVALID",
+        ),
+        (
+            lambda receiver, binding: receiver.append(
+                binding, chunk_index=0, data=b"abcd"
+            ),
+            "ARTIFACT_SIZE_MISMATCH",
+        ),
+        (lambda receiver, binding: receiver.complete(binding), "ARTIFACT_INTEGRITY_MISMATCH"),
+    ),
+)
+def test_order_size_and_integrity_failures_abort_and_delete(
+    tmp_path, failure, code
+):
+    binding = _binding()
+    receiver = BrowserBridgeArtifactReceiver(
+        spool_parent=tmp_path, authorizer=lambda _candidate: True
+    )
+    receiver.begin(
+        binding, byte_count=3, sha256=_digest(b"xyz"), mime_type="image/png"
+    )
+    try:
+        with pytest.raises(BrowserBridgeArtifactError) as exc:
+            failure(receiver, binding)
+        assert exc.value.code == code
+        assert exc.value.aborted is True
+        assert receiver.active_count == 0
+        assert receiver.reserved_bytes == 0
+        assert _spool_files(tmp_path) == []
+        with pytest.raises(BrowserBridgeArtifactError) as reused:
+            receiver.begin(
+                binding,
+                byte_count=3,
+                sha256=_digest(b"xyz"),
+                mime_type="image/png",
+            )
+        assert reused.value.code == "ARTIFACT_ID_REUSED"
+    finally:
+        receiver.close()
+
+
+def test_wrong_digest_aborts_only_at_terminal_verification(tmp_path):
+    binding = _binding()
+    receiver = BrowserBridgeArtifactReceiver(
+        spool_parent=tmp_path, authorizer=lambda _candidate: True
+    )
+    receiver.begin(
+        binding, byte_count=3, sha256=_digest(b"xyz"), mime_type="image/png"
+    )
+    receiver.append(binding, chunk_index=0, data=b"abc")
+    try:
+        with pytest.raises(BrowserBridgeArtifactError) as exc:
+            receiver.complete(binding)
+        assert exc.value.code == "ARTIFACT_INTEGRITY_MISMATCH"
+        assert exc.value.aborted is True
+        assert _spool_files(tmp_path) == []
+    finally:
+        receiver.close()
+
+
+def test_short_write_and_on_disk_size_mismatch_abort(tmp_path):
+    first = _binding(artifact_id="artifact-short-write")
+    receiver = BrowserBridgeArtifactReceiver(
+        spool_parent=tmp_path, authorizer=lambda _candidate: True
+    )
+    receiver.begin(
+        first, byte_count=3, sha256=_digest(b"abc"), mime_type="image/png"
+    )
+    transfer = receiver._transfers[first.artifact_id]
+    writer = transfer.writer
+    assert writer is not None
+
+    class ShortWriter:
+        def write(self, data):
+            writer.write(data[:-1])
+            return len(data) - 1
+
+        def close(self):
+            writer.close()
+
+    transfer.writer = ShortWriter()
+    with pytest.raises(BrowserBridgeArtifactError) as exc:
+        receiver.append(first, chunk_index=0, data=b"abc")
+    assert (exc.value.code, exc.value.aborted) == ("SPOOL_UNAVAILABLE", True)
+    assert receiver.active_count == 0
+
+    second = _binding(artifact_id="artifact-truncated")
+    receiver.begin(
+        second, byte_count=3, sha256=_digest(b"abc"), mime_type="image/png"
+    )
+    receiver.append(second, chunk_index=0, data=b"abc")
+    spool = _spool_files(tmp_path)
+    assert len(spool) == 1
+    os.truncate(spool[0], 2)
+    try:
+        with pytest.raises(BrowserBridgeArtifactError) as exc:
+            receiver.complete(second)
+        assert (exc.value.code, exc.value.aborted) == (
+            "ARTIFACT_INTEGRITY_MISMATCH",
+            True,
+        )
+        assert receiver.active_count == 0
+        assert _spool_files(tmp_path) == []
+    finally:
+        receiver.close()
+
+
+def test_declarations_and_process_spool_resources_are_hard_bounded(tmp_path):
+    receiver = BrowserBridgeArtifactReceiver(
+        spool_parent=tmp_path,
+        authorizer=lambda _candidate: True,
+        max_artifacts=1,
+        max_total_spool_bytes=10,
+    )
+    first = _binding(artifact_id="artifact-first")
+    second = _binding(artifact_id="artifact-second")
+    try:
+        receiver.begin(
+            first, byte_count=8, sha256=_digest(b"12345678"), mime_type="image/png"
+        )
+        with pytest.raises(BrowserBridgeArtifactError) as exc:
+            receiver.begin(
+                second, byte_count=1, sha256=_digest(b"1"), mime_type="image/png"
+            )
+        assert exc.value.code == "ARTIFACT_REGISTRY_FULL"
+        assert receiver.abort(first) is True
+
+        with pytest.raises(BrowserBridgeArtifactError) as exc:
+            receiver.begin(
+                second, byte_count=11, sha256=_digest(b"x" * 11), mime_type="image/png"
+            )
+        assert exc.value.code == "ARTIFACT_SPOOL_FULL"
+        with pytest.raises(BrowserBridgeArtifactError) as exc:
+            receiver.begin(
+                second,
+                byte_count=MAX_ARTIFACT_BYTES + 1,
+                sha256=_digest(b""),
+                mime_type="image/png",
+            )
+        assert exc.value.code == "ARTIFACT_SIZE_INVALID"
+        assert receiver.active_count == 0
+    finally:
+        receiver.close()
+
+
+@pytest.mark.parametrize("operation", ("begin", "append", "complete", "consume"))
+def test_current_route_authorization_is_rechecked_and_loss_purges_spool(
+    tmp_path, operation
+):
+    allowed = [True]
+    binding = _binding()
+    payload = b"abc"
+    receiver = BrowserBridgeArtifactReceiver(
+        spool_parent=tmp_path, authorizer=lambda _candidate: allowed[0]
+    )
+    receiver.begin(
+        binding,
+        byte_count=len(payload),
+        sha256=_digest(payload),
+        mime_type="image/png",
+    )
+    if operation in {"complete", "consume"}:
+        receiver.append(binding, chunk_index=0, data=payload)
+    if operation == "consume":
+        receiver.complete(binding)
+    allowed[0] = False
+    try:
+        with pytest.raises(BrowserBridgeArtifactError) as exc:
+            if operation == "begin":
+                receiver.begin(
+                    binding,
+                    byte_count=len(payload),
+                    sha256=_digest(payload),
+                    mime_type="image/png",
+                )
+            elif operation == "append":
+                receiver.append(binding, chunk_index=0, data=payload)
+            elif operation == "complete":
+                receiver.complete(binding)
+            else:
+                receiver.consume(binding, lambda stream, _descriptor: stream.read())
+        assert exc.value.code == "SCOPE_DENIED"
+        assert exc.value.aborted is True
+        assert receiver.active_count == 0
+        assert _spool_files(tmp_path) == []
+    finally:
+        receiver.close()
+
+
+def test_expiry_disconnect_and_revocation_cleanup_are_exact(tmp_path):
+    now = [1_000]
+    principal = _principal()
+    other_principal = _principal(bridge_id="bridge-2", key_generation=7)
+    receiver = BrowserBridgeArtifactReceiver(
+        spool_parent=tmp_path,
+        authorizer=lambda _candidate: True,
+        clock_ms=lambda: now[0],
+        ttl_ms=50,
+    )
+    disconnected = _binding(principal, artifact_id="artifact-disconnect")
+    revoked = _binding(
+        other_principal,
+        bridge_id="bridge-2",
+        connector_sid="sid-2",
+        artifact_id="artifact-revoke",
+    )
+    expiring = _binding(artifact_id="artifact-expire", op_id="op-expire")
+    for binding in (disconnected, revoked, expiring):
+        receiver.begin(
+            binding, byte_count=1, sha256=_digest(b"x"), mime_type="image/png"
+        )
+    try:
+        assert receiver.disconnect(
+            principal=replace(principal),
+            connector_sid="sid-1",
+            load_generation_id="load-generation-1",
+        ).artifacts == 0
+        summary = receiver.disconnect(
+            principal=principal,
+            connector_sid="sid-1",
+            load_generation_id="load-generation-1",
+        )
+        assert (summary.artifacts, summary.reserved_bytes) == (1, 1)
+        assert receiver.revoke_bridge(
+            bridge_id="bridge-2", key_generation=6
+        ).artifacts == 0
+        summary = receiver.revoke_bridge(bridge_id="bridge-2", key_generation=7)
+        assert (summary.artifacts, summary.reserved_bytes) == (1, 1)
+        assert receiver.active_count == 1
+
+        later = _binding(artifact_id="artifact-later", op_id="op-later")
+        receiver.begin(
+            later, byte_count=1, sha256=_digest(b"x"), mime_type="image/png"
+        )
+        now[0] = 1_050
+        summary = receiver.expire()
+        assert (summary.artifacts, summary.reserved_bytes) == (2, 2)
+        assert _spool_files(tmp_path) == []
+    finally:
+        receiver.close()
+
+
+def test_consumer_failure_still_consumes_and_deletes_private_spool(tmp_path):
+    binding = _binding()
+    receiver = BrowserBridgeArtifactReceiver(
+        spool_parent=tmp_path, authorizer=lambda _candidate: True
+    )
+    receiver.begin(
+        binding, byte_count=3, sha256=_digest(b"abc"), mime_type="image/png"
+    )
+    receiver.append(binding, chunk_index=0, data=b"abc")
+    receiver.complete(binding)
+
+    def fail(_stream, _descriptor):
+        raise RuntimeError("materializer failed")
+
+    try:
+        with pytest.raises(RuntimeError, match="materializer failed"):
+            receiver.consume(binding, fail)
+        assert receiver.active_count == 0
+        assert _spool_files(tmp_path) == []
+        with pytest.raises(BrowserBridgeArtifactError) as exc:
+            receiver.consume(binding, fail)
+        assert exc.value.code == "ARTIFACT_TERMINAL"
+    finally:
+        receiver.close()
+
+
+def test_consume_reauthorizes_after_open_and_retains_quota_until_consumer_returns(
+    tmp_path, monkeypatch
+):
+    allowed = [True]
+    binding = _binding()
+    payload = b"abc"
+    receiver = BrowserBridgeArtifactReceiver(
+        spool_parent=tmp_path,
+        authorizer=lambda _candidate: allowed[0],
+        max_artifacts=1,
+    )
+    receiver.begin(
+        binding, byte_count=3, sha256=_digest(payload), mime_type="image/png"
+    )
+    receiver.append(binding, chunk_index=0, data=payload)
+    receiver.complete(binding)
+
+    def consume_while_bounded(stream, _descriptor):
+        assert receiver.active_count == 1
+        assert receiver.reserved_bytes == len(payload)
+        with pytest.raises(BrowserBridgeArtifactError) as exc:
+            receiver.begin(
+                _binding(artifact_id="artifact-second"),
+                byte_count=1,
+                sha256=_digest(b"x"),
+                mime_type="image/png",
+            )
+        assert exc.value.code == "ARTIFACT_REGISTRY_FULL"
+        return stream.read()
+
+    try:
+        assert receiver.consume(binding, consume_while_bounded) == payload
+        assert receiver.active_count == 0
+        assert receiver.reserved_bytes == 0
+
+        retry = _binding(artifact_id="artifact-post-open-revoke")
+        receiver.begin(
+            retry, byte_count=3, sha256=_digest(payload), mime_type="image/png"
+        )
+        receiver.append(retry, chunk_index=0, data=payload)
+        receiver.complete(retry)
+        real_open = os.open
+
+        def revoke_after_open(path, flags):
+            descriptor = real_open(path, flags)
+            allowed[0] = False
+            return descriptor
+
+        monkeypatch.setattr(os, "open", revoke_after_open)
+        called = []
+        with pytest.raises(BrowserBridgeArtifactError) as exc:
+            receiver.consume(
+                retry,
+                lambda stream, _descriptor: called.append(stream.read()),
+            )
+        assert (exc.value.code, exc.value.aborted) == ("SCOPE_DENIED", True)
+        assert called == []
+        assert receiver.active_count == 0
+        assert receiver.reserved_bytes == 0
+        assert _spool_files(tmp_path) == []
+    finally:
+        receiver.close()
+
+
+def test_input_direction_is_exact_and_parent_symlinks_are_rejected(tmp_path):
+    principal = _principal()
+    input_binding = _binding(
+        principal,
+        direction="input",
+        purpose="upload_file",
+        artifact_id="artifact-upload",
+    )
+    receiver = BrowserBridgeArtifactReceiver(
+        spool_parent=tmp_path, authorizer=lambda candidate: candidate == input_binding
+    )
+    try:
+        receiver.begin(
+            input_binding,
+            byte_count=0,
+            sha256=_digest(b""),
+            mime_type="application/octet-stream",
+        )
+        assert receiver.complete(input_binding).purpose == "upload_file"
+    finally:
+        receiver.close()
+
+    symlink = tmp_path / "spool-link"
+    symlink.symlink_to(tmp_path, target_is_directory=True)
+    with pytest.raises(ValueError, match="non-symlink"):
+        BrowserBridgeArtifactReceiver(spool_parent=symlink)
+
+    with pytest.raises(BrowserBridgeArtifactError) as exc:
+        replace(input_binding, direction="output")
+    assert exc.value.code == "INVALID_PURPOSE"

--- a/tests/test_browser_bridge_bridges_foundation.py
+++ b/tests/test_browser_bridge_bridges_foundation.py
@@ -1,0 +1,485 @@
+from __future__ import annotations
+import asyncio
+import base64
+import importlib
+import io
+import json
+import sys
+import threading
+import pytest
+import helpers
+from contextlib import contextmanager
+from types import ModuleType, SimpleNamespace
+from typing import Any, Iterator
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    BROWSER_BRIDGE_INVENTORY_CONTRACT,
+    FIXED_BROWSER_BRIDGE_SCOPES,
+    BrowserBridgePairingStore,
+    BrowserBridgePairingUnavailable,
+    BrowserBridgeRecordRepository,
+)
+from browser_bridge_test_support import FakeResponse as _FakeResponse, FakeApiHandler as _FakeApiHandler
+
+
+EXTENSION_ID = "abcdefghijklmnopabcdefghijklmnop"
+
+
+PUBLIC_KEY = base64.urlsafe_b64encode(bytes(range(32))).rstrip(b"=").decode()
+
+
+NOW = 1_788_492_500_000
+
+
+def _record(
+    bridge_id: str,
+    *,
+    server_id: str = "server-A",
+    state: str = "active",
+    created_at_ms: int = NOW - 10_000,
+) -> dict[str, Any]:
+    return {
+        "trust_version": 1,
+        "bridge_id": bridge_id,
+        "server_instance_id": server_id,
+        "subject_id": "single_user",
+        "display_name": f"Browser host {bridge_id[-1]}",
+        "companion_instance_id": f"companion-{bridge_id}",
+        "extension_id": EXTENSION_ID,
+        "public_key": {
+            "algorithm": "Ed25519",
+            "encoding": "raw-base64url",
+            "value": PUBLIC_KEY,
+        },
+        "key_generation": 1,
+        "scopes": list(FIXED_BROWSER_BRIDGE_SCOPES),
+        "state": state,
+        "created_at_ms": created_at_ms,
+        "last_authenticated_at_ms": created_at_ms + 1_000,
+        "revoked_at_ms": created_at_ms + 2_000 if state == "revoked" else None,
+    }
+
+
+def _store(
+    records: list[dict[str, Any]],
+    *,
+    now: list[int] | None = None,
+) -> tuple[BrowserBridgePairingStore, dict[str, Any], BrowserBridgeRecordRepository]:
+    state: dict[str, Any] = {
+        "document": {"schema_version": 1, "bridges": records},
+        "saves": 0,
+    }
+
+    def load() -> Any:
+        return state["document"]
+
+    def save(value: dict[str, Any]) -> None:
+        state["saves"] += 1
+        state["document"] = value
+
+    repository = BrowserBridgeRecordRepository(load=load, save=save)
+    clock = now or [NOW]
+    return (
+        BrowserBridgePairingStore(repository=repository, clock_ms=lambda: clock[0]),
+        state,
+        repository,
+    )
+
+
+def test_inventory_is_server_subject_scoped_bounded_and_public_only() -> None:
+    store, _, _ = _store(
+        [
+            _record("bridge-old", created_at_ms=NOW - 20_000),
+            _record("bridge-new", state="revoked", created_at_ms=NOW - 5_000),
+            _record("bridge-other-server", server_id="server-B", created_at_ms=NOW),
+        ]
+    )
+
+    records = store.list_bridge_records(
+        server_instance_id="server-A",
+        subject_id="single_user",
+    )
+    public = [record.as_public_dict() for record in records]
+
+    assert [record["bridge_id"] for record in public] == ["bridge-new", "bridge-old"]
+    assert set(public[0]) == {
+        "bridge_id",
+        "display_name",
+        "state",
+        "key_generation",
+        "created_at_ms",
+        "last_authenticated_at_ms",
+        "revoked_at_ms",
+    }
+    serialized = json.dumps(public)
+    for forbidden in (
+        "public_key", "private_key", "companion_instance_id", "extension_id",
+        "server_instance_id", "subject_id", "scopes", "sid", "http://",
+    ):
+        assert forbidden not in serialized
+    assert store.bridge_record(
+        bridge_id="bridge-other-server",
+        server_instance_id="server-A",
+        subject_id="single_user",
+    ) is None
+
+
+def test_revoke_is_idempotent_durable_and_cannot_be_resurrected_by_auth() -> None:
+    now = [NOW]
+    store, state, repository = _store([_record("bridge-1")], now=now)
+    original_revoke = repository.revoke
+
+    def assert_locked_revoke(**kwargs):
+        assert store._lock._is_owned()
+        return original_revoke(**kwargs)
+
+    repository.revoke = assert_locked_revoke  # type: ignore[method-assign]
+    first = store.revoke_bridge(
+        bridge_id="bridge-1",
+        server_instance_id="server-A",
+        subject_id="single_user",
+    )
+
+    assert first is not None
+    assert first.already_revoked is False
+    assert first.bridge.state == "revoked"
+    assert first.bridge.revoked_at_ms == NOW
+    assert state["saves"] == 1
+    assert store.active_bridge_record(
+        bridge_id="bridge-1", server_instance_id="server-A"
+    ) is None
+    with pytest.raises(BrowserBridgePairingUnavailable):
+        store.mark_bridge_authenticated(
+            bridge_id="bridge-1",
+            key_generation=1,
+            authenticated_at_ms=NOW + 1,
+        )
+
+    now[0] += 50_000
+    repeated = store.revoke_bridge(
+        bridge_id="bridge-1",
+        server_instance_id="server-A",
+        subject_id="single_user",
+    )
+    assert repeated is not None
+    assert repeated.already_revoked is True
+    assert repeated.bridge.revoked_at_ms == NOW
+    assert state["saves"] == 1
+    # Durable trust material remains server-side for revocation history, but is
+    # never copied into the public record.
+    assert state["document"]["bridges"][0]["public_key"]["value"] == PUBLIC_KEY
+    assert "public_key" not in repeated.bridge.as_public_dict()
+
+
+def test_revoke_serializes_with_an_overlapping_authentication_write() -> None:
+    store, state, repository = _store([_record("bridge-1")])
+    mark_entered = threading.Event()
+    release_mark = threading.Event()
+    revoke_started = threading.Event()
+    revoke_finished = threading.Event()
+    failures: list[BaseException] = []
+    original_mark = repository.mark_authenticated
+
+    def blocking_mark(**kwargs):
+        mark_entered.set()
+        if not release_mark.wait(1):
+            raise AssertionError("test did not release authentication write")
+        return original_mark(**kwargs)
+
+    repository.mark_authenticated = blocking_mark  # type: ignore[method-assign]
+
+    def authenticate() -> None:
+        try:
+            store.mark_bridge_authenticated(
+                bridge_id="bridge-1",
+                key_generation=1,
+                authenticated_at_ms=NOW + 1,
+            )
+        except BaseException as error:
+            failures.append(error)
+
+    def revoke() -> None:
+        revoke_started.set()
+        try:
+            store.revoke_bridge(
+                bridge_id="bridge-1",
+                server_instance_id="server-A",
+                subject_id="single_user",
+            )
+        except BaseException as error:
+            failures.append(error)
+        finally:
+            revoke_finished.set()
+
+    auth_thread = threading.Thread(target=authenticate)
+    revoke_thread = threading.Thread(target=revoke)
+    auth_thread.start()
+    assert mark_entered.wait(1)
+    revoke_thread.start()
+    assert revoke_started.wait(1)
+    assert not revoke_finished.wait(0.05)
+    release_mark.set()
+    auth_thread.join(1)
+    revoke_thread.join(1)
+
+    assert not auth_thread.is_alive()
+    assert not revoke_thread.is_alive()
+    assert failures == []
+    assert state["document"]["bridges"][0]["state"] == "revoked"
+    assert state["document"]["bridges"][0]["revoked_at_ms"] == NOW
+
+
+def test_revoke_is_scoped_and_unknown_bridge_does_not_write() -> None:
+    store, state, _ = _store([_record("bridge-1")])
+
+    assert store.revoke_bridge(
+        bridge_id="bridge-1",
+        server_instance_id="server-B",
+        subject_id="single_user",
+    ) is None
+    assert store.revoke_bridge(
+        bridge_id="missing",
+        server_instance_id="server-A",
+        subject_id="single_user",
+    ) is None
+    assert state["saves"] == 0
+    assert state["document"]["bridges"][0]["state"] == "active"
+
+
+@pytest.mark.parametrize(
+    ("state", "revoked_at_ms"),
+    [("active", NOW), ("revoked", None)],
+)
+def test_inventory_fails_closed_on_inconsistent_revocation_state(
+    state: str,
+    revoked_at_ms: int | None,
+) -> None:
+    record = _record("bridge-1")
+    record["state"] = state
+    record["revoked_at_ms"] = revoked_at_ms
+    store, _, _ = _store([record])
+
+    with pytest.raises(BrowserBridgePairingUnavailable):
+        store.list_bridge_records(
+            server_instance_id="server-A",
+            subject_id="single_user",
+        )
+
+
+@contextmanager
+def _endpoint_module(monkeypatch: pytest.MonkeyPatch) -> Iterator[ModuleType]:
+    module_name = "plugins._a0_connector.api.browser_bridge_bridges"
+    api_stub = ModuleType("helpers.api")
+    api_stub.ApiHandler = _FakeApiHandler
+    api_stub.Request = object
+    api_stub.Response = _FakeResponse
+    runtime_stub = ModuleType("helpers.runtime")
+    runtime_stub.get_persistent_id = lambda: "server-A"
+    previous = sys.modules.pop(module_name, None)
+    previous_runtime = getattr(helpers, "runtime", None)
+    try:
+        with monkeypatch.context() as context:
+            context.setitem(sys.modules, "helpers.api", api_stub)
+            context.setitem(sys.modules, "helpers.runtime", runtime_stub)
+            context.setattr(helpers, "runtime", runtime_stub, raising=False)
+            yield importlib.import_module(module_name)
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous is not None:
+            sys.modules[module_name] = previous
+        if previous_runtime is not None:
+            helpers.runtime = previous_runtime
+
+
+def _request(raw: bytes) -> Any:
+    return SimpleNamespace(
+        data=raw,
+        content_length=len(raw),
+        is_json=True,
+        stream=io.BytesIO(raw),
+    )
+
+
+def test_endpoint_list_and_detail_are_protected_no_store_and_gate_independent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, _, _ = _store([_record("bridge-1")])
+    with _endpoint_module(monkeypatch) as endpoint:
+        monkeypatch.setattr(endpoint, "get_browser_bridge_pairing_store", lambda: store)
+        handler = endpoint.BrowserBridgeBridges(None, None)
+        listed = asyncio.run(handler.process({"action": "list"}, request=None))
+        detail = asyncio.run(
+            handler.process(
+                {"action": "detail", "bridge_id": "bridge-1"},
+                request=None,
+            )
+        )
+
+    listed_payload = json.loads(listed.response)
+    detail_payload = json.loads(detail.response)
+    assert handler.requires_auth() is True
+    assert handler.requires_csrf() is True
+    assert listed.headers["Cache-Control"] == "no-store"
+    assert listed_payload == {
+        "contract": BROWSER_BRIDGE_INVENTORY_CONTRACT,
+        "trust_version": 1,
+        "browser_control_ready": False,
+        "bridges": [detail_payload["bridge"]],
+    }
+    assert set(detail_payload) == {
+        "contract", "trust_version", "browser_control_ready", "bridge"
+    }
+    assert "get_browser_bridge_gate" not in vars(endpoint)
+    assert "configured_extension_id" not in vars(endpoint)
+
+
+def test_revoke_disconnects_only_matching_restricted_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, _, _ = _store([_record("bridge-1"), _record("bridge-2")])
+    disconnected: list[tuple[str, str]] = []
+
+    class Socket:
+        async def disconnect(self, sid, *, namespace):
+            disconnected.append((namespace, sid))
+
+    matching = SimpleNamespace(
+        principal=SimpleNamespace(
+            principal_type="browser_bridge",
+            principal_id="bridge-1",
+            subject_id="single_user",
+        )
+    )
+    other_bridge = SimpleNamespace(
+        principal=SimpleNamespace(
+            principal_type="browser_bridge",
+            principal_id="bridge-2",
+            subject_id="single_user",
+        )
+    )
+    ordinary = SimpleNamespace(principal=None)
+    manager = SimpleNamespace(
+        lock=threading.RLock(),
+        connections={
+            ("/ws", "secret-matching-sid"): matching,
+            ("/ws", "secret-other-sid"): other_bridge,
+            ("/ws", "secret-ordinary-sid"): ordinary,
+        },
+        socketio=Socket(),
+    )
+    ws_stub = ModuleType("helpers.ws_manager")
+    ws_stub.get_shared_ws_manager = lambda: manager
+
+    with _endpoint_module(monkeypatch) as endpoint:
+        monkeypatch.setattr(endpoint, "get_browser_bridge_pairing_store", lambda: store)
+        monkeypatch.setitem(sys.modules, "helpers.ws_manager", ws_stub)
+        handler = endpoint.BrowserBridgeBridges(None, None)
+        response = asyncio.run(
+            handler.process(
+                {"action": "revoke", "bridge_id": "bridge-1"},
+                request=None,
+            )
+        )
+
+    payload = json.loads(response.response)
+    assert response.status == 200
+    assert disconnected == [("/ws", "secret-matching-sid")]
+    assert payload == {
+        "contract": BROWSER_BRIDGE_INVENTORY_CONTRACT,
+        "trust_version": 1,
+        "browser_control_ready": False,
+        "revoked": True,
+        "already_revoked": False,
+        "bridge": {
+            "bridge_id": "bridge-1",
+            "display_name": "Browser host 1",
+            "state": "revoked",
+            "key_generation": 1,
+            "created_at_ms": NOW - 10_000,
+            "last_authenticated_at_ms": NOW - 9_000,
+            "revoked_at_ms": NOW,
+        },
+        "server_session_cleanup": "completed",
+    }
+    serialized = response.response.lower()
+    assert "sid" not in serialized
+    assert "public_key" not in serialized
+    assert "native" not in serialized
+    assert "tab" not in serialized
+
+
+def test_revoke_remains_successful_when_session_cleanup_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, state, _ = _store([_record("bridge-1")])
+    ws_stub = ModuleType("helpers.ws_manager")
+    ws_stub.get_shared_ws_manager = lambda: (_ for _ in ()).throw(
+        RuntimeError("not initialized")
+    )
+
+    with _endpoint_module(monkeypatch) as endpoint:
+        monkeypatch.setattr(endpoint, "get_browser_bridge_pairing_store", lambda: store)
+        monkeypatch.setitem(sys.modules, "helpers.ws_manager", ws_stub)
+        handler = endpoint.BrowserBridgeBridges(None, None)
+        response = asyncio.run(
+            handler.process(
+                {"action": "revoke", "bridge_id": "bridge-1"},
+                request=None,
+            )
+        )
+
+    payload = json.loads(response.response)
+    assert response.status == 200
+    assert payload["revoked"] is True
+    assert payload["server_session_cleanup"] == "pending"
+    assert state["document"]["bridges"][0]["state"] == "revoked"
+    assert state["document"]["bridges"][0]["revoked_at_ms"] == NOW
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        {},
+        {"action": "list", "bridge_id": "bridge-1"},
+        {"action": "detail"},
+        {"action": "revoke", "bridge_id": " bridge-1"},
+        {"action": "revoke", "bridge_id": "bridge-1", "server_id": "server-B"},
+        {"action": "delete", "bridge_id": "bridge-1"},
+    ],
+)
+def test_endpoint_rejects_nonexact_request_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+    document: dict[str, Any],
+) -> None:
+    with _endpoint_module(monkeypatch) as endpoint:
+        handler = endpoint.BrowserBridgeBridges(None, None)
+        response = asyncio.run(handler.process(document, request=None))
+
+    assert response.status == 400
+    assert json.loads(response.response) == {
+        "error": "invalid_bridge_inventory_request"
+    }
+    assert response.headers["Cache-Control"] == "no-store"
+
+
+def test_endpoint_rejects_duplicate_and_oversized_raw_json_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    duplicate = b'{"action":"list","action":"revoke"}'
+
+    class UnreadableStream(io.BytesIO):
+        def read(self, *_args, **_kwargs):
+            raise AssertionError("oversized request must fail before stream read")
+
+    oversized = SimpleNamespace(
+        data=b"",
+        content_length=8 * 1024 + 1,
+        is_json=True,
+        stream=UnreadableStream(b"secret"),
+    )
+    with _endpoint_module(monkeypatch) as endpoint:
+        handler = endpoint.BrowserBridgeBridges(None, None)
+        duplicate_response = asyncio.run(handler.handle_request(_request(duplicate)))
+        oversized_response = asyncio.run(handler.handle_request(oversized))
+
+    assert duplicate_response.status == 400
+    assert oversized_response.status == 400

--- a/tests/test_browser_bridge_challenge_foundation.py
+++ b/tests/test_browser_bridge_challenge_foundation.py
@@ -1,0 +1,436 @@
+from __future__ import annotations
+import asyncio
+import base64
+import importlib
+import io
+import json
+import sys
+import pytest
+from contextlib import contextmanager
+from types import ModuleType
+from typing import Any, Iterator
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from plugins._a0_connector.helpers.browser_bridge_auth import (
+    BRIDGE_CONNECTOR_HANDLER,
+    CHALLENGE_SOURCE_RATE_MAX,
+    CHALLENGE_TTL_MS,
+    BrowserBridgeChallengeFailed,
+    BrowserBridgeChallengeStore,
+    canonical_proof_bytes,
+)
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    BROWSER_BRIDGE_RECORD_SCHEMA_VERSION,
+    BROWSER_BRIDGE_TRUST_CONTRACT,
+    CONNECTOR_PROTOCOL,
+    FIXED_BROWSER_BRIDGE_SCOPES,
+    BrowserBridgePairingStore,
+    BrowserBridgeRecordRepository,
+    coarse_source_key,
+)
+from plugins._browser.helpers.bridge_foundation import BrowserBridgeGate
+from browser_bridge_test_support import FakeResponse as _FakeResponse
+
+
+EXTENSION_ID = "abcdefghijklmnopabcdefghijklmnop"
+
+
+BRIDGE_ID = "22222222-2222-4222-8222-222222222222"
+
+
+SERVER_ID = "server-instance-A"
+
+
+SERVER_BASE_URL = "http://localhost:50080"
+
+
+CLIENT_NONCE = base64.urlsafe_b64encode(bytes([3]) * 32).rstrip(b"=").decode()
+
+
+def _credential() -> tuple[
+    BrowserBridgePairingStore,
+    dict[str, Any],
+    Ed25519PrivateKey,
+]:
+    state: dict[str, Any] = {}
+
+    def load() -> Any:
+        return state.get("document")
+
+    def save(value: dict[str, Any]) -> None:
+        state["document"] = value
+
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    encoded_public_key = base64.urlsafe_b64encode(public_key).rstrip(b"=").decode()
+    repository = BrowserBridgeRecordRepository(load=load, save=save)
+    repository.add(
+        {
+            "trust_version": 1,
+            "bridge_id": BRIDGE_ID,
+            "server_instance_id": SERVER_ID,
+            "subject_id": "single_user",
+            "display_name": "Taylor's browser host",
+            "companion_instance_id": "companion-instance-A",
+            "extension_id": EXTENSION_ID,
+            "public_key": {
+                "algorithm": "Ed25519",
+                "encoding": "raw-base64url",
+                "value": encoded_public_key,
+            },
+            "key_generation": 1,
+            "scopes": list(FIXED_BROWSER_BRIDGE_SCOPES),
+            "state": "active",
+            "created_at_ms": 1_788_492_400_000,
+            "last_authenticated_at_ms": None,
+            "revoked_at_ms": None,
+        }
+    )
+    return BrowserBridgePairingStore(repository=repository), state, private_key
+
+
+def _challenge_store(
+    pairing: BrowserBridgePairingStore,
+    *,
+    clock: list[int] | None = None,
+) -> tuple[BrowserBridgeChallengeStore, list[int]]:
+    now = clock or [1_788_492_445_000]
+    identifiers = iter(
+        (
+            "33333333-3333-4333-8333-333333333333",
+            "44444444-4444-4444-8444-444444444444",
+            "55555555-5555-4555-8555-555555555555",
+        )
+    )
+    store = BrowserBridgeChallengeStore(
+        record_lookup=lambda bridge_id, server_id: pairing.active_bridge_record(
+            bridge_id=bridge_id,
+            server_instance_id=server_id,
+        ),
+        record_authenticated=lambda bridge_id, generation, authenticated_at: (
+            pairing.mark_bridge_authenticated(
+                bridge_id=bridge_id,
+                key_generation=generation,
+                authenticated_at_ms=authenticated_at,
+            )
+        ),
+        clock_ms=lambda: now[0],
+        random_bytes=lambda size: bytes([7]) * size,
+        id_factory=lambda: next(identifiers),
+    )
+    return store, now
+
+
+def _issue(store: BrowserBridgeChallengeStore):
+    return store.issue(
+        {
+            "trust_version": 1,
+            "bridge_id": BRIDGE_ID,
+            "client_nonce": CLIENT_NONCE,
+        },
+        source_key=coarse_source_key("127.0.0.1"),
+        server_instance_id=SERVER_ID,
+        server_base_url=SERVER_BASE_URL,
+    )
+
+
+def _proof(challenge) -> dict[str, Any]:
+    return {
+        "aud": SERVER_ID,
+        "bridge_id": BRIDGE_ID,
+        "challenge_id": challenge.challenge_id,
+        "client_nonce": CLIENT_NONCE,
+        "handler": BRIDGE_CONNECTOR_HANDLER,
+        "protocol": CONNECTOR_PROTOCOL,
+        "server_base_url": SERVER_BASE_URL,
+        "server_nonce": challenge.server_nonce,
+        "trust_version": 1,
+    }
+
+
+def _signature(private_key: Ed25519PrivateKey, proof: dict[str, Any]) -> str:
+    signature = private_key.sign(canonical_proof_bytes(proof))
+    return base64.urlsafe_b64encode(signature).rstrip(b"=").decode()
+
+
+def test_challenge_is_60_second_memory_only_and_response_is_bounded() -> None:
+    pairing, state, _ = _credential()
+    store, clock = _challenge_store(pairing)
+    before = json.loads(json.dumps(state["document"]))
+
+    challenge = _issue(store)
+    public = challenge.as_public_dict()
+
+    assert public == {
+        "trust_version": 1,
+        "challenge_id": "33333333-3333-4333-8333-333333333333",
+        "server_nonce": base64.urlsafe_b64encode(bytes([7]) * 32)
+        .rstrip(b"=")
+        .decode(),
+        "server_instance_id": SERVER_ID,
+        "server_base_url": SERVER_BASE_URL,
+        "expires_at_ms": clock[0] + CHALLENGE_TTL_MS,
+    }
+    assert state["document"] == before
+    assert CLIENT_NONCE not in repr(store._pending)
+    assert public["server_nonce"] not in repr(store._pending)
+
+
+def test_real_ed25519_proof_is_single_use_and_updates_last_authentication() -> None:
+    pairing, state, private_key = _credential()
+    store, clock = _challenge_store(pairing)
+    challenge = _issue(store)
+    proof = _proof(challenge)
+
+    principal = store.verify(proof=proof, signature=_signature(private_key, proof))
+
+    assert principal.as_security_context_dict() == {
+        "principal_type": "browser_bridge",
+        "bridge_id": BRIDGE_ID,
+        "server_instance_id": SERVER_ID,
+        "subject_id": "single_user",
+        "extension_id": EXTENSION_ID,
+        "companion_instance_id": "companion-instance-A",
+        "key_generation": 1,
+        "scopes": list(FIXED_BROWSER_BRIDGE_SCOPES),
+        "authenticated_at_ms": clock[0],
+    }
+    assert state["document"]["bridges"][0]["last_authenticated_at_ms"] == clock[0]
+    with pytest.raises(BrowserBridgeChallengeFailed, match="authentication failed"):
+        store.verify(proof=proof, signature=_signature(private_key, proof))
+
+
+@pytest.mark.parametrize(
+    "field_update",
+    [
+        {"handler": "plugins/_a0_connector/other"},
+        {"protocol": "a0-connector.v2"},
+        {"aud": "different-server"},
+        {"server_base_url": "https://different.example.test"},
+        {"trust_version": True},
+        {"unexpected": "field"},
+    ],
+)
+def test_first_invalid_proof_attempt_consumes_challenge(
+    field_update: dict[str, Any],
+) -> None:
+    pairing, state, private_key = _credential()
+    store, _ = _challenge_store(pairing)
+    challenge = _issue(store)
+    valid_proof = _proof(challenge)
+    invalid_proof = dict(valid_proof)
+    invalid_proof.update(field_update)
+
+    with pytest.raises(BrowserBridgeChallengeFailed, match="authentication failed"):
+        store.verify(
+            proof=invalid_proof,
+            signature=_signature(private_key, valid_proof),
+        )
+    with pytest.raises(BrowserBridgeChallengeFailed, match="authentication failed"):
+        store.verify(
+            proof=valid_proof,
+            signature=_signature(private_key, valid_proof),
+        )
+    assert state["document"]["bridges"][0]["last_authenticated_at_ms"] is None
+
+
+def test_wrong_signature_and_expiry_each_consume_or_remove_challenge() -> None:
+    pairing, state, private_key = _credential()
+    store, clock = _challenge_store(pairing)
+    first = _issue(store)
+    first_proof = _proof(first)
+    wrong_key = Ed25519PrivateKey.generate()
+
+    with pytest.raises(BrowserBridgeChallengeFailed, match="authentication failed"):
+        store.verify(proof=first_proof, signature=_signature(wrong_key, first_proof))
+
+    second = _issue(store)
+    second_proof = _proof(second)
+    clock[0] += CHALLENGE_TTL_MS
+    with pytest.raises(BrowserBridgeChallengeFailed, match="authentication failed"):
+        store.verify(proof=second_proof, signature=_signature(private_key, second_proof))
+    assert state["document"]["bridges"][0]["last_authenticated_at_ms"] is None
+
+
+def test_challenge_requires_active_exact_server_record_and_bounds_source_rate() -> None:
+    pairing, state, _ = _credential()
+    store, _ = _challenge_store(pairing)
+    invalid = {
+        "trust_version": 1,
+        "bridge_id": "unknown-bridge",
+        "client_nonce": CLIENT_NONCE,
+    }
+
+    for _ in range(CHALLENGE_SOURCE_RATE_MAX):
+        with pytest.raises(BrowserBridgeChallengeFailed, match="challenge failed"):
+            store.issue(
+                invalid,
+                source_key=coarse_source_key("198.51.100.8"),
+                server_instance_id=SERVER_ID,
+                server_base_url=SERVER_BASE_URL,
+            )
+    with pytest.raises(BrowserBridgeChallengeFailed, match="challenge failed"):
+        store.issue(
+            {
+                "trust_version": 1,
+                "bridge_id": BRIDGE_ID,
+                "client_nonce": CLIENT_NONCE,
+            },
+            source_key=coarse_source_key("198.51.100.8"),
+            server_instance_id=SERVER_ID,
+            server_base_url=SERVER_BASE_URL,
+        )
+
+    state["document"]["bridges"][0]["state"] = "revoked"
+    state["document"]["bridges"][0]["revoked_at_ms"] = 1_788_492_446_000
+    with pytest.raises(BrowserBridgeChallengeFailed, match="challenge failed"):
+        _issue(store)
+
+
+def test_canonical_proof_bytes_match_frozen_jcs_order_without_padding() -> None:
+    pairing, _, _ = _credential()
+    store, _ = _challenge_store(pairing)
+    proof = _proof(_issue(store))
+    encoded = canonical_proof_bytes(proof)
+
+    assert encoded == json.dumps(
+        proof,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    assert encoded.startswith(b'{"aud":')
+    assert b'"trust_version":1}' in encoded
+
+
+class _FakePublicApiHandler:
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+    @classmethod
+    def requires_auth(cls) -> bool:
+        return False
+
+    @classmethod
+    def requires_csrf(cls) -> bool:
+        return False
+
+
+@contextmanager
+def _endpoint_module(monkeypatch: pytest.MonkeyPatch) -> Iterator[ModuleType]:
+    module_name = "plugins._a0_connector.api.browser_bridge_challenge"
+    api_stub = ModuleType("helpers.api")
+    api_stub.Request = object
+    api_stub.Response = _FakeResponse
+    base_stub = ModuleType("plugins._a0_connector.api.v1.base")
+    base_stub.PublicConnectorApiHandler = _FakePublicApiHandler
+    v1_stub = ModuleType("plugins._a0_connector.api.v1")
+    v1_stub.base = base_stub
+    runtime_stub = ModuleType("helpers.runtime")
+    runtime_stub.get_persistent_id = lambda: SERVER_ID
+    previous = sys.modules.pop(module_name, None)
+    previous_base = sys.modules.get("plugins._a0_connector.api.v1.base")
+    previous_v1 = sys.modules.get("plugins._a0_connector.api.v1")
+    try:
+        with monkeypatch.context() as context:
+            import helpers
+
+            context.setitem(sys.modules, "helpers.api", api_stub)
+            context.setitem(sys.modules, "helpers.runtime", runtime_stub)
+            # `from helpers import runtime` may use the package attribute when
+            # framework integration tests have already imported the real module.
+            context.setattr(helpers, "runtime", runtime_stub, raising=False)
+            context.setitem(sys.modules, "plugins._a0_connector.api.v1", v1_stub)
+            context.setitem(sys.modules, "plugins._a0_connector.api.v1.base", base_stub)
+            yield importlib.import_module(module_name)
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous is not None:
+            sys.modules[module_name] = previous
+        if previous_base is not None:
+            sys.modules["plugins._a0_connector.api.v1.base"] = previous_base
+        if previous_v1 is not None:
+            sys.modules["plugins._a0_connector.api.v1"] = previous_v1
+
+
+def test_public_challenge_endpoint_is_generic_no_store_and_unadvertised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pairing, _, _ = _credential()
+    challenge_store, _ = _challenge_store(pairing)
+    raw = json.dumps(
+        {
+            "trust_version": 1,
+            "bridge_id": BRIDGE_ID,
+            "client_nonce": CLIENT_NONCE,
+        }
+    ).encode()
+    request = type(
+        "Request",
+        (),
+        {
+            "headers": {"Origin": SERVER_BASE_URL},
+            "script_root": "",
+            "url_root": f"{SERVER_BASE_URL}/",
+            "remote_addr": "127.0.0.1",
+            "data": raw,
+            "content_length": len(raw),
+            "is_json": True,
+            "stream": io.BytesIO(raw),
+        },
+    )()
+    with _endpoint_module(monkeypatch) as endpoint:
+        monkeypatch.setattr(
+            endpoint,
+            "get_browser_bridge_gate",
+            lambda: BrowserBridgeGate.from_value("preview"),
+        )
+        monkeypatch.setattr(
+            endpoint,
+            "get_browser_bridge_challenge_store",
+            lambda: challenge_store,
+        )
+        handler = endpoint.BrowserBridgeChallenge(None, None)
+        response = asyncio.run(handler.handle_request(request))
+
+        duplicate = b'{"trust_version":1,"bridge_id":"a","bridge_id":"b"}'
+        duplicate_request = type(
+            "Request",
+            (),
+            {
+                "content_length": len(duplicate),
+                "is_json": True,
+                "stream": io.BytesIO(duplicate),
+            },
+        )()
+        duplicate_response = asyncio.run(handler.handle_request(duplicate_request))
+
+    assert handler.requires_auth() is False
+    assert handler.requires_csrf() is False
+    assert response.status == 200
+    assert response.headers["Cache-Control"] == "no-store"
+    assert set(json.loads(response.response)) == {
+        "trust_version",
+        "challenge_id",
+        "server_nonce",
+        "server_instance_id",
+        "server_base_url",
+        "expires_at_ms",
+    }
+    assert duplicate_response.status == 400
+    assert json.loads(duplicate_response.response) == {
+        "contract": BROWSER_BRIDGE_TRUST_CONTRACT,
+        "trust_version": 1,
+        "error": "bridge_challenge_failed",
+    }
+    assert duplicate_response.headers["Cache-Control"] == "no-store"
+
+
+def test_record_store_shape_remains_public_key_only() -> None:
+    _, state, _ = _credential()
+    assert state["document"]["schema_version"] == BROWSER_BRIDGE_RECORD_SCHEMA_VERSION
+    assert "private_key" not in repr(state["document"])
+    assert "signature" not in repr(state["document"])

--- a/tests/test_browser_bridge_context_controller.py
+++ b/tests/test_browser_bridge_context_controller.py
@@ -1,0 +1,452 @@
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from copy import deepcopy
+from typing import Any, Sequence
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    BrowserBridgeContextAccess,
+    BrowserBridgeContextRoute,
+    BrowserContextSourcePage,
+    BrowserContextSourceSummary,
+)
+from plugins._a0_connector.helpers.browser_bridge_context_controller import (
+    CONTEXT_COMPLETE_EVENT,
+    CONTEXT_EVENT,
+    CONTEXT_LIST_EVENT,
+    CONTEXT_SEND_MESSAGE_EVENT,
+    CONTEXT_SNAPSHOT_EVENT,
+    CONTEXT_SUBSCRIBE_EVENT,
+    CONTEXT_UNSUBSCRIBE_EVENT,
+    RESTRICTED_HANDLER_ID,
+    WS_NAMESPACE,
+    BrowserBridgeContextController,
+    BrowserBridgeContextControllerDenied,
+    BrowserBridgeContextControllerError,
+)
+from plugins._a0_connector.helpers.browser_bridge_messages import (
+    BrowserBridgeMessageDispatcher,
+)
+
+
+def _principal(name: str = "A") -> WsPrincipal:
+    return WsPrincipal(
+        principal_type="browser_bridge",
+        principal_id=f"bridge-{name}",
+        subject_id="single_user",
+        scopes=frozenset({"context.list", "context.read", "context.message"}),
+        handler_path="plugins/_a0_connector/ws_connector",
+        handler_id=RESTRICTED_HANDLER_ID,
+        inbound_events=frozenset(
+            {
+                CONTEXT_LIST_EVENT,
+                CONTEXT_SUBSCRIBE_EVENT,
+                CONTEXT_UNSUBSCRIBE_EVENT,
+                CONTEXT_SEND_MESSAGE_EVENT,
+            }
+        ),
+        outbound_events=frozenset(
+            {CONTEXT_SNAPSHOT_EVENT, CONTEXT_EVENT, CONTEXT_COMPLETE_EVENT}
+        ),
+        key_generation=1,
+    )
+
+
+def _route(name: str = "A") -> BrowserBridgeContextRoute:
+    return BrowserBridgeContextRoute(
+        principal=_principal(name),
+        connector_sid=f"sid-{name}",
+        load_generation_id=f"generation-{name}",
+    )
+
+
+def _summary(context_id: str) -> BrowserContextSourceSummary:
+    return BrowserContextSourceSummary(
+        context_id=context_id,
+        label=f"Task {context_id}",
+        kind="task",
+        status="running",
+        created_at_ms=1,
+        updated_at_ms=2,
+    )
+
+
+class _Source:
+    def __init__(self) -> None:
+        self.summaries = [_summary("context-A"), _summary("context-B")]
+        self.pages: deque[BrowserContextSourcePage] = deque(
+            [BrowserContextSourcePage(entries=(), last_sequence=0, complete=False)]
+        )
+        self.reads: list[tuple[int, str | None, int | None, int]] = []
+
+    def list_contexts(
+        self, *, subject_id: str, limit: int
+    ) -> Sequence[BrowserContextSourceSummary]:
+        assert subject_id == "single_user"
+        return tuple(self.summaries[:limit])
+
+    def context_exists(self, *, subject_id: str, context_id: str) -> bool:
+        return subject_id == "single_user" and any(
+            item.context_id == context_id for item in self.summaries
+        )
+
+    def read_context(
+        self,
+        *,
+        subject_id: str,
+        context_id: str,
+        from_sequence: int,
+        history: str | None,
+        history_before: int | None,
+        limit: int,
+    ) -> BrowserContextSourcePage | None:
+        assert subject_id == "single_user"
+        assert context_id in {item.context_id for item in self.summaries}
+        self.reads.append((from_sequence, history, history_before, limit))
+        if len(self.pages) > 1:
+            return self.pages.popleft()
+        return self.pages[0]
+
+
+class _Manager:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str, dict[str, Any], dict[str, Any]]] = []
+
+    async def emit_to(
+        self,
+        namespace: str,
+        sid: str,
+        event: str,
+        data: dict[str, Any],
+        **kwargs: Any,
+    ) -> None:
+        self.calls.append((namespace, sid, event, deepcopy(data), dict(kwargs)))
+        await asyncio.sleep(0)
+
+
+def _build(
+    source: _Source,
+    current: dict[int, bool],
+    *,
+    max_streams: int = 32,
+) -> tuple[BrowserBridgeContextController, _Manager, list[tuple[str, str, str]]]:
+    authorizer = lambda route: current.get(id(route.principal), False)
+    access = BrowserBridgeContextAccess(
+        data_source=source,
+        route_authorizer=authorizer,
+    )
+    from browser_bridge_test_support import MemoryKeyValue
+    stored = MemoryKeyValue()
+    delivered: list[tuple[str, str, str]] = []
+    messages = BrowserBridgeMessageDispatcher(
+        access=access,
+        server_instance_id=lambda: "server-1",
+        load=stored.load,
+        save=stored.save,
+        deliver=lambda context_id, text, message_id: delivered.append(
+            (context_id, text, message_id)
+        ),
+    )
+    manager = _Manager()
+    return (
+        BrowserBridgeContextController(
+            access=access,
+            messages=messages,
+            manager=manager,
+            route_authorizer=authorizer,
+            max_streams=max_streams,
+            poll_interval_seconds=0.01,
+            cancel_wait_seconds=0.1,
+        ),
+        manager,
+        delivered,
+    )
+
+
+def test_list_subscribe_and_unsubscribe_use_exact_native_ack_and_emit_shapes() -> None:
+    async def scenario() -> None:
+        route = _route()
+        source = _Source()
+        source.pages = deque(
+            [
+                BrowserContextSourcePage(
+                    entries=(
+                        {"no": 4, "type": "response", "content": "safe text"},
+                    ),
+                    last_sequence=5,
+                    complete=True,
+                    history_before=4,
+                    has_more_history=True,
+                )
+            ]
+        )
+        controller, manager, _delivered = _build(
+            source, {id(route.principal): True}
+        )
+        listed = await controller.dispatch(
+            CONTEXT_LIST_EVENT,
+            route,
+            {"contract_version": 1, "limit": 1, "correlationId": "transport"},
+        )
+        assert set(listed) == {"contract_version", "contexts"}
+        assert [item["context_id"] for item in listed["contexts"]] == ["context-A"]
+
+        subscribed = await controller.dispatch(
+            CONTEXT_SUBSCRIBE_EVENT,
+            route,
+            {
+                "contract_version": 1,
+                "context_id": "context-A",
+                "from": 2,
+                "history": "tail",
+                "history_before": 5,
+            },
+        )
+        assert subscribed == {
+            "contract_version": 1,
+            "context_id": "context-A",
+            "subscribed": True,
+            "last_sequence": 5,
+            "history_before": 4,
+            "has_more_history": True,
+        }
+        assert source.reads[0] == (2, "tail", 5, 50)
+        assert [call[2] for call in manager.calls] == [
+            CONTEXT_SNAPSHOT_EVENT,
+            CONTEXT_COMPLETE_EVENT,
+        ]
+        snapshot = manager.calls[0]
+        assert snapshot[0:3] == (WS_NAMESPACE, "sid-A", CONTEXT_SNAPSHOT_EVENT)
+        assert snapshot[3] == {
+            "contract_version": 1,
+            "context_id": "context-A",
+            "events": [
+                {
+                    "context_id": "context-A",
+                    "sequence": 5,
+                    "event": "message",
+                    "data": {"role": "assistant", "text": "safe text"},
+                }
+            ],
+            "last_sequence": 5,
+            "complete": True,
+            "history_before": 4,
+            "has_more_history": True,
+        }
+        assert snapshot[4]["handler_id"] == RESTRICTED_HANDLER_ID
+        assert snapshot[4]["expected_principal"] is route.principal
+
+        assert await controller.dispatch(
+            CONTEXT_UNSUBSCRIBE_EVENT,
+            route,
+            {"contract_version": 1, "context_id": "context-A"},
+        ) == {
+            "contract_version": 1,
+            "context_id": "context-A",
+            "unsubscribed": True,
+        }
+        assert controller.stream_count == 0
+
+    asyncio.run(scenario())
+
+
+def test_live_projection_is_paged_bounded_and_completion_emits_once() -> None:
+    async def scenario() -> None:
+        route = _route()
+        source = _Source()
+        source.pages = deque(
+            [
+                BrowserContextSourcePage(
+                    entries=({"no": 0, "type": "tool", "content": "secret"},),
+                    last_sequence=1,
+                    complete=False,
+                ),
+                BrowserContextSourcePage(
+                    entries=(
+                        {"no": 1, "type": "input", "content": "visible"},
+                        {"no": 2, "type": "response", "content": "also visible"},
+                        {"no": 3, "type": "unknown", "content": "drop me"},
+                    ),
+                    last_sequence=4,
+                    complete=True,
+                ),
+                BrowserContextSourcePage(
+                    entries=(),
+                    last_sequence=4,
+                    complete=True,
+                ),
+            ]
+        )
+        controller, manager, _delivered = _build(
+            source,
+            {id(route.principal): True},
+        )
+        await controller.dispatch(
+            CONTEXT_LIST_EVENT, route, {"contract_version": 1}
+        )
+        await controller.dispatch(
+            CONTEXT_SUBSCRIBE_EVENT,
+            route,
+            {"contract_version": 1, "context_id": "context-A"},
+        )
+        for _ in range(20):
+            if any(call[2] == CONTEXT_COMPLETE_EVENT for call in manager.calls):
+                break
+            await asyncio.sleep(0.01)
+        assert controller.stream_count == 1
+        assert source.reads[:2] == [
+            (0, None, None, 50),
+            (1, None, None, 50),
+        ]
+        assert [call[2] for call in manager.calls] == [
+            CONTEXT_SNAPSHOT_EVENT,
+            CONTEXT_EVENT,
+            CONTEXT_EVENT,
+            CONTEXT_COMPLETE_EVENT,
+        ]
+        assert manager.calls[0][3]["events"][0]["data"] == {
+            "activity": "tool",
+            "status": "updated",
+        }
+        assert manager.calls[1][3] == {
+            "contract_version": 1,
+            "context_id": "context-A",
+            "sequence": 2,
+            "last_sequence": 1,
+            "event": "message",
+            "data": {"role": "user", "text": "visible"},
+        }
+        assert manager.calls[2][3] == {
+            "contract_version": 1,
+            "context_id": "context-A",
+            "sequence": 3,
+            "last_sequence": 4,
+            "event": "message",
+            "data": {"role": "assistant", "text": "also visible"},
+        }
+        assert manager.calls[3][3]["status"] == "completed"
+        assert all("secret" not in repr(call[3]) for call in manager.calls)
+        await controller.dispatch(
+            CONTEXT_UNSUBSCRIBE_EVENT,
+            route,
+            {"contract_version": 1, "context_id": "context-A"},
+        )
+        assert controller.stream_count == 0
+
+    asyncio.run(scenario())
+
+
+def test_send_accepts_only_empty_native_placeholders_and_durable_text_shape() -> None:
+    async def scenario() -> None:
+        route = _route()
+        source = _Source()
+        controller, _manager, delivered = _build(
+            source, {id(route.principal): True}
+        )
+        await controller.dispatch(
+            CONTEXT_LIST_EVENT, route, {"contract_version": 1}
+        )
+        result = await controller.dispatch(
+            CONTEXT_SEND_MESSAGE_EVENT,
+            route,
+            {
+                "contract_version": 1,
+                "context_id": "context-A",
+                "client_message_id": "message-1",
+                "text": "hello",
+                "artifact_ids": [],
+                "tab_candidates": [],
+            },
+        )
+        assert result == {
+            "contract_version": 1,
+            "context_id": "context-A",
+            "client_message_id": "message-1",
+            "status": "accepted",
+        }
+        assert delivered == [("context-A", "hello", "message-1")]
+        for field in ("artifact_ids", "tab_candidates"):
+            with pytest.raises(BrowserBridgeContextControllerDenied) as error:
+                await controller.dispatch(
+                    CONTEXT_SEND_MESSAGE_EVENT,
+                    route,
+                    {
+                        "contract_version": 1,
+                        "context_id": "context-A",
+                        "client_message_id": f"message-{field}",
+                        "text": "hello",
+                        field: ["untrusted"],
+                    },
+                )
+            assert error.value.code == "ATTACHMENT_AUTHORITY_UNAVAILABLE"
+        with pytest.raises(BrowserBridgeContextControllerError):
+            await controller.dispatch(
+                CONTEXT_SEND_MESSAGE_EVENT,
+                route,
+                {
+                    "contract_version": 1,
+                    "context_id": "context-A",
+                    "client_message_id": "message-extra",
+                    "text": "hello",
+                    "path": "/private/file",
+                },
+            )
+
+    asyncio.run(scenario())
+
+
+def test_capacity_stale_route_and_exact_disconnect_only_cancel_presentations() -> None:
+    async def scenario() -> None:
+        route_a = _route("A")
+        route_b = _route("B")
+        current = {id(route_a.principal): True, id(route_b.principal): True}
+        source = _Source()
+        controller, manager, _delivered = _build(
+            source, current, max_streams=2
+        )
+        await controller.dispatch(CONTEXT_LIST_EVENT, route_a, {"contract_version": 1})
+        await controller.dispatch(CONTEXT_LIST_EVENT, route_b, {"contract_version": 1})
+        await controller.dispatch(
+            CONTEXT_SUBSCRIBE_EVENT,
+            route_a,
+            {"contract_version": 1, "context_id": "context-A"},
+        )
+        await controller.dispatch(
+            CONTEXT_SUBSCRIBE_EVENT,
+            route_b,
+            {"contract_version": 1, "context_id": "context-B"},
+        )
+        with pytest.raises(BrowserBridgeContextControllerDenied) as full:
+            await controller.dispatch(
+                CONTEXT_SUBSCRIBE_EVENT,
+                route_a,
+                {"contract_version": 1, "context_id": "context-B"},
+            )
+        assert full.value.code == "CONTEXT_STREAM_LIMIT"
+
+        unrelated_agent_task = asyncio.create_task(asyncio.sleep(10))
+        assert await controller.disconnect(
+            principal=route_a.principal,
+            connector_sid=route_a.connector_sid,
+            load_generation_id=route_a.load_generation_id,
+        )
+        assert controller.stream_count == 1
+        assert not unrelated_agent_task.cancelled()
+
+        calls_before = len(manager.calls)
+        current[id(route_b.principal)] = False
+        for _ in range(20):
+            if controller.stream_count == 0:
+                break
+            await asyncio.sleep(0.01)
+        assert controller.stream_count == 0
+        assert len(manager.calls) == calls_before
+        unrelated_agent_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await unrelated_agent_task
+
+    asyncio.run(scenario())

--- a/tests/test_browser_bridge_context_foundation.py
+++ b/tests/test_browser_bridge_context_foundation.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+import json
+from types import SimpleNamespace
+from typing import Any, Sequence
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    MAX_CONTEXT_TEXT_BYTES,
+    AgentContextDataSource,
+    BrowserBridgeContextAccess,
+    BrowserBridgeContextDenied,
+    BrowserBridgeContextRoute,
+    BrowserBridgeContextUnavailable,
+    BrowserContextSourcePage,
+    BrowserContextSourceSummary,
+)
+
+
+CONTEXT_A = "context-A"
+CONTEXT_B = "context-B"
+
+
+def _principal(
+    *,
+    bridge_id: str = "bridge-A",
+    scopes: frozenset[str] | None = None,
+) -> WsPrincipal:
+    return WsPrincipal(
+        principal_type="browser_bridge",
+        principal_id=bridge_id,
+        subject_id="single_user",
+        scopes=scopes
+        or frozenset({"context.list", "context.read", "context.message"}),
+        handler_path="plugins/_a0_connector/ws_connector",
+        handler_id="ws_connector.WsConnector",
+        inbound_events=frozenset({"connector_context_list"}),
+        outbound_events=frozenset({"connector_context_snapshot"}),
+        key_generation=1,
+    )
+
+
+def _route(
+    *,
+    principal: WsPrincipal | None = None,
+    sid: str = "sid-A",
+    generation: str = "generation-A",
+) -> BrowserBridgeContextRoute:
+    return BrowserBridgeContextRoute(
+        principal=principal or _principal(),
+        connector_sid=sid,
+        load_generation_id=generation,
+    )
+
+
+def _summary(context_id: str) -> BrowserContextSourceSummary:
+    return BrowserContextSourceSummary(
+        context_id=context_id,
+        label=f"Task {context_id}",
+        kind="chat",
+        status="idle",
+        created_at_ms=1_000,
+        updated_at_ms=2_000,
+    )
+
+
+class _Source:
+    def __init__(self) -> None:
+        self.summaries: list[BrowserContextSourceSummary] = [
+            _summary(CONTEXT_A),
+            _summary(CONTEXT_B),
+        ]
+        self.existing = {CONTEXT_A, CONTEXT_B}
+        self.page = BrowserContextSourcePage(
+            entries=(),
+            last_sequence=0,
+            complete=True,
+        )
+        self.on_list = None
+        self.on_exists = None
+        self.on_read = None
+
+    def list_contexts(
+        self,
+        *,
+        subject_id: str,
+        limit: int,
+    ) -> Sequence[BrowserContextSourceSummary]:
+        assert subject_id == "single_user"
+        if self.on_list:
+            self.on_list()
+        return tuple(self.summaries[:limit])
+
+    def context_exists(self, *, subject_id: str, context_id: str) -> bool:
+        assert subject_id == "single_user"
+        if self.on_exists:
+            self.on_exists()
+        return context_id in self.existing
+
+    def read_context(
+        self,
+        *,
+        subject_id: str,
+        context_id: str,
+        from_sequence: int,
+        history: str | None,
+        history_before: int | None,
+        limit: int,
+    ) -> BrowserContextSourcePage | None:
+        assert subject_id == "single_user"
+        assert context_id in self.existing
+        if self.on_read:
+            self.on_read()
+        return self.page
+
+
+def _access(
+    source: _Source,
+    *,
+    current: list[bool] | None = None,
+) -> BrowserBridgeContextAccess:
+    state = current or [True]
+    return BrowserBridgeContextAccess(
+        data_source=source,
+        route_authorizer=lambda _route: state[0],
+    )
+
+
+def test_context_ids_must_be_advertised_before_subscribe_or_message() -> None:
+    source = _Source()
+    access = _access(source)
+    route = _route()
+    with pytest.raises(BrowserBridgeContextDenied) as subscribe_error:
+        access.subscribe(route, context_id=CONTEXT_A)
+    assert subscribe_error.value.code == "CONTEXTS_NOT_ADVERTISED"
+    with pytest.raises(BrowserBridgeContextDenied):
+        access.authorize_message_target(route, context_id=CONTEXT_A)
+
+    summaries = access.advertise_contexts(route)
+    assert [item["context_id"] for item in summaries] == [CONTEXT_A, CONTEXT_B]
+    assert set(summaries[0]) == {
+        "context_id",
+        "label",
+        "kind",
+        "status",
+        "created_at_ms",
+        "updated_at_ms",
+    }
+    access.subscribe(route, context_id=CONTEXT_A)
+    access.authorize_message_target(route, context_id=CONTEXT_A)
+    with pytest.raises(BrowserBridgeContextDenied) as unknown_error:
+        access.subscribe(route, context_id="context-unadvertised")
+    assert unknown_error.value.code == "CONTEXT_NOT_ADVERTISED"
+
+
+@pytest.mark.parametrize("changed", ["principal", "connector_sid", "load_generation_id"])
+def test_context_authority_is_isolated_to_exact_route(changed: str) -> None:
+    source = _Source()
+    access = _access(source)
+    route = _route()
+    access.advertise_contexts(route)
+    replacement: Any = _principal() if changed == "principal" else f"other-{changed}"
+    isolated = replace(route, **{changed: replacement})
+    with pytest.raises(BrowserBridgeContextDenied) as error:
+        access.subscribe(isolated, context_id=CONTEXT_A)
+    assert error.value.code == "CONTEXTS_NOT_ADVERTISED"
+    access.subscribe(route, context_id=CONTEXT_A)
+
+
+def test_relisting_replaces_advertisement_and_subscription_sets() -> None:
+    source = _Source()
+    access = _access(source)
+    route = _route()
+    access.advertise_contexts(route)
+    access.subscribe(route, context_id=CONTEXT_A)
+    source.summaries = [_summary(CONTEXT_B)]
+    access.advertise_contexts(route)
+    with pytest.raises(BrowserBridgeContextDenied):
+        access.authorize_message_target(route, context_id=CONTEXT_A)
+    with pytest.raises(BrowserBridgeContextDenied):
+        access.project_completion(route, context_id=CONTEXT_A, status="completed")
+
+
+def test_scope_and_current_route_are_rechecked_after_source_reads() -> None:
+    source = _Source()
+    current = [True]
+    access = _access(source, current=current)
+    route = _route()
+    source.on_list = lambda: current.__setitem__(0, False)
+    with pytest.raises(BrowserBridgeContextDenied) as list_error:
+        access.advertise_contexts(route)
+    assert list_error.value.code == "STALE_BRIDGE_ROUTE"
+
+    current[0] = True
+    source.on_list = None
+    access.advertise_contexts(route)
+    source.on_exists = lambda: current.__setitem__(0, False)
+    with pytest.raises(BrowserBridgeContextDenied) as subscribe_error:
+        access.subscribe(route, context_id=CONTEXT_A)
+    assert subscribe_error.value.code == "STALE_BRIDGE_ROUTE"
+
+    current[0] = True
+    source.on_exists = None
+    no_read = _route(principal=_principal(scopes=frozenset({"context.list"})))
+    access.advertise_contexts(no_read)
+    with pytest.raises(BrowserBridgeContextDenied) as scope_error:
+        access.subscribe(no_read, context_id=CONTEXT_A)
+    assert scope_error.value.code == "SCOPE_DENIED"
+
+
+def test_projection_keeps_only_actual_message_types_and_safe_activity() -> None:
+    secret = "raw-browser-secret"
+    source = _Source()
+    source.page = BrowserContextSourcePage(
+        entries=(
+            {
+                "no": 0,
+                "type": "user",
+                "content": "Please continue",
+                "heading": "/private/user/path",
+                "kvps": {"attachments": ["/private/file.txt"]},
+                "id": "message-A",
+                "timestamp": 1_700_000_000.25,
+            },
+            {
+                "no": 1,
+                "type": "response",
+                "content": "Done",
+                "kvps": {"selector": "#password"},
+            },
+            {
+                "no": 2,
+                "type": "tool",
+                "content": secret,
+                "heading": "evaluate javascript",
+                "kvps": {"script": "document.cookie", "url": "https://x.test/a?q=1"},
+            },
+            {
+                "no": 3,
+                "type": "error",
+                "content": "Traceback /secret/path",
+                "kvps": {"exception": secret},
+            },
+            {"no": 4, "type": "ai_response", "content": secret},
+            {"no": 5, "role": "assistant", "content": secret},
+            {"no": 6, "type": "page_snapshot", "content": secret},
+        ),
+        last_sequence=7,
+        complete=False,
+        history_before=2,
+        has_more_history=True,
+    )
+    access = _access(source)
+    route = _route()
+    access.advertise_contexts(route)
+    access.subscribe(route, context_id=CONTEXT_A)
+    snapshot = access.project_snapshot(
+        route,
+        context_id=CONTEXT_A,
+        history="tail",
+    )
+    assert snapshot["last_sequence"] == 7
+    assert snapshot["history_before"] == 2
+    assert snapshot["has_more_history"] is True
+    assert snapshot["complete"] is False
+    assert snapshot["events"] == [
+        {
+            "context_id": CONTEXT_A,
+            "sequence": 1,
+            "event": "message",
+            "data": {"role": "user", "text": "Please continue"},
+            "timestamp_ms": 1_700_000_000_250,
+            "correlation_id": "message-A",
+        },
+        {
+            "context_id": CONTEXT_A,
+            "sequence": 2,
+            "event": "message",
+            "data": {"role": "assistant", "text": "Done"},
+        },
+        {
+            "context_id": CONTEXT_A,
+            "sequence": 3,
+            "event": "activity",
+            "data": {"activity": "tool", "status": "updated"},
+        },
+        {
+            "context_id": CONTEXT_A,
+            "sequence": 4,
+            "event": "activity",
+            "data": {"activity": "status", "status": "failed"},
+        },
+    ]
+    serialized = json.dumps(snapshot)
+    for forbidden in (
+        secret,
+        "heading",
+        "kvps",
+        "attachments",
+        "selector",
+        "script",
+        "url",
+        "Traceback",
+        "page_snapshot",
+    ):
+        assert forbidden not in serialized
+
+
+def test_dropped_rows_advance_cursor_and_bounded_text_is_utf8_safe() -> None:
+    source = _Source()
+    source.page = BrowserContextSourcePage(
+        entries=(
+            {"no": 10, "type": "unknown", "content": "drop"},
+            {"no": 11, "type": "response", "content": "é" * 10_000},
+        ),
+        last_sequence=12,
+        complete=True,
+    )
+    access = _access(source)
+    route = _route()
+    access.advertise_contexts(route)
+    access.subscribe(route, context_id=CONTEXT_A)
+    snapshot = access.project_snapshot(
+        route,
+        context_id=CONTEXT_A,
+        from_sequence=10,
+    )
+    assert snapshot["last_sequence"] == 12
+    assert snapshot["complete"] is True
+    text = snapshot["events"][0]["data"]["text"]
+    assert len(text.encode("utf-8")) <= MAX_CONTEXT_TEXT_BYTES
+    assert text.endswith("[Text truncated]")
+    assert access.project_completion(
+        route,
+        context_id=CONTEXT_A,
+        status="completed",
+    ) == {"context_id": CONTEXT_A, "status": "completed"}
+
+
+def test_snapshot_route_is_rechecked_after_source_read() -> None:
+    source = _Source()
+    current = [True]
+    access = _access(source, current=current)
+    route = _route()
+    access.advertise_contexts(route)
+    access.subscribe(route, context_id=CONTEXT_A)
+    source.on_read = lambda: current.__setitem__(0, False)
+    with pytest.raises(BrowserBridgeContextDenied) as error:
+        access.project_snapshot(route, context_id=CONTEXT_A)
+    assert error.value.code == "STALE_BRIDGE_ROUTE"
+
+
+@pytest.mark.parametrize(
+    ("page", "arguments"),
+    [
+        (
+            BrowserContextSourcePage(
+                entries=({"no": 0, "type": "response", "content": "again"},),
+                last_sequence=0,
+                complete=False,
+            ),
+            {"from_sequence": 0},
+        ),
+        (
+            BrowserContextSourcePage(
+                entries=(),
+                last_sequence=0,
+                complete=False,
+            ),
+            {"history": "tail"},
+        ),
+    ],
+)
+def test_snapshot_rejects_nonadvancing_or_unpageable_source_pages(
+    page: BrowserContextSourcePage,
+    arguments: dict[str, Any],
+) -> None:
+    source = _Source()
+    source.page = page
+    access = _access(source)
+    route = _route()
+    access.advertise_contexts(route)
+    access.subscribe(route, context_id=CONTEXT_A)
+    with pytest.raises(BrowserBridgeContextUnavailable):
+        access.project_snapshot(route, context_id=CONTEXT_A, **arguments)
+
+
+def test_disconnect_drops_only_exact_route_state() -> None:
+    source = _Source()
+    access = _access(source)
+    route_a = _route()
+    route_b = _route(principal=_principal(bridge_id="bridge-B"), sid="sid-B")
+    access.advertise_contexts(route_a)
+    access.advertise_contexts(route_b)
+    assert access.disconnect(
+        principal=route_a.principal,
+        connector_sid=route_a.connector_sid,
+        load_generation_id=route_a.load_generation_id,
+    ) is True
+    with pytest.raises(BrowserBridgeContextDenied):
+        access.authorize_message_target(route_a, context_id=CONTEXT_A)
+    access.authorize_message_target(route_b, context_id=CONTEXT_A)
+
+
+def test_concrete_agent_context_source_reads_only_allowlisted_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Lock:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+    class _Log:
+        _lock = _Lock()
+        updates = [0]
+
+        def output(self, start=0, end=None):
+            values = [{"no": 0, "type": "user", "content": "hello"}]
+            selected = values[start:end]
+            return SimpleNamespace(items=selected, end=len(values) if end is None else end)
+
+    class _Context:
+        def __init__(self, context_id: str, type_name: str) -> None:
+            self.id = context_id
+            self.name = "Visible task"
+            self.type = SimpleNamespace(value=type_name)
+            self.paused = False
+            self.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+            self.last_message = datetime(2026, 1, 2, tzinfo=UTC)
+            self.log = _Log()
+            self.output_data = {"secret": "must not be read"}
+
+        def is_running(self) -> bool:
+            return False
+
+        def output(self):
+            raise AssertionError("broad AgentContext.output must not be used")
+
+    visible = _Context(CONTEXT_A, "user")
+    background = _Context("background-A", "background")
+
+    class _AgentContext:
+        @staticmethod
+        def all():
+            return [background, visible]
+
+        @staticmethod
+        def get(context_id: str):
+            return {visible.id: visible, background.id: background}.get(context_id)
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "agent",
+        SimpleNamespace(AgentContext=_AgentContext),
+    )
+    source = AgentContextDataSource()
+    summaries = source.list_contexts(subject_id="single_user", limit=10)
+    assert [summary.context_id for summary in summaries] == [CONTEXT_A]
+    assert summaries[0].label == "Visible task"
+    assert source.context_exists(subject_id="single_user", context_id=CONTEXT_A)
+    assert not source.context_exists(subject_id="single_user", context_id="background-A")
+    page = source.read_context(
+        subject_id="single_user",
+        context_id=CONTEXT_A,
+        from_sequence=0,
+        history=None,
+        history_before=None,
+        limit=10,
+    )
+    assert page is not None
+    assert page.entries == ({"no": 0, "type": "user", "content": "hello"},)
+    assert source.list_contexts(subject_id="other-subject", limit=10) == ()

--- a/tests/test_browser_bridge_credentials.py
+++ b/tests/test_browser_bridge_credentials.py
@@ -1,0 +1,103 @@
+"""Real Ed25519 rotation with synthetic public-record persistence only."""
+import base64
+import copy
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from plugins._a0_connector.helpers.browser_bridge_credentials import BrowserBridgeCredentialStore, ROTATION_TTL_MS
+from plugins._a0_connector.helpers.browser_bridge_pairing import BrowserBridgePairingUnavailable
+from plugins._a0_connector.helpers.browser_bridge_auth import BrowserBridgeChallengeStore, BrowserBridgeChallengeFailed
+from test_browser_bridge_challenge_foundation import _credential, _issue, _proof, _signature, BRIDGE_ID, SERVER_ID
+
+
+def setup_rotation():
+    pairing, state, old = _credential()
+    now = [1000]
+    pairing._clock_ms = lambda: now[0]
+    owner = BrowserBridgeCredentialStore(pairing)
+    new = Ed25519PrivateKey.generate()
+    public = {"algorithm":"Ed25519","encoding":"raw-base64url","value":base64.urlsafe_b64encode(
+        new.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)).rstrip(b"=").decode()}
+    args = dict(bridge_id=BRIDGE_ID, server_id=SERVER_ID, subject_id="single_user", key_generation=1,
+                rotation_id="rotation-1", public_key=public)
+    return pairing, owner, state, now, old, new, args
+
+
+def challenge_owner(pairing, owner, now):
+    return BrowserBridgeChallengeStore(
+        record_lookup=lambda bridge, server: pairing.active_bridge_record(bridge_id=bridge,server_instance_id=server),
+        record_candidates=owner.authentication_records, record_verified=owner.accept_verified_key,
+        clock_ms=lambda:now[0])
+
+
+def test_rotation_keeps_old_key_until_exact_fresh_proof_and_survives_reconstruction():
+    pairing, owner, state, now, old, new, args = setup_rotation()
+    original = copy.deepcopy(state)
+    pending = owner.begin(**args)
+    assert pending["status"] == "pending"
+    assert owner.begin(**args) == pending
+    assert state["document"]["bridges"][0]["public_key"] == original["document"]["bridges"][0]["public_key"]
+    auth = challenge_owner(pairing, BrowserBridgeCredentialStore(pairing), now)
+    proof = _proof(_issue(auth))
+    assert auth.verify(proof=proof, signature=_signature(old, proof)).key_generation == 1
+    proof = _proof(_issue(auth))
+    assert auth.verify(proof=proof, signature=_signature(new, proof)).key_generation == 2
+    record = pairing.active_bridge_record(bridge_id=BRIDGE_ID, server_instance_id=SERVER_ID)
+    assert record["rotation"]["status"] == "active"
+    assert record["public_key"] == args["public_key"]
+    assert record["scopes"] == original["document"]["bridges"][0]["scopes"]
+    with pytest.raises(BrowserBridgePairingUnavailable):
+        owner.self_revoke(bridge_id=BRIDGE_ID, server_id=SERVER_ID, subject_id="single_user", key_generation=1)
+    proof = _proof(_issue(auth))
+    with pytest.raises(BrowserBridgeChallengeFailed):
+        auth.verify(proof=proof, signature=_signature(old, proof))
+
+
+def test_pending_expiry_bad_proof_and_changed_payload_leave_old_key_active():
+    pairing, owner, state, now, old, new, args = setup_rotation()
+    owner.begin(**args)
+    with pytest.raises(BrowserBridgePairingUnavailable):
+        owner.begin(**{**args,"public_key":state["document"]["bridges"][0]["public_key"]})
+    auth = challenge_owner(pairing, owner, now)
+    proof = _proof(_issue(auth))
+    with pytest.raises(BrowserBridgeChallengeFailed):
+        auth.verify(proof=proof, signature=_signature(Ed25519PrivateKey.generate(), proof))
+    now[0] += ROTATION_TTL_MS
+    assert owner.begin(**args)["status"] == "expired"
+    proof = _proof(_issue(auth))
+    with pytest.raises(BrowserBridgeChallengeFailed):
+        auth.verify(proof=proof, signature=_signature(new, proof))
+    proof = _proof(_issue(auth))
+    assert auth.verify(proof=proof, signature=_signature(old, proof)).key_generation == 1
+
+
+def test_verified_pending_key_cannot_promote_replacement_or_resurrect_revocation():
+    pairing, owner, state, now, old, new, args = setup_rotation()
+    owner.begin(**args)
+    verified = owner.authentication_records(BRIDGE_ID, SERVER_ID)[1]
+    now[0] += ROTATION_TTL_MS
+    owner.begin(**{**args,"rotation_id":"rotation-2"})
+    with pytest.raises(BrowserBridgePairingUnavailable):
+        owner.accept_verified_key(verified, now[0])
+    verified = owner.authentication_records(BRIDGE_ID, SERVER_ID)[1]
+    pairing.revoke_bridge(bridge_id=BRIDGE_ID, server_instance_id=SERVER_ID, subject_id="single_user")
+    assert owner.authentication_records(BRIDGE_ID, SERVER_ID) == ()
+    assert "rotation" not in state["document"]["bridges"][0]
+    with pytest.raises(BrowserBridgePairingUnavailable):
+        owner.accept_verified_key(verified, now[0])
+
+
+def test_failed_public_key_commit_never_returns_authenticated_principal():
+    pairing, owner, state, now, old, new, args = setup_rotation()
+    owner.begin(**args)
+    before = copy.deepcopy(state)
+    def unavailable(_):
+        raise OSError("synthetic storage failure")
+    pairing._repository._save = unavailable
+    auth = challenge_owner(pairing, owner, now)
+    proof = _proof(_issue(auth))
+    with pytest.raises(BrowserBridgeChallengeFailed):
+        auth.verify(proof=proof, signature=_signature(new, proof))
+    assert state == before

--- a/tests/test_browser_bridge_cutover_foundation.py
+++ b/tests/test_browser_bridge_cutover_foundation.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from plugins._a0_connector.helpers import browser_bridge_cutover as cutover
+from plugins._a0_connector.helpers.browser_bridge_cutover import (
+    CUTOVER_CONTRACT,
+    CUTOVER_SCHEMA_VERSION,
+    CutoverState,
+    LegacyDetectionState,
+    build_cutover_foundation_status,
+    can_transition_cutover,
+    cutover_contract_schema,
+    detect_legacy_browser_bridge,
+    detect_legacy_browser_bridge_roots,
+    detect_installed_legacy_browser_bridge,
+)
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "browser_bridge_cutover_v1"
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_exact_legacy_fixture_matches_versioned_redacted_projection() -> None:
+    report = detect_legacy_browser_bridge(FIXTURES / "legacy_exact")
+    expected = json.loads((FIXTURES / "confirmed_public.json").read_text(encoding="utf-8"))
+
+    assert report.state is LegacyDetectionState.CONFIRMED
+    assert report.confirmed is True
+    assert report.to_public_dict() == expected
+
+
+def test_absent_and_corrupt_roots_fail_safe(tmp_path: Path) -> None:
+    missing = detect_legacy_browser_bridge(tmp_path / "missing")
+    assert missing.state is LegacyDetectionState.ABSENT
+    assert missing.inspected_marker_count == 0
+
+    corrupt = tmp_path / "corrupt"
+    _write(corrupt / "plugin.yaml", "name: [unterminated")
+    report = detect_legacy_browser_bridge(corrupt)
+    assert report.state is LegacyDetectionState.PARTIAL
+    assert report.reason_code == "legacy_bridge_fingerprint_incomplete"
+    assert build_cutover_foundation_status(report)["state"] == "blocked"
+
+
+def test_manifest_alone_or_one_marker_is_never_confirmation(tmp_path: Path) -> None:
+    root = tmp_path / "partial"
+    _write(root / "plugin.yaml", "name: chrome_extension\nversion: 1.0.0\n")
+    _write(
+        root / "tools/chrome_bridge.py",
+        "class ChromeBridge:\n    value = enqueue_command\n",
+    )
+
+    report = detect_legacy_browser_bridge(root)
+    assert report.state is LegacyDetectionState.PARTIAL
+    assert report.manifest_matched is True
+    assert report.matched_markers == ("legacy_tool",)
+
+
+def test_matching_name_with_unrelated_structure_is_not_confirmed(tmp_path: Path) -> None:
+    root = tmp_path / "false-positive"
+    _write(root / "plugin.yaml", "name: chrome_extension\nversion: 1.0.0\n")
+    _write(root / "tools/chrome_bridge.py", "class DifferentTool: pass\n")
+    _write(root / "api/session_upsert.py", "# one route is insufficient\n")
+
+    report = detect_legacy_browser_bridge(root)
+    assert report.state is LegacyDetectionState.PARTIAL
+    assert report.matched_markers == ()
+    assert report.confirmed is False
+
+
+def test_wrong_version_with_markers_is_partial_not_legacy_authority(tmp_path: Path) -> None:
+    root = tmp_path / "wrong-version"
+    _write(root / "plugin.yaml", "name: chrome_extension\nversion: 9.9.9\n")
+    _write(
+        root / "helpers/constants.py",
+        'SOURCE_NAME = "chrome_extension"\n'
+        'CTX_BROWSER_SESSION_ID = "chrome_browser_session_id"\n'
+        'CTX_CHROME_CAPABILITIES = "chrome_extension_capabilities"\n',
+    )
+    _write(
+        root / "default_config.yaml",
+        "command_timeout_seconds: 30\nredelivery_seconds: 8\n"
+        "stale_session_seconds: 600\nmax_inspect_nodes: 40\n"
+        "prompt_guidance: legacy\n",
+    )
+
+    report = detect_legacy_browser_bridge(root)
+    assert report.state is LegacyDetectionState.PARTIAL
+    assert report.manifest_matched is False
+    assert len(report.matched_markers) == 2
+
+
+def test_projection_is_deterministic_and_cannot_leak_source_values(tmp_path: Path) -> None:
+    secret = "sentinel-token-do-not-project"
+    sensitive_path = tmp_path / f"https-example.test-query-token-{secret}"
+    _write(
+        sensitive_path / "plugin.yaml",
+        "name: chrome_extension\nversion: 1.0.0\n"
+        f"description: https://example.test/?token={secret}\n",
+    )
+    _write(
+        sensitive_path / "tools/chrome_bridge.py",
+        f"# {secret}\nclass ChromeBridge:\n    value = enqueue_command\n",
+    )
+
+    first = detect_legacy_browser_bridge(sensitive_path).to_public_dict()
+    second = detect_legacy_browser_bridge(sensitive_path).to_public_dict()
+    serialized = json.dumps(first, sort_keys=True)
+
+    assert first == second
+    assert secret not in serialized
+    assert "example.test" not in serialized
+    assert str(sensitive_path) not in serialized
+    assert set(first) == set(cutover_contract_schema()["projection_fields"])
+
+
+def test_symlinked_markers_outside_root_are_rejected(tmp_path: Path) -> None:
+    outside = tmp_path / "outside.py"
+    outside.write_text("class ChromeBridge:\n    value = enqueue_command\n", encoding="utf-8")
+    root = tmp_path / "candidate"
+    _write(root / "plugin.yaml", "name: chrome_extension\nversion: 1.0.0\n")
+    (root / "tools").mkdir(parents=True)
+    (root / "tools" / "chrome_bridge.py").symlink_to(outside)
+
+    report = detect_legacy_browser_bridge(root)
+    assert report.state is LegacyDetectionState.PARTIAL
+    assert report.matched_markers == ()
+
+
+def test_symlinked_route_and_prompt_entries_are_not_structural_markers(
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path / "outside.txt"
+    outside.write_text("fixture", encoding="utf-8")
+    root = tmp_path / "candidate"
+    _write(root / "plugin.yaml", "name: chrome_extension\nversion: 1.0.0\n")
+    for relative_path in (
+        "api/session_upsert.py",
+        "api/command_pull.py",
+        "api/command_result.py",
+        "prompts/agent.system.tool.chrome_bridge.md",
+        "prompts/fw.chrome.system_context.md",
+    ):
+        path = root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.symlink_to(outside)
+
+    report = detect_legacy_browser_bridge(root)
+
+    assert report.state is LegacyDetectionState.PARTIAL
+    assert "legacy_command_routes" not in report.matched_markers
+    assert "legacy_prompt_pair" not in report.matched_markers
+
+
+def test_symlinked_root_is_unknown_and_blocks_cutover(tmp_path: Path) -> None:
+    real_root = tmp_path / "real"
+    _write(real_root / "plugin.yaml", "name: chrome_extension\nversion: 1.0.0\n")
+    linked_root = tmp_path / "linked"
+    linked_root.symlink_to(real_root, target_is_directory=True)
+
+    report = detect_legacy_browser_bridge(linked_root)
+
+    assert report.state is LegacyDetectionState.UNKNOWN
+    assert report.reason_code == "legacy_bridge_root_untrusted"
+    assert report.inspected_marker_count == 0
+    status = build_cutover_foundation_status(report)
+    assert status["state"] == "blocked"
+    assert status["quarantine"]["state"] == "not_applied"
+
+
+def test_unavailable_installed_root_discovery_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable_roots():
+        yield from ()
+        raise PermissionError("not public")
+
+    monkeypatch.setattr(
+        cutover,
+        "_installed_legacy_plugin_roots",
+        unavailable_roots,
+    )
+
+    report = detect_installed_legacy_browser_bridge()
+
+    assert report.state is LegacyDetectionState.UNKNOWN
+    assert report.reason_code == "legacy_bridge_detection_unavailable"
+    assert build_cutover_foundation_status(report)["state"] == "blocked"
+
+
+def test_unavailable_fingerprint_read_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "candidate"
+    root.mkdir()
+    monkeypatch.setattr(cutover, "_read_yaml_mapping", lambda *_args: ({}, True))
+
+    report = detect_legacy_browser_bridge(root)
+
+    assert report.state is LegacyDetectionState.UNKNOWN
+    assert report.reason_code == "legacy_bridge_detection_unavailable"
+
+
+def test_any_unavailable_marker_blocks_otherwise_sufficient_fingerprint(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "candidate"
+    _write(root / "plugin.yaml", "name: chrome_extension\nversion: 1.0.0\n")
+    monkeypatch.setattr(
+        cutover,
+        "_STRUCTURAL_MARKERS",
+        {
+            "marker_one": lambda _root_fd: cutover._MarkerInspection(matched=True),
+            "marker_two": lambda _root_fd: cutover._MarkerInspection(matched=True),
+            "unavailable": lambda _root_fd: cutover._MarkerInspection(
+                matched=False,
+                unavailable=True,
+            ),
+        },
+    )
+
+    report = detect_legacy_browser_bridge(root)
+
+    assert report.state is LegacyDetectionState.UNKNOWN
+    assert build_cutover_foundation_status(report)["state"] == "blocked"
+
+
+def test_fingerprint_reads_share_one_anchored_root_descriptor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "candidate"
+    _write(root / "plugin.yaml", "name: chrome_extension\nversion: 1.0.0\n")
+    observed_root_fds: list[int] = []
+    original_read_yaml = cutover._read_yaml_mapping
+
+    def read_yaml(root_fd: int, relative_path: str):
+        observed_root_fds.append(root_fd)
+        return original_read_yaml(root_fd, relative_path)
+
+    monkeypatch.setattr(cutover, "_read_yaml_mapping", read_yaml)
+    monkeypatch.setattr(
+        cutover,
+        "_STRUCTURAL_MARKERS",
+        {
+            "marker_one": lambda root_fd: (
+                observed_root_fds.append(root_fd)
+                or cutover._MarkerInspection(matched=False)
+            ),
+            "marker_two": lambda root_fd: (
+                observed_root_fds.append(root_fd)
+                or cutover._MarkerInspection(matched=False)
+            ),
+        },
+    )
+
+    detect_legacy_browser_bridge(root)
+
+    assert len(observed_root_fds) == 3
+    assert len(set(observed_root_fds)) == 1
+
+
+def test_cutover_schema_and_transition_graph_are_versioned_and_fail_closed() -> None:
+    schema = cutover_contract_schema()
+    assert schema["contract"] == CUTOVER_CONTRACT
+    assert schema["schema_version"] == CUTOVER_SCHEMA_VERSION
+    assert schema["minimum_structural_markers"] == 2
+
+    assert can_transition_cutover(CutoverState.NOT_DETECTED, CutoverState.LEGACY_DETECTED)
+    assert can_transition_cutover(CutoverState.DRAINING_LEGACY, CutoverState.BLOCKED)
+    assert can_transition_cutover(CutoverState.VERIFYING, CutoverState.COMPLETE)
+    assert not can_transition_cutover(CutoverState.NOT_DETECTED, CutoverState.COMPLETE)
+    assert not can_transition_cutover(CutoverState.COMPLETE, CutoverState.CANCELED)
+    assert not can_transition_cutover(CutoverState.CANCELED, CutoverState.LEGACY_DETECTED)
+
+
+def test_root_selection_and_foundation_status_never_claim_quarantine(tmp_path: Path) -> None:
+    detection = detect_legacy_browser_bridge_roots(
+        [tmp_path / "absent", FIXTURES / "legacy_exact"]
+    )
+
+    status = build_cutover_foundation_status(detection)
+
+    assert status["state"] == "legacy_detected"
+    assert status["legacy"]["state"] == "confirmed"
+    assert status["quarantine"] == {
+        "state": "not_applied",
+        "reason_code": "foundation_detection_only",
+    }
+
+
+def test_higher_priority_partial_root_blocks_shadowed_confirmed_copy(
+    tmp_path: Path,
+) -> None:
+    partial = tmp_path / "partial"
+    _write(partial / "plugin.yaml", "name: chrome_extension\nversion: 1.0.0\n")
+    detection = detect_legacy_browser_bridge_roots(
+        [partial, FIXTURES / "legacy_exact"]
+    )
+
+    status = build_cutover_foundation_status(detection)
+
+    assert status["state"] == "blocked"
+    assert status["legacy"]["state"] == "partial"
+    assert status["quarantine"] == {
+        "state": "not_applied",
+        "reason_code": "legacy_bridge_fingerprint_incomplete",
+    }

--- a/tests/test_browser_bridge_default_selection.py
+++ b/tests/test_browser_bridge_default_selection.py
@@ -1,0 +1,124 @@
+"""Global selection uses synthetic configuration, never live pairings or chats."""
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from plugins._a0_connector.helpers import browser_bridge_selection as selection
+
+
+@pytest.fixture
+def state(monkeypatch):
+    from helpers import plugins, runtime
+    from plugins._a0_connector.helpers import browser_bridge_bootstrap as bootstrap
+    from plugins._a0_connector.helpers import browser_bridge_pairing as pairing
+    from plugins._browser.helpers import bridge_foundation, config
+    state = SimpleNamespace(global_config={"runtime_backend": "container", "host_browser_selection": "", "proxy_server": "global-proxy"},
+                            projects={"internal": {"runtime_backend": "container"}}, writes=[], retired=[], active=True, ready=False)
+    def load(_name, agent=None, project_name="", agent_profile="", **kwargs):
+        project = getattr(agent, "project", project_name)
+        return dict(state.projects.get(project, state.global_config))
+    def save(name, project, profile, value, **kwargs):
+        assert (name, project, profile) == ("_browser", "", "")
+        assert config._production_selection_write.get() is True
+        state.writes.append(dict(value))
+        state.global_config = dict(value)
+    state.application = SimpleNamespace(registry=SimpleNamespace(
+        retire_bridge=state.retired.append, current_bridge_ready=lambda _: state.ready))
+    monkeypatch.setattr(plugins, "get_plugin_config", load)
+    monkeypatch.setattr(plugins, "save_plugin_config", save)
+    monkeypatch.setattr(runtime, "get_persistent_id", lambda: "server-test")
+    monkeypatch.setattr(bootstrap, "get_browser_bridge_application", lambda: state.application)
+    monkeypatch.setattr(bridge_foundation, "get_browser_bridge_gate", lambda: SimpleNamespace(state="available"))
+    monkeypatch.setattr(pairing, "configured_extension_id", lambda: "extension-test")
+    monkeypatch.setattr(pairing, "get_browser_bridge_pairing_store", lambda: SimpleNamespace(
+        active_bridge_record=lambda **_: {"subject_id": pairing.SUBJECT_ID, "extension_id": "extension-test"} if state.active else None))
+    return state
+
+
+def test_default_inherits_for_new_chats_without_changing_project_override(state, monkeypatch):
+    from agent import AgentContext
+    contexts = {}
+    for name, project in (("new-chat", "new-project"), ("internal-chat", "internal")):
+        context = SimpleNamespace(id=name)
+        context.agent0 = SimpleNamespace(context=context, project=project)
+        contexts[name] = context
+    monkeypatch.setattr(AgentContext, "get", staticmethod(contexts.get))
+    selection.select_default_bridge("browser-A", expected_bridge_id=None)
+    assert selection.selected_bridge("new-chat") == "browser-A"
+    assert selection.selected_bridge("internal-chat") is None
+    assert state.projects == {"internal": {"runtime_backend": "container"}}
+    assert state.global_config["proxy_server"] == "global-proxy"
+
+
+def test_default_cas_retires_before_replace_and_stale_clear_has_no_effect(state):
+    selection.select_default_bridge("browser-A", expected_bridge_id=None)
+    selection.select_default_bridge("browser-B", expected_bridge_id="browser-A")
+    assert state.retired == ["browser-A"]
+    with pytest.raises(RuntimeError):
+        selection.select_default_bridge(None, expected_bridge_id="browser-A")
+    assert len(state.writes) == 2
+    assert state.retired == ["browser-A"]
+    selection.select_default_bridge(None, expected_bridge_id="browser-B")
+    assert selection.default_selected_bridge() is None
+
+
+def test_inactive_pair_cannot_set_default_but_unavailable_owner_can_clear(state):
+    state.active = False
+    with pytest.raises(RuntimeError):
+        selection.select_default_bridge("browser-A", expected_bridge_id=None)
+    assert state.writes == []
+    state.active = True
+    selection.select_default_bridge("browser-A", expected_bridge_id=None)
+    state.application = None
+    selection.select_default_bridge(None, expected_bridge_id="browser-A")
+
+
+def test_no_chat_admission_selection_does_not_authorize_overridden_context(state, monkeypatch):
+    from agent import AgentContext
+    from plugins._a0_connector.helpers import browser_bridge_runtime_owner as owner_module
+    monkeypatch.setattr(AgentContext, "all", staticmethod(lambda: []))
+    owner = object.__new__(owner_module.BrowserBridgeRuntimeOwner)
+    assert not owner._selected("browser-A")
+    selection.select_default_bridge("browser-A", expected_bridge_id=None)
+    assert owner._selected("browser-A")
+    assert not owner._selected("browser-B")
+    assert not selection.selection_current("nonexistent-chat", "browser-A")
+
+
+def test_default_api_is_strict_read_only_and_readiness_is_not_selection(state):
+    from plugins._a0_connector.api.browser_bridge_selection import BrowserBridgeSelection
+    handler = object.__new__(BrowserBridgeSelection)
+    def request(body):
+        return asyncio.run(handler._dispatch(body))
+    response = request({"action": "default_status"})
+    assert response.status_code == 200
+    assert state.writes == []
+    response = request({"action": "use_default", "bridge_id": "browser-A", "expected_bridge_id": None})
+    value = json.loads(response.get_data())
+    assert value == {"contract": "a0.browser-bridge.default-selection.v1", "bridge_id": "browser-A",
+                     "selected": True, "browser_control_ready": False, "reconnect_required": True}
+    state.ready = True
+    assert json.loads(request({"action": "default_status"}).get_data())["browser_control_ready"] is True
+    assert request({"action": "default_status", "context_id": "chat"}).status_code == 400
+    assert request({"action": "use_default", "bridge_id": "browser-B"}).status_code == 400
+    assert request({"action": "clear_default", "expected_bridge_id": "browser-B"}).status_code == 409
+    assert request({"action": "clear_default", "expected_bridge_id": None}).status_code == 400
+
+
+def test_readiness_lookup_rechecks_admission_without_granting_context():
+    from test_browser_bridge_runtime_foundation import _registry, _admission, _principal, _hello
+    async def scenario():
+        admitted = [True]
+        registry = _registry(admission_evaluator=lambda *args: _admission(*args) if admitted[0] else None,
+                             context_authorizer=lambda *_: False)
+        principal = _principal()
+        registry.register_hello(principal=principal, connector_sid="sid-A", data=_hello(principal))
+        # Transport admission alone is provisional until exact reconciliation.
+        assert registry.current_bridge_ready("bridge-A") is False
+        assert registry.resolve_extension_route("context-A", "bridge-A") is None
+        admitted[0] = False
+        assert registry.current_bridge_ready("bridge-A") is False
+        assert registry.session_count == 0
+    asyncio.run(scenario())

--- a/tests/test_browser_bridge_events.py
+++ b/tests/test_browser_bridge_events.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from dataclasses import replace
+import hashlib
+from typing import Any
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    BrowserBridgeContextRoute,
+)
+from plugins._a0_connector.helpers.browser_bridge_events import (
+    BROWSER_EVENT,
+    BROWSER_EVENT_ACK,
+    RESTRICTED_HANDLER_ID,
+    WS_NAMESPACE,
+    BrowserBridgeCriticalEventReceiver,
+    BrowserBridgeEventDenied,
+    BrowserBridgeEventError,
+    LeaseInvalidation,
+    TurnFinalizedNotice,
+)
+
+
+def _route(generation: str = "generation-A") -> BrowserBridgeContextRoute:
+    principal = WsPrincipal(
+        principal_type="browser_bridge",
+        principal_id="bridge-A",
+        subject_id="single_user",
+        scopes=frozenset({"browser.operate"}),
+        handler_path="plugins/_a0_connector/ws_connector",
+        handler_id=RESTRICTED_HANDLER_ID,
+        inbound_events=frozenset({BROWSER_EVENT}),
+        outbound_events=frozenset({BROWSER_EVENT_ACK}),
+        key_generation=3,
+    )
+    return BrowserBridgeContextRoute(principal, "sid-A", generation)
+
+
+def _lease_event(
+    sequence: int,
+    *,
+    event_id: str | None = None,
+    generation: str = "generation-A",
+    change: str = "tab_closed",
+    state: str = "closed",
+    reason_code: str | None = "TAB_CLOSED",
+) -> dict[str, Any]:
+    return {
+        "contract_version": 1,
+        "event_id": event_id or f"event-{sequence}",
+        "load_generation_id": generation,
+        "event_sequence": sequence,
+        "delivery": "critical",
+        "event_type": "lease.changed",
+        "observed_at_ms": 1_000 + sequence,
+        "context_id": "context-A",
+        "browser_session_id": "browser-session-A",
+        "turn_id": "turn-A",
+        "op_id": None,
+        "action_id": None,
+        "data": {
+            "lease_id_digest": hashlib.sha256(b"lease-A").hexdigest(),
+            "browser_id_digest": hashlib.sha256(b"browser-A").hexdigest(),
+            "state": state,
+            "ownership": "created",
+            "disposition": "ephemeral",
+            "change": change,
+            "reason_code": reason_code,
+        },
+    }
+
+
+def _finalized_event(sequence: int) -> dict[str, Any]:
+    return {
+        "contract_version": 1,
+        "event_id": f"final-event-{sequence}",
+        "load_generation_id": "generation-A",
+        "event_sequence": sequence,
+        "delivery": "critical",
+        "event_type": "turn.finalized",
+        "observed_at_ms": 2_000 + sequence,
+        "context_id": "context-A",
+        "browser_session_id": "browser-session-A",
+        "turn_id": "turn-A",
+        "op_id": None,
+        "action_id": None,
+        "data": {
+            "control_id": "finalize-control-A",
+            "status": "completed",
+            "closed_count": 2,
+            "released_count": 1,
+            "retained_count": 1,
+            "already_finalized_count": 0,
+            "error_count": 0,
+        },
+    }
+
+
+class _Manager:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str, dict[str, Any], dict[str, Any]]] = []
+
+    async def emit_to(
+        self,
+        namespace: str,
+        sid: str,
+        event: str,
+        data: dict[str, Any],
+        **kwargs: Any,
+    ) -> None:
+        self.calls.append((namespace, sid, event, deepcopy(data), dict(kwargs)))
+
+
+def _receiver(
+    *,
+    route: BrowserBridgeContextRoute,
+    stored: list[Any],
+    manager: _Manager,
+    leases: list[LeaseInvalidation] | None = None,
+    finalizations: list[TurnFinalizedNotice] | None = None,
+    current: list[BrowserBridgeContextRoute] | None = None,
+    save=None,
+) -> BrowserBridgeCriticalEventReceiver:
+    leases = leases if leases is not None else []
+    finalizations = finalizations if finalizations is not None else []
+    current = current if current is not None else [route]
+
+    def is_current(candidate: BrowserBridgeContextRoute) -> bool:
+        expected = current[0]
+        return (
+            candidate.principal is expected.principal
+            and candidate.connector_sid == expected.connector_sid
+            and candidate.load_generation_id == expected.load_generation_id
+        )
+
+    return BrowserBridgeCriticalEventReceiver(
+        manager=manager,
+        server_instance_id=lambda: "server-A",
+        current_route_verifier=is_current,
+        invalidate_lease=lambda value: leases.append(value),
+        observe_finalization=lambda value: finalizations.append(value),
+        load=lambda: deepcopy(stored[0]),
+        save=save
+        or (lambda value: stored.__setitem__(0, deepcopy(value))),
+        ack_emit_seconds=0.1,
+    )
+
+
+def test_contiguous_event_is_hash_only_durable_before_exact_ack_and_replay() -> None:
+    async def scenario() -> None:
+        route = _route()
+        stored: list[Any] = [None]
+        manager = _Manager()
+        invalidations: list[LeaseInvalidation] = []
+        receiver = _receiver(
+            route=route,
+            stored=stored,
+            manager=manager,
+            leases=invalidations,
+        )
+        event = _lease_event(1)
+        assert await receiver.receive(route, event) == {
+            "contract_version": 1,
+            "event_id": "event-1",
+            "status": "accepted",
+        }
+        assert len(invalidations) == 1
+        invalidation = invalidations[0]
+        assert invalidation.principal is route.principal
+        assert invalidation.connector_sid == "sid-A"
+        assert invalidation.change == "tab_closed"
+        assert invalidation.state == "closed"
+        assert manager.calls[0][0:3] == (
+            WS_NAMESPACE,
+            "sid-A",
+            BROWSER_EVENT_ACK,
+        )
+        assert manager.calls[0][3] == {
+            "contract_version": 1,
+            "bridge_id": "bridge-A",
+            "load_generation_id": "generation-A",
+            "highest_contiguous_event_sequence": 1,
+        }
+        assert manager.calls[0][4]["handler_id"] == RESTRICTED_HANDLER_ID
+        assert manager.calls[0][4]["expected_principal"] is route.principal
+        persisted = repr(stored[0])
+        for raw in (
+            "server-A",
+            "bridge-A",
+            "single_user",
+            "generation-A",
+            "event-1",
+            "context-A",
+            "browser-session-A",
+            event["data"]["lease_id_digest"],
+        ):
+            assert raw not in persisted
+
+        await receiver.receive(route, event)
+        assert len(invalidations) == 1
+        assert len(manager.calls) == 2
+        assert manager.calls[-1][3]["highest_contiguous_event_sequence"] == 1
+        with pytest.raises(BrowserBridgeEventError) as conflict:
+            await receiver.receive(route, _lease_event(1, event_id="changed-event"))
+        assert conflict.value.code == "EVENT_SEQUENCE_CONFLICT"
+
+    asyncio.run(scenario())
+
+
+def test_gap_never_acks_forward_and_callback_failure_never_moves_cursor() -> None:
+    async def scenario() -> None:
+        route = _route()
+        stored: list[Any] = [None]
+        manager = _Manager()
+        invalidations: list[LeaseInvalidation] = []
+        receiver = _receiver(
+            route=route,
+            stored=stored,
+            manager=manager,
+            leases=invalidations,
+        )
+        await receiver.receive(route, _lease_event(2, event_id="event-two"))
+        assert manager.calls == []
+        assert next(iter(stored[0]["routes"].values()))["cursor"] == 0
+        await receiver.receive(route, _lease_event(1, event_id="event-one"))
+        assert manager.calls[-1][3]["highest_contiguous_event_sequence"] == 2
+        assert len(invalidations) == 2
+
+        receiver._invalidate_lease = lambda _value: (_ for _ in ()).throw(
+            RuntimeError("raw private callback error")
+        )
+        with pytest.raises(BrowserBridgeEventError) as callback_error:
+            await receiver.receive(route, _lease_event(3, event_id="event-three"))
+        assert callback_error.value.code == "EVENT_CALLBACK_FAILED"
+        assert "private" not in str(callback_error.value)
+        assert next(iter(stored[0]["routes"].values()))["cursor"] == 2
+        assert manager.calls[-1][3]["highest_contiguous_event_sequence"] == 2
+
+        replayed: list[LeaseInvalidation] = []
+        recovered = _receiver(
+            route=route,
+            stored=stored,
+            manager=manager,
+            leases=replayed,
+        )
+        await recovered.receive(route, _lease_event(3, event_id="event-three"))
+        assert len(replayed) == 1
+        assert next(iter(stored[0]["routes"].values()))["cursor"] == 3
+        assert manager.calls[-1][3]["highest_contiguous_event_sequence"] == 3
+
+    asyncio.run(scenario())
+
+
+def test_finalization_notice_is_informational_and_unsupported_events_fail_closed() -> None:
+    async def scenario() -> None:
+        route = _route()
+        stored: list[Any] = [None]
+        manager = _Manager()
+        notices: list[TurnFinalizedNotice] = []
+        receiver = _receiver(
+            route=route,
+            stored=stored,
+            manager=manager,
+            finalizations=notices,
+        )
+        event = _finalized_event(1)
+        await receiver.receive(route, event)
+        assert len(notices) == 1
+        notice = notices[0]
+        assert notice.status == "completed" and notice.closed_count == 2
+        assert not hasattr(notice, "control_id")
+        assert notice.control_id_digest == hashlib.sha256(
+            b"finalize-control-A"
+        ).hexdigest()
+        assert "finalize-control-A" not in repr(stored[0])
+
+        for invalid in (
+            {**_lease_event(2), "delivery": "best_effort"},
+            {**_lease_event(2), "event_type": "challenge.required"},
+            {**_lease_event(2), "event_type": {"untrusted": True}},
+            {
+                **_lease_event(2),
+                "data": {**_lease_event(2)["data"], "origin": "https://secret.example"},
+            },
+            {
+                **_lease_event(2),
+                "data": {**_lease_event(2)["data"], "state": ["closed"]},
+            },
+            {
+                **_lease_event(2),
+                "data": {
+                    **_lease_event(2)["data"],
+                    "change": "finalized",
+                    "state": "closed",
+                    "reason_code": "TAB_CLOSED",
+                },
+            },
+            {
+                **_finalized_event(2),
+                "data": {**_finalized_event(2)["data"], "error_count": 257},
+            },
+        ):
+            with pytest.raises(BrowserBridgeEventError):
+                await receiver.receive(route, invalid)
+        assert len(notices) == 1
+
+        unavailable = BrowserBridgeCriticalEventReceiver(
+            manager=manager,
+            server_instance_id=lambda: "server-A",
+            current_route_verifier=lambda _route: True,
+            load=lambda: None,
+            save=lambda _value: None,
+        )
+        # Passive creation neither grants nor withdraws Core authority and does
+        # not require an invalidation callback.
+        await unavailable.receive(
+            route,
+            _lease_event(
+                1,
+                event_id="passive-created",
+                change="created",
+                state="active",
+                reason_code=None,
+            ),
+        )
+        with pytest.raises(BrowserBridgeEventError) as missing_callback:
+            await unavailable.receive(route, _lease_event(2))
+        assert missing_callback.value.code == "EVENT_CALLBACK_FAILED"
+
+    asyncio.run(scenario())
+
+
+def test_verified_generation_replacement_cannot_be_reset_by_old_replay() -> None:
+    async def scenario() -> None:
+        old_route = _route("generation-old")
+        new_route = replace(old_route, load_generation_id="generation-new")
+        current = [old_route]
+        stored: list[Any] = [None]
+        manager = _Manager()
+        receiver = _receiver(
+            route=old_route,
+            stored=stored,
+            manager=manager,
+            current=current,
+        )
+        await receiver.receive(
+            old_route, _lease_event(1, generation="generation-old")
+        )
+        current[0] = new_route
+        await receiver.receive(
+            new_route, _lease_event(1, event_id="new-event", generation="generation-new")
+        )
+        assert len(stored[0]["routes"]) == 1
+        assert next(iter(stored[0]["routes"].values()))["cursor"] == 1
+        calls_before = len(manager.calls)
+        with pytest.raises(BrowserBridgeEventDenied):
+            await receiver.receive(
+                old_route,
+                _lease_event(2, event_id="old-replay", generation="generation-old"),
+            )
+        assert len(manager.calls) == calls_before
+        assert len(stored[0]["routes"]) == 1
+        assert next(iter(stored[0]["routes"].values()))["cursor"] == 1
+
+    asyncio.run(scenario())

--- a/tests/test_browser_bridge_foundation_status.py
+++ b/tests/test_browser_bridge_foundation_status.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from types import ModuleType
+
+from plugins._browser.helpers.bridge_foundation import (
+    BROWSER_BRIDGE_FOUNDATION_CONTRACT,
+    BROWSER_BRIDGE_ROLLOUT_ENV,
+    BROWSER_BRIDGE_STATUS_CONTRACT,
+    BrowserBridgeGate,
+    build_browser_bridge_status,
+    get_browser_bridge_gate,
+)
+from plugins._a0_connector.helpers.browser_bridge_cutover import (
+    LegacyBridgeDetection,
+    LegacyDetectionState,
+)
+
+
+def test_rollout_gate_accepts_only_frozen_states_and_fails_closed() -> None:
+    default = BrowserBridgeGate.from_value(None)
+    assert default.state == "disabled"
+    assert default.configured is False
+    assert BrowserBridgeGate.from_value("preview").state == "preview"
+    assert BrowserBridgeGate.from_value("AVAILABLE").state == "available"
+
+    invalid = BrowserBridgeGate.from_value("enabled")
+    assert invalid.state == "disabled"
+    assert invalid.reason_code == "invalid_rollout_defaulted_disabled"
+    assert "enabled" not in repr(invalid.as_dict())
+
+
+def test_rollout_gate_is_instance_scoped_and_off_by_default() -> None:
+    assert get_browser_bridge_gate(environ={}).state == "disabled"
+    assert get_browser_bridge_gate(
+        environ={BROWSER_BRIDGE_ROLLOUT_ENV: " PREVIEW "}
+    ).state == "preview"
+    invalid = get_browser_bridge_gate(
+        environ={BROWSER_BRIDGE_ROLLOUT_ENV: "enabled"}
+    )
+    assert invalid.state == "disabled"
+    assert invalid.reason_code == "invalid_rollout_defaulted_disabled"
+
+
+def test_foundation_status_is_redacted_and_does_not_infer_remote_health() -> None:
+    secret_bridge_id = "bridge-private-123"
+    status = build_browser_bridge_status(
+        {
+            "runtime_backend": "host_required",
+            "host_browser_selection": f"extension:{secret_bridge_id}",
+        },
+        BrowserBridgeGate.from_value("available"),
+        checked_at="2026-09-04T12:00:00Z",
+    )
+
+    assert status["foundation_contract"] == BROWSER_BRIDGE_FOUNDATION_CONTRACT
+    assert status["status_contract"] == BROWSER_BRIDGE_STATUS_CONTRACT
+    assert status["scope"] == "extension_bridge_foundation"
+    assert status["selection"]["runtime_backend"] == "host_required"
+    assert status["selection"]["browser_selection"] == "extension:<redacted>"
+    assert status["selection"]["configured_backend_id"] == "chrome_extension"
+    assert status["selection"]["state"] == "configured"
+    assert secret_bridge_id not in repr(status)
+    assert status["layers"]["server"]["state"] == "configured"
+    for name in (
+        "credential",
+        "companion",
+        "browser_registration",
+        "extension",
+        "chrome_permission",
+        "site_policy",
+        "runtime",
+    ):
+        assert status["layers"][name]["state"] == "unknown"
+        assert status["layers"][name]["checked_at"] is None
+    assert status["actions"] == []
+
+
+def test_disabled_foundation_reports_remote_layers_not_checked() -> None:
+    status = build_browser_bridge_status(
+        {"runtime_backend": "container", "host_browser_selection": ""},
+        BrowserBridgeGate.from_value("disabled"),
+        checked_at="2026-09-04T12:00:00Z",
+    )
+
+    assert status["gate"]["state"] == "disabled"
+    assert status["layers"]["server"]["state"] == "blocked"
+    assert status["layers"]["runtime"]["state"] == "not_checked"
+    assert status["selection"]["configured_backend_id"] == "container"
+
+
+def test_malformed_extension_selection_is_blocked_and_never_an_effective_backend() -> None:
+    status = build_browser_bridge_status(
+        {
+            "runtime_backend": "host_required",
+            "host_browser_selection": "extension:",
+        },
+        BrowserBridgeGate.from_value("available"),
+        checked_at="2026-09-04T12:00:00Z",
+    )
+
+    assert status["selection"]["state"] == "blocked"
+    assert status["selection"]["configured_backend_id"] is None
+    assert status["layers"]["runtime"]["state"] == "not_checked"
+    assert (
+        status["layers"]["runtime"]["reason_code"]
+        == "invalid_extension_browser_selection"
+    )
+
+
+def test_untrusted_runtime_backend_is_not_projected() -> None:
+    secret = "https://example.test/?token=do-not-project"
+    status = build_browser_bridge_status(
+        {"runtime_backend": secret, "host_browser_selection": "chrome"},
+        BrowserBridgeGate.from_value("available"),
+        checked_at="2026-09-04T12:00:00Z",
+    )
+
+    assert secret not in repr(status)
+    assert status["selection"]["runtime_backend"] is None
+    assert status["selection"]["configured_backend_id"] is None
+    assert status["selection"]["reason_code"] == "invalid_runtime_backend"
+    assert status["layers"]["runtime"]["reason_code"] == "invalid_runtime_backend"
+
+
+def test_browser_status_preserves_existing_keys_and_adds_foundation(monkeypatch) -> None:
+    class FakeApiHandler:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+    api_stub = ModuleType("helpers.api")
+    api_stub.ApiHandler = FakeApiHandler
+    api_stub.Request = object
+
+    config_stub = ModuleType("plugins._browser.helpers.config")
+    config_stub.get_browser_config = lambda: {
+        "runtime_backend": "container",
+        "host_browser_selection": "",
+    }
+    config_stub.build_browser_launch_config = lambda config: {
+        "browser_mode": "chromium",
+        "extensions": {"enabled": False},
+        "requires_full_browser": False,
+    }
+
+    view_stub = ModuleType("plugins._browser.helpers.interactive_view")
+    view_stub.collect_status = lambda: {"ready": False}
+    playwright_stub = ModuleType("plugins._browser.helpers.playwright")
+    playwright_stub.get_playwright_binary = lambda: None
+    playwright_stub.get_playwright_cache_dir = lambda: "/cache"
+    playwright_stub.get_playwright_cache_dirs = lambda: []
+    runtime_stub = ModuleType("plugins._browser.helpers.runtime")
+    runtime_stub.known_context_ids = lambda: []
+    connector_stub = ModuleType("plugins._a0_connector.helpers.ws_runtime")
+    connector_stub.all_host_browser_metadata = lambda: []
+
+    status_module_name = "plugins._browser.api.status"
+    previous_status_module = sys.modules.pop(status_module_name, None)
+    with monkeypatch.context() as context:
+        for name, module in {
+            "helpers.api": api_stub,
+            "plugins._browser.helpers.config": config_stub,
+            "plugins._browser.helpers.interactive_view": view_stub,
+            "plugins._browser.helpers.playwright": playwright_stub,
+            "plugins._browser.helpers.runtime": runtime_stub,
+            "plugins._a0_connector.helpers.ws_runtime": connector_stub,
+        }.items():
+            context.setitem(sys.modules, name, module)
+        status_api = importlib.import_module(status_module_name)
+        context.setattr(
+            status_api,
+            "get_browser_bridge_gate",
+            lambda: BrowserBridgeGate.from_value("disabled"),
+        )
+        context.setattr(
+            status_api,
+            "detect_installed_legacy_browser_bridge",
+            lambda: LegacyBridgeDetection(
+                state=LegacyDetectionState.ABSENT,
+                reason_code="legacy_bridge_absent",
+                manifest_matched=False,
+            ),
+        )
+
+        response = asyncio.run(status_api.Status(None, None).process({}, request=None))
+
+        sys.modules.pop(status_module_name, None)
+        if previous_status_module is not None:
+            sys.modules[status_module_name] = previous_status_module
+
+    assert {
+        "plugin",
+        "playwright",
+        "extensions",
+        "host_browser",
+        "interactive_view",
+        "contexts",
+    }.issubset(response)
+    assert response["extension_bridge"]["status_contract"] == BROWSER_BRIDGE_STATUS_CONTRACT
+    assert response["extension_bridge"]["scope"] == "extension_bridge_foundation"
+    assert response["extension_bridge"]["gate"]["state"] == "disabled"
+    assert response["extension_bridge"]["selection"]["state"] == "not_checked"
+    assert response["extension_bridge"]["cutover"]["state"] == "not_detected"
+
+
+def test_connector_discovery_does_not_imply_installation_or_runtime_admission(monkeypatch) -> None:
+    api_stub = ModuleType("helpers.api")
+    api_stub.Request = object
+    api_stub.Response = object
+
+    base_stub = ModuleType("plugins._a0_connector.api.v1.base")
+    base_stub.PublicConnectorApiHandler = object
+    version_stub = ModuleType("plugins._a0_connector.helpers.version")
+    version_stub.agent_zero_version = lambda: "test"
+
+    module_name = "plugins._a0_connector.api.v1.capabilities"
+    previous = sys.modules.pop(module_name, None)
+    with monkeypatch.context() as context:
+        context.setitem(sys.modules, "helpers.api", api_stub)
+        context.setitem(sys.modules, "plugins._a0_connector.api.v1.base", base_stub)
+        context.setitem(sys.modules, "plugins._a0_connector.helpers.version", version_stub)
+        capabilities = importlib.import_module(module_name)
+        features = capabilities._feature_list()
+
+        sys.modules.pop(module_name, None)
+        if previous is not None:
+            sys.modules[module_name] = previous
+
+    # One discovery boundary replaces six copies of the same import/stub check.
+    assert {
+        "browser_extension_bridge_foundation", "browser_extension_mv3_runtime_foundation",
+        "browser_bridge_pairing_v1", "browser_companion_release_metadata",
+    }.issubset(features)
+    assert {
+        "browser_extension_pairing", "browser_extension_runtime",
+        "browser_extension_bridge_v1", "connector_browser_control",
+        "browser_bridge_challenge_v1", "browser_bridge_approval_v1",
+        "browser_bridge_policy_v1", "browser_companion_install", "browser_companion_pairing",
+    }.isdisjoint(features)

--- a/tests/test_browser_bridge_legacy_quarantine.py
+++ b/tests/test_browser_bridge_legacy_quarantine.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from plugins._a0_connector.helpers import browser_bridge_legacy_quarantine as quarantine
+from plugins._a0_connector.helpers.browser_bridge_legacy_retirement import LegacyRetirementDenied
+
+
+def result():
+    return {"tool_name": "chrome_bridge", "tool_result": "Captured", "browser_session_id": "old-session", "command_id": "old-command", "command_status": "completed", "image_data_url": "data:image/png;base64,private", "image_width": 800}
+
+
+def document():
+    message = {"_cls": "Message", "ai": False, "content": result(), "metadata": {"user_attachment": "keep"}}
+    user = {"_cls": "Message", "ai": False, "content": {"image_data_url": "user-owned-image", "text": "chrome_bridge"}}
+    tree = {"_cls": "History", "bulks": [{"_cls": "Bulk", "records": [{"_cls": "Topic", "messages": [message]}]}], "topics": [], "current": {"_cls": "Topic", "messages": [user]}}
+    return {"id": "chat-owned", "data": {"source": "chrome_extension", "chrome_browser_session_id": "old-session", "chrome_extension_capabilities": {"read": True}, "user_data": "keep"}, "agents": [{"history": json.dumps(tree)}], "attachments": ["user-owned-image"]}
+
+
+def test_exact_serialized_slots_are_recoverable_and_idempotent():
+    doc, retained = document(), []
+    assert quarantine.quarantine_document(doc, store=retained.append) == {"context_keys": 3, "screenshots": 1}
+    assert doc["data"] == {"user_data": "keep"}
+    tree = json.loads(doc["agents"][0]["history"])
+    message = tree["bulks"][0]["records"][0]["messages"][0]
+    assert "image_data_url" not in message["content"]
+    assert message["content"]["image_width"] == 800
+    assert message["metadata"] == {"user_attachment": "keep"}
+    assert tree["current"]["messages"][0]["content"]["image_data_url"] == "user-owned-image"
+    assert doc["attachments"] == ["user-owned-image"]
+    recovery = json.loads(retained[0])
+    assert len(recovery["entries"]) == 4
+    assert "data:image/png;base64,private" in retained[0].decode()
+    assert "user-owned-image" not in retained[0].decode()
+    unchanged = copy.deepcopy(doc)
+    assert quarantine.quarantine_document(doc, store=retained.append) == {"context_keys": 0, "screenshots": 0}
+    assert doc == unchanged and len(retained) == 1
+
+
+def test_foreign_context_keys_and_non_tool_images_are_preserved():
+    doc = document()
+    doc["data"]["source"] = "other-client"
+    tree = json.loads(doc["agents"][0]["history"])
+    tree["bulks"][0]["records"][0]["messages"][0]["ai"] = True
+    doc["agents"][0]["history"] = json.dumps(tree)
+    original = copy.deepcopy(doc)
+    assert quarantine.quarantine_document(doc, store=lambda raw: pytest.fail("no owned data")) == {"context_keys": 0, "screenshots": 0}
+    assert doc == original
+
+
+def test_backup_failure_never_removes_original_data():
+    doc = document()
+    original = copy.deepcopy(doc)
+    def fail(_raw):
+        raise LegacyRetirementDenied("storage_write_failed")
+    with pytest.raises(LegacyRetirementDenied):
+        quarantine.quarantine_document(doc, store=fail)
+    assert doc == original
+
+
+def test_private_backup_is_exact_private_and_refuses_symlinks(tmp_path):
+    (tmp_path / "usr").mkdir()
+    raw = b'{"synthetic":"recover-me"}'
+    quarantine.retain_private(raw, root=tmp_path)
+    folder = tmp_path / "usr/browser_bridge_legacy_quarantine"
+    blob = folder / (hashlib.sha256(raw).hexdigest() + ".json")
+    assert blob.read_bytes() == raw
+    assert blob.stat().st_mode & 0o777 == 0o600
+    assert folder.stat().st_mode & 0o777 == 0o700
+    quarantine.retain_private(raw, root=tmp_path)
+    assert len(list(folder.iterdir())) == 1
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / "usr").symlink_to(tmp_path / "usr", target_is_directory=True)
+    with pytest.raises(LegacyRetirementDenied):
+        quarantine.retain_private(raw, root=other)
+    assert blob.read_bytes() == raw
+
+
+def live_context():
+    from helpers.history import History, Message
+    from helpers.log import Log
+    agent = SimpleNamespace(data={}, config=SimpleNamespace(profile=""), number=0)
+    agent.history = History(agent)
+    agent.history.current.messages = [Message(False, result(), tokens=10), Message(False, {"image_data_url": "user-owned-image"}, tokens=10)]
+    return SimpleNamespace(id="synthetic", data={"source": "chrome_extension", "chrome_browser_session_id": "old"}, agent0=agent, config=agent.config,
+        output_data={}, name="Synthetic", created_at=None, last_message=None, type=SimpleNamespace(value="user"), streaming_agent=None, log=Log())
+
+
+def test_real_persistence_save_hook_quarantines_live_history(monkeypatch):
+    from helpers import persist_chat, extension
+    path = Path(__file__).parents[1] / "plugins/_a0_connector/extensions/python/_functions/helpers/persist_chat/_serialize_context/start/_05_legacy_quarantine.py"
+    spec = importlib.util.spec_from_file_location("quarantine_fixture_hook", path)
+    hook = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(hook)
+    retained = []
+    monkeypatch.setattr(hook, "enabled", lambda: True)
+    monkeypatch.setattr(quarantine, "retain_private", retained.append)
+    monkeypatch.setattr(extension, "_get_extension_classes", lambda point, **kwargs: [hook.QuarantineLegacyContext] if point == "_functions/helpers/persist_chat/_serialize_context/start" else [])
+    context = live_context()
+    serialized = persist_chat._serialize_context(context)
+    assert context.data == {} and serialized["data"] == {}
+    assert "image_data_url" not in context.agent0.history.current.messages[0].content
+    assert context.agent0.history.current.messages[0].tokens == 0
+    assert "private" not in serialized["agents"][0]["history"]
+    assert "user-owned-image" in serialized["agents"][0]["history"]
+    assert len(retained) == 1
+
+
+def test_sweep_is_bounded_and_has_no_dormant_file_authority(monkeypatch):
+    from agent import AgentContext
+    from helpers import persist_chat
+    contexts = [SimpleNamespace(id=f"context-{i:02}") for i in range(25)]
+    saved = []
+    monkeypatch.setattr(quarantine, "enabled", lambda: True)
+    monkeypatch.setattr(AgentContext, "all", lambda: contexts)
+    monkeypatch.setattr(quarantine, "quarantine_context", lambda context: {"context_keys": 1, "screenshots": 0})
+    monkeypatch.setattr(persist_chat, "save_tmp_chat", lambda context: saved.append(context.id))
+    first = quarantine.sweep_loaded()
+    assert first["processed"] == 20 and first["next_offset"] == 20
+    second = quarantine.sweep_loaded(first["next_offset"])
+    assert second["processed"] == 5 and second["next_offset"] is None
+    assert len(saved) == len(set(saved)) == 25
+    assert first["activation_ready"] is False
+    assert first["dormant_chats"] == "quarantined_on_next_load"
+
+
+def test_exact_compressed_result_summary_is_quarantined_without_prose_rewriting():
+    doc = document()
+    tree = json.loads(doc["agents"][0]["history"])
+    message = tree["bulks"][0]["records"][0]["messages"][0]
+    message["summary"] = json.dumps(result())
+    doc["agents"][0]["history"] = json.dumps(tree)
+    assert quarantine.quarantine_document(doc, store=lambda raw: None)["screenshots"] == 2
+    tree = json.loads(doc["agents"][0]["history"])
+    message = tree["bulks"][0]["records"][0]["messages"][0]
+    assert "image_data_url" not in json.loads(message["summary"])
+    assert message["content"]["tool_result"] == "Captured"
+
+
+def test_duplicate_live_slot_is_rejected_before_backup_or_partial_removal():
+    context = live_context()
+    message = context.agent0.history.current.messages[0]
+    context.agent0.history.current.messages.append(message)
+    original = copy.deepcopy(context.data)
+    retained = []
+    with pytest.raises(LegacyRetirementDenied, match="legacy_quarantine_ambiguous"):
+        quarantine.quarantine_context(context, store=retained.append)
+    assert retained == [] and context.data == original
+    assert message.content["image_data_url"] == "data:image/png;base64,private"

--- a/tests/test_browser_bridge_legacy_retirement.py
+++ b/tests/test_browser_bridge_legacy_retirement.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import copy
+import asyncio
+import importlib.util
+from pathlib import Path
+import shutil
+import sys
+import time
+import types
+
+import pytest
+from flask import Flask
+
+from plugins._a0_connector.helpers import browser_bridge_legacy_retirement as retirement
+
+
+def adapter(tmp_path, monkeypatch):
+    root = tmp_path / "chrome_extension"
+    shutil.copytree(Path(__file__).parent / "fixtures/browser_bridge_cutover_v1/legacy_exact", root)
+    constants = types.ModuleType("usr.plugins.chrome_extension.helpers.constants")
+    constants.CTX_BROWSER_SESSION_ID = "chrome_browser_session_id"
+    constants.CTX_CHROME_CAPABILITIES = "chrome_extension_capabilities"
+    constants.CTX_SOURCE = "source"
+    constants.SOURCE_NAME = "chrome_extension"
+    monkeypatch.setitem(sys.modules, constants.__name__, constants)
+    path = root / "helpers/session_store.py"
+    spec = importlib.util.spec_from_file_location("legacy_retirement_fixture", path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return retirement.PrototypeRegistryAdapter(module, root), module
+
+
+def test_exact_prototype_drains_without_replay_or_browser_effects(tmp_path, monkeypatch):
+    driver, module = adapter(tmp_path, monkeypatch)
+    session = module.BrowserSession("session-private")
+    module._sessions[session.browser_session_id] = session
+    queued = module.BridgeCommand("queued", session.browser_session_id, "click", payload={"secret": "do-not-copy"})
+    unknown = module.BridgeCommand("unknown", session.browser_session_id, "type", status="dispatched", attempts=1, created_at=time.time()-60, timeout_seconds=1)
+    done = module.BridgeCommand("done", session.browser_session_id, "capture_visible_tab", status="completed", attempts=1, result={"image_data_url": "data:image/png;base64,secret"})
+    session.commands = {item.command_id: item for item in (queued, unknown, done)}
+    session.queue = list(session.commands)
+    stored, effects = {}, []
+    owner = retirement.LegacyRetirement(load=lambda: copy.deepcopy(stored.get("value")), save=lambda value: stored.update(value=copy.deepcopy(value)), adapter=lambda: driver, disable=lambda: effects.append("disable"))
+    owner.guard_installed = True
+    result = asyncio.run(owner.retire())
+    assert result["state"] == "legacy_disabled"
+    assert result["counts"] == {"completed": 1, "canceled_not_applied": 1, "outcome_unknown": 1}
+    assert result["browser_tabs_changed"] is False and result["activation_ready"] is False
+    assert effects == ["disable"] and module._sessions == {}
+    assert queued.payload == {} and done.result == {}
+    assert "secret" not in str(stored) and "session-private" not in str(stored)
+    with pytest.raises(retirement.LegacyRetirementDenied):
+        module.enqueue_command("session-private", "click")
+    assert asyncio.run(owner.retire()) == result
+    assert effects == ["disable"]
+
+
+def test_exact_terminal_result_is_accepted_once_and_payload_discarded(tmp_path, monkeypatch):
+    driver, module = adapter(tmp_path, monkeypatch)
+    session = module.BrowserSession("session")
+    command = module.BridgeCommand("command", "session", "click", status="dispatched", attempts=1)
+    session.commands["command"] = command
+    module._sessions["session"] = session
+    assert driver.begin() == 1
+    with pytest.raises(retirement.LegacyRetirementDenied):
+        driver.accept_result("foreign", "command", status="completed")
+    assert driver.accept_result("session", "command", status="completed", result={"image_data_url": "secret"}) == {"status": "completed"}
+    with pytest.raises(retirement.LegacyRetirementDenied):
+        driver.accept_result("session", "command", status="completed")
+    assert driver.finish()["completed"] == 1
+    assert command.result == {}
+
+
+def test_flask_guard_is_idle_by_default_and_corrupt_journal_blocks_legacy_only(monkeypatch):
+    stored = {}
+    owner = retirement.LegacyRetirement(load=lambda: stored.get("value"), save=lambda value: None)
+    monkeypatch.setattr(retirement, "_owner", owner)
+    app = Flask(__name__)
+    retirement.install_legacy_retirement_guard(app)
+    retirement.install_legacy_retirement_guard(app)
+    app.add_url_rule("/<path:path>", "fixture", lambda path: "untouched")
+    client = app.test_client()
+    assert client.get("/api/plugins/chrome_extension/session_upsert").status_code == 200
+    assert owner.active_requests == 0
+    stored["value"] = {"secret": "not-an-accepted-journal"}
+    for prefix in ("/api/plugins/", "/plugins/"):
+        response = client.get(prefix + "chrome_extension/command_pull")
+        assert response.status_code == 410 and b"secret" not in response.data
+        assert client.get(prefix + "other_plugin/command_pull").status_code == 200
+    assert client.get("/api/api_message").status_code == 200
+    assert client.get("/api/plugins/_a0_connector/browser_bridge_pairing").status_code == 200
+
+
+def test_interrupted_or_uninstalled_guard_never_replays_or_claims_success():
+    effects = []
+    owner = retirement.LegacyRetirement(load=lambda: None, save=lambda value: effects.append(value), adapter=lambda: None, disable=lambda: effects.append("disable"))
+    with pytest.raises(retirement.LegacyRetirementDenied):
+        asyncio.run(owner.retire())
+    assert effects == []
+    journal = {"schema_version": 1, "migration_id": "00000000-0000-0000-0000-000000000001", "state": "draining_legacy", "started_at_ms": 1, "completed": 0, "canceled_not_applied": 0, "outcome_unknown": 2}
+    owner.load = lambda: journal
+    owner.guard_installed = True
+    assert asyncio.run(owner.retire())["state"] == "blocked"
+    assert effects == []

--- a/tests/test_browser_bridge_local_approval.py
+++ b/tests/test_browser_bridge_local_approval.py
@@ -1,0 +1,54 @@
+import asyncio
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from plugins._a0_connector.helpers.browser_bridge_local_approval import BrowserBridgeLocalApprovalController
+from plugins._a0_connector.helpers.browser_bridge_action_authority import BrowserBridgeActionAuthorityUnavailable
+from test_browser_bridge_action_authority import _Harness, _operation, _notice, _principal
+
+
+def test_local_action_decision_requires_exact_retained_route_not_only_same_subject():
+    async def scenario():
+        h = _Harness(_operation(asyncio.get_running_loop(), _principal()))
+        h.authority.register_challenge(_notice(h.operation))
+        controller = BrowserBridgeLocalApprovalController(actions=h.authority, sites=None, current=lambda route: True)
+        fixture = json.loads((Path(__file__).parent / "fixtures/context-queue-approval-v1.json").read_text())
+        body = fixture["action_approval"]["params"]
+        route = h.current_route
+        for forged in (
+            replace(route, connector_sid="sid-other"),
+            replace(route, load_generation_id="generation-other"),
+            replace(route, principal=replace(route.principal)),
+        ):
+            with pytest.raises(BrowserBridgeActionAuthorityUnavailable):
+                await controller.dispatch(forged, body)
+        assert not h.resolutions
+        result = await controller.dispatch(route, body)
+        assert result["status"] == "accepted"
+        assert result["challenge_id"] == "challenge-A"
+        assert result == fixture["action_approval"]["result"]
+        assert (await controller.dispatch(route, body)) == result
+        await h.authority.close()
+    asyncio.run(scenario())
+
+
+def test_local_site_decision_cannot_cross_same_subject_bridge_socket():
+    from test_browser_bridge_site_authority import _Harness, _operation, _notice, _principal
+    from plugins._a0_connector.helpers.browser_bridge_site_authority import BrowserBridgeSiteAuthorityUnavailable
+
+    async def scenario():
+        principal = _principal()
+        h = _Harness(_operation(asyncio.get_running_loop(), principal))
+        sites = h.repository()
+        sites.register_event(_notice(principal))
+        controller = BrowserBridgeLocalApprovalController(actions=None, sites=sites, current=lambda route: True)
+        body = {"contract_version": 1, "challenge_id": "challenge-A", "kind": "site", "decision": "allow_once"}
+        with pytest.raises(BrowserBridgeSiteAuthorityUnavailable):
+            await controller.dispatch(replace(h.current_route, connector_sid="another-socket"), body)
+        assert not h.resolutions
+        assert (await controller.dispatch(h.current_route, body))["status"] == "accepted"
+        await sites.close()
+    asyncio.run(scenario())

--- a/tests/test_browser_bridge_messages.py
+++ b/tests/test_browser_bridge_messages.py
@@ -1,0 +1,149 @@
+from dataclasses import replace
+from types import SimpleNamespace
+import json
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_context import BrowserBridgeContextRoute
+from plugins._a0_connector.helpers.browser_bridge_messages import BrowserBridgeMessageDispatcher, BrowserBridgeMessageError
+from browser_bridge_test_support import MemoryKeyValue
+
+
+def _route():
+    principal = WsPrincipal(
+        principal_type="browser_bridge", principal_id="bridge-1", subject_id="single-user",
+        scopes=frozenset({"context.message"}), handler_path="plugins/_a0_connector/ws_connector",
+        handler_id="ws_connector.WsConnector", inbound_events=frozenset({"connector_send_message"}),
+        outbound_events=frozenset(), key_generation=1,
+    )
+    return BrowserBridgeContextRoute(principal, "sid-1", "load-1")
+
+
+def _message(**changes):
+    return {"contract_version": 1, "context_id": "ctx-1", "client_message_id": "message-1", "text": "private user conversation", **changes}
+
+
+def test_message_reservation_survives_reconstruction_without_repeating_effect():
+    route = _route()
+    stored = MemoryKeyValue()
+    effects = []
+    access = SimpleNamespace(authorize_message_target=lambda _route, **_kwargs: None)
+
+    def dispatcher():
+        return BrowserBridgeMessageDispatcher(
+            access=access, server_instance_id=lambda: "server-1",
+            load=stored.load, save=stored.save,
+            deliver=lambda *args: effects.append(args),
+        )
+
+    first = dispatcher().send(route, _message())
+    second = dispatcher().send(replace(route, connector_sid="fresh-sid", load_generation_id="fresh-load"), _message())
+    assert first == second and first["status"] == "accepted"
+    assert len(effects) == 1
+    assert "private user conversation" not in json.dumps(stored.value)
+    assert "ctx-1" not in json.dumps(stored.value)
+    with pytest.raises(BrowserBridgeMessageError, match="IDEMPOTENCY_CONFLICT"):
+        dispatcher().send(route, _message(text="changed text"))
+
+
+def test_uncertain_delivery_or_acceptance_write_never_replays_reserved_message():
+    for fail_delivery in (True, False):
+        stored = MemoryKeyValue()
+        effects = []
+
+        def save(key, value):
+            if value.get("record", {}).get("state") == "accepted":
+                raise OSError("owner secret path")
+            stored.save(key, value)
+
+        def deliver(*args):
+            effects.append(args)
+            if fail_delivery:
+                raise RuntimeError("raw server error")
+
+        dispatcher = BrowserBridgeMessageDispatcher(
+            access=SimpleNamespace(authorize_message_target=lambda *_args, **_kwargs: None),
+            server_instance_id=lambda: "server-1", load=stored.load, save=save, deliver=deliver,
+        )
+        for _ in range(2):
+            with pytest.raises(BrowserBridgeMessageError) as error:
+                dispatcher.send(_route(), _message())
+            assert error.value.code == "OUTCOME_UNKNOWN" and error.value.outcome == "unknown"
+            assert "secret" not in str(error.value) and "raw" not in str(error.value)
+        assert len(effects) == 1
+
+
+def test_message_authority_is_rechecked_after_durable_reservation():
+    current = [True]
+    effects = []
+    stored = MemoryKeyValue()
+
+    def authorize(*_args, **_kwargs):
+        if not current[0]:
+            raise PermissionError()
+
+    def save(key, value):
+        stored.save(key, value)
+        if value.get("record", {}).get("state") == "reserved":
+            current[0] = False
+
+    dispatcher = BrowserBridgeMessageDispatcher(
+        access=SimpleNamespace(authorize_message_target=authorize), server_instance_id=lambda: "server-1",
+        load=stored.load, save=save, deliver=lambda *args: effects.append(args),
+    )
+    with pytest.raises(BrowserBridgeMessageError, match="SCOPE_DENIED"):
+        dispatcher.send(_route(), _message())
+    assert effects == []
+    with pytest.raises(BrowserBridgeMessageError, match="INVALID_STATE"):
+        dispatcher.send(_route(), _message(attachments=["/private/file"]))
+
+
+def test_indexed_receipts_preserve_full_legacy_journal_and_fail_closed(monkeypatch, tmp_path):
+    from helpers import kvp
+    from plugins._a0_connector.helpers import browser_bridge_messages as module
+
+    monkeypatch.setattr(kvp, "_persistent_dir", lambda: str(tmp_path))
+    access = SimpleNamespace(authorize_message_target=lambda *_args, **_kwargs: None)
+    stored, effects = MemoryKeyValue(), []
+    seed = BrowserBridgeMessageDispatcher(
+        access=access, server_instance_id=lambda: "server-1",
+        load=stored.load, save=stored.save,
+        deliver=lambda *args: effects.append(args))
+    seed.send(_route(), _message())
+    key, value = next((key, value) for key, value in stored.value.items() if ".records." in key)
+    record = value["record"]
+    legacy = {"schema_version": 1, "records": {key.rsplit(".", 1)[1]: record}}
+    legacy["records"].update({f"{i:064x}": dict(record) for i in range(2047)})
+    kvp.set_persistent(module._STORE_KEY, legacy)
+
+    def dispatcher():
+        return BrowserBridgeMessageDispatcher(
+            access=access, server_instance_id=lambda: "server-1",
+            deliver=lambda *args: effects.append(args))
+
+    assert dispatcher().send(_route(), _message())["status"] == "accepted"
+    dispatcher().send(_route(), _message(client_message_id="new-message"))
+    dispatcher().send(_route(), _message(client_message_id="new-message"))
+    assert len(effects) == 2
+    assert kvp.get_persistent(module._STORE_KEY) == {**legacy, "schema_version": 2}
+    with pytest.raises(BrowserBridgeMessageError, match="IDEMPOTENCY_CONFLICT"):
+        dispatcher().send(_route(), _message(text="changed"))
+    keys = kvp.find_persistent(module._STORE_KEY + ".records.*")
+    assert len(keys) == 1
+    value = kvp.get_persistent(keys[0])
+    value["record"]["state"] = "reserved"
+    kvp.set_persistent(keys[0], value)
+    with pytest.raises(BrowserBridgeMessageError, match="OUTCOME_UNKNOWN"):
+        dispatcher().send(_route(), _message(client_message_id="new-message"))
+    kvp.set_persistent(keys[0], None)  # Corruption must not fall back to absent.
+    with pytest.raises(BrowserBridgeMessageError, match="MESSAGE_STORE_UNAVAILABLE"):
+        dispatcher().send(_route(), _message(client_message_id="new-message"))
+    kvp.set_persistent(module._STORE_KEY, {})
+    with pytest.raises(BrowserBridgeMessageError, match="MESSAGE_STORE_UNAVAILABLE"):
+        dispatcher().send(_route(), _message(client_message_id="corrupt-legacy"))
+    kvp.set_persistent(module._STORE_KEY, legacy)
+    monkeypatch.setattr(kvp, "set_persistent", lambda *_args: (_ for _ in ()).throw(OSError()))
+    with pytest.raises(BrowserBridgeMessageError, match="MESSAGE_STORE_UNAVAILABLE"):
+        dispatcher().send(_route(), _message(client_message_id="failed-write"))
+    assert len(effects) == 2

--- a/tests/test_browser_bridge_operations_foundation.py
+++ b/tests/test_browser_bridge_operations_foundation.py
@@ -1,0 +1,669 @@
+import asyncio
+import hashlib
+import json
+from dataclasses import replace
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_operations import (
+    BridgeAuthorization,
+    BrowserBridgeBrokerError,
+    BrowserBridgeOperationBroker,
+    CONTROL_EVENT,
+    OPERATION_EVENT,
+    OperationBinding,
+    SettlementStatus,
+    TurnBinding,
+)
+
+
+def _principal(**changes):
+    values = {
+        "principal_type": "browser_bridge",
+        "principal_id": "bridge-1",
+        "subject_id": "single-user",
+        "scopes": frozenset({"bridge.connect", "browser.operate", "browser.control"}),
+        "handler_path": "plugins/_a0_connector/ws_connector",
+        "handler_id": "ws_connector.WsConnector",
+        "inbound_events": frozenset(
+            {"connector_browser_op_result", "connector_browser_control_result"}
+        ),
+        "outbound_events": frozenset({OPERATION_EVENT, CONTROL_EVENT}),
+        "key_generation": 3,
+    }
+    values.update(changes)
+    return WsPrincipal(**values)
+
+
+def _binding(principal=None, **changes):
+    values = {
+        "principal": principal or _principal(),
+        "connector_sid": "sid-1",
+        "load_generation_id": "load-1",
+        "context_id": "context-1",
+        "browser_session_id": "session-1",
+        "turn_id": "turn-1",
+        "action_id": "action-1",
+        "op_id": "op-1",
+    }
+    values.update(changes)
+    return OperationBinding(**values)
+
+
+def _authorization(binding, *, actions=("click", "state"), features=("cursor_v1",)):
+    return BridgeAuthorization(
+        principal=binding.principal,
+        connector_sid=binding.connector_sid,
+        load_generation_id=binding.load_generation_id,
+        contract_version=1,
+        outer_features=frozenset(
+            {"browser_extension_bridge_v1", "connector_browser_control"}
+        ),
+        actions=frozenset(actions),
+        features=frozenset(features),
+    )
+
+
+async def _start(broker, binding, *, action="click", timeout_ms=5_000):
+    args = {"ref": "frame0:node24"}
+    if action == "click":
+        args["expected_action_class"] = "unknown"
+    return await broker.begin_operation(
+        binding,
+        action=action,
+        target={"tab_handle": "a0t1.generation.lease"},
+        args=args,
+        timeout_ms=timeout_ms,
+        required_capabilities=[action, "cursor_v1"],
+        policy={"origin_grant_id": "grant-1"},
+        display={"cursor": True, "foreground": False},
+    )
+
+
+def test_dispatch_barrier_waits_for_sender_and_survives_waiter_cancellation():
+    async def scenario():
+        binding = _binding()
+        entered, release = asyncio.Event(), asyncio.Event()
+
+        async def sender(*_args):
+            entered.set()
+            await release.wait()
+
+        broker = BrowserBridgeOperationBroker(authorizer=lambda *_args, **_kwargs: _authorization(binding), sender=sender)
+        ticket = await _start(broker, binding)
+        await entered.wait()
+        waiter = asyncio.create_task(broker.wait_dispatched(ticket))
+        await asyncio.sleep(0)
+        assert not waiter.done()
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        release.set()
+        await broker.wait_dispatched(ticket)
+        broker.disconnect(principal=binding.principal, connector_sid=binding.connector_sid, load_generation_id=binding.load_generation_id)
+        with pytest.raises(BrowserBridgeBrokerError):
+            await broker.wait_dispatched(ticket)
+
+    asyncio.run(scenario())
+
+
+def _success(payload):
+    keys = (
+        "contract_version", "bridge_id", "load_generation_id", "context_id",
+        "browser_session_id", "turn_id", "op_id", "action_id",
+    )
+    result = {key: payload[key] for key in keys}
+    result.update(ok=True, result={"value": 7}, receipts=[], artifacts=[])
+    return result
+
+
+def _control_success(payload):
+    keys = (
+        "contract_version", "method", "bridge_id", "load_generation_id",
+        "context_id", "browser_session_id", "turn_id", "control_id",
+    )
+    result = {key: payload[key] for key in keys}
+    if payload["method"] == "browser.cancel":
+        result.update(op_id=payload["op_id"], action_id=payload["action_id"])
+    result.update(ok=True, result={"contract_version": 1, "status": "canceled"})
+    return result
+
+
+def test_site_control_matches_pending_navigation_hash_and_rechecks_decision():
+    async def scenario():
+        sent = []
+        allowed = True
+
+        async def sender(*args):
+            sent.append(args)
+
+        binding = _binding()
+        broker = BrowserBridgeOperationBroker(
+            sender=sender, authorizer=lambda candidate: _authorization(candidate, actions=("navigate",)),
+        )
+        ticket = await broker.begin_operation(
+            binding, action="navigate", target={"tab_handle": "tab-1"}, args={"url": "https://next.example/path?q=private"},
+            timeout_ms=5_000, required_capabilities=["navigate"], policy={"origin_grant_id": "source-grant"},
+            display={"cursor": True, "foreground": False},
+        )
+        expected = {"action": "navigate", "target": {"tabHandle": "tab-1"}, "context_id": binding.context_id,
+                    "browser_session_id": binding.browser_session_id, "turn_id": binding.turn_id,
+                    "args": {"url": "https://next.example/path?q=private"}, "display": {"cursor": True, "foreground": False}}
+        assert ticket.canonical_parameter_hash == hashlib.sha256(json.dumps(expected, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()).hexdigest()
+        assert ticket.destination_origin == "https://next.example"
+        resolution = {"challenge_id": "challenge-1", "tab_handle": "tab-1", "document_id": None, "document_epoch": 0,
+                      "canonical_parameter_hash": ticket.canonical_parameter_hash, "target_fingerprint": "a" * 64,
+                      "origin": ticket.destination_origin, "action_class": "navigate", "decision": "deny", "grant": None}
+        control = await broker.begin_site_resolution(ticket, control_id="control-1", resolution=resolution,
+                                                     authorization_current=lambda: allowed)
+        await asyncio.sleep(0)
+        payload = next(item[2] for item in sent if item[1] == CONTROL_EVENT)
+        response = _control_success(payload)
+        response.update(op_id=binding.op_id, action_id=binding.action_id,
+                        result={"contract_version": 1, "control_id": "control-1", "challenge_id": "challenge-1", "status": "resolved", "decision": "deny"})
+        assert broker.settle_control(principal=binding.principal, connector_sid=binding.connector_sid,
+                                     load_generation_id=binding.load_generation_id, payload=response) == SettlementStatus.SETTLED
+        assert (await broker.wait_control(control)).result == response["result"]
+        second = await broker.begin_site_resolution(ticket, control_id="control-2", resolution=resolution,
+                                                    authorization_current=lambda: allowed)
+        allowed = False
+        await asyncio.sleep(0)
+        assert not (await broker.wait_control(second)).ok
+        assert not any(item[2].get("control_id") == "control-2" for item in sent)
+        broker.disconnect(principal=binding.principal, connector_sid=binding.connector_sid,
+                          load_generation_id=binding.load_generation_id)
+
+    asyncio.run(scenario())
+
+
+def test_operation_dispatch_is_canonical_bound_and_exactly_settled():
+    async def scenario():
+        sent = []
+
+        async def sender(sid, event, data, correlation, principal):
+            sent.append((sid, event, data, correlation, principal))
+
+        binding = _binding()
+        broker = BrowserBridgeOperationBroker(
+            sender=sender, authorizer=lambda candidate: _authorization(candidate)
+        )
+        ticket = await _start(broker, binding)
+        await asyncio.sleep(0)
+
+        assert len(sent) == 1
+        sid, event, data, correlation, principal = sent[0]
+        assert (sid, event, correlation, principal) == (
+            "sid-1", OPERATION_EVENT, "op-1", binding.principal
+        )
+        assert data == {
+            "contract_version": 1,
+            "bridge_id": "bridge-1",
+            "load_generation_id": "load-1",
+            "op_id": "op-1",
+            "action_id": "action-1",
+            "context_id": "context-1",
+            "browser_session_id": "session-1",
+            "turn_id": "turn-1",
+            "action": "click",
+            "target": {"tab_handle": "a0t1.generation.lease"},
+            "args": {
+                "ref": "frame0:node24",
+                "expected_action_class": "unknown",
+            },
+            "timeout_ms": 5_000,
+            "required_capabilities": ["click", "cursor_v1"],
+            "policy": {"origin_grant_id": "grant-1", "action_grant_id": None},
+            "display": {"cursor": True, "foreground": False},
+        }
+        assert "connector_sid" not in data
+        assert "key_generation" not in data
+
+        assert broker.settle_operation(
+            principal=principal,
+            connector_sid=sid,
+            load_generation_id="load-1",
+            payload=_success(data),
+        ) == SettlementStatus.SETTLED
+        completion = await broker.wait_operation(ticket)
+        assert completion.ok is True
+        assert completion.result == {"value": 7}
+        assert broker.settle_operation(
+            principal=principal,
+            connector_sid=sid,
+            load_generation_id="load-1",
+            payload=_success(data),
+        ) == SettlementStatus.DUPLICATE
+
+    asyncio.run(scenario())
+
+
+def test_authority_and_capabilities_fail_before_send_or_registry_insertion():
+    async def scenario():
+        sent = []
+
+        async def sender(*args):
+            sent.append(args)
+
+        binding = _binding()
+        broker = BrowserBridgeOperationBroker(
+            sender=sender,
+            authorizer=lambda candidate: replace(
+                _authorization(candidate), features=frozenset()
+            ),
+        )
+        with pytest.raises(BrowserBridgeBrokerError) as exc:
+            await _start(broker, binding)
+        assert exc.value.code == "UNSUPPORTED_CAPABILITY"
+        assert exc.value.outcome == "not_applied"
+        assert broker.pending_operation_count == 0
+
+        stale = BrowserBridgeOperationBroker(
+            sender=sender,
+            authorizer=lambda candidate: replace(
+                _authorization(candidate), load_generation_id="stale-load"
+            ),
+        )
+        with pytest.raises(BrowserBridgeBrokerError) as exc:
+            await _start(stale, binding)
+        assert exc.value.code == "SCOPE_DENIED"
+        await asyncio.sleep(0)
+        assert sent == []
+
+    asyncio.run(scenario())
+
+
+def test_every_operation_identity_dimension_is_exact_and_mismatch_stays_pending():
+    async def scenario():
+        sent = []
+
+        async def sender(_sid, _event, data, _correlation, _principal):
+            sent.append(data)
+
+        binding = _binding()
+        broker = BrowserBridgeOperationBroker(
+            sender=sender, authorizer=lambda candidate: _authorization(candidate)
+        )
+        ticket = await _start(broker, binding)
+        await asyncio.sleep(0)
+        valid = _success(sent[0])
+
+        mutations = {
+            "bridge_id": "other-bridge",
+            "load_generation_id": "other-load",
+            "context_id": "other-context",
+            "browser_session_id": "other-session",
+            "turn_id": "other-turn",
+            "action_id": "other-action",
+        }
+        for key, value in mutations.items():
+            candidate = dict(valid)
+            candidate[key] = value
+            assert broker.settle_operation(
+                principal=binding.principal,
+                connector_sid=binding.connector_sid,
+                load_generation_id=binding.load_generation_id,
+                payload=candidate,
+            ) == SettlementStatus.MISMATCH
+            assert broker.pending_operation_count == 1
+
+        equal_but_unbound_principal = replace(binding.principal)
+        assert broker.settle_operation(
+            principal=equal_but_unbound_principal,
+            connector_sid=binding.connector_sid,
+            load_generation_id=binding.load_generation_id,
+            payload=valid,
+        ) == SettlementStatus.MISMATCH
+        assert broker.settle_operation(
+            principal=binding.principal,
+            connector_sid="another-sid",
+            load_generation_id=binding.load_generation_id,
+            payload=valid,
+        ) == SettlementStatus.MISMATCH
+
+        invalid = dict(valid)
+        invalid["unexpected"] = "data"
+        assert broker.settle_operation(
+            principal=binding.principal,
+            connector_sid=binding.connector_sid,
+            load_generation_id=binding.load_generation_id,
+            payload=invalid,
+        ) == SettlementStatus.MISMATCH
+        assert not ticket._future.done()
+        assert broker.settle_operation(
+            principal=binding.principal,
+            connector_sid=binding.connector_sid,
+            load_generation_id=binding.load_generation_id,
+            payload=valid,
+        ) == SettlementStatus.SETTLED
+        assert (await broker.wait_operation(ticket)).ok
+
+    asyncio.run(scenario())
+
+
+def test_disconnect_is_generation_bound_and_mutations_become_unknown():
+    async def scenario():
+        async def sender(*_args):
+            return None
+
+        principal = _principal()
+        broker = BrowserBridgeOperationBroker(
+            sender=sender,
+            authorizer=lambda candidate: _authorization(
+                candidate, actions=("click", "state")
+            ),
+        )
+        mutation = await _start(broker, _binding(principal, op_id="op-m", action_id="action-m"))
+        read = await _start(
+            broker,
+            _binding(principal, op_id="op-r", action_id="action-r"),
+            action="state",
+        )
+        assert broker.disconnect(
+            principal=principal, connector_sid="sid-1", load_generation_id="stale"
+        ).operations == 0
+        assert broker.pending_operation_count == 2
+
+        summary = broker.disconnect(
+            principal=principal, connector_sid="sid-1", load_generation_id="load-1"
+        )
+        assert summary.operations == 2
+        mutation_result, read_result = await asyncio.gather(
+            broker.wait_operation(mutation), broker.wait_operation(read)
+        )
+        assert (mutation_result.code, mutation_result.outcome, mutation_result.retryable) == (
+            "OUTCOME_UNKNOWN", "unknown", False
+        )
+        assert (read_result.code, read_result.outcome, read_result.retryable) == (
+            "CONNECTION_LOST", "not_applied", True
+        )
+
+    asyncio.run(scenario())
+
+
+def test_expiry_is_deterministic_and_conservative_by_effect_class():
+    async def scenario():
+        now = [10_000]
+
+        async def sender(*_args):
+            return None
+
+        broker = BrowserBridgeOperationBroker(
+            sender=sender,
+            authorizer=lambda candidate: _authorization(
+                candidate, actions=("click", "state")
+            ),
+            clock_ms=lambda: now[0],
+        )
+        mutation = await _start(
+            broker, _binding(op_id="op-m", action_id="action-m"), timeout_ms=30
+        )
+        read = await _start(
+            broker,
+            _binding(op_id="op-r", action_id="action-r"),
+            action="state",
+            timeout_ms=30,
+        )
+        assert broker.expire(10_029).operations == 0
+        assert broker.expire(10_030).operations == 2
+        mutation_result, read_result = await asyncio.gather(
+            broker.wait_operation(mutation), broker.wait_operation(read)
+        )
+        assert mutation_result.code == "OUTCOME_UNKNOWN"
+        assert read_result.code == "DEADLINE_EXCEEDED"
+        assert read_result.retryable is True
+
+    asyncio.run(scenario())
+
+
+def test_waiter_cancellation_does_not_cancel_operation_or_its_receipt():
+    async def scenario():
+        sent = []
+
+        async def sender(_sid, _event, data, _correlation, _principal):
+            sent.append(data)
+
+        binding = _binding()
+        broker = BrowserBridgeOperationBroker(
+            sender=sender, authorizer=lambda candidate: _authorization(candidate)
+        )
+        ticket = await _start(broker, binding)
+        waiter = asyncio.create_task(broker.wait_operation(ticket))
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        await asyncio.sleep(0)
+        assert broker.pending_operation_count == 1
+        assert ticket._future.cancelled() is False
+        assert broker.settle_operation(
+            principal=binding.principal,
+            connector_sid=binding.connector_sid,
+            load_generation_id=binding.load_generation_id,
+            payload=_success(sent[0]),
+        ) == SettlementStatus.SETTLED
+        assert (await broker.wait_operation(ticket)).ok
+
+    asyncio.run(scenario())
+
+
+def test_cancel_and_finalize_use_exact_control_bindings_and_correlation():
+    async def scenario():
+        sent = []
+
+        async def sender(sid, event, data, correlation, principal):
+            sent.append((sid, event, data, correlation, principal))
+
+        principal = _principal()
+        broker = BrowserBridgeOperationBroker(
+            sender=sender, authorizer=lambda candidate: _authorization(candidate)
+        )
+        operation = await _start(broker, _binding(principal))
+        cancel = await broker.begin_cancel(
+            operation, control_id="control-cancel", reason="turn stopped", timeout_ms=1_000
+        )
+        turn = TurnBinding(
+            principal=principal,
+            connector_sid="sid-1",
+            load_generation_id="load-1",
+            context_id="context-1",
+            browser_session_id="session-1",
+            turn_id="turn-1",
+        )
+        finalize = await broker.begin_finalize(
+            turn,
+            control_id="control-finalize",
+            dispositions={"lease-created": "ephemeral", "lease-user": "handoff"},
+            reason="stopped",
+            timeout_ms=1_000,
+        )
+        await asyncio.sleep(0)
+        controls = {entry[2]["method"]: entry for entry in sent if entry[1] == CONTROL_EVENT}
+        cancel_wire = controls["browser.cancel"][2]
+        finalize_wire = controls["browser.finalize_turn"][2]
+        assert controls["browser.cancel"][3] == "control-cancel"
+        assert cancel_wire["load_generation_id"] == "load-1"
+        assert cancel_wire["browser_session_id"] == "session-1"
+        assert cancel_wire["op_id"] == "op-1"
+        assert cancel_wire["action_id"] == "action-1"
+        assert controls["browser.finalize_turn"][3] == "control-finalize"
+        assert finalize_wire["bridge_id"] == "bridge-1"
+        assert finalize_wire["load_generation_id"] == "load-1"
+        assert finalize_wire["dispositions"] == {
+            "lease-created": "ephemeral", "lease-user": "handoff"
+        }
+
+        bad = _control_success(cancel_wire)
+        bad["browser_session_id"] = "another-session"
+        assert broker.settle_control(
+            principal=principal,
+            connector_sid="sid-1",
+            load_generation_id="load-1",
+            payload=bad,
+        ) == SettlementStatus.MISMATCH
+        for ticket, wire in ((cancel, cancel_wire), (finalize, finalize_wire)):
+            assert broker.settle_control(
+                principal=principal,
+                connector_sid="sid-1",
+                load_generation_id="load-1",
+                payload=_control_success(wire),
+            ) == SettlementStatus.SETTLED
+            assert (await broker.wait_control(ticket)).ok
+
+    asyncio.run(scenario())
+
+
+def test_sender_failure_and_pending_bounds_never_claim_mutation_not_applied():
+    async def scenario():
+        async def failing_sender(*_args):
+            raise RuntimeError("raw transport secret")
+
+        broker = BrowserBridgeOperationBroker(
+            sender=failing_sender,
+            authorizer=lambda candidate: _authorization(candidate),
+            max_pending_operations=1,
+        )
+        mutation = await _start(broker, _binding())
+        await asyncio.sleep(0)
+        result = await broker.wait_operation(mutation)
+        assert (result.code, result.outcome) == ("OUTCOME_UNKNOWN", "unknown")
+        assert "secret" not in (result.error or "")
+
+        async def sender(*_args):
+            return None
+
+        bounded = BrowserBridgeOperationBroker(
+            sender=sender,
+            authorizer=lambda candidate: _authorization(candidate),
+            max_pending_operations=1,
+        )
+        await _start(bounded, _binding(op_id="first", action_id="first-action"))
+        with pytest.raises(BrowserBridgeBrokerError) as exc:
+            await _start(bounded, _binding(op_id="second", action_id="second-action"))
+        assert exc.value.code == "INVALID_STATE"
+        assert bounded.pending_operation_count == 1
+
+    asyncio.run(scenario())
+
+
+def test_noncanonical_or_oversize_payloads_are_rejected_before_send():
+    async def scenario():
+        sent = []
+
+        async def sender(*args):
+            sent.append(args)
+
+        broker = BrowserBridgeOperationBroker(
+            sender=sender, authorizer=lambda candidate: _authorization(candidate)
+        )
+        with pytest.raises(BrowserBridgeBrokerError) as exc:
+            await broker.begin_operation(
+                _binding(),
+                action="click",
+                target=None,
+                args={"not-json": object()},
+                timeout_ms=1_000,
+                required_capabilities=["click"],
+            )
+        assert exc.value.code == "INVALID_STATE"
+        with pytest.raises(BrowserBridgeBrokerError):
+            await broker.begin_operation(
+                _binding(op_id="op-large", action_id="action-large"),
+                action="click",
+                target=None,
+                args={"large": "x" * (512 * 1024)},
+                timeout_ms=1_000,
+                required_capabilities=["click"],
+            )
+        # The native RPC grammar is broader, but Core uses op/control IDs as
+        # restricted Socket.IO correlation IDs and must honor its 128-byte,
+        # alphanumeric/underscore/hyphen-only boundary before dispatch.
+        with pytest.raises(BrowserBridgeBrokerError):
+            await broker.begin_operation(
+                _binding(op_id="native.allowed.but-core-forbidden"),
+                action="click",
+                target=None,
+                args={},
+                timeout_ms=1_000,
+                required_capabilities=["click"],
+            )
+        assert sent == []
+        assert broker.pending_operation_count == 0
+
+    asyncio.run(scenario())
+
+
+def test_queued_dispatch_rechecks_revocation_and_pending_identity():
+    async def scenario():
+        sent = []
+        current = True
+
+        async def sender(*args):
+            sent.append(args)
+
+        binding = _binding()
+        broker = BrowserBridgeOperationBroker(
+            sender=sender,
+            authorizer=lambda candidate: _authorization(candidate) if current else None,
+        )
+        revoked = await _start(broker, binding)
+        current = False
+        result = await broker.wait_operation(revoked)
+        assert (result.code, result.outcome) == ("SCOPE_DENIED", "not_applied")
+        current = True
+        disconnected = await _start(broker, replace(binding, op_id="disconnected"))
+        broker.disconnect(principal=binding.principal, connector_sid="sid-1", load_generation_id="load-1")
+        assert (await broker.wait_operation(disconnected)).outcome == "unknown"
+        assert sent == []
+
+    asyncio.run(scenario())
+
+
+def test_completed_replies_do_not_release_running_transport_capacity():
+    async def scenario():
+        sent = []
+        release = asyncio.Event()
+
+        async def sender(_sid, _event, payload, _correlation, _principal):
+            sent.append(payload)
+            await release.wait()
+
+        broker = BrowserBridgeOperationBroker(
+            sender=sender, authorizer=_authorization,
+            max_pending_operations=1, max_pending_controls=1,
+        )
+        for index in range(2):
+            binding = _binding(op_id=f"op-{index}", action_id=f"action-{index}")
+            ticket = await _start(broker, binding)
+            await asyncio.sleep(0)
+            assert broker.settle_operation(
+                principal=binding.principal, connector_sid="sid-1", load_generation_id="load-1",
+                payload=_success(sent[-1]),
+            ) == SettlementStatus.SETTLED
+            assert (await broker.wait_operation(ticket)).ok
+        with pytest.raises(BrowserBridgeBrokerError, match="transport queue is full"):
+            await _start(broker, _binding(op_id="overflow", action_id="overflow"))
+        release.set()
+
+    asyncio.run(scenario())
+
+
+def test_late_valid_result_cannot_bypass_deadline_without_expiry_tick():
+    async def scenario():
+        now = [100]
+        sent = []
+
+        async def sender(_sid, _event, payload, _correlation, _principal):
+            sent.append(payload)
+
+        broker = BrowserBridgeOperationBroker(sender=sender, authorizer=_authorization, clock_ms=lambda: now[0])
+        binding = _binding()
+        ticket = await _start(broker, binding, timeout_ms=100)
+        await asyncio.sleep(0)
+        now[0] = 200
+        assert broker.settle_operation(
+            principal=binding.principal, connector_sid="sid-1", load_generation_id="load-1",
+            payload=_success(sent[0]),
+        ) == SettlementStatus.SETTLED
+        assert (await broker.wait_operation(ticket)).outcome == "unknown"
+
+    asyncio.run(scenario())

--- a/tests/test_browser_bridge_pairing_foundation.py
+++ b/tests/test_browser_bridge_pairing_foundation.py
@@ -1,0 +1,605 @@
+from __future__ import annotations
+import asyncio
+import base64
+import importlib
+import io
+import json
+import sys
+import threading
+import pytest
+from contextlib import contextmanager
+from types import ModuleType
+from typing import Any, Iterator
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    BROWSER_BRIDGE_EXTENSION_ID_ENV,
+    BROWSER_BRIDGE_TRUST_CONTRACT,
+    BROWSER_BRIDGE_TRUST_VERSION,
+    FIXED_BROWSER_BRIDGE_SCOPES,
+    PAIRING_MAX_FAILED_EXCHANGES,
+    PAIRING_TTL_MS,
+    BrowserBridgePairingError,
+    BrowserBridgePairingExchangeFailed,
+    BrowserBridgePairingStore,
+    BrowserBridgePairingUnavailable,
+    BrowserBridgeRecordRepository,
+    build_browser_bridge_pairing_foundation_status,
+    coarse_source_key,
+    normalize_server_base_url,
+    server_base_url_for_request,
+)
+from plugins._browser.helpers.bridge_foundation import BrowserBridgeGate, build_browser_bridge_status
+from browser_bridge_test_support import FakeResponse as _FakeResponse, FakeApiHandler as _FakeApiHandler
+
+
+EXTENSION_ID = "abcdefghijklmnopabcdefghijklmnop"
+
+
+PUBLIC_KEY = base64.urlsafe_b64encode(bytes(range(32))).rstrip(b"=").decode("ascii")
+
+
+def _repository() -> tuple[BrowserBridgeRecordRepository, dict[str, Any]]:
+    state: dict[str, Any] = {}
+
+    def load() -> Any:
+        return state.get("document")
+
+    def save(value: dict[str, Any]) -> None:
+        state["document"] = value
+
+    return BrowserBridgeRecordRepository(load=load, save=save), state
+
+
+def _id_factory() -> Any:
+    identifiers = iter(
+        (
+            "11111111-1111-4111-8111-111111111111",
+            "22222222-2222-4222-8222-222222222222",
+            "33333333-3333-4333-8333-333333333333",
+            "44444444-4444-4444-8444-444444444444",
+        )
+    )
+    return lambda: next(identifiers)
+
+
+def _store(
+    *,
+    now: list[int] | None = None,
+) -> tuple[BrowserBridgePairingStore, dict[str, Any], list[int]]:
+    repository, state = _repository()
+    clock = now or [1_788_492_400_000]
+    store = BrowserBridgePairingStore(
+        repository=repository,
+        clock_ms=lambda: clock[0],
+        random_bytes=lambda length: bytes([7]) * length,
+        id_factory=_id_factory(),
+    )
+    return store, state, clock
+
+
+def _create(store: BrowserBridgePairingStore, *, owner: str = "session-A"):
+    return store.create(
+        owner_id=owner,
+        server_instance_id="server-instance-A",
+        server_base_url="http://localhost:50080",
+        extension_id=EXTENSION_ID,
+        display_name="Taylor's browser host",
+    )
+
+
+def _exchange(creation, **updates: Any) -> dict[str, Any]:
+    value: dict[str, Any] = {
+        "trust_version": 1,
+        "pairing_code": creation.pairing_code,
+        "server_base_url": "http://localhost:50080",
+        "extension_id": EXTENSION_ID,
+        "companion_instance_id": "companion-instance-A",
+        "public_key": {
+            "algorithm": "Ed25519",
+            "encoding": "raw-base64url",
+            "value": PUBLIC_KEY,
+        },
+    }
+    value.update(updates)
+    return value
+
+
+def test_pairing_code_has_160_bits_is_memory_only_and_status_is_redacted() -> None:
+    store, state, clock = _store()
+    creation = _create(store)
+    public = creation.as_public_dict()
+
+    assert public["contract"] == BROWSER_BRIDGE_TRUST_CONTRACT
+    assert public["trust_version"] == BROWSER_BRIDGE_TRUST_VERSION
+    assert public["pairing_code"].startswith("A0B1-11111111-")
+    assert len(public["pairing_code"].rsplit("-", 1)[1]) == 32
+    assert public["expires_at_ms"] - public["created_at_ms"] == PAIRING_TTL_MS
+    assert public["native_runtime_location"] == "user_browser_host"
+    assert public["docker_install_target"] is False
+    assert public["connector_session_ready"] is False
+    assert public["browser_control_ready"] is False
+    assert creation.pairing_code not in repr(creation)
+    assert creation.pairing_code not in repr(store._pending)
+    assert state == {}
+
+    status = store.status(owner_id="session-A")
+    assert status["state"] == "pairing_pending"
+    assert status["pairing_code_present"] is False
+    assert "pairing_code" not in status
+    assert creation.pairing_code not in repr(status)
+
+    clock[0] += PAIRING_TTL_MS
+    assert store.status(owner_id="session-A")["state"] == "unpaired"
+
+
+def test_creating_second_intent_invalidates_first_for_same_session() -> None:
+    store, _, _ = _store()
+    first = _create(store)
+    second = _create(store)
+
+    with pytest.raises(BrowserBridgePairingExchangeFailed):
+        store.exchange(_exchange(first), source_key=coarse_source_key("127.0.0.1"))
+    assert store.status(owner_id="session-A")["pairing_id"] == second.pairing_id
+
+
+def test_exchange_is_single_use_and_persists_only_public_credential_state() -> None:
+    store, state, _ = _store()
+    creation = _create(store)
+    success = store.exchange(
+        _exchange(creation),
+        source_key=coarse_source_key("192.0.2.20"),
+    )
+    response = success.as_public_dict()
+
+    assert response["state"] == "paired"
+    assert response["server_instance_id"] == "server-instance-A"
+    assert response["scopes"] == list(FIXED_BROWSER_BRIDGE_SCOPES)
+    assert response["connector_session_ready"] is False
+    assert response["browser_control_ready"] is False
+    assert "private_key" not in repr(response)
+    assert "bearer" not in repr(response).lower()
+
+    stored = state["document"]
+    assert stored["schema_version"] == 1
+    assert len(stored["bridges"]) == 1
+    assert stored["bridges"][0]["public_key"]["value"] == PUBLIC_KEY
+    assert creation.pairing_code not in repr(stored)
+    assert "private_key" not in repr(stored)
+
+    with pytest.raises(BrowserBridgePairingExchangeFailed):
+        store.exchange(
+            _exchange(creation),
+            source_key=coarse_source_key("192.0.2.20"),
+        )
+    assert store.status(owner_id="session-A")["state"] == "paired"
+    assert store.status(
+        owner_id="session-A",
+        server_instance_id="different-server-instance",
+    )["state"] == "unpaired"
+
+
+def test_exactly_one_concurrent_exchange_consumes_pairing() -> None:
+    store, state, _ = _store()
+    creation = _create(store)
+    successes: list[str] = []
+    failures: list[str] = []
+
+    def exchange() -> None:
+        try:
+            successes.append(
+                store.exchange(
+                    _exchange(creation),
+                    source_key=coarse_source_key("198.51.100.7"),
+                ).bridge_id
+            )
+        except BrowserBridgePairingExchangeFailed:
+            failures.append("pairing_exchange_failed")
+
+    threads = [threading.Thread(target=exchange) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(successes) == 1
+    assert failures == ["pairing_exchange_failed"]
+    assert len(state["document"]["bridges"]) == 1
+
+
+def test_five_failed_matching_exchanges_consume_the_intent() -> None:
+    store, _, _ = _store()
+    creation = _create(store)
+    incorrect = creation.pairing_code[:-1] + (
+        "0" if creation.pairing_code[-1] != "0" else "1"
+    )
+
+    for _ in range(PAIRING_MAX_FAILED_EXCHANGES):
+        with pytest.raises(BrowserBridgePairingExchangeFailed):
+            store.exchange(
+                _exchange(creation, pairing_code=incorrect),
+                source_key=coarse_source_key("203.0.113.10"),
+            )
+
+    with pytest.raises(BrowserBridgePairingExchangeFailed):
+        store.exchange(
+            _exchange(creation),
+            source_key=coarse_source_key("203.0.113.10"),
+        )
+    assert store.status(owner_id="session-A")["state"] == "unpaired"
+
+
+def test_source_exchange_rate_is_bounded_and_failure_remains_generic() -> None:
+    store, _, _ = _store()
+    creation = _create(store)
+    invalid = _exchange(creation, pairing_code="not-a-pairing-code")
+    source = coarse_source_key("203.0.113.12")
+
+    for _ in range(20):
+        with pytest.raises(
+            BrowserBridgePairingExchangeFailed,
+            match="pairing exchange failed",
+        ):
+            store.exchange(invalid, source_key=source)
+    with pytest.raises(
+        BrowserBridgePairingExchangeFailed,
+        match="pairing exchange failed",
+    ):
+        store.exchange(_exchange(creation), source_key=source)
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"trust_version": True},
+        {"server_base_url": "https://different.example.test"},
+        {"extension_id": "bcdefghijklmnopabcdefghijklmnopa"},
+        {"companion_instance_id": " companion"},
+        {"public_key": {"algorithm": "Ed25519", "encoding": "raw-base64url", "value": "x"}},
+        {"unexpected": "field"},
+    ],
+)
+def test_exchange_schema_and_identity_mismatches_share_generic_failure(
+    updates: dict[str, Any],
+) -> None:
+    store, _, _ = _store()
+    creation = _create(store)
+    request = _exchange(creation)
+    request.update(updates)
+
+    with pytest.raises(
+        BrowserBridgePairingExchangeFailed,
+        match="pairing exchange failed",
+    ):
+        store.exchange(request, source_key=coarse_source_key("203.0.113.11"))
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "http://agent.example.test",
+        "https://user:password@agent.example.test",
+        "https://agent.example.test/a0?secret=value",
+        "https://agent.example.test/a0#fragment",
+        "https://agent.example.test/%2e%2e/private",
+        "https://bad_host.example.test",
+        "http://localhost:0",
+    ],
+)
+def test_server_base_url_fails_closed_on_unsafe_values(value: str) -> None:
+    with pytest.raises(BrowserBridgePairingError):
+        normalize_server_base_url(value)
+
+
+def test_server_url_uses_external_browser_origin_and_supports_docker_loopback() -> None:
+    request = type(
+        "Request",
+        (),
+        {
+            "headers": {"Origin": "http://localhost:50080"},
+            "script_root": "",
+            "url_root": "http://localhost:50080/",
+        },
+    )()
+
+    assert server_base_url_for_request(request, environ={}) == "http://localhost:50080"
+    assert normalize_server_base_url("https://agent.example.test/a0/") == (
+        "https://agent.example.test/a0"
+    )
+
+    mismatched = type(
+        "Request",
+        (),
+        {
+            "headers": {"Origin": "https://attacker.example.test"},
+            "script_root": "",
+            "url_root": "https://agent.example.test/",
+        },
+    )()
+    with pytest.raises(BrowserBridgePairingUnavailable):
+        server_base_url_for_request(mismatched, environ={})
+
+
+@pytest.mark.parametrize("gate", [None, "invalid", "disabled"])
+def test_pairing_foundation_is_disabled_by_default(gate: str | None) -> None:
+    status = build_browser_bridge_pairing_foundation_status(
+        BrowserBridgeGate.from_value(gate),
+        environ={BROWSER_BRIDGE_EXTENSION_ID_ENV: EXTENSION_ID},
+    )
+
+    assert status["state"] == "disabled"
+    assert status["pairing_create_enabled"] is False
+    assert status["pairing_exchange_enabled"] is False
+    assert status["connector_session_ready"] is False
+    assert status["browser_control_ready"] is False
+
+
+def test_pairing_foundation_requires_server_pinned_extension_id() -> None:
+    unavailable = build_browser_bridge_pairing_foundation_status(
+        BrowserBridgeGate.from_value("preview"),
+        environ={},
+    )
+    available = build_browser_bridge_pairing_foundation_status(
+        BrowserBridgeGate.from_value("preview"),
+        environ={BROWSER_BRIDGE_EXTENSION_ID_ENV: EXTENSION_ID},
+    )
+
+    assert unavailable["state"] == "disabled"
+    assert unavailable["reason_code"] == "expected_extension_id_not_configured"
+    assert available["state"] == "available"
+    assert available["pairing_create_enabled"] is True
+    assert available["connector_session_ready"] is False
+
+
+def test_browser_status_adds_trust_foundation_without_runtime_claims(monkeypatch) -> None:
+    monkeypatch.setenv(BROWSER_BRIDGE_EXTENSION_ID_ENV, EXTENSION_ID)
+    status = build_browser_bridge_status(
+        None,
+        BrowserBridgeGate.from_value("preview"),
+        checked_at="2026-09-04T12:00:00Z",
+    )
+
+    assert status["trust"]["contract"] == BROWSER_BRIDGE_TRUST_CONTRACT
+    assert status["trust"]["state"] == "available"
+    assert status["trust"]["connector_session_ready"] is False
+    assert status["trust"]["browser_control_ready"] is False
+    assert EXTENSION_ID not in repr(status["trust"])
+
+
+class _FakePublicApiHandler(_FakeApiHandler):
+    @classmethod
+    def requires_auth(cls) -> bool:
+        return False
+
+    @classmethod
+    def requires_csrf(cls) -> bool:
+        return False
+
+
+@contextmanager
+def _endpoint_module(
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+) -> Iterator[ModuleType]:
+    api_stub = ModuleType("helpers.api")
+    api_stub.ApiHandler = _FakeApiHandler
+    api_stub.Request = object
+    api_stub.Response = _FakeResponse
+    api_stub.session = {}
+    base_stub = ModuleType("plugins._a0_connector.api.v1.base")
+    base_stub.PublicConnectorApiHandler = _FakePublicApiHandler
+    v1_stub = ModuleType("plugins._a0_connector.api.v1")
+    v1_stub.base = base_stub
+    runtime_stub = ModuleType("helpers.runtime")
+    runtime_stub.get_persistent_id = lambda: "server-A"
+    previous = sys.modules.pop(module_name, None)
+    previous_base = sys.modules.get("plugins._a0_connector.api.v1.base")
+    previous_v1 = sys.modules.get("plugins._a0_connector.api.v1")
+    try:
+        with monkeypatch.context() as context:
+            context.setitem(sys.modules, "helpers.api", api_stub)
+            context.setitem(sys.modules, "helpers.runtime", runtime_stub)
+            context.setitem(sys.modules, "plugins._a0_connector.api.v1", v1_stub)
+            context.setitem(sys.modules, "plugins._a0_connector.api.v1.base", base_stub)
+            yield importlib.import_module(module_name)
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous is not None:
+            sys.modules[module_name] = previous
+        if previous_base is not None:
+            sys.modules["plugins._a0_connector.api.v1.base"] = previous_base
+        if previous_v1 is not None:
+            sys.modules["plugins._a0_connector.api.v1"] = previous_v1
+
+
+def test_pairing_endpoint_keeps_default_auth_csrf_and_no_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "plugins._a0_connector.api.browser_bridge_pairing"
+    store, _, _ = _store()
+    request = type(
+        "Request",
+        (),
+        {
+            "headers": {"Origin": "http://localhost:50080"},
+            "script_root": "",
+            "url_root": "http://localhost:50080/",
+            "data": b"",
+            "content_length": 0,
+            "is_json": True,
+        },
+    )()
+    with _endpoint_module(monkeypatch, module_name) as endpoint:
+        monkeypatch.setenv(BROWSER_BRIDGE_EXTENSION_ID_ENV, EXTENSION_ID)
+        monkeypatch.setattr(endpoint, "get_browser_bridge_pairing_store", lambda: store)
+        monkeypatch.setattr(
+            endpoint,
+            "get_browser_bridge_gate",
+            lambda: BrowserBridgeGate.from_value("preview"),
+        )
+        monkeypatch.setattr(endpoint, "configured_extension_id", lambda: EXTENSION_ID)
+        monkeypatch.setattr(endpoint.runtime, "get_persistent_id", lambda: "server-A")
+        handler = endpoint.BrowserBridgePairing(None, None)
+        response = asyncio.run(
+            handler.process(
+                {"action": "create", "display_name": "Browser host"},
+                request,
+            )
+        )
+
+    payload = json.loads(response.response)
+    assert handler.requires_auth() is True
+    assert handler.requires_csrf() is True
+    assert response.status == 201
+    assert response.headers["Cache-Control"] == "no-store"
+    assert payload["state"] == "pairing_pending"
+    assert payload["connector_session_ready"] is False
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        {"action": "create", "display_name": " Browser host"},
+        {"action": "create", "display_name": "x" * 193},
+        {"action": "cancel", "pairing_id": " pairing-id"},
+    ],
+)
+def test_pairing_endpoint_rejects_malformed_presentation_values(
+    monkeypatch: pytest.MonkeyPatch,
+    document: dict[str, Any],
+) -> None:
+    module_name = "plugins._a0_connector.api.browser_bridge_pairing"
+    with _endpoint_module(monkeypatch, module_name) as endpoint:
+        handler = endpoint.BrowserBridgePairing(None, None)
+        response = asyncio.run(handler.process(document, request=None))
+
+    assert response.status == 400
+    assert json.loads(response.response) == {"error": "invalid_pairing_request"}
+    assert response.headers["Cache-Control"] == "no-store"
+
+
+def test_public_exchange_endpoint_has_no_ambient_auth_and_generic_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "plugins._a0_connector.api.browser_bridge_exchange"
+    with _endpoint_module(monkeypatch, module_name) as endpoint:
+        monkeypatch.setattr(
+            endpoint,
+            "get_browser_bridge_gate",
+            lambda: BrowserBridgeGate.from_value("preview"),
+        )
+        monkeypatch.setattr(endpoint, "configured_extension_id", lambda: EXTENSION_ID)
+        handler = endpoint.BrowserBridgeExchange(None, None)
+        response = asyncio.run(handler.process({}, request=None))
+
+    payload = json.loads(response.response)
+    assert handler.requires_auth() is False
+    assert handler.requires_csrf() is False
+    assert response.status == 400
+    assert payload == {
+        "contract": BROWSER_BRIDGE_TRUST_CONTRACT,
+        "trust_version": 1,
+        "error": "pairing_exchange_failed",
+    }
+    assert response.headers["Cache-Control"] == "no-store"
+
+
+def test_public_exchange_endpoint_accepts_only_the_frozen_pairing_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "plugins._a0_connector.api.browser_bridge_exchange"
+    store, state, _ = _store()
+    creation = _create(store)
+    with _endpoint_module(monkeypatch, module_name) as endpoint:
+        monkeypatch.setattr(
+            endpoint,
+            "get_browser_bridge_gate",
+            lambda: BrowserBridgeGate.from_value("preview"),
+        )
+        monkeypatch.setattr(endpoint, "configured_extension_id", lambda: EXTENSION_ID)
+        monkeypatch.setattr(endpoint, "get_browser_bridge_pairing_store", lambda: store)
+        handler = endpoint.BrowserBridgeExchange(None, None)
+        response = asyncio.run(handler.process(_exchange(creation), request=None))
+
+    payload = json.loads(response.response)
+    assert response.status == 200
+    assert payload["contract"] == BROWSER_BRIDGE_TRUST_CONTRACT
+    assert payload["state"] == "paired"
+    assert payload["server_base_url"] == "http://localhost:50080"
+    assert payload["scopes"] == list(FIXED_BROWSER_BRIDGE_SCOPES)
+    assert payload["native_runtime_location"] == "user_browser_host"
+    assert payload["docker_install_target"] is False
+    assert payload["connector_session_ready"] is False
+    assert payload["browser_control_ready"] is False
+    assert response.headers["Cache-Control"] == "no-store"
+    assert creation.pairing_code not in response.response
+    assert creation.pairing_code not in repr(state["document"])
+
+
+def test_public_exchange_rejects_oversized_body_before_reading_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "plugins._a0_connector.api.browser_bridge_exchange"
+
+    class UnreadableStream(io.BytesIO):
+        def read(self, *args, **kwargs):
+            raise AssertionError("oversized body must be rejected before reading")
+
+    request = type(
+        "Request",
+        (),
+        {
+            "content_length": 8 * 1024 + 1,
+            "is_json": True,
+            "stream": UnreadableStream(b"secret"),
+        },
+    )()
+    with _endpoint_module(monkeypatch, module_name) as endpoint:
+        handler = endpoint.BrowserBridgeExchange(None, None)
+        response = asyncio.run(handler.handle_request(request))
+
+    assert response.status == 400
+    assert json.loads(response.response)["error"] == "pairing_exchange_failed"
+    assert response.headers["Cache-Control"] == "no-store"
+
+
+@pytest.mark.parametrize(
+    ("module_name", "raw_body", "expected_error"),
+    [
+        (
+            "plugins._a0_connector.api.browser_bridge_pairing",
+            b'{"action":"status","action":"create"}',
+            "invalid_pairing_request",
+        ),
+        (
+            "plugins._a0_connector.api.browser_bridge_exchange",
+            b'{"trust_version":1,"public_key":{"algorithm":"Ed25519",'
+            b'"algorithm":"Ed25519"}}',
+            "pairing_exchange_failed",
+        ),
+    ],
+)
+def test_pairing_endpoints_reject_duplicate_json_object_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+    raw_body: bytes,
+    expected_error: str,
+) -> None:
+    request = type(
+        "Request",
+        (),
+        {
+            "content_length": len(raw_body),
+            "is_json": True,
+            "stream": io.BytesIO(raw_body),
+        },
+    )()
+    with _endpoint_module(monkeypatch, module_name) as endpoint:
+        handler_class = (
+            endpoint.BrowserBridgePairing
+            if module_name.endswith("browser_bridge_pairing")
+            else endpoint.BrowserBridgeExchange
+        )
+        response = asyncio.run(handler_class(None, None).handle_request(request))
+
+    assert response.status == 400
+    assert json.loads(response.response)["error"] == expected_error
+    assert response.headers["Cache-Control"] == "no-store"

--- a/tests/test_browser_bridge_policy_foundation.py
+++ b/tests/test_browser_bridge_policy_foundation.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import threading
+from typing import Any
+
+import pytest
+
+from plugins._a0_connector.helpers.browser_bridge_policy import (
+    BROWSER_BRIDGE_POLICY_CONTRACT,
+    BrowserBridgePolicyError,
+    BrowserBridgePolicyRepository,
+    BrowserBridgePolicyUnavailable,
+    normalize_site_origin,
+)
+
+
+SERVER_ID = "server-instance-A"
+BRIDGE_ID = "22222222-2222-4222-8222-222222222222"
+SUBJECT_ID = "single_user"
+
+
+def _repository() -> tuple[BrowserBridgePolicyRepository, dict[str, Any]]:
+    state: dict[str, Any] = {}
+    sequence = iter(
+        (
+            "11111111-1111-4111-8111-111111111111",
+            "22222222-2222-4222-8222-222222222222",
+            "33333333-3333-4333-8333-333333333333",
+        )
+    )
+
+    def load() -> Any:
+        return state.get("document")
+
+    def save(value: dict[str, Any]) -> None:
+        state["document"] = value
+
+    return (
+        BrowserBridgePolicyRepository(
+            load=load,
+            save=save,
+            clock_ms=lambda: 1_788_492_400_000,
+            id_factory=lambda: next(sequence),
+        ),
+        state,
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("HTTPS://Example.COM:443/", "https://example.com"),
+        ("https://x", "https://x"),
+        ("http://localhost:50080", "http://localhost:50080"),
+        ("https://bücher.example", "https://xn--bcher-kva.example"),
+        ("http://[0:0::1]:80/", "http://[::1]"),
+    ],
+)
+def test_site_origin_normalizes_exact_http_origins(raw: str, expected: str) -> None:
+    assert normalize_site_origin(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        " https://example.com",
+        "ftp://example.com",
+        "https://*.example.com",
+        "https://user@example.com",
+        "https://example.com/path",
+        "https://example.com?query=secret",
+        "https://example.com#fragment",
+        "https://\ud800.example",
+        "https://example.com\\@evil.example",
+        "https://127.0.0.999",
+        "https://0x7f000001",
+        "https://017700000001",
+        "https://example.123",
+        "http://[fe80::1%25en0]",
+        "https://example..com",
+        "https://-example.com",
+        "chrome://settings",
+    ],
+)
+def test_site_origin_rejects_non_origin_and_ambiguous_values(value: str) -> None:
+    with pytest.raises(BrowserBridgePolicyError):
+        normalize_site_origin(value)
+
+
+def test_policy_is_default_deny_idempotent_and_exactly_scoped() -> None:
+    repository, state = _repository()
+    identity = {
+        "server_instance_id": SERVER_ID,
+        "bridge_id": BRIDGE_ID,
+        "subject_id": SUBJECT_ID,
+    }
+    assert repository.active_grant(**identity, origin="https://example.com") is None
+    assert state == {}
+    first = repository.allow(**identity, origin="HTTPS://Example.COM:443/")
+    repeated = repository.allow(**identity, origin="https://example.com")
+    assert repeated == first
+    assert first.origin == "https://example.com"
+    assert len(state["document"]["grants"]) == 1
+    stored = state["document"]["grants"][0]
+    assert stored["server_instance_id"] == SERVER_ID
+    assert stored["bridge_id"] == BRIDGE_ID
+    assert stored["subject_id"] == SUBJECT_ID
+    assert repository.active_grant(**identity, origin="https://example.com") == first
+    assert repository.list_grants(
+        server_instance_id="server-instance-B",
+        bridge_id=BRIDGE_ID,
+        subject_id=SUBJECT_ID,
+    ) == ()
+
+    assert repository.revoke(**identity, origin="https://example.com") is True
+    assert repository.revoke(**identity, origin="https://example.com") is False
+    assert repository.active_grant(**identity, origin="https://example.com") is None
+
+
+def test_all_websites_is_explicit_persistent_scoped_and_revocable_without_origin_accumulation():
+    repository, state = _repository()
+    identity = dict(server_instance_id=SERVER_ID, bridge_id=BRIDGE_ID, subject_id=SUBJECT_ID)
+    assert repository.site_mode(**identity) == "ask_per_site"
+    repository.set_site_mode(**identity, site_mode="allow_all_websites")
+    assert state["document"]["schema_version"] == 2
+    loaded = BrowserBridgePolicyRepository(load=lambda: state["document"])
+    grant = loaded.active_grant(**identity, origin="https://one.example")
+    assert grant.origin == "https://one.example"
+    assert grant == loaded.active_grant(**identity, origin="https://one.example")
+    assert grant.grant_id != loaded.active_grant(**identity, origin="https://two.example").grant_id
+    assert loaded.list_grants(**identity) == ()
+    for key in identity:
+        assert loaded.active_grant(**{**identity, key: "other"}, origin="https://one.example") is None
+    for origin in ("chrome://settings", "file:///private", "https://*.example", "https://u:p@example.com"):
+        with pytest.raises(BrowserBridgePolicyError):
+            loaded.active_grant(**identity, origin=origin)
+    saved = repository.allow(**identity, origin="https://saved.example")
+    repository.set_site_mode(**identity, site_mode="ask_per_site")
+    assert repository.active_grant(**identity, origin="https://one.example") is None
+    assert repository.active_grant(**identity, origin="https://saved.example") == saved
+    assert state["document"]["schema_version"] == 1
+
+
+def test_all_websites_rejects_corruption_and_unconfirmed_writes():
+    identity = dict(server_instance_id=SERVER_ID, bridge_id=BRIDGE_ID, subject_id=SUBJECT_ID)
+    no_save = BrowserBridgePolicyRepository(load=lambda: None, save=lambda value: None)
+    with pytest.raises(BrowserBridgePolicyUnavailable):
+        no_save.set_site_mode(**identity, site_mode="allow_all_websites")
+    broken = BrowserBridgePolicyRepository(load=lambda: {"schema_version": 2, "grants": [], "all_websites": [True]})
+    with pytest.raises(BrowserBridgePolicyUnavailable):
+        broken.active_grant(**identity, origin="https://example.com")
+
+
+def test_protected_all_websites_action_derives_authority_and_readback(monkeypatch):
+    from plugins._a0_connector.api import browser_bridge_policy as endpoint
+    repository, state = _repository()
+    pairing = _PairingStore()
+    monkeypatch.setattr(endpoint.runtime, "get_persistent_id", lambda: SERVER_ID)
+    monkeypatch.setattr(endpoint, "get_browser_bridge_pairing_store", lambda: pairing)
+    monkeypatch.setattr(endpoint, "get_browser_bridge_policy_repository", lambda: repository)
+    handler = endpoint.BrowserBridgePolicy(None, None)
+    body = {"action": "set_mode", "bridge_id": BRIDGE_ID, "site_mode": "allow_all_websites"}
+    response = asyncio.run(handler.process(body, request=None))
+    assert response.status_code == 200 and response.headers["Cache-Control"] == "no-store"
+    assert json.loads(response.get_data()) ["site_mode"] == "allow_all_websites"
+    assert state["document"]["all_websites"][0]["subject_id"] == SUBJECT_ID
+    assert asyncio.run(handler.process({**body, "subject_id": "other"}, request=None)).status_code == 400
+    pairing.active = False
+    assert asyncio.run(handler.process(body, request=None)).status_code == 409
+
+
+def test_policy_read_modify_write_is_atomic_for_duplicate_allows() -> None:
+    repository, state = _repository()
+    grants = []
+
+    def allow() -> None:
+        grants.append(
+            repository.allow(
+                server_instance_id=SERVER_ID,
+                bridge_id=BRIDGE_ID,
+                subject_id=SUBJECT_ID,
+                origin="https://example.com",
+            )
+        )
+
+    threads = [threading.Thread(target=allow) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(grants) == 8
+    assert len({grant.grant_id for grant in grants}) == 1
+    assert len(state["document"]["grants"]) == 1
+
+
+def test_corrupt_or_oversized_policy_store_fails_closed() -> None:
+    repository, state = _repository()
+    state["document"] = {"schema_version": 1, "grants": [{}]}
+    with pytest.raises(BrowserBridgePolicyUnavailable):
+        repository.list_grants(
+            server_instance_id=SERVER_ID,
+            bridge_id=BRIDGE_ID,
+            subject_id=SUBJECT_ID,
+        )
+    with pytest.raises(BrowserBridgePolicyUnavailable):
+        repository.allow(
+            server_instance_id=SERVER_ID,
+            bridge_id=BRIDGE_ID,
+            subject_id=SUBJECT_ID,
+            origin="https://example.com",
+        )
+
+
+class _PairingStore:
+    def __init__(self, *, active: bool = True) -> None:
+        self.active = active
+        self.calls: list[tuple[str, str]] = []
+
+    def active_bridge_record(
+        self,
+        *,
+        bridge_id: str,
+        server_instance_id: str,
+    ) -> dict[str, Any] | None:
+        self.calls.append((bridge_id, server_instance_id))
+        if not self.active or bridge_id != BRIDGE_ID or server_instance_id != SERVER_ID:
+            return None
+        return {"subject_id": SUBJECT_ID, "state": "active"}
+
+
+def test_policy_api_is_protected_no_store_and_non_activating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugins._a0_connector.api import browser_bridge_policy as endpoint
+
+    repository, state = _repository()
+    pairing = _PairingStore()
+    monkeypatch.setattr(endpoint.runtime, "get_persistent_id", lambda: SERVER_ID)
+    monkeypatch.setattr(endpoint, "get_browser_bridge_pairing_store", lambda: pairing)
+    monkeypatch.setattr(endpoint, "get_browser_bridge_policy_repository", lambda: repository)
+    handler = endpoint.BrowserBridgePolicy(None, None)
+
+    response = asyncio.run(
+        handler.process(
+            {"action": "allow", "bridge_id": BRIDGE_ID, "origin": "https://example.com/"},
+            request=None,
+        )
+    )
+    payload = json.loads(response.get_data(as_text=True))
+    assert handler.requires_auth() is True
+    assert handler.requires_csrf() is True
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "no-store"
+    assert payload["contract"] == BROWSER_BRIDGE_POLICY_CONTRACT
+    assert payload["site_mode"] == "ask_per_site"
+    assert payload["operation_grants_enabled"] is False
+    assert payload["browser_control_ready"] is False
+    assert payload["grants"][0]["origin"] == "https://example.com"
+    assert set(payload) == {
+        "contract",
+        "policy_version",
+        "site_mode",
+        "bridge_id",
+        "grants",
+        "operation_grants_enabled",
+        "browser_control_ready",
+    }
+    assert set(payload["grants"][0]) == {
+        "grant_id",
+        "origin",
+        "created_at_ms",
+        "updated_at_ms",
+    }
+    assert pairing.calls == [(BRIDGE_ID, SERVER_ID)]
+    assert state["document"]["grants"][0]["subject_id"] == SUBJECT_ID
+
+    listed = asyncio.run(
+        handler.process(
+            {"action": "list", "bridge_id": BRIDGE_ID},
+            request=None,
+        )
+    )
+    assert json.loads(listed.get_data(as_text=True)) == payload
+
+    revoked = asyncio.run(
+        handler.process(
+            {"action": "revoke", "bridge_id": BRIDGE_ID, "origin": "https://example.com"},
+            request=None,
+        )
+    )
+    revoked_payload = json.loads(revoked.get_data(as_text=True))
+    assert revoked_payload["revoked"] is True
+    assert revoked_payload["grants"] == []
+    assert set(revoked_payload) == {*payload, "revoked"}
+
+
+def test_policy_api_rejects_unknown_bridge_extra_authority_and_duplicate_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugins._a0_connector.api import browser_bridge_policy as endpoint
+
+    repository, state = _repository()
+    pairing = _PairingStore(active=False)
+    monkeypatch.setattr(endpoint.runtime, "get_persistent_id", lambda: SERVER_ID)
+    monkeypatch.setattr(endpoint, "get_browser_bridge_pairing_store", lambda: pairing)
+    monkeypatch.setattr(endpoint, "get_browser_bridge_policy_repository", lambda: repository)
+    handler = endpoint.BrowserBridgePolicy(None, None)
+
+    unavailable = asyncio.run(
+        handler.process(
+            {"action": "allow", "bridge_id": BRIDGE_ID, "origin": "https://example.com"},
+            request=None,
+        )
+    )
+    assert unavailable.status_code == 409
+    assert state == {}
+
+    extra = asyncio.run(
+        handler.process(
+            {
+                "action": "allow",
+                "bridge_id": BRIDGE_ID,
+                "origin": "https://example.com",
+                "subject_id": "attacker-selected",
+            },
+            request=None,
+        )
+    )
+    assert extra.status_code == 400
+
+    raw = (
+        b'{"action":"allow","bridge_id":"'
+        + BRIDGE_ID.encode()
+        + b'","origin":"https://example.com","origin":"https://evil.example"}'
+    )
+    request = type(
+        "Request",
+        (),
+        {
+            "content_length": len(raw),
+            "is_json": True,
+            "stream": io.BytesIO(raw),
+        },
+    )()
+    duplicate = asyncio.run(handler.handle_request(request))
+    assert duplicate.status_code == 400
+    assert state == {}
+
+    oversized = type(
+        "Request",
+        (),
+        {
+            "content_length": endpoint.MAX_POLICY_REQUEST_BYTES + 1,
+            "is_json": True,
+            "stream": io.BytesIO(b"{}"),
+        },
+    )()
+    too_large = asyncio.run(handler.handle_request(oversized))
+    assert too_large.status_code == 400
+    assert state == {}
+
+
+def test_policy_api_fails_closed_when_active_record_has_no_subject(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugins._a0_connector.api import browser_bridge_policy as endpoint
+
+    repository, state = _repository()
+    pairing = _PairingStore()
+    pairing.active_bridge_record = lambda **_kwargs: {"state": "active"}
+    monkeypatch.setattr(endpoint.runtime, "get_persistent_id", lambda: SERVER_ID)
+    monkeypatch.setattr(endpoint, "get_browser_bridge_pairing_store", lambda: pairing)
+    monkeypatch.setattr(endpoint, "get_browser_bridge_policy_repository", lambda: repository)
+
+    response = asyncio.run(
+        endpoint.BrowserBridgePolicy(None, None).process(
+            {"action": "allow", "bridge_id": BRIDGE_ID, "origin": "https://example.com"},
+            request=None,
+        )
+    )
+    assert response.status_code == 503
+    assert state == {}

--- a/tests/test_browser_bridge_production_reconciliation.py
+++ b/tests/test_browser_bridge_production_reconciliation.py
@@ -1,0 +1,123 @@
+"""Real production registry/controller/dispatcher, synthetic transport and state."""
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from plugins._a0_connector.helpers.browser_bridge_application import BrowserBridgeApplication
+from plugins._a0_connector.helpers.browser_bridge_bootstrap import admitted_hello_projection
+from plugins._a0_connector.helpers.browser_bridge_reconciliation import BrowserBridgeReconciliationController
+from plugins._a0_connector.helpers.browser_bridge_operations import SettlementStatus
+from plugins._a0_connector.helpers.browser_bridge_transport import PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+from plugins._browser.helpers.extension_sessions import ExtensionSessionRegistry
+from test_browser_bridge_application import Memory
+from test_browser_bridge_runtime_foundation import _registry, _principal, _hello
+
+
+def application(timeout_ms=1_000):
+    emitted, replayed = [], []
+    sent = asyncio.Event()
+    async def sender(*args):
+        emitted.append(args)
+        sent.set()
+    app = object.__new__(BrowserBridgeApplication)
+    app.transport_profile = PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    app._state_lock = threading.RLock()
+    app._closed = False
+    app._reconciliation_tasks = {}
+    app.registry = _registry(sender=sender)
+    app.browser = SimpleNamespace(installed=True, lifecycle=SimpleNamespace(
+        registry=ExtensionSessionRegistry(persistence=Memory()),
+        replay_pending=lambda: replayed.append(True)))
+    app.reconciliation = BrowserBridgeReconciliationController(
+        broker=app.registry.broker, snapshot_source=app._reconciliation_snapshot,
+        route_current=app.registry.route_current_for_reconciliation,
+        promote=app.registry.promote_reconciled, timeout_ms=timeout_ms)
+    return app, emitted, replayed, sent
+
+
+def result_for(control, hello):
+    # Exact native-wrapped extension result, not a prevalidated summary.
+    result = {"contract_version": 1, "control_id": control["control_id"],
+              "install_instance_id": hello["host_browser"]["extension"]["install_instance_id"],
+              "load_generation_id": control["load_generation_id"],
+              "leases": [], "inflight_operations": [], "terminal_action_receipts": [],
+              "pending_critical_events": [], "prior_generation_orphans": []}
+    return {key: control[key] for key in ("contract_version", "method", "bridge_id", "load_generation_id", "control_id")} | {"ok": True, "result": result}
+
+
+def test_first_hello_has_no_work_second_reconciles_once_then_exact_response_promotes():
+    async def scenario():
+        app, emitted, replayed, sent = application()
+        principal = _principal()
+        hello = _hello(principal)
+        session, turn = app.browser.lifecycle.registry.begin_turn(
+            context_id="context-A", browser_id="extension:bridge-A", bridge_id="bridge-A")
+        first = app.register_hello(principal=principal, connector_sid="sid-A", data=hello)
+        assert emitted == [] and replayed == [] and app._reconciliation_tasks == {}
+        assert not app.registry.current_bridge_ready("bridge-A")
+        assert app.registry.resolve_extension_route("context-A", "bridge-A") is None
+        second = app.register_hello(principal=principal, connector_sid="sid-A", data=hello)
+        assert admitted_hello_projection(first) == admitted_hello_projection(second)
+        tasks = tuple(app._reconciliation_tasks.values())
+        app.register_hello(principal=principal, connector_sid="sid-A", data=hello)
+        assert tuple(app._reconciliation_tasks.values()) == tasks
+        await asyncio.wait_for(sent.wait(), 1)
+        control = emitted[0][2]
+        assert control["method"] == "browser.reconcile" and len(emitted) == 1
+        assert control["expected_contexts"] == [{"context_id": "context-A",
+            "browser_session_id": session.browser_session_id, "active_turn_ids": [turn.turn_id]}]
+        response = await app.dispatch(principal, "sid-A", "connector_browser_control_result", result_for(control, hello))
+        assert response["status"] == SettlementStatus.SETTLED
+        assert app.registry.current_bridge_ready("bridge-A")
+        assert app.registry.resolve_extension_route("context-A", "bridge-A") is not None
+        await tasks[0]
+        assert replayed == [True]
+        app.register_hello(principal=principal, connector_sid="sid-A", data=hello)
+        assert len(emitted) == 1 and app.registry.current_bridge_ready("bridge-A")
+        app.registry.retire_all()
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("mode", ["replacement", "timeout"])
+def test_replacement_and_timeout_cannot_promote_or_replay(mode):
+    async def scenario():
+        app, emitted, replayed, sent = application(timeout_ms=20 if mode == "timeout" else 1_000)
+        principal = _principal()
+        hello = _hello(principal)
+        app.register_hello(principal=principal, connector_sid="sid-A", data=hello)
+        app.register_hello(principal=principal, connector_sid="sid-A", data=hello)
+        tasks = tuple(app._reconciliation_tasks.values())
+        await asyncio.wait_for(sent.wait(), 1)
+        if mode == "replacement":
+            newer = _hello(principal)
+            newer["host_browser"]["extension"]["load_generation_id"] = "generation-B"
+            app.register_hello(principal=principal, connector_sid="sid-A", data=newer)
+            response = await app.dispatch(principal, "sid-A", "connector_browser_control_result", result_for(emitted[0][2], hello))
+            assert response["status"] != SettlementStatus.SETTLED
+        outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+        if mode == "replacement":
+            assert len(outcomes) == 1 and getattr(outcomes[0], "code", None) == "CONNECTION_LOST"
+        assert not app.registry.current_bridge_ready("bridge-A") and replayed == []
+        current = app.registry.current_sid_route(principal, "sid-A")
+        assert (current is not None and current.load_generation_id == "generation-B") if mode == "replacement" else current is None
+        app.registry.retire_all()
+    asyncio.run(scenario())
+
+
+def test_private_stage_diagnostics_are_allowlisted_bounded_and_redacted(monkeypatch, caplog):
+    from plugins._a0_connector.helpers import browser_bridge_application as module
+    monkeypatch.setattr(module, "_stage_counts", {})
+    for _ in range(10):
+        module.record_production_browser_stage("RECONCILIATION_STARTED")
+    module.record_production_browser_stage("PRIVATE_BRIDGE_CANARY")
+    module._record_reconciliation_failure(SimpleNamespace(code="PRIVATE_EXCEPTION_CANARY"))
+    module._record_reconciliation_failure(SimpleNamespace(code="DEADLINE_EXCEEDED"))
+    for code in ("ADMISSION_HEARTBEAT_REJECTED", "ADMISSION_RELEASE_UNVERIFIED", "RECONCILIATION_BROKER_SCOPE_LOST"):
+        for _ in range(10):
+            module.record_production_browser_stage(code)
+    assert len(caplog.records) == 22
+    assert "PRIVATE_" not in caplog.text
+    assert "RECONCILIATION_OTHER_FAILURE" in caplog.text
+    assert "RECONCILIATION_TIMEOUT" in caplog.text

--- a/tests/test_browser_bridge_queue.py
+++ b/tests/test_browser_bridge_queue.py
@@ -1,0 +1,166 @@
+import asyncio
+import json
+
+import pytest
+
+from helpers import message_queue
+from plugins._a0_connector.helpers.browser_bridge_context import BrowserBridgeContextAccess, BrowserBridgeContextRoute
+from plugins._a0_connector.helpers.browser_bridge_messages import BrowserBridgeMessageDispatcher
+from plugins._a0_connector.helpers.browser_bridge_queue import BrowserBridgeQueueController, BrowserBridgeQueueError
+from test_browser_bridge_application import Source
+from browser_bridge_test_support import MemoryKeyValue
+from test_browser_bridge_runtime_foundation import _principal
+
+
+class Context:
+    def __init__(self):
+        self.data, self.output = {}, {}
+
+    def get_data(self, key):
+        return self.data.get(key)
+
+    def set_data(self, key, value):
+        self.data[key] = value
+
+    def set_output_data(self, key, value):
+        self.output[key] = value
+
+
+class Harness:
+    def __init__(self):
+        self.current = True
+        self.route = BrowserBridgeContextRoute(_principal(), "sid-A", "generation-A")
+        self.access = BrowserBridgeContextAccess(data_source=Source(), route_authorizer=lambda route: self.current and route is self.route)
+        self.access.advertise_contexts(self.route)
+        self.queue_store, self.message_store = MemoryKeyValue(), MemoryKeyValue()
+        self.context = Context()
+        self.effects, self.emitted = [], []
+        self.messages = BrowserBridgeMessageDispatcher(
+            access=self.access, server_instance_id=lambda: "server-A", load=self.message_store.load,
+            save=self.message_store.save, deliver=lambda *args: self.effects.append(args))
+        self.controller = BrowserBridgeQueueController(
+            access=self.access, messages=self.messages, manager=self,
+            server_instance_id=lambda: "server-A", context_get=lambda context: self.context,
+            queue_service=message_queue, load=self.queue_store.load, save=self.queue_store.save,
+            mark_dirty=lambda context: None)
+
+    async def emit_to(self, *args, **kwargs):
+        self.emitted.append((args, kwargs))
+
+    async def add(self, **changes):
+        return await self.controller.dispatch("connector_message_queue_add", self.route, {
+            "contract_version": 1, "context_id": "context-A", "client_message_id": "message-A",
+            "text": "private queue text", **changes})
+
+    async def action(self, action, item_id):
+        return await self.controller.dispatch("connector_message_queue_" + action, self.route, {
+            "contract_version": 1, "context_id": "context-A", "item_id": item_id})
+
+
+def test_real_core_queue_replays_send_once_and_uses_exact_private_projection():
+    async def scenario():
+        h = Harness()
+        message_queue.add(h.context, "unrelated secret", ["/private/path"], item_id="foreign")
+        first = await h.add()
+        assert (await h.add())["item_id"] == first["item_id"]
+        assert len(message_queue.get_queue(h.context)) == 2
+        assert len(first["message_queue"]) == 1
+        with pytest.raises(BrowserBridgeQueueError, match="QUEUE_ITEM_NOT_FOUND"):
+            await h.action("remove", "foreign")
+        with pytest.raises(BrowserBridgeQueueError, match="IDEMPOTENCY_CONFLICT"):
+            await h.add(text="changed")
+        assert (await h.action("send", first["item_id"]))["status"] == "sent"
+        assert (await h.action("send", first["item_id"]))["status"] == "sent"
+        assert len(h.effects) == 1
+        assert (await h.add())["status"] == "sent"
+        assert [item["id"] for item in message_queue.get_queue(h.context)] == ["foreign"]
+        assert "private queue text" not in json.dumps(h.queue_store.value)
+        assert "context-A" not in json.dumps(h.queue_store.value)
+        assert "unrelated secret" not in json.dumps(h.emitted, default=str)
+        assert all(kwargs["expected_principal"] is h.route.principal for _, kwargs in h.emitted)
+    asyncio.run(scenario())
+
+
+def test_queue_stale_unadvertised_and_attachment_requests_have_no_effect():
+    async def scenario():
+        h = Harness()
+        with pytest.raises(BrowserBridgeQueueError, match="INVALID_STATE"):
+            await h.add(attachments=["/private/path"])
+        with pytest.raises(BrowserBridgeQueueError, match="SCOPE_DENIED"):
+            await h.add(context_id="other")
+        h.current = False
+        with pytest.raises(BrowserBridgeQueueError, match="SCOPE_DENIED"):
+            await h.add()
+        assert not message_queue.get_queue(h.context)
+        assert h.queue_store.value == {}
+    asyncio.run(scenario())
+
+
+def test_uncertain_queue_effect_keeps_hash_reservation_and_never_reexecutes():
+    async def scenario():
+        h = Harness()
+        first = await h.add()
+        def partial(*args):
+            h.effects.append(args)
+            raise RuntimeError("private transport exception")
+        h.messages._deliver = partial
+        for _ in range(2):
+            with pytest.raises(BrowserBridgeQueueError, match="OUTCOME_UNKNOWN"):
+                await h.action("send", first["item_id"])
+        assert len(h.effects) == 1
+        assert not message_queue.get_queue(h.context)
+        assert "private transport exception" not in json.dumps(h.queue_store.value)
+        h = Harness()
+        original_get = h.controller.journal.get
+        reads = [0]
+        def failed_projection(key):
+            reads[0] += 1
+            if reads[0] > 1:
+                raise BrowserBridgeQueueError("QUEUE_STORE_UNAVAILABLE")
+            return original_get(key)
+        h.controller.journal.get = failed_projection
+        with pytest.raises(BrowserBridgeQueueError, match="OUTCOME_UNKNOWN"):
+            await h.add()
+        h.controller.journal.get = original_get
+        assert (await h.add())["status"] == "queued"
+        assert len(message_queue.get_queue(h.context)) == 1
+    asyncio.run(scenario())
+
+
+def test_indexed_queue_retains_old_receipts_without_lifetime_lockout(monkeypatch, tmp_path):
+    from helpers import kvp
+    from plugins._a0_connector.helpers import browser_bridge_queue as module
+    from plugins._a0_connector.helpers.browser_bridge_journal import BrowserBridgeJournal
+
+    monkeypatch.setattr(kvp, "_persistent_dir", lambda: str(tmp_path))
+
+    async def scenario():
+        h = Harness()
+        first = await h.add()
+        record = h.queue_store.value[module._STORE_KEY + ".records." + first["item_id"]]["record"]
+        legacy = {"schema_version": 1, "records": {first["item_id"]: record}}
+        legacy["records"].update({f"{i:064x}": dict(record) for i in range(2047)})
+        kvp.set_persistent(module._STORE_KEY, legacy)
+
+        def reconnect():
+            h.controller.journal = BrowserBridgeJournal(
+                module._STORE_KEY, module._validate_record,
+                lambda: BrowserBridgeQueueError("QUEUE_STORE_UNAVAILABLE"))
+
+        reconnect()
+        fresh = await h.add(client_message_id="fresh")
+        await h.action("remove", fresh["item_id"])
+        await h.action("remove", first["item_id"])
+        reconnect()
+        assert (await h.add())["status"] == "removed"
+        assert (await h.add(client_message_id="fresh"))["status"] == "removed"
+        assert not message_queue.get_queue(h.context)
+        assert kvp.get_persistent(module._STORE_KEY) == {**legacy, "schema_version": 2}
+        with pytest.raises(BrowserBridgeQueueError, match="IDEMPOTENCY_CONFLICT"):
+            await h.add(text="changed")
+        for i in range(32):
+            await h.add(client_message_id=f"live-{i}")
+        with pytest.raises(BrowserBridgeQueueError, match="QUEUE_LIMIT"):
+            await h.add(client_message_id="over-live-limit")
+        assert len(h.controller.project(h.route, "context-A")["message_queue"]) == 32
+    asyncio.run(scenario())

--- a/tests/test_browser_bridge_reconciliation.py
+++ b/tests/test_browser_bridge_reconciliation.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+import json
+from pathlib import Path
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_operations import (
+    BridgeAuthorization,
+    BrowserBridgeOperationBroker,
+    ReconciliationBinding,
+    SettlementStatus,
+)
+from plugins._a0_connector.helpers.browser_bridge_reconciliation import (
+    BrowserBridgeReconciliationController,
+    BrowserBridgeReconciliationError,
+    BrowserBridgeReconciliationSummary,
+    ExpectedReconciliationContext,
+    ReconciliationEventCursor,
+    ReconciliationSnapshot,
+    parse_browser_reconcile_result,
+)
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+)
+
+
+FIXTURE = json.loads(
+    (Path(__file__).parent / "fixtures" / "browser-reconcile-v1.json").read_text()
+)
+
+
+def _principal() -> WsPrincipal:
+    profile = PRODUCTION_BROWSER_BRIDGE_TRANSPORT
+    return WsPrincipal(
+        principal_type=profile.principal_type,
+        principal_id="bridge-dev-1",
+        subject_id="single-user",
+        scopes=frozenset({"browser.control", "browser.operate"}),
+        handler_path=profile.handler_path,
+        handler_id=profile.handler_id,
+        inbound_events=frozenset(
+            {"connector_browser_control_result", "connector_browser_event"}
+        ),
+        outbound_events=frozenset({"connector_browser_control"}),
+        key_generation=1,
+    )
+
+
+def _binding(principal: WsPrincipal | None = None) -> ReconciliationBinding:
+    return ReconciliationBinding(
+        principal=principal or _principal(),
+        connector_sid="sid-dev-1",
+        load_generation_id="load-dev-1",
+        control_id="reconcile-1",
+        transport_profile=PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    )
+
+
+def _snapshot() -> ReconciliationSnapshot:
+    return ReconciliationSnapshot(
+        expected_contexts=(
+            ExpectedReconciliationContext(
+                "context-1", "browser-session-1", ("turn-1",)
+            ),
+        ),
+        event_cursors=(ReconciliationEventCursor("load-dev-1", 7),),
+        known_control_ids=("finalize-older-1",),
+    )
+
+
+def _authorization(binding: ReconciliationBinding) -> BridgeAuthorization:
+    return BridgeAuthorization(
+        principal=binding.principal,
+        connector_sid=binding.connector_sid,
+        load_generation_id=binding.load_generation_id,
+        contract_version=1,
+        outer_features=frozenset({"connector_browser_control"}),
+        actions=frozenset(),
+        features=frozenset(),
+    )
+
+
+def _controller(*, timeout_ms: int = 1_000):
+    sent: list[tuple] = []
+    state = {"current": True, "phase": "provisional"}
+    promoted: list[BrowserBridgeReconciliationSummary] = []
+
+    async def sender(*args):
+        sent.append(args)
+
+    broker = BrowserBridgeOperationBroker(
+        sender=sender,
+        authorizer=_authorization,
+        transport_profile=PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+    )
+
+    def current(_binding):
+        return state["current"] and state["phase"] in {
+            "provisional",
+            "ready",
+        }
+
+    def promote(_binding, summary):
+        if not current(_binding) or state["phase"] != "provisional":
+            return False
+        promoted.append(summary)
+        state["phase"] = "ready"
+        return True
+
+    controller = BrowserBridgeReconciliationController(
+        broker=broker,
+        snapshot_source=lambda _binding: _snapshot(),
+        route_current=current,
+        promote=promote,
+        transport_profile=PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+        timeout_ms=timeout_ms,
+    )
+    return controller, broker, sent, state, promoted
+
+
+def test_fixture_reconcile_promotes_synchronously_and_retains_counts_only():
+    async def scenario():
+        controller, broker, sent, state, promoted = _controller()
+        binding = _binding()
+        task = controller.start(
+            binding, expected_install_instance_id="install-dev-1"
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert sent[0][2] == FIXTURE["core_control"]
+        assert sent[0][3] == "reconcile-1"
+        native_request = deepcopy(sent[0][2])
+        for name in ("method", "bridge_id", "load_generation_id"):
+            native_request.pop(name)
+        assert native_request == FIXTURE["extension_request"]
+        assert (
+            FIXTURE["core_control_result"]["result"]
+            == FIXTURE["extension_result"]
+        )
+        assert state["phase"] == "provisional"
+
+        status = broker.settle_control(
+            principal=binding.principal,
+            connector_sid=binding.connector_sid,
+            load_generation_id=binding.load_generation_id,
+            payload=FIXTURE["core_control_result"],
+        )
+        assert status == SettlementStatus.SETTLED
+        # Promotion is part of synchronous acceptance, before a following
+        # critical-event handler can run.
+        assert state["phase"] == "ready"
+        summary = await task
+        assert summary == BrowserBridgeReconciliationSummary(1, 1, 1, 1, 1)
+        assert promoted == [summary]
+        assert set(summary.as_wire_dict()) == {
+            "contract_version",
+            "lease_count",
+            "inflight_operation_count",
+            "terminal_receipt_count",
+            "pending_critical_event_count",
+            "prior_generation_orphan_count",
+        }
+
+    asyncio.run(scenario())
+
+
+def test_forged_full_result_does_not_settle_or_promote():
+    async def scenario():
+        controller, broker, _sent, _state, promoted = _controller()
+        binding = _binding()
+        task = controller.start(
+            binding, expected_install_instance_id="install-dev-1"
+        )
+        await asyncio.sleep(0)
+        forged = deepcopy(FIXTURE["core_control_result"])
+        forged["result"]["leases"][0]["identity"]["provider_tab_id"] = True
+        assert (
+            broker.settle_control(
+                principal=binding.principal,
+                connector_sid=binding.connector_sid,
+                load_generation_id=binding.load_generation_id,
+                payload=forged,
+            )
+            == SettlementStatus.MISMATCH
+        )
+        forged_outer_version = deepcopy(FIXTURE["core_control_result"])
+        forged_outer_version["contract_version"] = True
+        assert (
+            broker.settle_control(
+                principal=binding.principal,
+                connector_sid=binding.connector_sid,
+                load_generation_id=binding.load_generation_id,
+                payload=forged_outer_version,
+            )
+            == SettlementStatus.MISMATCH
+        )
+        assert promoted == []
+        broker.disconnect(
+            principal=binding.principal,
+            connector_sid=binding.connector_sid,
+            load_generation_id=binding.load_generation_id,
+        )
+        with pytest.raises(BrowserBridgeReconciliationError) as error:
+            await task
+        assert error.value.code == "CONNECTION_LOST"
+
+    asyncio.run(scenario())
+
+
+def test_stale_route_is_rejected_inside_result_acceptance():
+    async def scenario():
+        controller, broker, _sent, state, promoted = _controller()
+        binding = _binding()
+        task = controller.start(
+            binding, expected_install_instance_id="install-dev-1"
+        )
+        await asyncio.sleep(0)
+        state["current"] = False
+        assert (
+            broker.settle_control(
+                principal=binding.principal,
+                connector_sid=binding.connector_sid,
+                load_generation_id=binding.load_generation_id,
+                payload=FIXTURE["core_control_result"],
+            )
+            == SettlementStatus.SETTLED
+        )
+        assert promoted == []
+        with pytest.raises(BrowserBridgeReconciliationError) as error:
+            await task
+        assert error.value.code == "SCOPE_DENIED"
+
+    asyncio.run(scenario())
+
+
+def test_timeout_never_promotes():
+    async def scenario():
+        controller, _broker, _sent, _state, promoted = _controller(timeout_ms=10)
+        task = controller.start(
+            _binding(), expected_install_instance_id="install-dev-1"
+        )
+        with pytest.raises(BrowserBridgeReconciliationError) as error:
+            await task
+        assert error.value.code == "DEADLINE_EXCEEDED"
+        assert promoted == []
+
+    asyncio.run(scenario())
+
+
+def test_result_parser_rejects_duplicate_peer_authority_without_adopting_it():
+    result = deepcopy(FIXTURE["extension_result"])
+    result["leases"].append(deepcopy(result["leases"][0]))
+    with pytest.raises(BrowserBridgeReconciliationError) as error:
+        parse_browser_reconcile_result(
+            result,
+            binding=_binding(),
+            expected_install_instance_id="install-dev-1",
+            transport_profile=PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+        )
+    assert error.value.code == "RECONCILE_RESULT_INVALID"
+
+    envelope_alias = deepcopy(FIXTURE["extension_result"])
+    envelope_alias["pending_critical_events"][0]["correlationId"] = "rpc-1"
+    with pytest.raises(BrowserBridgeReconciliationError) as error:
+        parse_browser_reconcile_result(
+            envelope_alias,
+            binding=_binding(),
+            expected_install_instance_id="install-dev-1",
+            transport_profile=PRODUCTION_BROWSER_BRIDGE_TRANSPORT,
+        )
+    assert error.value.code == "RECONCILE_RESULT_INVALID"

--- a/tests/test_browser_bridge_runtime_foundation.py
+++ b/tests/test_browser_bridge_runtime_foundation.py
@@ -1,0 +1,780 @@
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from copy import deepcopy
+from dataclasses import replace
+from typing import Any
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_approval import BrowserApprovalRoute
+from plugins._a0_connector.helpers.browser_bridge_artifacts import ArtifactBinding
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    BrowserBridgeContextAccess,
+    BrowserBridgeContextRoute,
+)
+from plugins._a0_connector.helpers.browser_bridge_operations import (
+    OperationBinding,
+    SettlementStatus,
+    TurnBinding,
+)
+from plugins._a0_connector.helpers.browser_bridge_runtime import (
+    CONTROL_EVENT,
+    EXPECTED_LIMITS,
+    OPERATION_EVENT,
+    REQUIRED_INBOUND_EVENTS,
+    REQUIRED_OUTBOUND_EVENTS,
+    REQUIRED_OUTER_FEATURES,
+    REQUIRED_SCOPES,
+    CompleteRuntimeAdmission,
+    RuntimeActivationAttestation,
+    BrowserBridgeRuntimeDenied,
+    BrowserBridgeRuntimeError,
+    BrowserBridgeRuntimeRegistry,
+    VerifiedActivePrincipal,
+    context_access_authorizer,
+    exact_route_cleanup,
+    normalize_bridge_hello,
+    restricted_browser_sender,
+)
+
+
+EXTENSION_ID = "a" * 32
+SERVER_ID = "server-A"
+
+
+def _principal(bridge_id: str = "bridge-A") -> WsPrincipal:
+    return WsPrincipal(
+        principal_type="browser_bridge",
+        principal_id=bridge_id,
+        subject_id="single_user",
+        scopes=REQUIRED_SCOPES,
+        handler_path="plugins/_a0_connector/ws_connector",
+        handler_id="ws_connector.WsConnector",
+        inbound_events=REQUIRED_INBOUND_EVENTS,
+        outbound_events=REQUIRED_OUTBOUND_EVENTS,
+        key_generation=1,
+    )
+
+
+def _active(
+    principal: WsPrincipal,
+    *,
+    server_id: str = SERVER_ID,
+) -> VerifiedActivePrincipal:
+    return VerifiedActivePrincipal(
+        principal=principal,
+        server_instance_id=server_id,
+        extension_id=EXTENSION_ID,
+        companion_instance_id=f"companion-{principal.principal_id}",
+    )
+
+
+def _hello(
+    principal: WsPrincipal,
+    *,
+    generation: str = "generation-A",
+) -> dict[str, Any]:
+    return {
+        "protocol": "a0-connector.v1",
+        "features": sorted(REQUIRED_OUTER_FEATURES),
+        "host_browser": {
+            "supported": True,
+            "enabled": True,
+            "status": "ready",
+            "backend_id": "chrome_extension",
+            "browser_id": f"extension:{principal.principal_id}",
+            "browser_label": "Chrome - Agent Zero Extension",
+            "contract_version": 1,
+            "features": ["browser_extension_bridge_v1"],
+            "capabilities": {
+                "actions": ["open", "list", "state", "navigate"],
+                "features": ["tab_leases_v1", "cursor_v1"],
+                "limits": dict(EXPECTED_LIMITS),
+            },
+            "extension": {
+                "id": EXTENSION_ID,
+                "version": "0.2.0",
+                "manifest_version": 3,
+                "install_instance_id": "install-A",
+                "load_generation_id": generation,
+            },
+            "companion": {
+                "instance_id": f"companion-{principal.principal_id}",
+                "version": "2.12.0",
+                "platform": "darwin",
+                "arch": "arm64",
+            },
+        },
+    }
+
+
+def _admission(
+    active: VerifiedActivePrincipal,
+    sid: str,
+    hello,
+    **changes: Any,
+) -> CompleteRuntimeAdmission:
+    now = time.time_ns() // 1_000_000
+    values = {
+        "principal": active.principal,
+        "server_instance_id": active.server_instance_id,
+        "connector_sid": sid,
+        "load_generation_id": hello.load_generation_id,
+        "install_instance_id": hello.install_instance_id,
+        "contract_version": hello.contract_version,
+        "outer_features": hello.outer_features,
+        "actions": hello.actions,
+        "features": hello.features,
+        "release_trust_ready": True,
+        "activation_attested": True,
+        "legacy_control_plane_inactive": True,
+        "operation_transport_ready": True,
+        "control_transport_ready": True,
+        "context_transport_ready": True,
+        "event_transport_ready": True,
+        "artifact_transport_ready": True,
+        "approval_transport_ready": True,
+        "session_lifecycle_ready": True,
+        "policy_enforcement_ready": True,
+        "activation": RuntimeActivationAttestation(
+            active.principal, active.server_instance_id, sid, hello.load_generation_id,
+            active.extension_id, hello.install_instance_id, hello.outer_features,
+            "preview_authorized", True, True, True, True, now, now + 30_000,
+        ),
+    }
+    values.update(changes)
+    return CompleteRuntimeAdmission(**values)
+
+
+async def _sender(*_args) -> None:
+    return None
+
+
+def test_activation_requires_current_typed_server_evidence_not_ready_flags():
+    principal = _principal()
+    for changes in (
+        {"selected_bridge": False}, {"heartbeat_fresh": False}, {"subject_profile_bound": False},
+        {"connector_sid": "other"}, {"install_instance_id": "other"}, {"rollout": "preview"},
+        {"issued_at_ms": 1, "expires_at_ms": 2},
+    ):
+        def evaluate(active, sid, hello):
+            admission = _admission(active, sid, hello)
+            return replace(admission, activation=replace(admission.activation, **changes))
+
+        registry = _registry(admission_evaluator=evaluate)
+        with pytest.raises(BrowserBridgeRuntimeDenied):
+            registry.register_hello(principal=principal, connector_sid="sid-A", data=_hello(principal))
+        assert registry.session_count == 0
+    registry = _registry(admission_evaluator=lambda active, sid, hello: _admission(active, sid, hello, activation=None))
+    with pytest.raises(BrowserBridgeRuntimeDenied):
+        registry.register_hello(principal=principal, connector_sid="sid-A", data=_hello(principal))
+
+
+def _registry(
+    *,
+    active_verifier=None,
+    admission_evaluator=None,
+    context_authorizer=None,
+    cleanup_callbacks=(),
+    max_sessions: int = 32,
+    sender=_sender,
+) -> BrowserBridgeRuntimeRegistry:
+    return BrowserBridgeRuntimeRegistry(
+        sender=sender,
+        active_principal_verifier=(active_verifier or _active),
+        admission_evaluator=(admission_evaluator or _admission),
+        context_authorizer=(
+            context_authorizer
+            or (lambda _route, context_id: context_id == "context-A")
+        ),
+        cleanup_callbacks=cleanup_callbacks,
+        max_sessions=max_sessions,
+    )
+
+
+async def _reconcile_registered(registry, route):
+    """Explicit real controller/broker settlement over a synthetic transport."""
+    from plugins._a0_connector.helpers.browser_bridge_operations import ReconciliationBinding
+    from plugins._a0_connector.helpers.browser_bridge_reconciliation import (
+        BrowserBridgeReconciliationController, ReconciliationSnapshot,
+    )
+    binding = ReconciliationBinding(route.principal, route.connector_sid,
+                                    route.load_generation_id, uuid.uuid4().hex,
+                                    route.transport_profile)
+    assert registry.begin_reconciliation(binding)
+    controller = BrowserBridgeReconciliationController(
+        broker=registry.broker, snapshot_source=lambda _: ReconciliationSnapshot(),
+        route_current=registry.route_current_for_reconciliation,
+        promote=registry.promote_reconciled, transport_profile=route.transport_profile)
+    sent = asyncio.Event()
+    previous_sender = registry.broker._sender
+    async def sender(sid, event, payload, correlation, principal):
+        assert sid == route.connector_sid and principal is route.principal
+        assert event == "connector_browser_control" and payload["method"] == "browser.reconcile"
+        assert correlation == binding.control_id
+        sent.set()
+    registry.broker._sender = sender
+    try:
+        task = controller.start(binding, expected_install_instance_id=route.hello.install_instance_id)
+        await asyncio.wait_for(sent.wait(), 1)
+        response = {
+            "contract_version": 1, "method": "browser.reconcile", "bridge_id": route.bridge_id,
+            "load_generation_id": route.load_generation_id, "control_id": binding.control_id,
+            "ok": True, "result": {"contract_version": 1, "control_id": binding.control_id,
+                "install_instance_id": route.hello.install_instance_id,
+                "load_generation_id": route.load_generation_id, "leases": [],
+                "inflight_operations": [], "terminal_action_receipts": [],
+                "pending_critical_events": [], "prior_generation_orphans": []},
+        }
+        assert registry.settle_control(principal=route.principal, connector_sid=route.connector_sid,
+                                      load_generation_id=route.load_generation_id, payload=response) == SettlementStatus.SETTLED
+        await task
+        assert registry.current_bridge_ready(route.bridge_id)
+    finally:
+        registry.broker._sender = previous_sender
+
+
+def test_exact_hello_is_bounded_but_cannot_supply_runtime_admission() -> None:
+    principal = _principal()
+    active = _active(principal)
+    hello = normalize_bridge_hello(principal, active, _hello(principal))
+    assert hello.bridge_id == principal.principal_id
+    assert hello.browser_id == "extension:bridge-A"
+    assert hello.load_generation_id == "generation-A"
+    assert hello.actions == frozenset({"open", "list", "state", "navigate"})
+    assert hello.limits == EXPECTED_LIMITS
+
+    registry = BrowserBridgeRuntimeRegistry(
+        sender=_sender,
+        active_principal_verifier=_active,
+    )
+    with pytest.raises(BrowserBridgeRuntimeDenied) as error:
+        registry.register_hello(
+            principal=principal,
+            connector_sid="sid-A",
+            data=_hello(principal),
+        )
+    assert error.value.code == "RUNTIME_NOT_ADMITTED"
+    assert registry.session_count == 0
+
+
+def test_hello_rejects_authority_injection_and_unproven_capabilities() -> None:
+    principal = _principal()
+    active = _active(principal)
+    malformed = []
+
+    for version in ("2.11.9", "2.12.0-preview", "02.12.0", "2.12", "v2.12.0"):
+        old_companion = _hello(principal)
+        old_companion["host_browser"]["companion"]["version"] = version
+        malformed.append(old_companion)
+
+    remote_authority = _hello(principal)
+    remote_authority["remote_exec"] = {"enabled": True}
+    malformed.append(remote_authority)
+
+    wrong_route = _hello(principal)
+    wrong_route["host_browser"]["browser_id"] = "extension:another-bridge"
+    malformed.append(wrong_route)
+
+    wrong_extension = _hello(principal)
+    wrong_extension["host_browser"]["extension"]["id"] = "b" * 32
+    malformed.append(wrong_extension)
+
+    excessive = _hello(principal)
+    excessive["host_browser"]["capabilities"]["actions"] = [
+        f"unproven-{index}" for index in range(65)
+    ]
+    malformed.append(excessive)
+
+    unknown_action = _hello(principal)
+    unknown_action["host_browser"]["capabilities"]["actions"] = ["evaluate"]
+    malformed.append(unknown_action)
+
+    for candidate in malformed:
+        with pytest.raises(BrowserBridgeRuntimeError):
+            normalize_bridge_hello(principal, active, candidate)
+
+
+def test_same_bridge_reconnect_replaces_generation_after_fail_isolated_cleanup() -> None:
+    cleanup: list[tuple[WsPrincipal, str, str]] = []
+
+    def broken(*_args) -> None:
+        raise RuntimeError("cleanup canary")
+
+    def record(principal, sid, generation) -> None:
+        cleanup.append((principal, sid, generation))
+
+    registry = _registry(cleanup_callbacks=(broken, record))
+    first_principal = _principal()
+    first = registry.register_hello(
+        principal=first_principal,
+        connector_sid="sid-old",
+        data=_hello(first_principal, generation="generation-old"),
+    )
+    replacement_principal = replace(first_principal)
+    replacement = registry.register_hello(
+        principal=replacement_principal,
+        connector_sid="sid-new",
+        data=_hello(replacement_principal, generation="generation-new"),
+    )
+    assert not registry.current_bridge_ready("bridge-A")
+    asyncio.run(_reconcile_registered(registry, replacement))
+
+    assert registry.session_count == 1
+    assert cleanup == [(first_principal, "sid-old", "generation-old")]
+    assert registry.authorize_context_route(
+        BrowserBridgeContextRoute(
+            first.principal,
+            first.connector_sid,
+            first.load_generation_id,
+        )
+    ) is False
+    resolved = registry.resolve_extension_route("context-A", "bridge-A")
+    assert resolved is not None
+    assert resolved.principal is replacement_principal
+    assert resolved.connector_sid == "sid-new"
+    assert resolved.load_generation_id == "generation-new"
+    assert replacement.principal is replacement_principal
+
+
+def test_exact_hello_replay_refreshes_admission_without_disconnect_cleanup() -> None:
+    cleanup: list[tuple[WsPrincipal, str, str]] = []
+    principal = _principal()
+    registry = _registry(
+        cleanup_callbacks=(
+            lambda candidate, sid, generation: cleanup.append(
+                (candidate, sid, generation)
+            ),
+        ),
+    )
+    first = registry.register_hello(
+        principal=principal,
+        connector_sid="sid-A",
+        data=_hello(principal),
+    )
+    asyncio.run(_reconcile_registered(registry, first))
+    replayed = registry.register_hello(
+        principal=principal,
+        connector_sid="sid-A",
+        data=_hello(principal),
+    )
+
+    assert cleanup == []
+    assert registry.session_count == 1
+    assert registry.current_sid_route(principal, "sid-A") is replayed
+    assert replayed.principal is first.principal
+    assert replayed.hello == first.hello
+    assert registry.current_bridge_ready("bridge-A")
+
+
+def test_active_different_principal_cannot_replace_same_sid_or_capacity() -> None:
+    registry = _registry(max_sessions=1)
+    principal_a = _principal("bridge-A")
+    admitted = registry.register_hello(
+        principal=principal_a,
+        connector_sid="shared-sid",
+        data=_hello(principal_a),
+    )
+    asyncio.run(_reconcile_registered(registry, admitted))
+    principal_b = _principal("bridge-B")
+    with pytest.raises(BrowserBridgeRuntimeDenied) as conflict:
+        registry.register_hello(
+            principal=principal_b,
+            connector_sid="shared-sid",
+            data=_hello(principal_b),
+        )
+    assert conflict.value.code == "ROUTE_CONFLICT"
+    assert registry.resolve_extension_route("context-A", "bridge-A") is not None
+
+    with pytest.raises(BrowserBridgeRuntimeDenied) as capacity:
+        registry.register_hello(
+            principal=principal_b,
+            connector_sid="sid-B",
+            data=_hello(principal_b),
+        )
+    assert capacity.value.code == "SESSION_LIMIT"
+    assert registry.session_count == 1
+
+
+def test_explicit_context_route_composes_context_approval_artifact_and_broker() -> None:
+    principal = _principal()
+    registry = _registry()
+    route = registry.register_hello(
+        principal=principal,
+        connector_sid="sid-A",
+        data=_hello(principal),
+    )
+    assert registry.resolve_extension_route("context-A", "bridge-A") is None
+    asyncio.run(_reconcile_registered(registry, route))
+
+    resolved = registry.resolve_extension_route("context-A", "bridge-A")
+    assert resolved is not None
+    assert resolved.browser_id == "extension:bridge-A"
+    assert registry.resolve_extension_route("context-B", "bridge-A") is None
+    assert registry.resolve_extension_route("context-A", "bridge-B") is None
+
+    context_route = BrowserBridgeContextRoute(
+        principal, "sid-A", route.load_generation_id
+    )
+    assert registry.authorize_context_route(context_route)
+    assert not registry.authorize_context_route(
+        replace(context_route, principal=replace(principal))
+    )
+
+    approval_route = BrowserApprovalRoute(
+        server_instance_id=SERVER_ID,
+        principal=principal,
+        connector_sid="sid-A",
+        load_generation_id=route.load_generation_id,
+        context_id="context-A",
+        browser_session_id="browser-session-A",
+        turn_id="turn-A",
+        action_id="action-A",
+        op_id="op-A",
+        tab_handle="tab-A",
+        document_id="document-A",
+        document_epoch=1,
+    )
+    assert registry.authorize_approval_route(approval_route)
+    assert not registry.authorize_approval_route(
+        replace(approval_route, context_id="context-B")
+    )
+    assert registry.authorize_artifact_route(
+        principal=principal,
+        connector_sid="sid-A",
+        load_generation_id=route.load_generation_id,
+        context_id="context-A",
+    )
+    assert registry.authorize_artifact_binding(
+        ArtifactBinding(
+            principal=principal,
+            connector_sid="sid-A",
+            load_generation_id=route.load_generation_id,
+            bridge_id="bridge-A",
+            context_id="context-A",
+            browser_session_id="browser-session-A",
+            turn_id="turn-A",
+            action_id="action-A",
+            op_id="op-A",
+            artifact_id="artifact-A",
+            direction="output",
+            purpose="screenshot",
+        )
+    )
+
+    binding = OperationBinding(
+        principal=principal,
+        connector_sid="sid-A",
+        load_generation_id=route.load_generation_id,
+        context_id="context-A",
+        browser_session_id="browser-session-A",
+        turn_id="turn-A",
+        action_id="action-A",
+        op_id="op-A",
+    )
+    authorization = registry.authorize_broker(binding)
+    assert authorization is not None
+    assert authorization.principal is principal
+    assert authorization.actions == route.hello.actions
+    assert registry.authorize_broker(
+        replace(binding, context_id="context-B")
+    ) is None
+
+
+def test_route_is_rechecked_after_context_authorizer_and_server_change() -> None:
+    principal = _principal()
+    current_server = [SERVER_ID]
+
+    def verifier(candidate: WsPrincipal) -> VerifiedActivePrincipal:
+        return _active(candidate, server_id=current_server[0])
+
+    def context_authorizer(_route, _context_id) -> bool:
+        current_server[0] = "server-B"
+        return True
+
+    registry = _registry(
+        active_verifier=verifier,
+        context_authorizer=context_authorizer,
+    )
+    route = registry.register_hello(
+        principal=principal,
+        connector_sid="sid-A",
+        data=_hello(principal),
+    )
+    asyncio.run(_reconcile_registered(registry, route))
+    assert registry.resolve_extension_route("context-A", "bridge-A") is None
+    assert registry.session_count == 0
+
+
+def test_context_access_adapter_uses_the_exact_registered_route() -> None:
+    class _Access(BrowserBridgeContextAccess):
+        def __init__(self) -> None:
+            self.calls = []
+
+        def authorize_message_target(self, route, *, context_id) -> None:
+            self.calls.append((route, context_id))
+            if context_id != "context-A":
+                raise PermissionError("not advertised")
+
+    principal = _principal()
+    access = _Access()
+    registry = _registry(context_authorizer=context_access_authorizer(access))
+    registered = registry.register_hello(
+        principal=principal,
+        connector_sid="sid-A",
+        data=_hello(principal),
+    )
+    asyncio.run(_reconcile_registered(registry, registered))
+    assert registry.resolve_extension_route("context-A", "bridge-A") is not None
+    projected_route, context_id = access.calls[-1]
+    assert context_id == "context-A"
+    assert projected_route.principal is principal
+    assert projected_route.connector_sid == "sid-A"
+    assert projected_route.load_generation_id == registered.load_generation_id
+    assert registry.resolve_extension_route("context-B", "bridge-A") is None
+
+
+def test_result_settlement_requires_the_exact_current_registered_route() -> None:
+    async def scenario() -> None:
+        sent: list[dict[str, Any]] = []
+
+        async def sender(_sid, _event, payload, _correlation, _principal) -> None:
+            sent.append(payload)
+
+        principal = _principal()
+        registry = _registry(sender=sender)
+        route = registry.register_hello(
+            principal=principal,
+            connector_sid="sid-A",
+            data=_hello(principal),
+        )
+        await _reconcile_registered(registry, route)
+        binding = OperationBinding(
+            principal,
+            "sid-A",
+            route.load_generation_id,
+            "context-A",
+            "browser-session-A",
+            "turn-A",
+            "action-A",
+            "op-A",
+        )
+        ticket = await registry.broker.begin_operation(
+            binding,
+            action="state",
+            target=None,
+            args={},
+            timeout_ms=5_000,
+            required_capabilities=["state"],
+        )
+        await asyncio.sleep(0)
+        wire = sent[0]
+        result = {
+            key: wire[key]
+            for key in (
+                "contract_version",
+                "bridge_id",
+                "load_generation_id",
+                "context_id",
+                "browser_session_id",
+                "turn_id",
+                "op_id",
+                "action_id",
+            )
+        }
+        result.update(ok=True, result={"status": "ready"}, receipts=[], artifacts=[])
+        assert registry.settle_operation(
+            principal=replace(principal),
+            connector_sid="sid-A",
+            load_generation_id=route.load_generation_id,
+            payload=result,
+        ) == SettlementStatus.MISMATCH
+        assert registry.settle_operation(
+            principal=principal,
+            connector_sid="sid-A",
+            load_generation_id=route.load_generation_id,
+            payload=result,
+        ) == SettlementStatus.SETTLED
+        assert (await registry.broker.wait_operation(ticket)).ok
+
+        control = await registry.broker.begin_finalize(
+            TurnBinding(
+                principal,
+                "sid-A",
+                route.load_generation_id,
+                "context-A",
+                "browser-session-A",
+                "turn-A",
+            ),
+            control_id="control-A",
+            dispositions={},
+            reason="turn complete",
+            timeout_ms=5_000,
+        )
+        await asyncio.sleep(0)
+        control_wire = sent[1]
+        control_result = {
+            key: control_wire[key]
+            for key in (
+                "contract_version",
+                "method",
+                "bridge_id",
+                "load_generation_id",
+                "context_id",
+                "browser_session_id",
+                "turn_id",
+                "control_id",
+            )
+        }
+        control_result.update(
+            ok=True,
+            result={"contract_version": 1, "control_id": "control-A"},
+        )
+        assert registry.settle_control(
+            principal=principal,
+            connector_sid="sid-A",
+            load_generation_id="stale-generation",
+            payload=control_result,
+        ) == SettlementStatus.MISMATCH
+        assert registry.settle_control(
+            principal=principal,
+            connector_sid="sid-A",
+            load_generation_id=route.load_generation_id,
+            payload=control_result,
+        ) == SettlementStatus.SETTLED
+        assert (await registry.broker.wait_control(control)).ok
+
+    asyncio.run(scenario())
+
+
+def test_restricted_sender_uses_exact_shared_manager_boundary() -> None:
+    class _Manager:
+        def __init__(self) -> None:
+            self.calls = []
+
+        async def emit_to(self, *args, **kwargs) -> None:
+            self.calls.append((args, kwargs))
+
+    async def scenario() -> None:
+        manager = _Manager()
+        sender = restricted_browser_sender(manager)
+        principal = _principal()
+        payload = {"contract_version": 1}
+        await sender("sid-A", OPERATION_EVENT, payload, "op-A", principal)
+        assert manager.calls == [
+            (
+                ("/ws", "sid-A", OPERATION_EVENT, payload),
+                {
+                    "handler_id": "ws_connector.WsConnector",
+                    "correlation_id": "op-A",
+                    "expected_principal": principal,
+                },
+            )
+        ]
+        with pytest.raises(BrowserBridgeRuntimeDenied) as error:
+            await sender(
+                "sid-A",
+                "connector_context_snapshot",
+                {},
+                "snapshot-A",
+                principal,
+            )
+        assert error.value.code == "EVENT_NOT_ALLOWED"
+        assert len(manager.calls) == 1
+
+    asyncio.run(scenario())
+
+
+def test_admission_revocation_retires_route_before_rejecting_late_result() -> None:
+    async def scenario() -> None:
+        admitted = [True]
+
+        def evaluator(active, sid, hello):
+            return _admission(active, sid, hello) if admitted[0] else None
+
+        principal = _principal()
+        registry = _registry(admission_evaluator=evaluator)
+        route = registry.register_hello(
+            principal=principal,
+            connector_sid="sid-A",
+            data=_hello(principal),
+        )
+        await _reconcile_registered(registry, route)
+        binding = OperationBinding(
+            principal,
+            "sid-A",
+            route.load_generation_id,
+            "context-A",
+            "browser-session-A",
+            "turn-A",
+            "action-A",
+            "op-A",
+        )
+        ticket = await registry.broker.begin_operation(
+            binding,
+            action="state",
+            target=None,
+            args={},
+            timeout_ms=5_000,
+            required_capabilities=["state"],
+        )
+        admitted[0] = False
+        assert registry.settle_operation(
+            principal=principal,
+            connector_sid="sid-A",
+            load_generation_id=route.load_generation_id,
+            payload={"op_id": "op-A"},
+        ) == SettlementStatus.MISMATCH
+        completion = await registry.broker.wait_operation(ticket)
+        assert completion.ok is False
+        assert completion.code == "CONNECTION_LOST"
+        assert registry.session_count == 0
+
+    asyncio.run(scenario())
+
+
+def test_disconnect_is_exact_and_callbacks_receive_principal_object_identity() -> None:
+    class _CleanupTarget:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def disconnect(self, **identity) -> None:
+            self.calls.append(identity)
+
+    target = _CleanupTarget()
+    principal = _principal()
+    registry = _registry(
+        cleanup_callbacks=(exact_route_cleanup(target),)
+    )
+    route = registry.register_hello(
+        principal=principal,
+        connector_sid="sid-A",
+        data=_hello(principal),
+    )
+    assert not registry.disconnect(
+        principal=principal,
+        connector_sid="sid-A",
+        load_generation_id="stale-generation",
+    )
+    assert not registry.disconnect(
+        principal=replace(principal),
+        connector_sid="sid-A",
+        load_generation_id=route.load_generation_id,
+    )
+    assert registry.disconnect(
+        principal=principal,
+        connector_sid="sid-A",
+        load_generation_id=route.load_generation_id,
+    )
+    assert target.calls == [
+        {
+            "principal": principal,
+            "connector_sid": "sid-A",
+            "load_generation_id": route.load_generation_id,
+        }
+    ]
+    assert registry.session_count == 0

--- a/tests/test_browser_bridge_runtime_owner.py
+++ b/tests/test_browser_bridge_runtime_owner.py
@@ -1,0 +1,295 @@
+from dataclasses import replace
+from datetime import datetime, timezone
+from types import SimpleNamespace
+import base64
+import json
+import threading
+import time
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from plugins._a0_connector.helpers import browser_bridge_release_policy as policy
+from plugins._a0_connector.helpers import browser_bridge_runtime_owner as owner_module
+from plugins._a0_connector.helpers.browser_bridge_runtime import normalize_bridge_hello
+from test_browser_bridge_runtime_foundation import _principal, _active, _hello
+
+
+def _signed_policy(monkeypatch):
+    private = Ed25519PrivateKey.from_private_bytes(bytes(range(32)))
+    public = private.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    monkeypatch.setattr(policy, "TRUSTED_RELEASE_KEYS", {"test-root": base64.b64encode(public).decode()})
+    principal = _principal()
+    hello = normalize_bridge_hello(principal, _active(principal), _hello(principal))
+    payload = {
+        "contract": policy.POLICY_CONTRACT, "issued_at_ms": 1000,
+        "expires_at_ms": 100000,
+        "releases": [{key: getattr(hello, key) for key in policy._ENTRY_FIELDS}],
+    }
+    signed = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    envelope = {"key_id": "test-root", "policy": payload,
+                "signature": base64.b64encode(private.sign(signed)).decode()}
+    return envelope
+
+
+def test_release_policy_verifies_real_signature_and_rejects_tamper_expiry_unknown_root(monkeypatch):
+    envelope = _signed_policy(monkeypatch)
+    raw = json.dumps(envelope).encode()
+    assert len(policy.verify_policy_document(raw, now_ms=2000)) == 1
+    with pytest.raises(ValueError):
+        policy.verify_policy_document(raw, now_ms=100000)
+    envelope["policy"]["releases"][0]["companion_version"] = "2.13.0"
+    with pytest.raises(Exception):
+        policy.verify_policy_document(json.dumps(envelope).encode(), now_ms=2000)
+    monkeypatch.setattr(policy, "TRUSTED_RELEASE_KEYS", {})
+    with pytest.raises(ValueError):
+        policy.verify_policy_document(raw, now_ms=2000)
+
+
+def test_release_policy_rejects_duplicate_keys_and_symlink(monkeypatch, tmp_path):
+    envelope = _signed_policy(monkeypatch)
+    raw = json.dumps(envelope).encode()
+    duplicate = raw.replace(b'"key_id": "test-root"', b'"key_id": "test-root", "key_id": "test-root"')
+    with pytest.raises(ValueError):
+        policy.verify_policy_document(duplicate, now_ms=2000)
+    target = tmp_path / "policy.json"
+    target.write_bytes(raw)
+    link = tmp_path / "alias.json"
+    link.symlink_to(target)
+    monkeypatch.setenv(policy.POLICY_ENV, str(link))
+    with pytest.raises(OSError):
+        policy._read_owned_policy()
+
+
+def test_release_policy_pins_only_genuine_publisher_and_rejects_fixture_signatures():
+    assert dict(policy.TRUSTED_RELEASE_KEYS) == {
+        "publisher-2026": "GEOygP0rBYlVYZEx+bgDhUZ3sVpfVyedoI9Jo+bcYII="}
+    with pytest.raises(TypeError):
+        policy.TRUSTED_RELEASE_KEYS["fixture"] = "not-a-root"
+    payload = {"contract": policy.POLICY_CONTRACT, "issued_at_ms": 1000,
+               "expires_at_ms": 100000, "releases": [{
+                   "extension_id": "nhliclifilepdkoolioacpjpijomfplj",
+                   "extension_version": "0.1.0", "companion_version": "2.12.0",
+                   "companion_platform": "darwin", "companion_arch": "aarch64"}]}
+    fixture = Ed25519PrivateKey.from_private_bytes(bytes(range(32)))
+    signature = base64.b64encode(fixture.sign(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode())).decode()
+    for key_id in ("publisher-2026", "test-root", "development", "fixture"):
+        envelope = {"key_id": key_id, "policy": payload, "signature": signature}
+        with pytest.raises(Exception):
+            policy.verify_policy_document(json.dumps(envelope).encode(), now_ms=2000)
+
+
+def test_release_policy_supports_exact_both_mac_runtime_slices_without_schema_relaxation(monkeypatch):
+    envelope = _signed_policy(monkeypatch)  # Test-only root; never publisher signing.
+    entry = {"extension_id": "nhliclifilepdkoolioacpjpijomfplj", "extension_version": "0.1.0",
+             "companion_version": "2.12.0", "companion_platform": "darwin", "companion_arch": "aarch64"}
+    payload = envelope["policy"]
+    payload["releases"] = [entry, {**entry, "companion_arch": "x86_64"}]
+    fixture = Ed25519PrivateKey.from_private_bytes(bytes(range(32)))
+
+    def encoded():
+        envelope["signature"] = base64.b64encode(fixture.sign(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode())).decode()
+        return json.dumps(envelope).encode()
+
+    assert [row["companion_arch"] for row in policy.verify_policy_document(encoded(), now_ms=2000)] == ["aarch64", "x86_64"]
+    payload["releases"].append(dict(entry))
+    with pytest.raises(ValueError):
+        policy.verify_policy_document(encoded(), now_ms=2000)
+    payload["releases"].pop()
+    payload["releases"][0]["companion_version"] = "2.12.0-dev"
+    with pytest.raises(ValueError):
+        policy.verify_policy_document(encoded(), now_ms=2000)
+    payload["releases"][0]["companion_version"] = "2.12.0"
+    payload["platforms"] = ["macos"]
+    with pytest.raises(ValueError):
+        policy.verify_policy_document(encoded(), now_ms=2000)
+
+
+def test_owner_admission_rechecks_release_activity_selection_and_missing_transport(monkeypatch):
+    principal = _principal()
+    active = _active(principal)
+    hello = normalize_bridge_hello(principal, active, _hello(principal))
+    owner = object.__new__(owner_module.BrowserBridgeRuntimeOwner)
+    owner._closed = False
+    connection = SimpleNamespace(principal=principal, last_activity=datetime.now(timezone.utc))
+    owner.manager = SimpleNamespace(
+        lock=threading.RLock(), connections={("/ws", "sid-A"): connection},
+        principal_for_sid=lambda namespace, sid: principal,
+    )
+    owner.application = SimpleNamespace(installed=True, runtime_boundaries=lambda: owner_module.REQUIRED_BOUNDARIES)
+    owner.verify_principal = lambda candidate: active if candidate is principal else None
+    owner._selected = lambda bridge: True
+    evidence = owner_module.VerifiedBrowserRelease(
+        principal=principal, server_instance_id=active.server_instance_id,
+        connector_sid="sid-A", load_generation_id=hello.load_generation_id,
+        install_instance_id=hello.install_instance_id,
+        **{key: getattr(hello, key) for key in policy._ENTRY_FIELDS},
+    )
+    owner._release_verifier = lambda *_args: evidence
+    monkeypatch.setattr(owner_module, "configured_extension_id", lambda: active.extension_id)
+    monkeypatch.setattr(owner_module, "get_browser_bridge_gate", lambda: SimpleNamespace(state="available"))
+    monkeypatch.setattr(owner_module, "detect_installed_legacy_browser_bridge", lambda: SimpleNamespace(state=owner_module.LegacyDetectionState.ABSENT))
+    admitted = owner.evaluate_admission(active, "sid-A", hello)
+    assert admitted is not None
+    assert admitted.activation.expires_at_ms - admitted.activation.issued_at_ms == 30000
+    owner._release_verifier = lambda *_args: replace(evidence, connector_sid="other")
+    assert owner.evaluate_admission(active, "sid-A", hello) is None
+    owner._release_verifier = lambda *_args: evidence
+    connection.last_activity = datetime.fromtimestamp(time.time() - 31, timezone.utc)
+    assert owner.evaluate_admission(active, "sid-A", hello) is None
+    connection.last_activity = datetime.now(timezone.utc)
+    owner._selected = lambda bridge: False
+    assert owner.evaluate_admission(active, "sid-A", hello) is None
+    owner._selected = lambda bridge: True
+    owner.application.runtime_boundaries = lambda: owner_module.REQUIRED_BOUNDARIES - {"artifact"}
+    assert owner.evaluate_admission(active, "sid-A", hello) is None
+
+
+def test_normal_startup_remains_inert_without_gate_and_never_supplies_fake_release(monkeypatch):
+    monkeypatch.setattr(owner_module, "get_browser_bridge_gate", lambda: SimpleNamespace(state="disabled"))
+    assert owner_module.install_configured_browser_runtime(object()) is False
+    with pytest.raises(TypeError):
+        owner_module.configure_verified_browser_releases(None)
+
+
+def test_admission_heartbeat_snapshot_cannot_precede_concurrent_authenticated_activity(monkeypatch):
+    principal = _principal()
+    active = _active(principal)
+    hello = normalize_bridge_hello(principal, active, _hello(principal))
+    owner = object.__new__(owner_module.BrowserBridgeRuntimeOwner)
+    owner._closed = False
+    now = [2_000_000]
+    connection = SimpleNamespace(principal=principal, last_activity=datetime.fromtimestamp(now[0] / 1000, timezone.utc))
+    owner.manager = SimpleNamespace(lock=threading.RLock(), connections={("/ws", "sid-A"): connection},
+                                    principal_for_sid=lambda namespace, sid: principal)
+    owner.application = SimpleNamespace(installed=True, runtime_boundaries=lambda: owner_module.REQUIRED_BOUNDARIES)
+    def verify(candidate):
+        # Another authenticated receive can advance activity after admission
+        # starts but before it acquires the manager's heartbeat snapshot lock.
+        with owner.manager.lock:
+            now[0] += 11
+            connection.last_activity = datetime.fromtimestamp(now[0] / 1000, timezone.utc)
+        return active if candidate is principal else None
+    owner.verify_principal = verify
+    owner._selected = lambda bridge: True
+    owner._release_verifier = lambda *_args: owner_module.VerifiedBrowserRelease(
+        principal=principal, server_instance_id=active.server_instance_id, connector_sid="sid-A",
+        load_generation_id=hello.load_generation_id, install_instance_id=hello.install_instance_id,
+        **{key: getattr(hello, key) for key in policy._ENTRY_FIELDS})
+    monkeypatch.setattr(owner_module.time, "time_ns", lambda: now[0] * 1_000_000)
+    monkeypatch.setattr(owner_module, "configured_extension_id", lambda: active.extension_id)
+    monkeypatch.setattr(owner_module, "get_browser_bridge_gate", lambda: SimpleNamespace(state="available"))
+    monkeypatch.setattr(owner_module, "detect_installed_legacy_browser_bridge", lambda: SimpleNamespace(state=owner_module.LegacyDetectionState.ABSENT))
+    assert owner.evaluate_admission(active, "sid-A", hello) is not None
+    # The fix must not clamp genuinely future/stale timestamps into freshness.
+    owner.verify_principal = lambda candidate: active
+    for timestamp in (now[0] + 1, now[0] - 30_000):
+        connection.last_activity = datetime.fromtimestamp(timestamp / 1000, timezone.utc)
+        assert owner.evaluate_admission(active, "sid-A", hello) is None
+
+
+def test_server_hooks_keep_guard_and_await_exact_owner_shutdown(monkeypatch):
+    import asyncio
+    from contextlib import asynccontextmanager, nullcontext
+    from pathlib import Path
+    from helpers import extension, subagents, ui_server
+    from plugins._a0_connector.helpers import browser_bridge_legacy_retirement as legacy
+
+    root = Path(__file__).resolve().parents[1]
+    enabled, events, applications = [True], [], []
+    def paths(_agent, prefix, point):
+        roots = [root]
+        if enabled[0]:
+            roots.append(root / "plugins/_a0_connector")
+        return [str(base / prefix / point) for base in roots]
+    monkeypatch.setattr(subagents, "get_paths", paths)
+    monkeypatch.setattr(extension.cache, "get", lambda *_args: None)
+    monkeypatch.setattr(extension.cache, "add", lambda *_args: None)
+    monkeypatch.setattr(ui_server.UiServerRuntime, "refresh_runtime_settings", lambda self: None)
+    monkeypatch.setattr(ui_server, "set_shared_ws_manager", lambda manager: events.append("manager"))
+    monkeypatch.setattr(legacy, "install_legacy_retirement_guard", lambda app: events.append("guard"))
+    monkeypatch.setattr(owner_module, "install_configured_browser_runtime", lambda manager: events.append("install") or True)
+    async def retire(*, manager):
+        await asyncio.sleep(0)
+        events.append(("retired", manager))
+    monkeypatch.setattr(owner_module, "retire_configured_browser_runtime", retire)
+    monkeypatch.setattr(ui_server.mcp_server.DynamicMcpProxy, "get_instance", lambda: object())
+    monkeypatch.setattr(ui_server.fasta2a_server.DynamicA2AProxy, "get_instance", lambda: object())
+    original_starlette = ui_server.Starlette
+    def starlette(**kwargs):
+        app = original_starlette(**kwargs)
+        applications.append(app)
+        return app
+    monkeypatch.setattr(ui_server, "Starlette", starlette)
+    @asynccontextmanager
+    async def lifespan(app):
+        yield
+    monitor = SimpleNamespace(lifespan=lambda: lifespan, stage=lambda *_args: nullcontext())
+
+    server = ui_server.UiServerRuntime.create()
+    assert events == ["manager", "guard"]
+    assert not server._routes_registered and not server._transport_registered
+    async def attempt():
+        with pytest.raises(RuntimeError, match="serving failed"):
+            async with applications[-1].router.lifespan_context(applications[-1]):
+                assert events == ["install"]
+                enabled[0] = False  # Cleanup must not depend on current discovery.
+                raise RuntimeError("serving failed")
+    for _ in range(2):  # Uvicorn retries reuse this same server, not create().
+        events.clear()
+        enabled[0] = True
+        server.build_asgi_app(monitor)
+        assert events == []  # No service installed before lifespan entry.
+        asyncio.run(attempt())
+        assert events == ["install", ("retired", server.ws_manager)]
+
+    original_start = ui_server.call_extensions_async
+    async def fail_after_install(*args, **kwargs):
+        await original_start(*args, **kwargs)
+        raise RuntimeError("later startup hook failed")
+    monkeypatch.setattr(ui_server, "call_extensions_async", fail_after_install)
+    events.clear()
+    enabled[0] = True
+    async def failed_start():
+        with pytest.raises(RuntimeError, match="later startup hook failed"):
+            async with applications[-1].router.lifespan_context(applications[-1]):
+                pytest.fail("failed startup must not begin serving")
+    asyncio.run(failed_start())
+    assert events == ["install", ("retired", server.ws_manager)]
+    monkeypatch.setattr(ui_server, "call_extensions_async", original_start)
+
+    events.clear()
+    enabled[0] = False
+    ui_server.UiServerRuntime.create()
+    assert events == ["manager", "guard"]
+    async def disabled_start():
+        async with applications[-1].router.lifespan_context(applications[-1]):
+            pass
+    asyncio.run(disabled_start())
+    assert events == ["manager", "guard"]
+    events.clear()
+    enabled[0] = True
+    def fail_settings(self):
+        raise RuntimeError("settings unavailable")
+    monkeypatch.setattr(ui_server.UiServerRuntime, "refresh_runtime_settings", fail_settings)
+    with pytest.raises(RuntimeError, match="settings unavailable"):
+        ui_server.UiServerRuntime.create()
+    assert events == ["manager"]  # No service installed for a failed construction.
+
+
+def test_shutdown_cannot_retire_a_different_servers_owner(monkeypatch):
+    import asyncio
+
+    manager, other, closed = object(), object(), []
+    async def close():
+        await asyncio.sleep(0)
+        closed.append(True)
+        return True
+    owner = SimpleNamespace(manager=manager, close=close)
+    monkeypatch.setattr(owner_module, "_owner", owner)
+    monkeypatch.setattr(owner_module, "_retiring", False)
+    assert asyncio.run(owner_module.retire_configured_browser_runtime(manager=other)) is False
+    assert owner_module._owner is owner and not closed
+    assert asyncio.run(owner_module.retire_configured_browser_runtime(manager=manager)) is True
+    assert owner_module._owner is None and closed == [True]

--- a/tests/test_browser_bridge_session_foundation.py
+++ b/tests/test_browser_bridge_session_foundation.py
@@ -1,0 +1,489 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import importlib
+import sys
+import threading
+from contextlib import contextmanager
+from dataclasses import FrozenInstanceError, replace
+from types import ModuleType
+from typing import Any, Iterator
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+import helpers
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers import browser_bridge_session as session
+from plugins._a0_connector.helpers import ws_runtime
+from plugins._a0_connector.helpers.browser_bridge_auth import (
+    BRIDGE_CONNECTOR_HANDLER,
+    BrowserBridgeChallengeStore,
+    canonical_proof_bytes,
+)
+from plugins._a0_connector.helpers.browser_bridge_pairing import (
+    CONNECTOR_PROTOCOL,
+    FIXED_BROWSER_BRIDGE_SCOPES,
+    BrowserBridgePairingStore,
+    BrowserBridgeRecordRepository,
+    coarse_source_key,
+)
+from plugins._browser.helpers.bridge_foundation import BrowserBridgeGate
+
+
+EXTENSION_ID = "abcdefghijklmnopabcdefghijklmnop"
+OTHER_EXTENSION_ID = "bcdefghijklmnopabcdefghijklmnopa"
+BRIDGE_ID = "22222222-2222-4222-8222-222222222222"
+SERVER_ID = "server-instance-A"
+SERVER_BASE_URL = "http://localhost:50080"
+CLIENT_NONCE = base64.urlsafe_b64encode(bytes([3]) * 32).rstrip(b"=").decode()
+HANDLER_ID = "plugins._a0_connector.api.ws_connector.WsConnector"
+
+
+class _SessionFixture:
+    def __init__(self) -> None:
+        self.state: dict[str, Any] = {}
+        self.now = 1_788_492_445_000
+        self.gate = "preview"
+        self.server_id = SERVER_ID
+        self.extension_id: str | None = EXTENSION_ID
+        self._challenge_number = 0
+        self.flask = ModuleType("flask")
+        self.flask.Flask = object
+        self.flask.session = {}
+        self.flask.request = _Request(SERVER_BASE_URL)
+        self.runtime = ModuleType("helpers.runtime")
+        self.runtime.get_persistent_id = lambda: self.server_id
+
+        def load() -> Any:
+            return self.state.get("document")
+
+        def save(value: dict[str, Any]) -> None:
+            self.state["document"] = value
+
+        self.private_key = Ed25519PrivateKey.generate()
+        public_key = self.private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        encoded_public_key = base64.urlsafe_b64encode(public_key).rstrip(b"=").decode()
+        repository = BrowserBridgeRecordRepository(load=load, save=save)
+        repository.add(
+            {
+                "trust_version": 1,
+                "bridge_id": BRIDGE_ID,
+                "server_instance_id": SERVER_ID,
+                "subject_id": "single_user",
+                "display_name": "Synthetic browser host",
+                "companion_instance_id": "companion-instance-A",
+                "extension_id": EXTENSION_ID,
+                "public_key": {
+                    "algorithm": "Ed25519",
+                    "encoding": "raw-base64url",
+                    "value": encoded_public_key,
+                },
+                "key_generation": 1,
+                "scopes": list(FIXED_BROWSER_BRIDGE_SCOPES),
+                "state": "active",
+                "created_at_ms": self.now - 45_000,
+                "last_authenticated_at_ms": None,
+                "revoked_at_ms": None,
+            }
+        )
+        self.pairing = BrowserBridgePairingStore(repository=repository)
+        self.challenges = BrowserBridgeChallengeStore(
+            record_lookup=lambda bridge_id, server_id: self.pairing.active_bridge_record(
+                bridge_id=bridge_id,
+                server_instance_id=server_id,
+            ),
+            record_authenticated=lambda bridge_id, generation, authenticated_at: (
+                self.pairing.mark_bridge_authenticated(
+                    bridge_id=bridge_id,
+                    key_generation=generation,
+                    authenticated_at_ms=authenticated_at,
+                )
+            ),
+            clock_ms=lambda: self.now,
+            random_bytes=lambda size: bytes([7]) * size,
+            id_factory=self._next_challenge_id,
+        )
+
+    def _next_challenge_id(self) -> str:
+        self._challenge_number += 1
+        return f"challenge-{self._challenge_number}"
+
+    def auth(self) -> dict[str, Any]:
+        challenge = self.challenges.issue(
+            {
+                "trust_version": 1,
+                "bridge_id": BRIDGE_ID,
+                "client_nonce": CLIENT_NONCE,
+            },
+            source_key=coarse_source_key("127.0.0.1"),
+            server_instance_id=SERVER_ID,
+            server_base_url=SERVER_BASE_URL,
+        )
+        proof = {
+            "aud": SERVER_ID,
+            "bridge_id": BRIDGE_ID,
+            "challenge_id": challenge.challenge_id,
+            "client_nonce": CLIENT_NONCE,
+            "handler": BRIDGE_CONNECTOR_HANDLER,
+            "protocol": CONNECTOR_PROTOCOL,
+            "server_base_url": SERVER_BASE_URL,
+            "server_nonce": challenge.server_nonce,
+            "trust_version": 1,
+        }
+        signature = self.private_key.sign(canonical_proof_bytes(proof))
+        return {
+            "handlers": [BRIDGE_CONNECTOR_HANDLER],
+            "principal": {
+                "type": "browser_bridge",
+                "proof": proof,
+                "signature": base64.urlsafe_b64encode(signature)
+                .rstrip(b"=")
+                .decode(),
+            },
+        }
+
+
+@pytest.fixture
+def bridge_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> _SessionFixture:
+    fixture = _SessionFixture()
+    monkeypatch.delenv("A0_BROWSER_BRIDGE_SERVER_BASE_URL", raising=False)
+    monkeypatch.setitem(sys.modules, "flask", fixture.flask)
+    monkeypatch.setitem(sys.modules, "helpers.runtime", fixture.runtime)
+    monkeypatch.setattr(helpers, "runtime", fixture.runtime, raising=False)
+    monkeypatch.setattr(
+        session,
+        "get_browser_bridge_gate",
+        lambda: BrowserBridgeGate.from_value(fixture.gate),
+    )
+    monkeypatch.setattr(
+        session,
+        "get_browser_bridge_challenge_store",
+        lambda: fixture.challenges,
+    )
+    monkeypatch.setattr(
+        session,
+        "get_browser_bridge_pairing_store",
+        lambda: fixture.pairing,
+    )
+    monkeypatch.setattr(
+        session,
+        "configured_extension_id",
+        lambda: fixture.extension_id,
+    )
+    return fixture
+
+
+@contextmanager
+def _request_at(
+    bridge_session: _SessionFixture,
+    base_url: str = SERVER_BASE_URL,
+) -> Iterator[None]:
+    previous = bridge_session.flask.request
+    bridge_session.flask.request = _Request(base_url)
+    try:
+        yield
+    finally:
+        bridge_session.flask.request = previous
+
+
+def _authenticate(
+    bridge_session: _SessionFixture,
+    auth: dict[str, Any],
+    *,
+    base_url: str = SERVER_BASE_URL,
+) -> WsPrincipal | None:
+    with _request_at(bridge_session, base_url):
+        return session.authenticate(auth, handler_id=HANDLER_ID)
+
+
+def test_real_proof_creates_only_the_immutable_hello_principal(
+    bridge_session: _SessionFixture,
+) -> None:
+    principal = _authenticate(bridge_session, bridge_session.auth())
+
+    assert principal == WsPrincipal(
+        principal_type="browser_bridge",
+        principal_id=BRIDGE_ID,
+        subject_id="single_user",
+        scopes=frozenset(FIXED_BROWSER_BRIDGE_SCOPES),
+        handler_path=BRIDGE_CONNECTOR_HANDLER,
+        handler_id=HANDLER_ID,
+        inbound_events=frozenset({"connector_hello"}),
+        outbound_events=frozenset(),
+        key_generation=1,
+    )
+    assert isinstance(principal.scopes, frozenset)
+    assert isinstance(principal.inbound_events, frozenset)
+    assert bridge_session.state["document"]["bridges"][0][
+        "last_authenticated_at_ms"
+    ] == bridge_session.now
+    with pytest.raises(FrozenInstanceError):
+        principal.principal_id = "replacement"  # type: ignore[misc]
+
+
+def test_auth_schema_is_exact_and_rejected_shapes_do_not_consume_proof(
+    bridge_session: _SessionFixture,
+) -> None:
+    auth = bridge_session.auth()
+    principal = auth["principal"]
+    invalid = [
+        {**auth, "api_key": "ambient-authority"},
+        {**auth, "handlers": []},
+        {**auth, "handlers": [BRIDGE_CONNECTOR_HANDLER, "api/state_sync"]},
+        {**auth, "handlers": ["plugins/_a0_connector/other"]},
+        {**auth, "principal": None},
+        {
+            **auth,
+            "principal": {
+                key: value
+                for key, value in principal.items()
+                if key != "signature"
+            },
+        },
+        {**auth, "principal": {**principal, "scopes": ["browser.operate"]}},
+        {**auth, "principal": {**principal, "type": "webui_session"}},
+    ]
+
+    for candidate in invalid:
+        assert _authenticate(bridge_session, candidate) is None
+
+    assert _authenticate(bridge_session, auth) is not None
+
+
+@pytest.mark.parametrize(
+    ("current_server_id", "current_extension_id", "request_base_url"),
+    [
+        ("different-server", EXTENSION_ID, SERVER_BASE_URL),
+        (SERVER_ID, OTHER_EXTENSION_ID, SERVER_BASE_URL),
+        (SERVER_ID, None, SERVER_BASE_URL),
+        (SERVER_ID, EXTENSION_ID, "http://localhost:50081"),
+    ],
+)
+def test_authentication_rechecks_current_server_id_url_and_extension_pin(
+    bridge_session: _SessionFixture,
+    current_server_id: str,
+    current_extension_id: str | None,
+    request_base_url: str,
+) -> None:
+    bridge_session.server_id = current_server_id
+    bridge_session.extension_id = current_extension_id
+
+    assert (
+        _authenticate(
+            bridge_session,
+            bridge_session.auth(),
+            base_url=request_base_url,
+        )
+        is None
+    )
+
+
+def test_gate_blocks_before_consumption_and_revalidates_established_principal(
+    bridge_session: _SessionFixture,
+) -> None:
+    auth = bridge_session.auth()
+    bridge_session.gate = "disabled"
+    assert _authenticate(bridge_session, auth) is None
+
+    bridge_session.gate = "preview"
+    principal = _authenticate(bridge_session, auth)
+    assert principal is not None
+    assert session.is_active(principal) is True
+
+    bridge_session.gate = "disabled"
+    assert session.is_active(principal) is False
+
+
+def test_active_principal_revalidates_server_pin_scopes_and_revocation(
+    bridge_session: _SessionFixture,
+) -> None:
+    principal = _authenticate(bridge_session, bridge_session.auth())
+    assert principal is not None
+    assert session.is_active(principal) is True
+
+    bridge_session.server_id = "different-server"
+    assert session.is_active(principal) is False
+    bridge_session.server_id = SERVER_ID
+
+    bridge_session.extension_id = OTHER_EXTENSION_ID
+    assert session.is_active(principal) is False
+    bridge_session.extension_id = EXTENSION_ID
+
+    wrong_scopes = WsPrincipal(
+        principal_type=principal.principal_type,
+        principal_id=principal.principal_id,
+        subject_id=principal.subject_id,
+        scopes=frozenset({"bridge.connect"}),
+        handler_path=principal.handler_path,
+        handler_id=principal.handler_id,
+        inbound_events=principal.inbound_events,
+        outbound_events=principal.outbound_events,
+        key_generation=principal.key_generation,
+    )
+    assert session.is_active(wrong_scopes) is False
+    assert session.is_active(replace(principal, key_generation=2)) is False
+    assert session.is_active(replace(principal, subject_id="different-subject")) is False
+
+    record = bridge_session.state["document"]["bridges"][0]
+    record["state"] = "revoked"
+    record["revoked_at_ms"] = bridge_session.now + 1
+    assert session.is_active(principal) is False
+
+
+class _PrincipalManager:
+    def __init__(self, principal: WsPrincipal) -> None:
+        self.principal = principal
+
+    def principal_for_sid(self, namespace: str, sid: str) -> WsPrincipal:
+        return self.principal
+
+
+def test_restricted_connector_hello_ignores_malicious_legacy_authority(
+    bridge_session: _SessionFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _load_ws_connector(monkeypatch) as ws_connector_module:
+        WsConnector = ws_connector_module.WsConnector
+    principal = _authenticate(bridge_session, bridge_session.auth())
+    assert principal is not None
+    sid = "restricted-bridge-sid"
+    before_sids = ws_runtime.connected_sids()
+    connector = WsConnector(
+        None,
+        threading.RLock(),
+        manager=_PrincipalManager(principal),  # type: ignore[arg-type]
+    )
+    connector._principal = principal
+    connector._principal_sid = sid
+
+    asyncio.run(connector.on_connect(sid))
+    response = asyncio.run(
+        connector.process(
+            "connector_hello",
+            {
+                "context_id": "victim-context",
+                "features": ["remote_file_tree", "code_execution_remote"],
+                "exec_config": {"enabled": True},
+                "remote_files": {"enabled": True, "write_enabled": True},
+                "remote_exec": {"enabled": True},
+                "computer_use": {"supported": True, "enabled": True},
+                "gateway": {"master_enabled": True, "scopes": {"files": True}},
+                "host_browser": {
+                    "backend_id": "legacy_cdp",
+                    "features": ["evaluate", "raw_cdp"],
+                },
+            },
+            sid,
+        )
+    )
+
+    assert response == {
+        "protocol": CONNECTOR_PROTOCOL,
+        "features": [],
+        "principal_type": "browser_bridge",
+        "connector_session_ready": False,
+        "browser_control_ready": False,
+        "reason_code": "scoped_runtime_not_available",
+    }
+    assert ws_runtime.connected_sids() == before_sids
+    assert ws_runtime.subscribed_contexts_for_sid(sid) == set()
+    assert ws_runtime.host_browser_metadata_for_sid(sid) is None
+    assert ws_runtime.remote_file_metadata_for_sid(sid) is None
+    assert ws_runtime.remote_exec_metadata_for_sid(sid) is None
+    assert ws_runtime.computer_use_metadata_for_sid(sid) is None
+    assert ws_runtime.launcher_gateway_metadata_for_sid(sid) is None
+
+
+class _Request:
+    def __init__(self, base_url: str) -> None:
+        self.headers = {"Origin": base_url}
+        self.script_root = ""
+        self.url_root = f"{base_url}/"
+        self.remote_addr = "127.0.0.1"
+
+
+class _PrintStyle:
+    @staticmethod
+    def debug(_message: str) -> None:
+        return None
+
+    @staticmethod
+    def error(_message: str) -> None:
+        return None
+
+
+class _WsHandler:
+    def __init__(
+        self,
+        socketio_server: Any,
+        lock: Any,
+        *,
+        manager: Any = None,
+        namespace: str = "/ws",
+    ) -> None:
+        self.socketio = socketio_server
+        self.lock = lock
+        self._manager = manager
+        self._namespace = namespace
+        self._principal: WsPrincipal | None = None
+        self._principal_sid: str | None = None
+
+    @property
+    def identifier(self) -> str:
+        return f"{self.__class__.__module__}.{self.__class__.__name__}"
+
+    @property
+    def namespace(self) -> str:
+        return self._namespace
+
+    @property
+    def manager(self) -> Any:
+        return self._manager
+
+    def principal_for_sid(self, _sid: str) -> WsPrincipal | None:
+        return self._principal
+
+
+class _WsResult:
+    @classmethod
+    def error(cls, *, code: str, message: str, **_kwargs: Any) -> dict[str, str]:
+        return {"code": code, "message": message}
+
+
+@contextmanager
+def _load_ws_connector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[ModuleType]:
+    module_name = "plugins._a0_connector.api.ws_connector"
+    parent = importlib.import_module("plugins._a0_connector.api")
+    previous_attribute = getattr(parent, "ws_connector", None)
+    previous = sys.modules.pop(module_name, None)
+    print_style_stub = ModuleType("helpers.print_style")
+    print_style_stub.PrintStyle = _PrintStyle
+    ws_stub = ModuleType("helpers.ws")
+    ws_stub.WsHandler = _WsHandler
+    ws_manager_stub = ModuleType("helpers.ws_manager")
+    ws_manager_stub.WsResult = _WsResult
+    try:
+        with monkeypatch.context() as context:
+            context.setitem(sys.modules, "helpers.print_style", print_style_stub)
+            context.setitem(sys.modules, "helpers.ws", ws_stub)
+            context.setitem(sys.modules, "helpers.ws_manager", ws_manager_stub)
+            yield importlib.import_module(module_name)
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous is not None:
+            sys.modules[module_name] = previous
+        if previous_attribute is None:
+            if hasattr(parent, "ws_connector"):
+                delattr(parent, "ws_connector")
+        else:
+            parent.ws_connector = previous_attribute

--- a/tests/test_browser_bridge_setup_webui.py
+++ b/tests/test_browser_bridge_setup_webui.py
@@ -1,0 +1,581 @@
+from __future__ import annotations
+import re
+import shutil
+import pytest
+from pathlib import Path
+from browser_bridge_test_support import run_model, run_node
+
+
+def test_os_links_stay_scoped_and_unverified_metadata_never_means_ready():
+    run_model("browser-bridge-setup-store.js", r'''
+import assert from "node:assert/strict";
+assert.equal(browserHostPlatform({platform:"MacIntel"}),"macos");
+assert.equal(browserHostPlatform({userAgentData:{platform:"Windows"}}),"windows");
+assert.equal(browserHostPlatform({platform:"Linux x86_64"}),"linux");
+assert.equal(browserHostPlatform({platform:"Linux",userAgent:"Android"}),"");
+const setup={contract:"a0.browser-bridge.setup.v1",setup_enabled:true,browser_control_ready:false,
+ install_target:"browser_host",host_verification_required:true,extension_id:"a".repeat(32),
+ extension_url:"https://chromewebstore.google.com/detail/"+"a".repeat(32),companion_version:"2.12.0",
+ installers:[{platform:"macos",arch:"universal2",url:"https://releases.example.test/bridge.dmg"}]};
+const calls=[];
+const model=createBrowserSetupModel({platform:"macos",api:async(_,body)=>{calls.push(body);return setup;}});
+await model.mount();assert.deepEqual(calls,[{}]);assert.equal(model.installers().length,1);
+model.platform="windows";assert.equal(model.installers().length,0);assert.match(model.availabilityText(),/No Windows/);
+model.platform="linux";assert.equal(model.installers().length,0);assert.match(model.availabilityText(),/No Linux/);
+for (const invalid of [{...setup,browser_control_ready:true},{...setup,setup_enabled:false},
+ {...setup,extension_url:"https://example.test"},{...setup,installers:[{...setup.installers[0],url:"javascript:alert(1)"}]},
+ {...setup,installers:[...setup.installers,...setup.installers]}]) assert.throws(()=>parseSetup(invalid));
+model.cleanup();assert.equal(model.setup,null);
+''')
+
+
+def test_setup_closed_panel_discards_async_response():
+    run_model("browser-bridge-setup-store.js", r'''
+import assert from "node:assert/strict";
+let finish;const model=createBrowserSetupModel({api:()=>new Promise(resolve=>finish=resolve)});
+const request=model.mount();model.cleanup();finish({});await request;
+assert.equal(model.setup,null);assert.equal(model.state,"not_checked");
+''')
+
+
+def test_alpine_store_registration_does_not_start_pairing_without_modal_config():
+    source = (Path(__file__).resolve().parents[1] / "plugins/_browser/webui/browser-config-store.js").read_text()
+    source = re.sub(r"^import .*;\n", "", source, flags=re.M).replace("export const store =", "const store =")
+    script = "const createStore=(_,model)=>model; const callJsonApi=()=>{throw Error('Unexpected API call')};\n" + source
+    script += "\nawait store.init(); if(store.pairingPanelActive || store.pairingStatusLoading)throw Error('Registration started pairing');"
+    run_node(script)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_selection_readback_respects_modal_scope_and_preserves_unrelated_drafts():
+    run_model("browser-bridge-selection-store.js", r'''
+import assert from "node:assert/strict";
+const modal={pluginName:"_browser",projectName:"",agentProfileKey:"",
+ settings:{runtime_backend:"container",host_browser_selection:"",proxy_server:"unsaved"}};
+const calls=[];
+const api=async(endpoint,body)=>{calls.push({endpoint,body});return {ok:true,data:{
+ runtime_backend:body.project_name?"host_required":"container",
+ host_browser_selection:body.project_name?"extension:bridge-1":"",proxy_server:"stored"}};};
+await refreshBrowserSettingsScope(api,modal,()=>true);
+assert.equal(modal.settings.runtime_backend,"container");
+assert.equal(modal.settings.host_browser_selection,"");
+assert.equal(modal.settings.proxy_server,"unsaved");
+assert.deepEqual(calls[0],{endpoint:"/plugins",body:{action:"get_config",plugin_name:"_browser",project_name:"",agent_profile:""}});
+modal.projectName="project-1";await refreshBrowserSettingsScope(api,modal,()=>true);
+assert.equal(modal.settings.host_browser_selection,"extension:bridge-1");
+let resolve;const pending=refreshBrowserSettingsScope(()=>new Promise(done=>resolve=done),modal,()=>true);
+modal.projectName="project-2";modal.settings={runtime_backend:"container",host_browser_selection:""};
+resolve({ok:true,data:{runtime_backend:"host_required",host_browser_selection:"extension:stale"}});
+await pending;assert.equal(modal.settings.host_browser_selection,"");
+await refreshBrowserSettingsScope(api,modal,()=>false);assert.equal(calls.length,2);
+''')
+
+
+def test_selection_status_is_read_only_and_changes_require_exact_readback():
+    run_model("browser-bridge-selection-store.js", r'''
+import assert from "node:assert/strict";
+let bridge = null, wrong = false;
+const calls = [], notices = [], updates = [];
+const reply = (chat=false) => ({contract:chat?"a0.browser-bridge.selection.v1":"a0.browser-bridge.default-selection.v1",...(chat?{context_id:"chat-1"}:{}),
+ bridge_id:bridge,selected:bridge !== null,browser_control_ready:false,reconnect_required:bridge !== null});
+const model = createBridgeSelectionModel({context:()=>"chat-1",confirm:async()=>true,
+ notify:(...v)=>notices.push(v),onSelected:v=>updates.push(v),api:async(_,body)=>{
+ calls.push(body);if(body.action === "use_default")bridge = wrong ? "other" : body.bridge_id;
+ if(body.action === "clear_default")bridge = null;return reply(body.action === "status");}});
+const modal = {settings:{proxy_server:"unsaved"}};
+await model.mount(modal);
+assert.deepEqual(calls,[{action:"default_status"},{action:"status",context_id:"chat-1"}]);
+assert.equal(updates.length,0);assert.equal(model.selection.ready,false);
+await model.useBrowser("browser-1");
+assert.deepEqual(calls.at(-2),{action:"use_default",bridge_id:"browser-1",expected_bridge_id:null});
+assert.equal(model.selectedHere("browser-1"),true);assert.deepEqual(updates,[modal]);
+assert.equal(model.selectedDefault("browser-1"),true);
+await model.clear();
+assert.deepEqual(calls.at(-2),{action:"clear_default",expected_bridge_id:"browser-1"});
+assert.equal(model.selection.selected,false);
+wrong=true;await model.useBrowser("browser-2");
+assert.equal(model.defaultSelection,null);assert.equal(model.state,"unavailable");
+assert.equal(updates.length,2);assert.equal(notices.at(-1)[0],"error");
+model.cleanup();
+''')
+
+
+def test_readiness_timer_is_read_only_visible_nonoverlapping_and_cleanup_fenced():
+    run_model("browser-bridge-selection-store.js", r'''
+import assert from "node:assert/strict";
+let chat="",visible=true,ready=false,defer=false,resolve,next=0;
+const timers=new Map(),calls=[];
+const reply=()=>({contract:"a0.browser-bridge.default-selection.v1",bridge_id:"chrome-1",selected:true,
+ browser_control_ready:ready,reconnect_required:!ready});
+const model=createBridgeSelectionModel({context:()=>chat,confirm:async()=>false,notify:()=>{},visible:()=>visible,
+ schedule:(fn,ms)=>{assert.equal(ms,5000);timers.set(++next,fn);return next;},unschedule:id=>timers.delete(id),
+ api:async(_,body)=>{calls.push(body);if(defer)return new Promise(done=>resolve=done);return reply();}});
+await model.mount({});assert.equal(timers.size,1);const tick=[...timers.values()][0];
+assert.equal(model.defaultSelection.ready,false);
+ready=true;tick();await new Promise(done=>setImmediate(done));assert.equal(model.defaultSelection.ready,true);
+assert.deepEqual(calls,[{action:"default_status"},{action:"default_status"}]);
+visible=false;tick();assert.equal(calls.length,2);visible=true;
+model.busy=true;tick();assert.equal(calls.length,2);model.busy=false;
+defer=true;tick();tick();assert.equal(calls.length,3);
+chat="different-chat";resolve(reply());await new Promise(done=>setImmediate(done));tick();assert.equal(calls.length,3);
+model.cleanup();assert.equal(timers.size,0);assert.equal(model.timer,null);tick();assert.equal(calls.length,3);
+chat="";const pending=model.mount({});model.cleanup();resolve(reply());await pending;
+assert.equal(timers.size,0);assert.equal(model.defaultSelection,null);
+''')
+
+
+def test_selection_ignores_stale_chat_and_rejects_forged_readiness():
+    run_model("browser-bridge-selection-store.js", r'''
+import assert from "node:assert/strict";
+const base={contract:"a0.browser-bridge.selection.v1",context_id:"chat-1",
+ bridge_id:null,selected:false,browser_control_ready:false,reconnect_required:false};
+let context="chat-1", resolve;
+const updates=[], notices=[], calls=[];
+const model=createBridgeSelectionModel({context:()=>context,confirm:async()=>true,
+ notify:(...v)=>notices.push(v),onSelected:v=>updates.push(v),api:async(_,body)=>{
+ calls.push(body);if(body.action==="status")return base;
+ if(body.action==="default_status"){const {context_id,...rest}=base;return {...rest,contract:"a0.browser-bridge.default-selection.v1"};}
+ return new Promise(done=>resolve=done);}});
+await model.mount({});const pending=model.useBrowser("browser-1");context="chat-2";
+const {context_id,...defaultBase}=base;
+resolve({...defaultBase,contract:"a0.browser-bridge.default-selection.v1",bridge_id:"browser-1",selected:true,reconnect_required:true});await pending;
+assert.equal(updates.length,0);assert.equal(notices.length,0);
+assert.equal(model.canSelect("browser-2"),false);await model.useBrowser("browser-2");
+assert.equal(calls.length,3);model.cleanup();assert.equal(model.selection,null);
+for(const invalid of [{...base,browser_control_ready:true},{...base,extra:true},
+ {...base,selected:true,bridge_id:"browser-1",browser_control_ready:true,reconnect_required:true}]) {
+ assert.throws(()=>parseSelection(invalid,"chat-1"));
+}
+''')
+
+
+def test_default_selection_works_without_chat_and_preserves_project_override():
+    run_model("browser-bridge-selection-store.js", r'''
+import assert from "node:assert/strict";
+let chat="",bridge=null;const calls=[];
+const model=createBridgeSelectionModel({context:()=>chat,confirm:async()=>true,notify:()=>{},api:async(_,body)=>{
+ calls.push(body);if(body.action==="use_default")bridge=body.bridge_id;
+ if(body.action==="clear_default")bridge=null;
+ if(body.action==="status")return {contract:"a0.browser-bridge.selection.v1",context_id:chat,bridge_id:"project-browser",selected:true,browser_control_ready:false,reconnect_required:true};
+ return {contract:"a0.browser-bridge.default-selection.v1",bridge_id:bridge,selected:bridge!==null,browser_control_ready:bridge!==null,reconnect_required:false};
+}});
+await model.mount({});assert.deepEqual(calls,[{action:"default_status"}]);
+assert.equal(model.canSelect("chrome-1"),true);await model.useBrowser("chrome-1");
+assert.deepEqual(calls.at(-1),{action:"use_default",bridge_id:"chrome-1",expected_bridge_id:null});
+assert.equal(model.selectedDefault("chrome-1"),true);assert.match(model.statusText(),/Chrome is connected/);
+assert.equal(model.contextStatusText(),"");
+model.cleanup();chat="chat-1";await model.mount({});assert.match(model.contextStatusText(),/project settings are kept/);
+await model.useBrowser("chrome-2");assert.deepEqual(calls.at(-2),{action:"use_default",bridge_id:"chrome-2",expected_bridge_id:"chrome-1"});
+assert.equal(model.selection.bridgeId,"project-browser");assert.equal(model.defaultSelection.bridgeId,"chrome-2");
+await model.clear();assert.deepEqual(calls.at(-2),{action:"clear_default",expected_bridge_id:"chrome-2"});
+assert.equal(model.selection.bridgeId,"project-browser");model.cleanup();
+''')
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+SOURCE = ROOT / "plugins/_browser/webui/browser-bridge-access-store.js"
+
+
+ACCESS_FIXTURES = r'''
+import assert from "node:assert/strict";
+const bridge = (id, state="active") => ({bridge_id:id,display_name:"Browser " + id,state,key_generation:1});
+const inventory = (bridges) => ({contract:"a0.browser-bridge.bridges.v1",trust_version:1,browser_control_ready:false,bridges});
+const policy = (id, grants=[]) => ({contract:"a0.browser-bridge.site-policy.v1",policy_version:1,bridge_id:id,site_mode:"ask_per_site",operation_grants_enabled:false,browser_control_ready:false,grants});
+const grant = {grant_id:"grant-1",origin:"https://example.com"};
+'''
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="Node required")
+def test_access_model_scopes_mutations_confirms_revocation_and_does_not_infer_readiness():
+    run_model("browser-bridge-access-store.js", ACCESS_FIXTURES + r'''
+const calls = [], notices = [];
+let revoked = false, approved = false;
+const model = createBridgeAccessModel({
+  confirm: async () => approved, notify: (...args) => notices.push(args),
+  api: async (endpoint, body) => {
+    calls.push({endpoint, body});
+    if (endpoint.endsWith("_bridges")) {
+      if (body.action === "revoke") { revoked = true; return {...inventory([]),revoked:true,bridge:bridge("bridge-1","revoked")}; }
+      return inventory([bridge("bridge-1",revoked?"revoked":"active")]);
+    }
+    return policy(body.bridge_id, body.action === "allow" ? [grant] : []);
+  },
+});
+await model.mount();
+assert.equal(model.selectedId,"bridge-1");
+assert.equal(model.policyState,"loaded");
+for (const value of ["https://example.com/path","https://example.com?","https://example.com#","https://u:p@example.com","https://*.example.com","https://example.com\\path","file:///tmp/a","https://example.com."]) assert.equal(normalizeSiteOrigin(value), "");
+model.originDraft="HTTPS://EXAMPLE.COM:443/";
+assert.equal(model.canAllowSite(), true);
+await model.allowSite();
+assert.deepEqual(calls.at(-1).body,{action:"allow",bridge_id:"bridge-1",origin:"https://example.com"});
+assert.deepEqual(model.grants,[{id:"grant-1",origin:"https://example.com"}]);
+assert.equal(model.originDraft, "");
+await model.revokeSite("https://other.example");
+assert.equal(calls.at(-1).body.action,"allow");
+await model.revokeBridge();
+assert.equal(revoked,false);
+approved=true;
+await model.revokeBridge();
+assert.equal(revoked,true);
+assert.equal(model.selectedBridge().state,"revoked");
+assert.equal(model.canManageSites(),false);
+assert.equal(model.grants.length,0);
+model.cleanup();
+assert.equal(model.bridges.length,0);
+assert.equal(model.selectedId,"");
+assert.equal(notices.length,2);
+''')
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="Node required")
+def test_access_model_discards_stale_host_responses_and_closed_panel_confirmation():
+    run_model("browser-bridge-access-store.js", ACCESS_FIXTURES + r'''
+let resolveOld, resolveConfirm, defer=false;
+let writes=0;
+const model=createBridgeAccessModel({notify:()=>{},confirm:()=>new Promise(r=>{resolveConfirm=r;}),api:async(endpoint,body)=>{
+  if(body.action!=="list") writes++;
+  if(endpoint.endsWith("_bridges")) return inventory([bridge("bridge-1"),bridge("bridge-2")]);
+  if(defer && body.bridge_id==="bridge-1") return await new Promise(r=>{resolveOld=r;});
+  return policy(body.bridge_id);
+}});
+await model.mount();
+defer=true;
+const pending=model.selectBridge("bridge-1");
+await model.selectBridge("bridge-2");
+resolveOld(policy("bridge-1",[grant])); await pending;
+assert.equal(model.selectedId,"bridge-2");
+assert.deepEqual(model.grants,[]);
+const confirmation=model.revokeBridge();
+model.cleanup();resolveConfirm(true);await confirmation;
+assert.equal(writes,0);
+assert.equal(model.active,false);
+''')
+
+
+def test_management_ui_uses_plain_text_and_existing_notification_system():
+    source = SOURCE.read_text()
+    html = (ROOT / "plugins/_browser/webui/config.html").read_text()
+    assert 'x-destroy="$store.browserBridgeAccess.cleanup(); $store.browserBridgeSelection.cleanup()"' in html
+    assert 'x-text="grant.origin"' in html
+    assert "Revoke browser access" in html
+    assert "frontendNotification" in source and "frontendOnly: true" in source
+    assert "localStorage" not in source and "sessionStorage" not in source
+    assert "browser_bridge_exchange" not in source
+
+
+def test_quiet_inventory_refresh_preserves_draft_and_never_changes_consent():
+    run_model("browser-bridge-access-store.js", ACCESS_FIXTURES + r'''
+const calls=[];const model=createBridgeAccessModel({notify:()=>{},confirm:async()=>false,
+ api:async(endpoint,body)=>{calls.push(body);return endpoint.endsWith("_bridges")?inventory([bridge("bridge-1")]):policy(body.bridge_id);}});
+await model.mount();model.originDraft="https://still-typing.example";
+await model.refresh({background:true});
+assert.equal(model.originDraft,"https://still-typing.example");
+assert.deepEqual(calls.at(-1),{action:"list"});
+assert.equal(calls.length,3);
+model.busy=true;await model.refresh({background:true});assert.equal(calls.length,3);
+''')
+
+
+def test_all_websites_requires_confirmation_and_discards_stale_setting_response():
+    run_model("browser-bridge-access-store.js", ACCESS_FIXTURES + r'''
+let approved=false, pendingConfirm, writes=0;
+const model=createBridgeAccessModel({notify:()=>{},confirm:async()=>approved,
+ api:async(endpoint,body)=>{
+  if(endpoint.endsWith("_bridges"))return inventory([bridge("bridge-1"),bridge("bridge-2")]);
+  if(body.action==="set_mode"){writes++;return {...policy(body.bridge_id),site_mode:body.site_mode};}
+  return policy(body.bridge_id);
+ }});
+await model.mount();assert.equal(model.siteMode,"ask_per_site");
+await model.setAllWebsites(true);assert.equal(writes,0);
+approved=true;await model.setAllWebsites(true);
+assert.equal(writes,1);assert.equal(model.siteMode,"allow_all_websites");
+await model.setAllWebsites(false);assert.equal(model.siteMode,"ask_per_site");
+await model.selectBridge("bridge-2");assert.equal(model.siteMode,"ask_per_site");
+model.cleanup();await model.setAllWebsites(true);assert.equal(writes,2);
+let resolveConfirm;
+const other=createBridgeAccessModel({notify:()=>{},confirm:()=>new Promise(r=>resolveConfirm=r),
+ api:async(endpoint,body)=>{if(body.action!=="list")writes++;return endpoint.endsWith("_bridges")?inventory([bridge("bridge-1")]):policy(body.bridge_id);}});
+await other.mount();const pending=other.setAllWebsites(true);other.cleanup();resolveConfirm(true);await pending;
+assert.equal(writes,2);
+''')
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+CONFIG_HTML = PROJECT_ROOT / "plugins" / "_browser" / "webui" / "config.html"
+
+
+CONFIG_STORE = (
+    PROJECT_ROOT / "plugins" / "_browser" / "webui" / "browser-config-store.js"
+)
+
+
+def _store_source() -> str:
+    source = CONFIG_STORE.read_text(encoding="utf-8")
+    source = re.sub(r"^import .*;\n", "", source, flags=re.M)
+    return "const notifications = {frontendNotification: async () => {}};\n" + source.replace(
+        'export const store = createStore("browserConfig", {',
+        'const store = createStore("browserConfig", {',
+    )
+
+
+def test_pairing_panel_is_transient_redacted_and_explicitly_browser_host_only() -> None:
+    html = CONFIG_HTML.read_text(encoding="utf-8")
+    store = CONFIG_STORE.read_text(encoding="utf-8")
+
+    assert 'id="browser-pairing-title"' in html
+    assert "Single-use pairing code" in html
+    assert "five-minute lifetime" in html
+    assert "Copy code" in html
+    assert "Regenerate" in html
+    assert "Cancel pending code" in html
+    assert "Install the companion on the computer running Chrome." in html
+    assert "Never install it inside Docker." in html
+    assert "Your saved pairing stays on that computer" in html
+    assert 'x-text="$store.browserConfig.pairingCode"' in html
+    assert 'x-html="$store.browserConfig.pairingCode"' not in html
+    assert "browser_bridge_exchange" not in html + store
+    assert "localStorage" not in store
+    assert "sessionStorage" not in store
+    assert "clearPairingCode();" in store
+    assert 'action: "create"' in store
+    assert 'action: "status"' in store
+    assert 'action: "cancel"' in store
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="node is required")
+def test_pairing_store_creates_copies_cancels_and_clears_code_without_persistence() -> None:
+    source = _store_source()
+    script = """
+const calls = [];
+let copied = "";
+const createStore = (_name, value) => value;
+const showConfirmDialog = async () => false;
+const window = { setInterval: () => 1, clearInterval: () => {}, isSecureContext: true };
+Object.defineProperty(globalThis, "navigator", {
+  configurable: true,
+  value: { clipboard: { writeText: async (value) => { copied = value; } } },
+});
+const code = "A0B1-11111111-00000000000000000000000000000000";
+const callJsonApi = async (endpoint, payload) => {
+  calls.push({ endpoint, payload });
+  const now = Date.now();
+  if (payload.action === "create") {
+    return {
+      contract: "a0.browser-bridge.trust.v1",
+      trust_version: 1,
+      state: "pairing_pending",
+      pairing_id: "11111111-1111-4111-8111-111111111111",
+      pairing_code: code,
+      server: {
+        base_url: "http://localhost:50080",
+        instance_fingerprint: "sha256:00000000000000000000",
+      },
+      extension_id: "abcdefghijklmnopabcdefghijklmnop",
+      display_name: payload.display_name,
+      created_at_ms: now,
+      expires_at_ms: now + 300000,
+      expires_in_seconds: 300,
+      native_runtime_location: "user_browser_host",
+      docker_install_target: false,
+      connector_session_ready: false,
+      browser_control_ready: false,
+    };
+  }
+  if (payload.action === "cancel") {
+    return {
+      contract: "a0.browser-bridge.trust.v1",
+      trust_version: 1,
+      state: "unpaired",
+      reason_code: "no_active_bridge_record",
+      pairing_id: null,
+      server_base_url: null,
+      extension_id: null,
+      display_name: null,
+      expires_at_ms: null,
+      pairing_code_present: false,
+      native_runtime_location: "user_browser_host",
+      docker_install_target: false,
+      connector_session_ready: false,
+      browser_control_ready: false,
+      server_pairing_enabled: true,
+      canceled: true,
+    };
+  }
+  throw new Error("unexpected action");
+};
+""" + source + """
+store.pairingPanelActive = true;
+store.pairingPanelGeneration = 1;
+store.pairingDisplayName = "My browser host";
+store.pairingStatus = {
+  state: "unpaired",
+  reasonCode: "no_active_bridge_record",
+  pairingId: "",
+  expiresAtMs: 0,
+  serverPairingEnabled: true,
+};
+await store.createBrowserBridgePairing();
+if (store.pairingCode !== code) throw new Error("pairing code was not presented");
+if (!store.pairingCodeAvailable()) throw new Error("fresh pairing code was unavailable");
+if (calls[0].endpoint !== "/plugins/_a0_connector/browser_bridge_pairing") {
+  throw new Error("wrong pairing endpoint");
+}
+if (JSON.stringify(calls[0].payload) !== JSON.stringify({
+  action: "create",
+  display_name: "My browser host",
+})) throw new Error("create request was not exact");
+await store.copyBrowserBridgePairingCode();
+if (copied !== code) throw new Error("explicit copy did not use current code");
+await store.cancelBrowserBridgePairing();
+if (store.pairingError) throw new Error(store.pairingError);
+if (store.pairingCode !== "") throw new Error("cancel retained pairing code");
+if (calls[1].payload.action !== "cancel") throw new Error("cancel was not sent");
+if ("extension_id" in calls[0].payload || "server_base_url" in calls[0].payload) {
+  throw new Error("UI supplied server-owned identity");
+}
+store.pairingCode = code;
+store.pairingCodePairingId = "stale";
+store.cleanup();
+if (store.pairingCode !== "") throw new Error("panel cleanup retained pairing code");
+"""
+
+    run_node(script)
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="node is required")
+def test_pairing_status_projection_drops_server_secrets_and_never_claims_control() -> None:
+    source = _store_source()
+    script = """
+const createStore = (_name, value) => value;
+const showConfirmDialog = async () => false;
+const window = { setInterval: () => 1, clearInterval: () => {} };
+const navigator = {};
+const callJsonApi = async (_endpoint, payload) => {
+  if (payload.action !== "status") throw new Error("unexpected action");
+  return {
+    contract: "a0.browser-bridge.trust.v1",
+    trust_version: 1,
+    state: "pairing_pending",
+    reason_code: "pairing_intent_active",
+    pairing_id: "11111111-1111-4111-8111-111111111111",
+    expires_at_ms: Date.now() + 300000,
+    pairing_code_present: false,
+    pairing_code: "MUST-NOT-ENTER-STORE",
+    extension_id: "abcdefghijklmnopabcdefghijklmnop",
+    public_key: { value: "MUST-NOT-ENTER-STORE" },
+    server_base_url: "http://localhost:50080",
+    server_pairing_enabled: true,
+    connector_session_ready: false,
+    browser_control_ready: false,
+  };
+};
+""" + source + """
+store.pairingPanelActive = true;
+store.pairingPanelGeneration = 1;
+await store.loadBrowserBridgePairingStatus();
+const serialized = JSON.stringify(store.pairingStatus);
+if (serialized.includes("MUST-NOT-ENTER-STORE")) throw new Error("secret entered status");
+if (serialized.includes("extension_id") || serialized.includes("public_key")) {
+  throw new Error("identity entered status projection");
+}
+if (store.pairingCode !== "") throw new Error("status restored a pairing code");
+if (store.pairingStatus.state !== "not_checked") {
+  throw new Error("secret-bearing status was not rejected");
+}
+if (!store.pairingStatusLabel().includes("not been checked")) {
+  throw new Error("rejected status claimed a known state");
+}
+const redactedPending = normalizePairingStatus({
+  contract: "a0.browser-bridge.trust.v1",
+  trust_version: 1,
+  state: "pairing_pending",
+  reason_code: "pairing_intent_active",
+  pairing_id: "11111111-1111-4111-8111-111111111111",
+  expires_at_ms: Date.now() + 300000,
+  pairing_code_present: false,
+  extension_id: "abcdefghijklmnopabcdefghijklmnop",
+  server_base_url: "http://localhost:50080",
+  display_name: "Browser host",
+  server_pairing_enabled: true,
+  native_runtime_location: "user_browser_host",
+  docker_install_target: false,
+  connector_session_ready: false,
+  browser_control_ready: false,
+});
+if (!redactedPending) throw new Error("valid redacted status was rejected");
+if (JSON.stringify(redactedPending).includes("abcdefghijklmnop")) {
+  throw new Error("extension identity entered status projection");
+}
+store.pairingStatus = redactedPending;
+store.pairingNowMs = Date.now();
+if (!store.pairingStatusLabel().includes("Regenerate")) {
+  throw new Error("redacted pending status lacked regeneration guidance");
+}
+if (store.pairingStatus.connectorSessionReady || store.pairingStatus.browserControlReady) {
+  throw new Error("UI claimed runtime readiness");
+}
+"""
+
+    run_node(script)
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="node is required")
+def test_late_pairing_response_cannot_restore_code_after_panel_teardown() -> None:
+    source = _store_source()
+    script = """
+let resolveCreate;
+const createStore = (_name, value) => value;
+const showConfirmDialog = async () => false;
+const window = { setInterval: () => 1, clearInterval: () => {} };
+const navigator = {};
+const callJsonApi = async (_endpoint, payload) => {
+  if (payload.action !== "create") throw new Error("unexpected action");
+  return await new Promise((resolve) => { resolveCreate = resolve; });
+};
+""" + source + """
+store.pairingPanelActive = true;
+store.pairingPanelGeneration = 7;
+store.pairingStatus = {
+  state: "unpaired",
+  reasonCode: "no_active_bridge_record",
+  pairingId: "",
+  expiresAtMs: 0,
+  serverPairingEnabled: true,
+};
+const pending = store.createBrowserBridgePairing();
+await Promise.resolve();
+store.cleanup();
+const now = Date.now();
+resolveCreate({
+  contract: "a0.browser-bridge.trust.v1",
+  trust_version: 1,
+  state: "pairing_pending",
+  pairing_id: "11111111-1111-4111-8111-111111111111",
+  pairing_code: "A0B1-11111111-00000000000000000000000000000000",
+  server: {
+    base_url: "http://localhost:50080",
+    instance_fingerprint: "sha256:00000000000000000000",
+  },
+  extension_id: "abcdefghijklmnopabcdefghijklmnop",
+  display_name: "My browser host",
+  created_at_ms: now,
+  expires_at_ms: now + 300000,
+  expires_in_seconds: 300,
+  native_runtime_location: "user_browser_host",
+  docker_install_target: false,
+  connector_session_ready: false,
+  browser_control_ready: false,
+});
+await pending;
+if (store.pairingCode !== "") throw new Error("late response restored pairing code");
+if (store.pairingPanelActive) throw new Error("panel was reactivated by late response");
+"""
+
+    run_node(script)

--- a/tests/test_browser_bridge_site_authority.py
+++ b/tests/test_browser_bridge_site_authority.py
@@ -1,0 +1,810 @@
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from dataclasses import replace
+import hashlib
+import io
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_context import (
+    BrowserBridgeContextRoute,
+)
+from plugins._a0_connector.helpers.browser_bridge_events import (
+    BROWSER_EVENT,
+    BROWSER_EVENT_ACK,
+    RESTRICTED_HANDLER_ID,
+    BrowserBridgeCriticalEventReceiver,
+    BrowserBridgeEventError,
+    SiteChallengeNotice,
+)
+from plugins._a0_connector.helpers.browser_bridge_operations import (
+    BrokerCompletion,
+    ControlBinding,
+    ControlTicket,
+    OperationBinding,
+    OperationTicket,
+)
+from plugins._a0_connector.helpers.browser_bridge_site_authority import (
+    MAX_TURN_GRANT_TTL_MS,
+    SITE_AUTHORITY_CONTRACT,
+    BrowserBridgeSiteAuthorityRepository,
+    BrowserBridgeSiteAuthorityUnavailable,
+)
+
+
+NOW_MS = 1_000_000
+ORIGIN = "https://example.com"
+PARAMETER_HASH = "a" * 64
+LEASE_ID = "lease-A"
+TAB_HANDLE = "browser-A"
+
+
+def _principal(subject: str = "single_user") -> WsPrincipal:
+    return WsPrincipal(
+        principal_type="browser_bridge",
+        principal_id="bridge-A",
+        subject_id=subject,
+        scopes=frozenset(
+            {"browser.operate", "browser.control", "browser.approval"}
+        ),
+        handler_path="plugins/_a0_connector/ws_connector",
+        handler_id=RESTRICTED_HANDLER_ID,
+        inbound_events=frozenset({BROWSER_EVENT}),
+        outbound_events=frozenset({BROWSER_EVENT_ACK}),
+        key_generation=3,
+    )
+
+
+def _operation(
+    loop: asyncio.AbstractEventLoop,
+    principal: WsPrincipal,
+    *,
+    op_id: str = "op-A",
+    action_id: str = "action-A",
+    turn_id: str = "turn-A",
+    origin: str = ORIGIN,
+) -> OperationTicket:
+    binding = OperationBinding(
+        principal=principal,
+        connector_sid="sid-A",
+        load_generation_id="generation-A",
+        context_id="context-A",
+        browser_session_id="browser-session-A",
+        turn_id=turn_id,
+        action_id=action_id,
+        op_id=op_id,
+    )
+    return OperationTicket(
+        binding=binding,
+        deadline_ms=NOW_MS + 90_000,
+        effect="mutating",
+        _future=loop.create_future(),
+        action="navigate",
+        target_tab_handle=TAB_HANDLE,
+        canonical_parameter_hash=PARAMETER_HASH,
+        destination_origin=origin,
+    )
+
+
+def _fingerprint(
+    *,
+    origin: str = ORIGIN,
+    generation: str = "generation-A",
+    document_id: str | None = None,
+    document_epoch: int = 0,
+) -> str:
+    value = {
+        "action_class": "navigate",
+        "browser_id_digest": hashlib.sha256(TAB_HANDLE.encode()).hexdigest(),
+        "document_epoch": document_epoch,
+        "document_id": document_id,
+        "lease_id_digest": hashlib.sha256(LEASE_ID.encode()).hexdigest(),
+        "load_generation_id": generation,
+        "origin": origin,
+    }
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _notice(
+    principal: WsPrincipal,
+    *,
+    challenge_id: str = "challenge-A",
+    op_id: str = "op-A",
+    action_id: str = "action-A",
+    turn_id: str = "turn-A",
+    origin: str = ORIGIN,
+    target_fingerprint: str | None = None,
+) -> SiteChallengeNotice:
+    return SiteChallengeNotice(
+        principal=principal,
+        connector_sid="sid-A",
+        load_generation_id="generation-A",
+        context_id="context-A",
+        browser_session_id="browser-session-A",
+        turn_id=turn_id,
+        action_id=action_id,
+        op_id=op_id,
+        challenge_id=challenge_id,
+        origin=origin,
+        canonical_parameter_hash=PARAMETER_HASH,
+        target_fingerprint=target_fingerprint or _fingerprint(origin=origin),
+        lease_id_digest=hashlib.sha256(LEASE_ID.encode()).hexdigest(),
+        browser_id_digest=hashlib.sha256(TAB_HANDLE.encode()).hexdigest(),
+        document_id=None,
+        document_epoch=0,
+        summary="Untrusted extension wording must not be shown or retained.",
+        expires_at_ms=NOW_MS + 60_000,
+    )
+
+
+class _Harness:
+    def __init__(
+        self,
+        operation: OperationTicket,
+        *,
+        completion_gate: asyncio.Future[BrokerCompletion] | None = None,
+    ) -> None:
+        self.operations = {operation.binding.op_id: operation}
+        self.operation = operation
+        self.selection_allowed = True
+        self.lease = SimpleNamespace(
+            binding=operation.binding,
+            lease_id=LEASE_ID,
+            tab_handle=TAB_HANDLE,
+            origin=ORIGIN,
+        )
+        self.completion_gate = completion_gate
+        self.resolutions: list[dict[str, Any]] = []
+        self.control_index = 0
+        self.grant_index = 0
+        self.current_route = BrowserBridgeContextRoute(
+            operation.binding.principal,
+            operation.binding.connector_sid,
+            operation.binding.load_generation_id,
+        )
+
+    def current_operation(self, **kwargs: Any) -> OperationTicket | None:
+        operation = self.operations.get(kwargs["op_id"])
+        if operation is None:
+            return None
+        binding = operation.binding
+        if (
+            binding.principal is kwargs["principal"]
+            and binding.connector_sid == kwargs["connector_sid"]
+            and binding.load_generation_id == kwargs["load_generation_id"]
+        ):
+            return operation
+        return None
+
+    @staticmethod
+    def remaining_operation_ms(_operation: OperationTicket) -> int:
+        return 90_000
+
+    def lease_for(self, binding: OperationBinding, handle: str) -> Any | None:
+        if (
+            binding.principal is self.lease.binding.principal
+            and binding.connector_sid == self.lease.binding.connector_sid
+            and binding.load_generation_id == self.lease.binding.load_generation_id
+            and binding.context_id == self.lease.binding.context_id
+            and binding.browser_session_id
+            == self.lease.binding.browser_session_id
+            and binding.turn_id == self.lease.binding.turn_id
+            and handle == self.lease.tab_handle
+        ):
+            return self.lease
+        return None
+
+    def route_verifier(self, route: BrowserBridgeContextRoute) -> bool:
+        current = self.current_route
+        return (
+            route.principal is current.principal
+            and route.connector_sid == current.connector_sid
+            and route.load_generation_id == current.load_generation_id
+        )
+
+    def turn_current(self, binding: OperationBinding) -> bool:
+        return any(
+            candidate.binding.principal is binding.principal
+            and candidate.binding.connector_sid == binding.connector_sid
+            and candidate.binding.load_generation_id == binding.load_generation_id
+            and candidate.binding.context_id == binding.context_id
+            and candidate.binding.browser_session_id == binding.browser_session_id
+            and candidate.binding.turn_id == binding.turn_id
+            for candidate in self.operations.values()
+        )
+
+    def selection_current(self, context_id: str, bridge_id: str) -> bool:
+        return bool(
+            self.selection_allowed
+            and context_id == self.operation.binding.context_id
+            and bridge_id == self.operation.binding.bridge_id
+        )
+
+    def control_id(self) -> str:
+        self.control_index += 1
+        return f"control-{chr(64 + self.control_index)}"
+
+    def grant_id(self) -> str:
+        self.grant_index += 1
+        return f"grant-{chr(64 + self.grant_index)}"
+
+    async def begin_resolution(
+        self,
+        operation: OperationTicket,
+        **kwargs: Any,
+    ) -> ControlTicket:
+        assert operation in self.operations.values()
+        assert kwargs["authorization_current"]() is True
+        self.resolutions.append(deepcopy(kwargs))
+        binding = operation.binding
+        return ControlTicket(
+            ControlBinding(
+                binding.principal,
+                binding.connector_sid,
+                binding.load_generation_id,
+                binding.context_id,
+                binding.browser_session_id,
+                binding.turn_id,
+                kwargs["control_id"],
+                "browser.resolve_challenge",
+                binding.op_id,
+                binding.action_id,
+            ),
+            NOW_MS + kwargs["timeout_ms"],
+            asyncio.get_running_loop().create_future(),
+        )
+
+    async def wait_control(self, ticket: ControlTicket) -> BrokerCompletion:
+        if self.completion_gate is not None:
+            return await self.completion_gate
+        resolution = self.resolutions[-1]["resolution"]
+        return BrokerCompletion(
+            ok=True,
+            result={
+                "contract_version": 1,
+                "control_id": ticket.binding.control_id,
+                "challenge_id": resolution["challenge_id"],
+                "status": "resolved",
+                "decision": resolution["decision"],
+            },
+        )
+
+    def repository(self, **kwargs: Any) -> BrowserBridgeSiteAuthorityRepository:
+        return BrowserBridgeSiteAuthorityRepository(
+            current_operation=self.current_operation,
+            remaining_operation_ms=self.remaining_operation_ms,
+            lease_for=self.lease_for,
+            route_verifier=self.route_verifier,
+            turn_current=self.turn_current,
+            selection_current=self.selection_current,
+            begin_resolution=self.begin_resolution,
+            wait_control=self.wait_control,
+            server_instance_id=lambda: "server-A",
+            clock_ms=lambda: NOW_MS,
+            control_id_factory=self.control_id,
+            grant_id_factory=self.grant_id,
+            **kwargs,
+        )
+
+
+def test_challenge_registration_requires_exact_retained_intent_lease_and_fingerprint() -> None:
+    async def scenario() -> None:
+        principal = _principal()
+        operation = _operation(asyncio.get_running_loop(), principal)
+        harness = _Harness(operation)
+        repository = harness.repository()
+        challenge = repository.register_event(_notice(principal))
+        assert challenge is None
+        assert repository.list_pending(subject_id="single_user") == (
+            {
+                "challenge_id": "challenge-A",
+                "origin": ORIGIN,
+                "action_class": "navigate",
+                "summary": f"Allow navigation to {ORIGIN}?",
+                "options": ["deny", "allow_once", "allow_turn"],
+                "expires_at_ms": NOW_MS + 60_000,
+            },
+        )
+        assert repository.list_pending(
+            subject_id="single_user",
+            context_id="context-A",
+            bridge_id="bridge-A",
+        ) == repository.list_pending(subject_id="single_user")
+        assert repository.list_pending(
+            subject_id="single_user",
+            context_id="context-B",
+            bridge_id="bridge-A",
+        ) == ()
+        assert "Untrusted extension wording" not in repr(
+            repository.list_pending(subject_id="single_user")
+        )
+        assert repository.list_pending(subject_id="another_user") == ()
+
+        other = _operation(
+            asyncio.get_running_loop(),
+            principal,
+            op_id="op-B",
+            action_id="action-B",
+        )
+        harness.operations["op-B"] = other
+        for invalid in (
+            _notice(
+                principal,
+                challenge_id="challenge-B",
+                op_id="op-B",
+                action_id="action-B",
+                target_fingerprint="b" * 64,
+            ),
+            replace(
+                _notice(
+                    principal,
+                    challenge_id="challenge-C",
+                    op_id="op-B",
+                    action_id="action-B",
+                ),
+                lease_id_digest="c" * 64,
+            ),
+            replace(
+                _notice(
+                    principal,
+                    challenge_id="challenge-D",
+                    op_id="op-B",
+                    action_id="action-B",
+                ),
+                canonical_parameter_hash="d" * 64,
+            ),
+        ):
+            with pytest.raises(BrowserBridgeSiteAuthorityUnavailable):
+                repository.register_event(invalid)
+        await repository.close()
+
+    asyncio.run(scenario())
+
+
+def test_allow_once_is_idempotent_and_grants_only_after_matching_control_result() -> None:
+    async def scenario() -> None:
+        principal = _principal()
+        operation = _operation(asyncio.get_running_loop(), principal)
+        gate: asyncio.Future[BrokerCompletion] = (
+            asyncio.get_running_loop().create_future()
+        )
+        harness = _Harness(operation, completion_gate=gate)
+        repository = harness.repository()
+        repository.register_event(_notice(principal))
+        first = await repository.decide(
+            subject_id="single_user",
+            challenge_id="challenge-A",
+            decision="allow_once",
+        )
+        second = await repository.decide(
+            subject_id="single_user",
+            challenge_id="challenge-A",
+            decision="allow_once",
+        )
+        assert first is second
+        assert first.as_public_dict() == second.as_public_dict()
+        await asyncio.sleep(0)
+        assert repository.resolution_task_count == 1
+        assert repository.grant_for_operation(operation, origin=ORIGIN) is None
+        resolution = harness.resolutions[0]["resolution"]
+        assert set(resolution) == {
+            "challenge_id",
+            "tab_handle",
+            "document_id",
+            "document_epoch",
+            "canonical_parameter_hash",
+            "target_fingerprint",
+            "origin",
+            "action_class",
+            "decision",
+            "grant",
+        }
+        assert resolution["grant"] == {
+            "origin_grant_id": "grant-A",
+            "scope": "operation",
+            "origin": ORIGIN,
+            "expires_at_ms": NOW_MS + 60_000,
+        }
+        gate.set_result(
+            BrokerCompletion(
+                ok=True,
+                result={
+                    "contract_version": 1,
+                    "control_id": "control-A",
+                    "challenge_id": "challenge-A",
+                    "status": "resolved",
+                    "decision": "allow_once",
+                },
+            )
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        grant = repository.grant_for_operation(operation, origin=ORIGIN)
+        assert grant is not None and grant.scope == "operation"
+        assert repository.grant_for_operation(
+            replace(operation, destination_origin="https://evil.example"),
+            origin=ORIGIN,
+        ) is None
+        repository.cancel_operation(operation)
+        assert repository.grant_for_operation(operation, origin=ORIGIN) is None
+        await repository.close()
+
+    asyncio.run(scenario())
+
+
+def test_site_decision_is_withdrawn_when_server_selection_changes() -> None:
+    async def scenario() -> None:
+        principal = _principal()
+        operation = _operation(asyncio.get_running_loop(), principal)
+        harness = _Harness(operation)
+        repository = harness.repository()
+        repository.register_event(_notice(principal))
+        harness.selection_allowed = False
+        with pytest.raises(BrowserBridgeSiteAuthorityUnavailable):
+            await repository.decide(
+                subject_id="single_user",
+                challenge_id="challenge-A",
+                decision="allow_once",
+            )
+        assert harness.resolutions == []
+        await repository.close()
+
+        queued_operation = _operation(
+            asyncio.get_running_loop(), _principal()
+        )
+        queued = _Harness(queued_operation)
+        queued_repository = queued.repository()
+        queued_repository.register_event(_notice(queued_operation.binding.principal))
+        await queued_repository.decide(
+            subject_id="single_user",
+            challenge_id="challenge-A",
+            decision="allow_once",
+        )
+        queued.selection_allowed = False
+        await asyncio.sleep(0)
+        assert queued.resolutions == []
+        with pytest.raises(BrowserBridgeSiteAuthorityUnavailable):
+            await queued_repository.decide(
+                subject_id="single_user",
+                challenge_id="challenge-A",
+                decision="allow_once",
+            )
+        await queued_repository.close()
+
+    asyncio.run(scenario())
+
+
+def test_allow_turn_is_exact_route_and_turn_bound_then_lifecycle_revoked() -> None:
+    async def scenario() -> None:
+        principal = _principal()
+        operation = _operation(asyncio.get_running_loop(), principal)
+        harness = _Harness(operation)
+        repository = harness.repository()
+        repository.register_event(_notice(principal))
+        await repository.decide(
+            subject_id="single_user",
+            challenge_id="challenge-A",
+            decision="allow_turn",
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        next_operation = _operation(
+            asyncio.get_running_loop(),
+            principal,
+            op_id="op-next",
+            action_id="action-next",
+        )
+        harness.operations[next_operation.binding.op_id] = next_operation
+        turn_grant = repository.turn_grant_for(
+            next_operation.binding,
+            origin=ORIGIN,
+        )
+        assert turn_grant is not None and turn_grant.scope == "turn"
+        grant = repository.grant_for_operation(next_operation, origin=ORIGIN)
+        assert grant is not None and grant.scope == "turn"
+        assert grant.expires_at_ms == NOW_MS + MAX_TURN_GRANT_TTL_MS
+        assert repository.grant_for_operation(
+            replace(next_operation, destination_origin="https://other.example"),
+            origin=ORIGIN,
+        ) is None
+        repository.register_event(
+            _notice(
+                principal,
+                challenge_id="challenge-B",
+                op_id="op-next",
+                action_id="action-next",
+            )
+        )
+        assert repository.list_pending(subject_id="single_user") == ()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert len(harness.resolutions) == 2
+        assert harness.resolutions[-1]["resolution"]["decision"] == "allow_turn"
+        assert harness.resolutions[-1]["resolution"]["grant"]["origin_grant_id"] == (
+            turn_grant.origin_grant_id
+        )
+        summary = repository.finalize_turn(
+            principal=principal,
+            connector_sid="sid-A",
+            load_generation_id="generation-A",
+            context_id="context-A",
+            browser_session_id="browser-session-A",
+            turn_id="turn-A",
+        )
+        assert summary.grants == 1
+        assert repository.grant_for_operation(next_operation, origin=ORIGIN) is None
+        await repository.close()
+
+    asyncio.run(scenario())
+
+
+class _Manager:
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, ...]] = []
+
+    async def emit_to(self, *args: Any, **kwargs: Any) -> None:
+        self.calls.append((*args, kwargs))
+
+
+def _challenge_event(notice: SiteChallengeNotice) -> dict[str, Any]:
+    return {
+        "contract_version": 1,
+        "event_id": "event-challenge-A",
+        "load_generation_id": notice.load_generation_id,
+        "event_sequence": 1,
+        "delivery": "critical",
+        "event_type": "challenge.required",
+        "observed_at_ms": NOW_MS,
+        "context_id": notice.context_id,
+        "browser_session_id": notice.browser_session_id,
+        "turn_id": notice.turn_id,
+        "op_id": notice.op_id,
+        "action_id": notice.action_id,
+        "data": {
+            "challenge_id": notice.challenge_id,
+            "kind": "site",
+            "origin": notice.origin,
+            "action_class": "navigate",
+            "canonical_parameter_hash": notice.canonical_parameter_hash,
+            "target_fingerprint": notice.target_fingerprint,
+            "lease_id_digest": notice.lease_id_digest,
+            "browser_id_digest": notice.browser_id_digest,
+            "document_id": notice.document_id,
+            "document_epoch": notice.document_epoch,
+            "summary": notice.summary,
+            "options": ["deny", "allow_once", "allow_turn"],
+            "expires_at_ms": notice.expires_at_ms,
+        },
+    }
+
+
+def test_critical_challenge_registration_precedes_cursor_and_persists_hashes_only() -> None:
+    async def scenario() -> None:
+        principal = _principal()
+        operation = _operation(asyncio.get_running_loop(), principal)
+        harness = _Harness(operation)
+        repository = harness.repository()
+        route = harness.current_route
+        state: list[Any] = [None]
+        manager = _Manager()
+        receiver = BrowserBridgeCriticalEventReceiver(
+            manager=manager,
+            server_instance_id=lambda: "server-A",
+            current_route_verifier=harness.route_verifier,
+            register_site_challenge=repository.register_event,
+            load=lambda: deepcopy(state[0]),
+            save=lambda value: state.__setitem__(0, deepcopy(value)),
+            ack_emit_seconds=0.1,
+        )
+        notice = _notice(principal)
+        await receiver.receive(route, _challenge_event(notice))
+        assert repository.pending_count == 1
+        assert next(iter(state[0]["routes"].values()))["cursor"] == 1
+        persisted = repr(state[0])
+        for raw in (ORIGIN, notice.summary, notice.target_fingerprint):
+            assert raw not in persisted
+        assert manager.calls[-1][2] == BROWSER_EVENT_ACK
+
+        rejected_state: list[Any] = [None]
+        rejected = BrowserBridgeCriticalEventReceiver(
+            manager=manager,
+            server_instance_id=lambda: "server-A",
+            current_route_verifier=harness.route_verifier,
+            register_site_challenge=repository.register_event,
+            load=lambda: deepcopy(rejected_state[0]),
+            save=lambda value: rejected_state.__setitem__(0, deepcopy(value)),
+            ack_emit_seconds=0.1,
+        )
+        invalid = replace(
+            _notice(
+                principal,
+                challenge_id="challenge-B",
+                op_id="op-A",
+                action_id="action-A",
+            ),
+            target_fingerprint="b" * 64,
+        )
+        invalid_event = _challenge_event(invalid)
+        invalid_event["event_id"] = "event-challenge-B"
+        with pytest.raises(BrowserBridgeEventError) as failure:
+            await rejected.receive(route, invalid_event)
+        assert failure.value.code == "EVENT_CALLBACK_FAILED"
+        assert next(iter(rejected_state[0]["routes"].values()))["cursor"] == 0
+        await repository.close()
+
+    asyncio.run(scenario())
+
+
+def test_protected_api_is_strict_no_store_and_decision_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugins._a0_connector.api import browser_bridge_site_authority as endpoint
+
+    public = {
+        "challenge_id": "challenge-A",
+        "origin": ORIGIN,
+        "action_class": "navigate",
+        "summary": f"Allow navigation to {ORIGIN}?",
+        "options": ["deny", "allow_once", "allow_turn"],
+        "expires_at_ms": NOW_MS + 60_000,
+    }
+
+    class Repository:
+        def list_pending(
+            self,
+            *,
+            subject_id: str,
+            context_id: str,
+            bridge_id: str,
+        ) -> tuple[dict[str, Any], ...]:
+            assert subject_id == "single_user"
+            assert context_id == "context-A"
+            assert bridge_id == "bridge-A"
+            return (public,)
+
+        async def decide(self, **kwargs: Any) -> Any:
+            assert kwargs == {
+                "subject_id": "single_user",
+                "challenge_id": "challenge-A",
+                "decision": "deny",
+            }
+            return SimpleNamespace(
+                as_public_dict=lambda: {
+                    "challenge_id": "challenge-A",
+                    "decision": "deny",
+                    "control_id": "control-A",
+                    "status": "accepted",
+                    "expires_at_ms": NOW_MS + 60_000,
+                }
+            )
+
+    monkeypatch.setattr(endpoint, "selected_bridge", lambda _context: None)
+    monkeypatch.setattr(
+        endpoint,
+        "get_browser_bridge_site_authority_repository",
+        lambda: pytest.fail("unselected context resolved site authority"),
+    )
+    empty = asyncio.run(
+        endpoint.BrowserBridgeSiteAuthority(None, None).process(
+            {"action": "list", "context_id": "context-missing"},
+            request=None,
+        )
+    )
+    assert json.loads(empty.get_data(as_text=True))["challenges"] == []
+    monkeypatch.setattr(
+        endpoint,
+        "get_browser_bridge_site_authority_repository",
+        lambda: Repository(),
+    )
+    monkeypatch.setattr(
+        endpoint,
+        "selected_bridge",
+        lambda context: "bridge-A" if context == "context-A" else None,
+    )
+    handler = endpoint.BrowserBridgeSiteAuthority(None, None)
+    listed = asyncio.run(
+        handler.process(
+            {"action": "list", "context_id": "context-A"}, request=None
+        )
+    )
+    listed_payload = json.loads(listed.get_data(as_text=True))
+    assert handler.requires_auth() is True and handler.requires_csrf() is True
+    assert listed.status_code == 200
+    assert listed.headers["Cache-Control"] == "no-store"
+    assert listed_payload == {
+        "contract": SITE_AUTHORITY_CONTRACT,
+        "authority_version": 1,
+        "browser_control_ready": False,
+        "challenges": [public],
+    }
+    decided = asyncio.run(
+        handler.process(
+            {
+                "action": "decide",
+                "challenge_id": "challenge-A",
+                "decision": "deny",
+            },
+            request=None,
+        )
+    )
+    assert json.loads(decided.get_data(as_text=True)) == {
+        "contract": SITE_AUTHORITY_CONTRACT,
+        "authority_version": 1,
+        "browser_control_ready": False,
+        "challenge_id": "challenge-A",
+        "decision": "deny",
+        "control_id": "control-A",
+        "status": "accepted",
+        "expires_at_ms": NOW_MS + 60_000,
+    }
+    extra = asyncio.run(
+        handler.process(
+            {
+                "action": "decide",
+                "challenge_id": "challenge-A",
+                "decision": "deny",
+                "origin": "https://attacker.example",
+            },
+            request=None,
+        )
+    )
+    assert extra.status_code == 400
+
+    raw = b'{"action":"list","action":"decide"}'
+    request = SimpleNamespace(
+        content_length=len(raw),
+        is_json=True,
+        stream=io.BytesIO(raw),
+    )
+    duplicate = asyncio.run(handler.handle_request(request))
+    assert duplicate.status_code == 400
+
+
+def test_saved_site_policy_auto_resolves_only_exact_live_navigation_and_rechecks_withdrawal():
+    async def scenario():
+        principal = _principal()
+        operation = _operation(asyncio.get_running_loop(), principal)
+        harness = _Harness(operation)
+        allowed = ["all-sites-policy-generation"]
+        repo = harness.repository(saved_origin_grant=lambda binding, origin: allowed[0])
+        repo.register_challenge(_notice(principal))
+        assert repo.list_pending(subject_id=principal.subject_id) == ()
+        await asyncio.sleep(0)
+        assert harness.resolutions[0]["resolution"]["decision"] == "allow_once"
+        assert harness.resolutions[0]["resolution"]["grant"]["origin"] == ORIGIN
+        assert harness.resolutions[0]["resolution"]["grant"]["scope"] == "operation"
+        await repo.close()
+
+        harness = _Harness(operation)
+        repo = harness.repository(saved_origin_grant=lambda binding, origin: allowed[0])
+        repo.register_challenge(_notice(principal))
+        allowed[0] = None  # Withdraw before the scheduled control dispatch.
+        await asyncio.sleep(0)
+        assert harness.resolutions == []
+        await repo.close()
+    asyncio.run(scenario())
+
+
+def test_default_repository_is_unavailable() -> None:
+    repository = BrowserBridgeSiteAuthorityRepository()
+    principal = _principal()
+    binding = OperationBinding(
+        principal,
+        "sid-A",
+        "generation-A",
+        "context-A",
+        "browser-session-A",
+        "turn-A",
+        "action-A",
+        "op-A",
+    )
+    assert repository.turn_grant_for(binding, origin=ORIGIN) is None

--- a/tests/test_browser_bridge_transport_profiles.py
+++ b/tests/test_browser_bridge_transport_profiles.py
@@ -1,0 +1,53 @@
+"""Production transport identity and retired-channel rejection."""
+from dataclasses import replace
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_transport import (
+    PRODUCTION_BROWSER_BRIDGE_TRANSPORT as PROFILE,
+    RUNTIME_REQUIRED_SCOPES,
+    RUNTIME_REQUIRED_INBOUND_EVENTS,
+    RUNTIME_REQUIRED_OUTBOUND_EVENTS,
+    require_browser_bridge_transport_profile,
+    runtime_transport_profile_for_principal,
+    transport_profile_for_principal_identity,
+)
+
+
+def principal():
+    return WsPrincipal(
+        principal_type=PROFILE.principal_type, principal_id="bridge-1",
+        subject_id="user-1", scopes=RUNTIME_REQUIRED_SCOPES,
+        handler_path=PROFILE.handler_path, handler_id=PROFILE.handler_id,
+        inbound_events=RUNTIME_REQUIRED_INBOUND_EVENTS,
+        outbound_events=RUNTIME_REQUIRED_OUTBOUND_EVENTS, key_generation=1,
+    )
+
+
+def test_only_server_owned_production_profile_is_accepted():
+    assert require_browser_bridge_transport_profile(PROFILE) is PROFILE
+    assert runtime_transport_profile_for_principal(principal()) is PROFILE
+    for forged in (replace(PROFILE), "production", None,
+                   replace(PROFILE, profile_id="local-development")):
+        with pytest.raises(ValueError):
+            require_browser_bridge_transport_profile(forged)
+
+
+def test_retired_development_identity_is_rejected_even_with_full_scopes():
+    retired = replace(principal(), principal_type="browser_bridge_development",
+        handler_path="plugins/_a0_connector/ws_browser_development",
+        handler_id="ws_browser_development.WsBrowserDevelopment")
+    for validate in (transport_profile_for_principal_identity,
+                     runtime_transport_profile_for_principal):
+        with pytest.raises(ValueError):
+            validate(retired)
+
+
+def test_identity_alone_does_not_grant_runtime_capabilities():
+    incomplete = replace(principal(), scopes=frozenset({"bridge.connect"}),
+                         inbound_events=frozenset({"connector_hello"}),
+                         outbound_events=frozenset())
+    assert transport_profile_for_principal_identity(incomplete) is PROFILE
+    with pytest.raises(ValueError):
+        runtime_transport_profile_for_principal(incomplete)

--- a/tests/test_browser_bridge_ws_bootstrap.py
+++ b/tests/test_browser_bridge_ws_bootstrap.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+import importlib.util
+from pathlib import Path
+import sys
+import threading
+from typing import Any, Iterator
+from contextlib import contextmanager
+
+from plugins._a0_connector.helpers.browser_bridge_application import (
+    BrowserBridgeApplication,
+)
+from plugins._a0_connector.helpers.browser_bridge_bootstrap import (
+    admitted_hello_projection,
+    bind_browser_bridge_application,
+    browser_bridge_principal_events,
+    get_browser_bridge_application,
+    retire_browser_bridge_application,
+)
+from plugins._a0_connector.helpers.browser_bridge_runtime import (
+    EXPECTED_LIMITS,
+    REQUIRED_INBOUND_EVENTS,
+    REQUIRED_OUTBOUND_EVENTS,
+)
+from plugins._browser.helpers.extension_sessions import (
+    ExtensionSessionLifecycle,
+    ExtensionSessionRegistry,
+)
+from test_browser_bridge_runtime_foundation import (
+    EXTENSION_ID,
+    _active,
+    _admission,
+    _hello,
+    _principal,
+)
+
+
+class _Memory:
+    def __init__(self) -> None:
+        self.value: Any = None
+
+    def load(self) -> Any:
+        return deepcopy(self.value)
+
+    def save(self, value: Any) -> None:
+        self.value = deepcopy(value)
+
+
+class _Manager:
+    def __init__(self, principal: Any) -> None:
+        self.principal = principal
+        self.emitted: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def principal_for_sid(self, _namespace: str, _sid: str) -> Any:
+        return self.principal
+
+    async def emit_to(self, *args: Any, **kwargs: Any) -> None:
+        self.emitted.append((args, kwargs))
+
+
+@contextmanager
+def _loaded_connector() -> Iterator[type]:
+    path = (
+        Path(__file__).parents[1]
+        / "plugins"
+        / "_a0_connector"
+        / "api"
+        / "ws_connector.py"
+    )
+    previous = sys.modules.pop("ws_connector", None)
+    spec = importlib.util.spec_from_file_location("ws_connector", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["ws_connector"] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module.WsConnector
+    finally:
+        sys.modules.pop("ws_connector", None)
+        if previous is not None:
+            sys.modules["ws_connector"] = previous
+
+
+def _application(manager: _Manager) -> BrowserBridgeApplication:
+    memory = _Memory()
+    return BrowserBridgeApplication(
+        manager=manager,
+        server_instance_id=lambda: "server-A",
+        lifecycle=ExtensionSessionLifecycle(
+            registry=ExtensionSessionRegistry(persistence=memory)
+        ),
+        active_principal_verifier=_active,
+        admission_evaluator=_admission,
+        context_authorizer=lambda _route, context_id: context_id == "context-A",
+    )
+
+
+def test_bootstrap_default_is_hello_only_and_explicit_binding_is_bounded() -> None:
+    async def scenario() -> None:
+        bind_browser_bridge_application(None)
+        assert get_browser_bridge_application() is None
+        assert browser_bridge_principal_events() == (
+            frozenset({"connector_hello"}),
+            frozenset(),
+        )
+
+        principal = _principal()
+        application = _application(_Manager(principal))
+        try:
+            bind_browser_bridge_application(application)
+        except RuntimeError as error:
+            assert "not installed" in str(error)
+        else:
+            raise AssertionError("uninstalled application was bound")
+        application.install()
+        bind_browser_bridge_application(application)
+        assert get_browser_bridge_application() is application
+        assert browser_bridge_principal_events() == (
+            REQUIRED_INBOUND_EVENTS,
+            REQUIRED_OUTBOUND_EVENTS,
+        )
+        try:
+            await application.close()
+        except RuntimeError as error:
+            assert "retire" in str(error)
+        else:
+            raise AssertionError("bound application bypassed explicit retirement")
+        try:
+            bind_browser_bridge_application(None)
+        except RuntimeError as error:
+            assert "retire" in str(error)
+        else:
+            raise AssertionError("installed owner was cleared without retirement")
+        assert await retire_browser_bridge_application(application)
+        assert get_browser_bridge_application() is None
+
+    asyncio.run(scenario())
+
+
+def test_handler_registers_exact_hello_and_returns_full_authenticated_route() -> None:
+    async def scenario() -> None:
+        principal = _principal()
+        manager = _Manager(principal)
+        application = _application(manager)
+        application.install()
+        bind_browser_bridge_application(application)
+        try:
+            with _loaded_connector() as WsConnector:
+                WsConnector.principal_is_active = classmethod(
+                    lambda _cls, candidate: candidate is principal
+                )
+                connector = WsConnector(
+                    None,
+                    threading.RLock(),
+                    manager=manager,
+                )
+                connector._principal = principal
+                connector._principal_sid = "sid-A"
+                transport_data = {**_hello(principal), "correlationId": "hello-transport-1"}
+                response = await connector.process(
+                    "connector_hello",
+                    transport_data,
+                    "sid-A",
+                )
+                assert transport_data["correlationId"] == "hello-transport-1"
+                route = application.registry.current_sid_route(principal, "sid-A")
+                assert route is not None
+                assert response == admitted_hello_projection(route)
+                assert response == {
+                    "protocol": "a0-connector.v1",
+                    "principal_type": "browser_bridge",
+                    "features": [
+                        "browser_extension_bridge_v1",
+                        "connector_browser_artifact_chunks",
+                        "connector_browser_control",
+                        "connector_browser_event",
+                    ],
+                    "connector_session_ready": True,
+                    "browser_control_ready": True,
+                    "activation": {
+                        "principal": "browser_bridge",
+                        "bridge_id": "bridge-A",
+                        "key_generation": 1,
+                        "extension_id": EXTENSION_ID,
+                        "install_instance_id": "install-A",
+                        "server_features": [
+                            "browser_extension_bridge_v1",
+                            "connector_browser_artifact_chunks",
+                            "connector_browser_control",
+                            "connector_browser_event",
+                        ],
+                        "rollout": "preview_authorized",
+                        "selected_bridge": True,
+                        "heartbeat_fresh": True,
+                        "subject_profile_bound": True,
+                        "legacy_control_plane_inactive": True,
+                    },
+                    "connector_binding": {
+                        "server_instance_id": "server-A",
+                        "bridge_id": "bridge-A",
+                        "connector_sid": "sid-A",
+                        "key_generation": 1,
+                        "load_generation_id": "generation-A",
+                    },
+                    "host_browser": {
+                        "supported": True,
+                        "enabled": True,
+                        "status": "ready",
+                        "backend_id": "chrome_extension",
+                        "browser_id": "extension:bridge-A",
+                        "browser_label": "Chrome - Agent Zero Extension",
+                        "contract_version": 1,
+                        "features": ["browser_extension_bridge_v1"],
+                        "capabilities": {
+                            "actions": ["list", "navigate", "open", "state"],
+                            "features": ["cursor_v1", "tab_leases_v1"],
+                            "limits": dict(EXPECTED_LIMITS),
+                        },
+                        "extension": {
+                            "version": "0.2.0",
+                            "manifest_version": 3,
+                            "load_generation_id": "generation-A",
+                        },
+                        "companion": {
+                            "version": "2.12.0",
+                            "platform": "darwin",
+                            "arch": "arm64",
+                        },
+                    },
+                }
+                serialized = repr(response)
+                for forbidden in (
+                    "single_user",
+                    "companion-bridge-A",
+                    "exec_config",
+                    "remote_files",
+                    "public_key",
+                ):
+                    assert forbidden not in serialized
+
+                # Only framework metadata is stripped; arbitrary document
+                # fields still reach (and are rejected by) strict decoders.
+                invalid = await connector.process("connector_hello", {
+                    **transport_data, "unexpected_authority": True,
+                }, "sid-A")
+                assert invalid.as_result(handler_id=connector.identifier,
+                    fallback_correlation_id="hello-transport-2")["error"]["code"] == "INVALID_HELLO"
+
+                forwarded = []
+                async def capture_dispatch(candidate, sid, event, document):
+                    forwarded.append((candidate, sid, event, document))
+                    return {"accepted": True}
+                application.dispatch = capture_dispatch
+                operation = {"contract_version": 1, "correlationId": "op-transport-1", "unknown": True}
+                await connector.process("connector_browser_op_result", operation, "sid-A")
+                assert forwarded == [(principal, "sid-A", "connector_browser_op_result",
+                    {"contract_version": 1, "unknown": True})]
+                assert operation["correlationId"] == "op-transport-1"
+                del application.dispatch
+
+                second = WsConnector(
+                    None,
+                    threading.RLock(),
+                    manager=manager,
+                )
+                second._principal = principal
+                second._principal_sid = "sid-unadmitted"
+                denied = await second.process(
+                    "connector_browser_op_result",
+                    {"contract_version": 1},
+                    "sid-unadmitted",
+                )
+                projected = denied.as_result(
+                    handler_id=second.identifier,
+                    fallback_correlation_id=None,
+                )
+                assert projected["ok"] is False
+                assert projected["error"] == {
+                    "code": "RUNTIME_NOT_ADMITTED",
+                    "error": "Browser bridge request rejected",
+                }
+
+                await connector.on_disconnect("sid-A")
+                assert application.registry.session_count == 0
+        finally:
+            await retire_browser_bridge_application(application)
+
+    asyncio.run(scenario())
+
+
+def test_handler_never_routes_restricted_event_into_legacy_when_owner_disappears() -> None:
+    async def scenario() -> None:
+        principal = _principal()
+        manager = _Manager(principal)
+        bind_browser_bridge_application(None)
+        with _loaded_connector() as WsConnector:
+            WsConnector.principal_is_active = classmethod(
+                lambda _cls, candidate: candidate is principal
+            )
+            connector = WsConnector(None, threading.RLock(), manager=manager)
+            connector._principal = principal
+            connector._principal_sid = "sid-A"
+
+            def legacy_result(*_args: Any, **_kwargs: Any) -> None:
+                raise AssertionError("restricted event reached legacy handler")
+
+            connector._handle_browser_op_result = legacy_result
+            denied = await connector.process(
+                "connector_browser_op_result",
+                {"contract_version": 1},
+                "sid-A",
+            )
+            projected = denied.as_result(
+                handler_id=connector.identifier,
+                fallback_correlation_id=None,
+            )
+            assert projected["error"]["code"] == "RUNTIME_NOT_ADMITTED"
+
+    asyncio.run(scenario())

--- a/tests/test_browser_companion_release_metadata.py
+++ b/tests/test_browser_companion_release_metadata.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import sys
+from contextlib import contextmanager
+from types import ModuleType
+
+import pytest
+
+from plugins._a0_connector.helpers.browser_companion_release import (
+    CATALOG_KEY_FINGERPRINT_ENV,
+    CATALOG_URL_ENV,
+    INSTALL_CONTRACT,
+    RELEASE_METADATA_CONTRACT,
+    RELEASE_METADATA_ENV,
+    SERVER_MINIMUM_SECURE_COMPANION,
+    browser_companion_release_status,
+)
+
+
+def _artifact(platform: str, arch: str, kind: str) -> dict[str, object]:
+    suffix = {
+        ("macos", "installer"): ".dmg",
+        ("windows", "installer"): ".exe",
+        ("linux", "bootstrap"): ".sh",
+    }.get((platform, kind), ".tar.gz")
+    name = f"a0-browser-bridge-{platform}-{arch}-{kind}{suffix}"
+    return {
+        "name": name,
+        "platform": platform,
+        "arch": arch,
+        "kind": kind,
+        "download_url": f"https://releases.example.test/v2.12.0/{name}",
+        "sha256": "ab" * 32,
+        "size": 1_234_567,
+    }
+
+
+def _document() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "release": "2.12.0",
+        "channel": "stable",
+        "published_at": "2026-09-04T00:00:00Z",
+        "protocol": {"min": 1, "max": 1},
+        "trust": {"min": 1, "max": 1},
+        "minimum_secure_companion": "2.12.0",
+        "catalog_signature_url": "https://releases.example.test/v2.12.0/catalog.sig",
+        "release_key_id": "release-root-2026",
+        "artifacts": [
+            _artifact("macos", "universal2", "installer"),
+            _artifact("macos", "universal2", "payload"),
+            _artifact("windows", "x86_64", "installer"),
+            _artifact("windows", "x86_64", "payload"),
+            _artifact("windows", "arm64", "installer"),
+            _artifact("windows", "arm64", "payload"),
+            _artifact("linux", "any", "bootstrap"),
+            _artifact("linux", "x86_64", "payload"),
+            _artifact("linux", "aarch64", "payload"),
+        ],
+    }
+
+
+def _environment(document: dict[str, object] | None = None) -> dict[str, str]:
+    return {
+        CATALOG_URL_ENV: "https://releases.example.test/v2.12.0/catalog.json",
+        CATALOG_KEY_FINGERPRINT_ENV: f"sha256:{'cd' * 32}",
+        RELEASE_METADATA_ENV: json.dumps(document or _document()),
+    }
+
+
+def test_release_metadata_is_unavailable_and_host_targeted_by_default() -> None:
+    status = browser_companion_release_status(environ={})
+
+    assert status["ok"] is False
+    assert status["contract"] == RELEASE_METADATA_CONTRACT
+    assert status["install_contract"] == INSTALL_CONTRACT
+    assert status["install_ready"] is False
+    assert status["state"] == "unavailable"
+    assert status["catalog"] is None
+    assert status["release"] is None
+    assert status["artifacts"] == []
+    assert status["delivery"]["target"] == "browser_host"
+    assert status["delivery"]["docker_container_install"] is False
+    assert status["verification"] == {
+        "server_validation": "metadata_shape_and_compatibility_only",
+        "catalog_signature_verified": False,
+        "artifact_verified": False,
+        "host_verification_required": True,
+    }
+
+
+def test_scoped_v2_metadata_requires_exact_complete_declared_platform_groups() -> None:
+    document = _document()
+    document.update(schema_version=2, platforms=["macos"])
+    document["artifacts"] = document["artifacts"][:2]
+    status = browser_companion_release_status(environ=_environment(document))
+    assert status["state"] == "available"
+    assert len(status["artifacts"]) == 2
+    assert status["install_ready"] is False
+    assert status["verification"]["catalog_signature_verified"] is False
+    for platforms in ([], ["macos", "macos"], ["windows", "macos"], ["android"], ["macos", "windows"], [True]):
+        invalid = {**document, "platforms": platforms}
+        assert browser_companion_release_status(environ=_environment(invalid))["state"] == "unavailable"
+
+
+def test_setup_projection_requires_enabled_server_and_keeps_os_links_exact():
+    from plugins._a0_connector.helpers.browser_bridge_setup import browser_bridge_setup_status
+    document = _document()
+    document.update(schema_version=2, platforms=["macos"])
+    document["artifacts"] = document["artifacts"][:2]
+    environment = _environment(document)
+    environment["A0_BROWSER_BRIDGE_EXTENSION_ID"] = "a" * 32
+    assert browser_bridge_setup_status(environ=environment)["installers"] == []
+    environment["A0_BROWSER_BRIDGE_ROLLOUT"] = "available"
+    setup = browser_bridge_setup_status(environ=environment)
+    assert setup["browser_control_ready"] is False
+    assert setup["host_verification_required"] is True
+    assert setup["install_target"] == "browser_host"
+    assert setup["extension_url"] == "https://chromewebstore.google.com/detail/" + "a" * 32
+    assert setup["installers"] == [{"platform": "macos", "arch": "universal2", "url": document["artifacts"][0]["download_url"]}]
+    for invalid in (
+        {**document, "schema_version": 1},
+        {**document, "artifacts": document["artifacts"][:1]},
+        {**document, "artifacts": document["artifacts"] + [_artifact("linux", "any", "bootstrap")]},
+    ):
+        assert browser_companion_release_status(environ=_environment(invalid))["state"] == "unavailable"
+
+
+def test_complete_compatible_metadata_projects_only_public_release_fields() -> None:
+    status = browser_companion_release_status(environ=_environment())
+
+    assert status["ok"] is True
+    assert status["state"] == "available"
+    assert status["contract"] == RELEASE_METADATA_CONTRACT
+    assert status["install_contract"] == INSTALL_CONTRACT
+    assert status["install_ready"] is False
+    assert status["compatibility"]["compatible"] is True
+    assert (
+        status["compatibility"]["server_minimum_secure_companion"]
+        == SERVER_MINIMUM_SECURE_COMPANION
+    )
+    assert "verified release" not in status["message"].lower()
+    assert status["verification"]["host_verification_required"] is True
+    assert status["verification"]["catalog_signature_verified"] is False
+    assert status["release"] == {
+        "version": "2.12.0",
+        "channel": "stable",
+        "published_at": "2026-09-04T00:00:00Z",
+        "minimum_secure_companion": "2.12.0",
+        "effective_minimum_secure_companion": SERVER_MINIMUM_SECURE_COMPANION,
+    }
+    assert len(status["artifacts"]) == 9
+    assert all(item["download_url"].startswith("https://") for item in status["artifacts"])
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda document: document.update({"extension_origins": ["chrome-extension://secret/"]}),
+        lambda document: document.update({"native_host_path": "/Users/private/bridge"}),
+        lambda document: document["artifacts"][0].update(
+            {"download_url": "https://token@example.test/file.bin"}
+        ),
+        lambda document: document.update({"protocol": {"min": 2, "max": 2}}),
+        lambda document: document.update({"minimum_secure_companion": "2.13.0"}),
+        lambda document: document["artifacts"].pop(),
+    ],
+)
+def test_untrusted_or_incompatible_metadata_fails_closed_without_echo(
+    mutate,
+) -> None:
+    document = _document()
+    mutate(document)
+    secret = "sentinel-server-credential"
+    private_key = "sentinel-release-signing-private-key"
+    environment = _environment(document)
+    environment["UNRELATED_SECRET"] = secret
+    environment["A0_BROWSER_COMPANION_SIGNING_PRIVATE_KEY"] = private_key
+
+    status = browser_companion_release_status(environ=environment)
+    serialized = json.dumps(status, sort_keys=True)
+
+    assert status["state"] == "unavailable"
+    assert status["catalog"] is None
+    assert status["release"] is None
+    assert status["artifacts"] == []
+    assert secret not in serialized
+    assert private_key not in serialized
+    assert "chrome-extension://" not in serialized
+    assert "/Users/private" not in serialized
+    assert "token@" not in serialized
+
+
+@pytest.mark.parametrize(
+    "environment_update",
+    [
+        {CATALOG_URL_ENV: "https://latest.example.test/catalog.json?token=secret"},
+        {CATALOG_URL_ENV: "https://releases.example.test/catalog.json?"},
+        {CATALOG_URL_ENV: "https://releases.example.test/catalog.json#"},
+        {CATALOG_URL_ENV: "https://releases.example.test\\ambiguous/catalog.json"},
+        {CATALOG_URL_ENV: "https://releases.example.test/%0a/catalog.json"},
+        {CATALOG_URL_ENV: "https://releases.example.test/%2f/catalog.json"},
+        {CATALOG_URL_ENV: "https://releases.example.test/%2e%2e/catalog.json"},
+        {CATALOG_URL_ENV: "https://releases.example.test//ambiguous/catalog.json"},
+        {CATALOG_URL_ENV: "https://.example.test/catalog.json"},
+        {CATALOG_URL_ENV: "https://releases.example.test:/catalog.json"},
+        {CATALOG_URL_ENV: "https://127.1/catalog.json"},
+        {CATALOG_URL_ENV: " https://releases.example.test/catalog.json"},
+        {CATALOG_URL_ENV: "https://releases.exämple/catalog.json"},
+        {CATALOG_KEY_FINGERPRINT_ENV: "sha256:not-a-release-root"},
+        {RELEASE_METADATA_ENV: "{"},
+    ],
+)
+def test_invalid_pinned_configuration_fails_closed(
+    environment_update: dict[str, str],
+) -> None:
+    environment = _environment()
+    environment.update(environment_update)
+
+    status = browser_companion_release_status(environ=environment)
+
+    assert status["ok"] is False
+    assert status["state"] == "unavailable"
+    assert status["reason_code"] == "browser_companion_release_invalid"
+    assert status["catalog"] is None
+    assert status["artifacts"] == []
+    assert "token=secret" not in json.dumps(status, sort_keys=True)
+
+
+def test_duplicate_json_fields_fail_closed() -> None:
+    raw_metadata = json.dumps(_document()).replace(
+        '"schema_version": 1,',
+        '"schema_version": 2, "schema_version": 1,',
+        1,
+    )
+    environment = _environment()
+    environment[RELEASE_METADATA_ENV] = raw_metadata
+
+    status = browser_companion_release_status(environ=environment)
+
+    assert status["state"] == "unavailable"
+    assert status["reason_code"] == "browser_companion_release_invalid"
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda document: document.update({"schema_version": True}),
+        lambda document: document.update({"release": 212}),
+        lambda document: document.update({"release_key_id": 2026}),
+        lambda document: document["artifacts"][0].update({"name": 123}),
+    ],
+)
+def test_metadata_rejects_json_values_with_the_wrong_scalar_type(mutate) -> None:
+    document = _document()
+    mutate(document)
+
+    status = browser_companion_release_status(environ=_environment(document))
+
+    assert status["ok"] is False
+    assert status["state"] == "unavailable"
+    assert status["reason_code"] == "browser_companion_release_invalid"
+
+
+def test_release_below_server_security_floor_is_incompatible() -> None:
+    document = _document()
+    document["release"] = "2.11.0"
+    document["minimum_secure_companion"] = "2.11.0"
+
+    status = browser_companion_release_status(environ=_environment(document))
+
+    assert status["state"] == "unavailable"
+    assert status["reason_code"] == "browser_companion_release_incompatible"
+    assert status["compatibility"]["server_minimum_secure_companion"] == "2.12.0"
+    assert status["release"] is None
+
+
+def test_server_security_floor_cannot_be_lowered_by_metadata() -> None:
+    document = _document()
+    document["minimum_secure_companion"] = "2.11.0"
+
+    status = browser_companion_release_status(environ=_environment(document))
+
+    assert status["state"] == "available"
+    assert status["release"]["minimum_secure_companion"] == "2.11.0"
+    assert status["release"]["effective_minimum_secure_companion"] == "2.12.0"
+
+
+@contextmanager
+def _load_endpoint_module(monkeypatch: pytest.MonkeyPatch):
+    class FakeApiHandler:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        @classmethod
+        def requires_auth(cls) -> bool:
+            return True
+
+        @classmethod
+        def requires_csrf(cls) -> bool:
+            return cls.requires_auth()
+
+    class FakeResponse:
+        def __init__(self, *, response: str, status: int, mimetype: str) -> None:
+            self.response = response
+            self.status = status
+            self.mimetype = mimetype
+
+    api_stub = ModuleType("helpers.api")
+    api_stub.ApiHandler = FakeApiHandler
+    api_stub.Request = object
+    api_stub.Response = FakeResponse
+    module_name = "plugins._a0_connector.api.v1.browser_companion_release"
+    previous = sys.modules.pop(module_name, None)
+    try:
+        with monkeypatch.context() as context:
+            context.setitem(sys.modules, "helpers.api", api_stub)
+            yield importlib.import_module(module_name)
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous is not None:
+            sys.modules[module_name] = previous
+
+
+def test_endpoint_is_authenticated_csrf_protected_and_rejects_request_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _load_endpoint_module(monkeypatch) as endpoint:
+        handler = endpoint.BrowserCompanionRelease(None, None)
+        assert handler.requires_auth() is True
+        assert handler.requires_csrf() is True
+
+        response = asyncio.run(
+            handler.process(
+                {"download_url": "https://page.example.test/untrusted.bin"},
+                request=None,
+            )
+        )
+
+    assert response.status == 400
+    assert "request_body_not_supported" in response.response
+    assert "page.example.test" not in response.response
+
+
+def test_endpoint_returns_server_projection_without_request_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _load_endpoint_module(monkeypatch) as endpoint:
+        expected = {"state": "unavailable", "source": "server"}
+        monkeypatch.setattr(
+            endpoint,
+            "browser_companion_release_status",
+            lambda: expected,
+        )
+        response = asyncio.run(handler_process(endpoint, {}))
+
+    assert response is expected
+
+
+def test_endpoint_rejects_non_json_request_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = type(
+        "Request",
+        (),
+        {
+            "is_json": False,
+            "content_length": 22,
+            "data": b"download_url=untrusted",
+        },
+    )()
+    with _load_endpoint_module(monkeypatch) as endpoint:
+        response = asyncio.run(handler_process(endpoint, {}, request=request))
+
+    assert response.status == 400
+    assert "request_body_not_supported" in response.response
+
+
+def test_endpoint_rejects_malformed_application_json_request_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = type(
+        "Request",
+        (),
+        {
+            "is_json": True,
+            "content_length": 1,
+            "data": b"{",
+        },
+    )()
+    with _load_endpoint_module(monkeypatch) as endpoint:
+        response = asyncio.run(handler_process(endpoint, {}, request=request))
+
+    assert response.status == 400
+    assert "request_body_not_supported" in response.response
+
+
+def test_endpoint_accepts_only_a_parsed_empty_json_object_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = type(
+        "Request",
+        (),
+        {
+            "is_json": True,
+            "content_length": 5,
+            "data": b" {} \n",
+        },
+    )()
+    with _load_endpoint_module(monkeypatch) as endpoint:
+        expected = {"state": "unavailable", "source": "server"}
+        monkeypatch.setattr(endpoint, "browser_companion_release_status", lambda: expected)
+        response = asyncio.run(handler_process(endpoint, {}, request=request))
+
+    assert response is expected
+
+
+
+
+async def handler_process(endpoint, payload: dict[str, object], *, request=None):
+    handler = endpoint.BrowserCompanionRelease(None, None)
+    return await handler.process(payload, request=request)

--- a/tests/test_browser_extension_first_open.py
+++ b/tests/test_browser_extension_first_open.py
@@ -1,0 +1,214 @@
+"""First-open decisions are server-owned and never native challenge receipts."""
+import asyncio
+from dataclasses import replace
+import json
+
+import pytest
+
+from plugins._browser.helpers.extension_first_open import FirstOpenSiteAuthority, FirstOpenDenied
+from plugins._browser.helpers.extension_leases import ExtensionLeaseIndex
+from plugins._browser.helpers.extension_runtime import ExtensionBrowserRuntime, ExtensionBrowserError
+from plugins._a0_connector.helpers.browser_bridge_operations import BrowserBridgeOperationBroker
+from test_browser_extension_runtime import _fixture, _authorize
+
+
+def test_first_open_waits_for_explicit_choice_then_once_covers_only_resulting_lease():
+    async def scenario():
+        binding, policy = _fixture()
+        authority = FirstOpenSiteAuthority()
+        live = [True]
+        current = lambda _binding: live[0]
+        leases = ExtensionLeaseIndex(authorizer=current)
+        sent = []
+        active = [binding]
+
+        async def sender(sid, event, payload, correlation, principal):
+            sent.append(payload)
+            keys = ("contract_version", "bridge_id", "load_generation_id", "context_id", "browser_session_id", "turn_id", "op_id", "action_id")
+            result = {"browser_id": "tab-1", "tab_handle": "tab-1", "lease_id": "lease-1",
+                      "origin": "https://example.com", "disposition": "ephemeral"} if payload["action"] == "open" else {}
+            broker.settle_operation(principal=principal, connector_sid=sid, load_generation_id="load-1",
+                payload={**{key: payload[key] for key in keys}, "ok": True, "result": result, "receipts": [], "artifacts": []})
+
+        def observe(bound, call, result):
+            if call.action == "open":
+                leases.observe_open(bound, result, call.origin)
+                authority.observe_open(bound, call.origin, result)
+
+        broker = BrowserBridgeOperationBroker(sender=sender, authorizer=_authorize)
+        runtime = ExtensionBrowserRuntime("context-1", "bridge-1", broker=broker,
+            binding_factory=lambda: active[0], policy_repository=policy, server_instance_id="server-1",
+            target_origin_resolver=leases.origin_for, binding_current=current, result_observer=observe,
+            first_open_authority=authority)
+        task = asyncio.create_task(runtime.call("open", "https://example.com/private?secret=canary"))
+        await asyncio.sleep(0)
+        pending = authority.list_pending(subject_id="single-user", context_id="context-1", bridge_id="bridge-1")
+        assert len(pending) == 1 and pending[0]["action_class"] == "open" and sent == []
+        assert "secret" not in json.dumps(pending)
+        authority.decide(subject_id="single-user", challenge_id=pending[0]["challenge_id"], decision="allow_once")
+        assert (await task)["tab_handle"] == "tab-1"
+        assert sent[0]["policy"]["origin_grant_id"].startswith("open-grant-")
+        assert policy.active_grant(server_instance_id="server-1", bridge_id="bridge-1", subject_id="single-user", origin="https://example.com") is None
+        active[0] = replace(binding, op_id="op-2", action_id="action-2")
+        assert await runtime.call("state", "tab-1") == {}
+        assert authority.grant_for(active[0], "https://example.com") is None
+        assert authority.grant_for(active[0], "https://example.com", "foreign-tab") is None
+        assert authority.grant_for(replace(active[0], turn_id="another-turn"), "https://example.com", "tab-1") is None
+        with pytest.raises(ExtensionBrowserError, match="TAB_NOT_OWNED"):
+            await runtime.call("state", "foreign-tab")
+        second = asyncio.create_task(runtime.call("open", "https://example.com/second"))
+        await asyncio.sleep(0)
+        assert len(sent) == 2
+        authority.retire()
+        with pytest.raises(ExtensionBrowserError, match="APPROVAL_DENIED"):
+            await second
+    asyncio.run(scenario())
+
+
+def test_all_websites_bypasses_only_site_prompt_not_action_approval():
+    async def scenario():
+        binding, policy = _fixture()
+        policy.set_site_mode(server_instance_id="server-1", bridge_id="bridge-1",
+            subject_id="single-user", site_mode="allow_all_websites")
+        authority = FirstOpenSiteAuthority()
+        sent = []
+        active = [binding]
+        async def sender(sid, event, payload, correlation, principal):
+            sent.append(payload)
+            keys = ("contract_version", "bridge_id", "load_generation_id", "context_id", "browser_session_id", "turn_id", "op_id", "action_id")
+            broker.settle_operation(principal=principal, connector_sid=sid, load_generation_id="load-1",
+                payload={**{key: payload[key] for key in keys}, "ok": True, "result": {}, "receipts": [], "artifacts": []})
+        broker = BrowserBridgeOperationBroker(sender=sender, authorizer=_authorize)
+        runtime = ExtensionBrowserRuntime("context-1", "bridge-1", broker=broker,
+            binding_factory=lambda: active[0], policy_repository=policy, server_instance_id="server-1",
+            target_origin_resolver=lambda binding, handle: "https://one.example",
+            binding_current=lambda binding: True, first_open_authority=authority)
+        await runtime.call("open", "https://one.example/private")
+        active[0] = replace(binding, op_id="second", action_id="second", turn_id="second-turn")
+        await runtime.call("open", "https://two.example/private")
+        assert len(sent) == 2 and authority.list_pending(subject_id="single-user", context_id="context-1", bridge_id="bridge-1") == ()
+        assert sent[0]["policy"]["origin_grant_id"] != sent[1]["policy"]["origin_grant_id"]
+        with pytest.raises(ExtensionBrowserError, match="APPROVAL_REQUIRED"):
+            await runtime.call("click", "tab-1", "ref-1")
+        assert len(sent) == 2
+    asyncio.run(scenario())
+
+
+def test_first_open_turn_scope_denial_staleness_expiry_and_cancellation():
+    async def scenario():
+        binding, _ = _fixture()
+        now = [1000]
+        current = [True]
+        authority = FirstOpenSiteAuthority(clock_ms=lambda: now[0])
+        def pending():
+            return authority.list_pending(subject_id="single-user", context_id="context-1", bridge_id="bridge-1")
+        async def begin():
+            task = asyncio.create_task(authority.request(binding, "https://example.com", current=lambda b: current[0]))
+            await asyncio.sleep(0)
+            return task, pending()[0]["challenge_id"]
+        task, challenge = await begin()
+        with pytest.raises(FirstOpenDenied):
+            authority.decide(subject_id="other-subject", challenge_id=challenge, decision="allow_turn")
+        authority.decide(subject_id="single-user", challenge_id=challenge, decision="allow_turn")
+        grant = await task
+        assert authority.grant_for(replace(binding, op_id="next-op"), "https://example.com") == grant
+        for field in ("connector_sid", "load_generation_id", "context_id", "browser_session_id", "turn_id"):
+            assert authority.grant_for(replace(binding, **{field: "different"}), "https://example.com") is None
+        assert authority.grant_for(replace(binding, principal=replace(binding.principal)), "https://example.com") is None
+        assert authority.grant_for(binding, "https://elsewhere.example") is None
+        current[0] = False
+        assert authority.grant_for(binding, "https://example.com") is None
+        current[0] = True
+        task, challenge = await begin()
+        authority.decide(subject_id="single-user", challenge_id=challenge, decision="deny")
+        with pytest.raises(FirstOpenDenied):
+            await task
+        task, challenge = await begin()
+        now[0] += 120_000
+        assert pending() == ()
+        with pytest.raises(FirstOpenDenied):
+            await task
+        task, challenge = await begin()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert pending() == ()
+    asyncio.run(scenario())
+
+
+def test_protected_api_lists_and_decides_server_open_without_native_receipt(monkeypatch):
+    from plugins._a0_connector.api import browser_bridge_site_authority as endpoint
+    from types import SimpleNamespace
+    async def scenario():
+        binding, policy = _fixture()
+        binding = replace(binding, principal=replace(binding.principal, subject_id=endpoint.SUBJECT_ID))
+        authority = FirstOpenSiteAuthority(policy_repository=policy, server_instance_id="server-1")
+        monkeypatch.setattr(endpoint, "selected_bridge", lambda context: "bridge-1")
+        monkeypatch.setattr(endpoint, "current_first_open_authority", lambda: authority)
+        monkeypatch.setattr(endpoint, "get_browser_bridge_site_authority_repository", lambda: SimpleNamespace(list_pending=lambda **kw: ()))
+        task = asyncio.create_task(authority.request(binding, "https://example.com", current=lambda b: True))
+        await asyncio.sleep(0)
+        handler = object.__new__(endpoint.BrowserBridgeSiteAuthority)
+        response = await handler._dispatch({"action": "list", "context_id": "context-1"})
+        assert response.headers["Cache-Control"] == "no-store"
+        listed = json.loads(response.get_data())
+        challenge = listed["challenges"][0]
+        assert challenge["action_class"] == "open" and listed["browser_control_ready"] is False
+        rejected = await handler._dispatch({"action": "decide", "challenge_id": "native-challenge", "decision": "allow_site"})
+        assert rejected.status_code == 400
+        response = await handler._dispatch({"action": "decide", "challenge_id": challenge["challenge_id"], "decision": "allow_site"})
+        assert response.status_code == 200
+        assert json.loads(response.get_data())["control_id"].startswith("open-decision-")
+        saved = policy.active_grant(server_instance_id="server-1", bridge_id="bridge-1", subject_id=endpoint.SUBJECT_ID, origin="https://example.com")
+        assert await task == saved.grant_id
+    asyncio.run(scenario())
+
+
+def test_remember_persists_exact_origin_before_waking_and_survives_turn_retirement():
+    async def scenario():
+        binding, policy = _fixture()
+        authority = FirstOpenSiteAuthority(policy_repository=policy, server_instance_id="server-1")
+        task = asyncio.create_task(authority.request(binding, "https://example.com", current=lambda b: True))
+        await asyncio.sleep(0)
+        prompt = authority.list_pending(subject_id="single-user", context_id="context-1", bridge_id="bridge-1")[0]
+        assert prompt["options"] == ["deny", "allow_once", "allow_turn", "allow_site"]
+        original_save = policy._save
+        def save(value):
+            assert not task.done()
+            original_save(value)
+        policy._save = save
+        authority.decide(subject_id="single-user", challenge_id=prompt["challenge_id"], decision="allow_site")
+        saved = policy.active_grant(server_instance_id="server-1", bridge_id="bridge-1", subject_id="single-user", origin="https://example.com")
+        assert saved is not None and await task == saved.grant_id
+        authority.retire()
+        # The next chat/turn reads the normal durable policy, not a stale request.
+        assert policy.active_grant(server_instance_id="server-1", bridge_id="bridge-1", subject_id="single-user", origin="https://example.com") == saved
+        for override in ({"origin": "https://sub.example.com"}, {"bridge_id": "other-bridge"}, {"subject_id": "other-subject"}, {"server_instance_id": "other-server"}):
+            scope = dict(server_instance_id="server-1", bridge_id="bridge-1", subject_id="single-user", origin="https://example.com")
+            assert policy.active_grant(**(scope | override)) is None
+    asyncio.run(scenario())
+
+
+def test_remember_save_failure_or_stale_selection_never_releases_grant():
+    async def scenario():
+        for fail_save in (True, False):
+            binding, policy = _fixture()
+            live = [True]
+            authority = FirstOpenSiteAuthority(policy_repository=policy, server_instance_id="server-1")
+            task = asyncio.create_task(authority.request(binding, "https://example.com", current=lambda b: live[0]))
+            await asyncio.sleep(0)
+            prompt = authority.list_pending(subject_id="single-user", context_id="context-1", bridge_id="bridge-1")[0]
+            original_save = policy._save
+            def save(value):
+                if fail_save:
+                    raise OSError("synthetic storage unavailable")
+                original_save(value)
+                live[0] = False
+            policy._save = save
+            with pytest.raises(Exception):
+                authority.decide(subject_id="single-user", challenge_id=prompt["challenge_id"], decision="allow_site")
+            assert authority.grant_for(binding, "https://example.com") is None
+            authority.retire()
+            with pytest.raises(FirstOpenDenied):
+                await task
+    asyncio.run(scenario())

--- a/tests/test_browser_extension_leases.py
+++ b/tests/test_browser_extension_leases.py
@@ -1,0 +1,60 @@
+from dataclasses import replace
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_operations import OperationBinding, TurnBinding
+from plugins._browser.helpers.extension_leases import ExtensionLeaseIndex, ExtensionLeaseError
+
+
+def test_correlated_open_index_is_current_route_session_scoped_and_bounded():
+    principal = WsPrincipal(
+        principal_type="browser_bridge", principal_id="bridge", subject_id="user",
+        scopes=frozenset({"browser.operate"}), handler_path="plugins/_a0_connector/ws_connector",
+        handler_id="ws_connector.WsConnector", inbound_events=frozenset(),
+        outbound_events=frozenset(), key_generation=1,
+    )
+    binding = OperationBinding(principal, "sid", "generation", "context", "session", "turn", "action", "op")
+    current = [True]
+    index = ExtensionLeaseIndex(authorizer=lambda _: current[0], max_leases=1)
+    result = {"lease_id": "lease", "tab_handle": "tab", "browser_id": "tab", "origin": "https://example.com", "disposition": "ephemeral", "title": "not retained"}
+    lease = index.observe_open(binding, result, "https://example.com")
+    assert not hasattr(lease, "title")
+    assert index.origin_for(binding, "tab") == "https://example.com"
+    for other in (
+        replace(binding, principal=replace(principal)), replace(binding, connector_sid="new-sid"),
+        replace(binding, load_generation_id="new-generation"), replace(binding, context_id="other"),
+        replace(binding, browser_session_id="other"), replace(binding, turn_id="other"),
+    ):
+        assert index.origin_for(other, "tab") is None
+    with pytest.raises(ExtensionLeaseError):
+        index.observe_open(binding, {**result, "origin": "https://other.example"}, "https://example.com")
+    with pytest.raises(ExtensionLeaseError):
+        index.observe_open(binding, {**result, "lease_id": "second", "tab_handle": "second-tab", "browser_id": "second-tab"}, "https://example.com")
+    navigation = {key: result[key] for key in ("lease_id", "tab_handle", "browser_id", "origin")}
+    assert index.document_for(binding, "tab") is None
+    content = {key: result[key] for key in ("lease_id", "tab_handle", "browser_id")}
+    content.update(document_id="document-1", document_epoch="1", title="not authority", text="not retained",
+                   nodes=[{"ref": "doc:1:opaque", "role": "button", "name": "not authority"}], truncated=False)
+    index.observe_content(binding, "tab", content)
+    document = index.document_for(binding, "tab")
+    assert document.document_id == "document-1" and document.document_epoch == 1
+    assert document.refs == frozenset({"doc:1:opaque"}) and not hasattr(document, "text")
+    for changes in ({"document_id": "other-document"}, {"document_epoch": "0"},
+                    {"nodes": content["nodes"] * 2}, {"document_epoch": "9007199254740992"}):
+        with pytest.raises(ExtensionLeaseError):
+            index.observe_content(binding, "tab", {**content, **changes})
+    navigation["origin"] = "https://next.example"
+    index.observe_navigation(binding, "tab", navigation, "https://next.example")
+    assert index.origin_for(binding, "tab") == "https://next.example"
+    assert index.document_for(binding, "tab") is None
+    with pytest.raises(ExtensionLeaseError):
+        index.observe_navigation(binding, "tab", {**navigation, "lease_id": "other"}, "https://next.example")
+    current[0] = False
+    assert index.origin_for(binding, "tab") is None
+    current[0] = True
+    index.retire_turn(TurnBinding(principal, "sid", "generation", "context", "session", "turn"))
+    assert index.origin_for(binding, "tab") is None
+    index.observe_open(binding, result, "https://example.com")
+    index.invalidate(principal=principal, connector_sid="sid", load_generation_id="generation")
+    assert index.origin_for(binding, "tab") is None

--- a/tests/test_browser_extension_reconnect_selection.py
+++ b/tests/test_browser_extension_reconnect_selection.py
@@ -1,0 +1,63 @@
+"""Pre-operation reconnect waits never send or retry browser operations."""
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from plugins._browser.helpers import extension_runtime as runtime_module
+from plugins._browser.helpers import config, bridge_foundation
+
+
+def setup(monkeypatch, *, ready_at=15.0, change=None):
+    now = [0.0]
+    calls = []
+    agent = SimpleNamespace(context=SimpleNamespace(id="context-1"))
+    selected = {"runtime_backend": "host_required", "host_browser_selection": "extension:bridge-1"}
+    runtime = object.__new__(runtime_module.ExtensionBrowserRuntime)
+    runtime.context_id, runtime.bridge_id = "context-1", "bridge-1"
+    def factory(actual_agent, bridge):
+        assert actual_agent is agent and bridge == "bridge-1"
+        calls.append(now[0])
+        return runtime if now[0] >= ready_at else None
+    async def advance(seconds):
+        now[0] += seconds
+        if change is not None:
+            change(selected)
+    monkeypatch.setattr(runtime_module, "_runtime_factory", factory)
+    monkeypatch.setattr(runtime_module, "_runtime_factory_owner", object())
+    monkeypatch.setattr(config, "get_browser_config", lambda **kw: selected)
+    monkeypatch.setattr(bridge_foundation, "get_browser_bridge_gate", lambda: SimpleNamespace(state="available"))
+    monkeypatch.setattr(runtime_module.asyncio, "sleep", advance)
+    monkeypatch.setattr(runtime_module.asyncio, "get_running_loop", lambda: SimpleNamespace(time=lambda: now[0]))
+    return agent, runtime, now, calls
+
+
+def test_reconnect_wait_resolves_only_after_existing_owner_becomes_ready(monkeypatch):
+    agent, runtime, now, calls = setup(monkeypatch)
+    assert asyncio.run(runtime_module.wait_selected_extension_runtime(agent, "bridge-1")) is runtime
+    assert now[0] == 15.0 and calls[0] == 0 and calls[-1] == 15.0
+    assert not hasattr(runtime, "_broker")  # Acquisition never performs any work.
+
+
+@pytest.mark.parametrize("change", ["selection", "owner", "cancel", "timeout"])
+def test_reconnect_wait_is_bounded_cancellable_and_never_adopts_replacement(monkeypatch, change):
+    def alter(selected):
+        if change == "selection":
+            selected["host_browser_selection"] = "extension:another-bridge"
+        elif change == "owner":
+            monkeypatch.setattr(runtime_module, "_runtime_factory_owner", object())
+        elif change == "cancel":
+            raise asyncio.CancelledError()
+    agent, runtime, now, calls = setup(monkeypatch, ready_at=30.0, change=alter)
+    if change == "cancel":
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(runtime_module.wait_selected_extension_runtime(agent, "bridge-1"))
+    else:
+        assert asyncio.run(runtime_module.wait_selected_extension_runtime(agent, "bridge-1")) is None
+    assert now[0] == (25.0 if change == "timeout" else 0.25)
+    assert len(calls) == (101 if change == "timeout" else 1)
+
+
+def test_absent_factory_does_not_wait_or_infer_installation(monkeypatch):
+    monkeypatch.setattr(runtime_module, "_runtime_factory", None)
+    assert asyncio.run(runtime_module.wait_selected_extension_runtime(None, "bridge-1")) is None

--- a/tests/test_browser_extension_runtime.py
+++ b/tests/test_browser_extension_runtime.py
@@ -1,0 +1,277 @@
+import asyncio
+from dataclasses import replace
+from copy import deepcopy
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_operations import (
+    BridgeAuthorization, BrowserBridgeOperationBroker, OperationBinding,
+)
+from plugins._a0_connector.helpers.browser_bridge_policy import BrowserBridgePolicyRepository
+from plugins._browser.helpers.extension_runtime import (
+    ExtensionBrowserError, ExtensionBrowserRuntime, encode_extension_call,
+)
+
+
+def _fixture():
+    principal = WsPrincipal(
+        principal_type="browser_bridge", principal_id="bridge-1", subject_id="single-user",
+        scopes=frozenset({"browser.operate", "browser.control"}),
+        handler_path="plugins/_a0_connector/ws_connector", handler_id="ws_connector.WsConnector",
+        inbound_events=frozenset({"connector_browser_op_result", "connector_browser_control_result"}),
+        outbound_events=frozenset({"connector_browser_op", "connector_browser_control"}), key_generation=1,
+    )
+    binding = OperationBinding(principal, "sid-1", "load-1", "context-1", "session-1", "turn-1", "action-1", "op-1")
+    stored = [None]
+    policy = BrowserBridgePolicyRepository(load=lambda: deepcopy(stored[0]), save=lambda value: stored.__setitem__(0, deepcopy(value)))
+    return binding, policy
+
+
+def _authorize(binding):
+    return BridgeAuthorization(
+        binding.principal, binding.connector_sid, binding.load_generation_id, 1,
+        frozenset({"browser_extension_bridge_v1", "connector_browser_control"}),
+        frozenset({"open", "list", "state", "content", "navigate", "scroll", "ensure", "status"}),
+        frozenset({"tab_leases_v1", "tab_groups_v1", "semantic_dom_v1", "cursor_v1"}),
+    )
+
+
+def _allow(policy, origin="https://example.com"):
+    return policy.allow(server_instance_id="server-1", bridge_id="bridge-1", subject_id="single-user", origin=origin)
+
+
+def _runtime(binding, policy, sender, *, binding_factory=None):
+    broker = BrowserBridgeOperationBroker(sender=sender, authorizer=_authorize)
+    runtime = ExtensionBrowserRuntime(
+        "context-1", "bridge-1", broker=broker,
+        binding_factory=binding_factory or (lambda: binding), policy_repository=policy,
+        server_instance_id="server-1", target_origin_resolver=lambda _binding, handle: "https://example.com" if handle == "a0t1.load.tab" else None,
+    )
+    return runtime, broker
+
+
+def test_foreground_preference_is_server_owned_action_scoped_and_fail_quiet():
+    binding, policy = _fixture()
+    runtime, _ = _runtime(binding, policy, None)
+    assert runtime._operation_display("open") == {"cursor": False, "foreground": False}
+    enabled = [True]
+    runtime._foreground_preference = lambda: enabled[0]
+    for action in ("open", "hover", "click", "type", "scroll", "upload_file"):
+        assert runtime._operation_display(action)["foreground"] is True
+    for action in ("list", "state", "content", "navigate", "status", "ensure", "screenshot"):
+        assert runtime._operation_display(action)["foreground"] is False
+    for disabled in (False, None, 1, "true"):
+        enabled[0] = disabled
+        assert runtime._operation_display("scroll") == {"cursor": True, "foreground": False}
+    def unavailable():
+        raise RuntimeError("settings unavailable")
+    runtime._foreground_preference = unavailable
+    assert runtime._operation_display("open")["foreground"] is False
+    with pytest.raises(ExtensionBrowserError):
+        encode_extension_call("open", ("https://example.com",), {"foreground": True})
+
+
+def test_authorized_open_dispatch_projects_latest_foreground_preference():
+    from plugins._browser.helpers.extension_first_open import FirstOpenSiteAuthority
+    async def scenario():
+        binding, policy = _fixture()
+        authority = FirstOpenSiteAuthority()
+        sent = []
+        enabled = [False]
+        async def sender(sid, _event, payload, _correlation, principal):
+            sent.append(payload)
+            keys = ("contract_version", "bridge_id", "load_generation_id", "context_id", "browser_session_id", "turn_id", "op_id", "action_id")
+            broker.settle_operation(principal=principal, connector_sid=sid, load_generation_id="load-1", payload={
+                **{key: payload[key] for key in keys}, "ok": True,
+                "result": {}, "receipts": [], "artifacts": [],
+            })
+        runtime, broker = _runtime(binding, policy, sender)
+        runtime._foreground_preference = lambda: enabled[0]
+        runtime._first_open_authority = authority
+        runtime._binding_current = lambda _binding: True
+        task = asyncio.create_task(runtime.call("open", "https://example.com"))
+        await asyncio.sleep(0)
+        pending = authority.list_pending(subject_id="single-user", context_id="context-1", bridge_id="bridge-1")
+        assert len(pending) == 1 and sent == []
+        # A user's preference change during the real approval wait is honored.
+        enabled[0] = True
+        authority.decide(subject_id="single-user", challenge_id=pending[0]["challenge_id"], decision="allow_once")
+        await task
+        assert sent[0]["display"] == {"cursor": False, "foreground": True}
+        assert sent[0]["policy"]["origin_grant_id"] is not None
+    asyncio.run(scenario())
+
+
+def test_canonical_codec_rejects_legacy_fields_and_unimplemented_actions():
+    call = encode_extension_call("open", ("HTTPS://EXAMPLE.COM:443/path?q=1",), {})
+    assert call.args == {"url": "https://example.com/path?q=1", "disposition": "ephemeral"}
+    assert call.target is None and call.origin == "https://example.com"
+    assert "tab_groups_v1" in call.required_capabilities
+    for method, args, kwargs in (
+        ("type_submit", ("tab", "ref", "text"), {}),
+        ("content", ("tab", {"selector": "input"}), {}),
+        ("state", (123,), {}),
+        ("list", (), {"include_content": True}),
+        ("open", ("https://user:secret@example.com/",), {}),
+        ("open", ("http://127.1/",), {}),
+        ("open", ("https://example.com/",), {"policy": {"origin_grant_id": "forged"}}),
+    ):
+        with pytest.raises(ExtensionBrowserError):
+            encode_extension_call(method, args, kwargs)
+
+
+def test_hover_accepts_browser_tool_ref_form_but_never_coordinates():
+    call = encode_extension_call("hover", ("a0t1.load.tab",), {
+        "ref": "ref-1", "x": 0.0, "y": 0.0, "offset_x": 0.0, "offset_y": 0.0,
+    })
+    assert call.action == "hover" and call.args == {"ref": "ref-1"}
+    assert "trusted_input_v1" in call.required_capabilities
+    for kwargs in ({"ref": "ref-1", "x": 1}, {"ref": "ref-1", "y": False},
+                   {"ref": "ref-1", "selector": "button"}, {"ref": None}):
+        with pytest.raises(ExtensionBrowserError):
+            encode_extension_call("hover", ("a0t1.load.tab",), kwargs)
+
+
+def test_click_requires_current_action_authority_and_never_accepts_a_risk_downgrade():
+    call = encode_extension_call("click", ("a0t1.load.tab", "ref-1"), {})
+    assert call.args == {"ref": "ref-1", "expected_action_class": "unknown"}
+    with pytest.raises(ExtensionBrowserError):
+        encode_extension_call("click", ("a0t1.load.tab", "ref-1"), {"expected_action_class": "reversible_input"})
+
+    async def scenario():
+        binding, policy = _fixture()
+        _allow(policy)
+        sent = []
+        async def sender(*args):
+            sent.append(args)
+        runtime, _ = _runtime(binding, policy, sender)
+        with pytest.raises(ExtensionBrowserError, match="APPROVAL_REQUIRED"):
+            await runtime.call("click", "a0t1.load.tab", "ref-1")
+        assert sent == []
+    asyncio.run(scenario())
+
+
+def test_type_codec_binds_exact_utf8_and_requires_action_authority():
+    import hashlib
+
+    text = "Private \U0001f511\nsecond line"
+    call = encode_extension_call("type", ("a0t1.load.tab", "ref-1", text), {})
+    assert call.args == {"ref": "ref-1", "text": text, "text_sha256": hashlib.sha256(text.encode()).hexdigest(),
+                         "expected_action_class": "sensitive_input"}
+    assert "trusted_input_v1" in call.required_capabilities
+    for invalid in ("", "\x00", "\r", "\ud800", "\U0001f511" * 8193, None):
+        with pytest.raises(ExtensionBrowserError, match="INVALID_STATE"):
+            encode_extension_call("type", ("a0t1.load.tab", "ref-1", invalid), {})
+    with pytest.raises(ExtensionBrowserError):
+        encode_extension_call("type", ("a0t1.load.tab", "ref-1", text), {"submit": True})
+
+    async def scenario():
+        binding, policy = _fixture()
+        sent = []
+        async def sender(*args):
+            sent.append(args)
+        runtime, _ = _runtime(binding, policy, sender)
+        with pytest.raises(ExtensionBrowserError, match="APPROVAL_REQUIRED"):
+            await runtime.call("type", "a0t1.load.tab", "ref-1", text)
+        assert sent == []
+    asyncio.run(scenario())
+
+
+def test_cross_origin_request_requires_challenge_lane_and_uses_source_permission():
+    async def scenario():
+        binding, policy = _fixture()
+        source_grant = _allow(policy)
+        sent = []
+
+        async def sender(sid, _event, payload, _correlation, principal):
+            sent.append(payload)
+            keys = ("contract_version", "bridge_id", "load_generation_id", "context_id", "browser_session_id", "turn_id", "op_id", "action_id")
+            broker.settle_operation(principal=principal, connector_sid=sid, load_generation_id="load-1", payload={
+                **{key: payload[key] for key in keys}, "ok": False, "code": "APPROVAL_DENIED", "error": "Site request denied",
+                "error_data": {"outcome": "not_applied", "retryable": False, "details": {}},
+            })
+
+        broker = BrowserBridgeOperationBroker(sender=sender, authorizer=_authorize)
+        runtime = ExtensionBrowserRuntime(
+            "context-1", "bridge-1", broker=broker, binding_factory=lambda: binding,
+            policy_repository=policy, server_instance_id="server-1",
+            target_origin_resolver=lambda _binding, _handle: "https://example.com",
+            site_challenge_ready=lambda _binding: True,
+        )
+        with pytest.raises(ExtensionBrowserError) as denied:
+            await runtime.call("navigate", "a0t1.load.tab", "https://next.example/path")
+        assert denied.value.code == "APPROVAL_DENIED"
+        assert len(sent) == 1 and sent[0]["policy"]["origin_grant_id"] == source_grant.grant_id
+        assert sent[0]["args"] == {"url": "https://next.example/path"}
+
+    asyncio.run(scenario())
+
+
+def test_browser_call_uses_exact_server_binding_and_saved_origin_grant():
+    async def scenario():
+        binding, policy = _fixture()
+        grant = _allow(policy)
+        sent = []
+
+        async def sender(sid, event, payload, correlation, principal):
+            sent.append(payload)
+            keys = ("contract_version", "bridge_id", "load_generation_id", "context_id", "browser_session_id", "turn_id", "op_id", "action_id")
+            broker.settle_operation(
+                principal=principal, connector_sid=sid, load_generation_id="load-1",
+                payload={**{key: payload[key] for key in keys}, "ok": True, "result": {"browser_id": "a0t1.load.tab"}, "receipts": [], "artifacts": []},
+            )
+
+        runtime, broker = _runtime(binding, policy, sender)
+        assert await runtime.call("open", "https://example.com/page") == {"browser_id": "a0t1.load.tab"}
+        assert sent[0]["policy"] == {"origin_grant_id": grant.grant_id, "action_grant_id": None}
+        assert sent[0]["context_id"] == "context-1"
+        assert sent[0]["display"] == {"cursor": False, "foreground": False}
+        assert "profile_mode" not in sent[0] and "cdp_endpoint" not in sent[0]
+
+    asyncio.run(scenario())
+
+
+def test_policy_and_target_isolation_deny_without_dispatch():
+    async def scenario():
+        binding, policy = _fixture()
+        sent = []
+
+        async def sender(*args):
+            sent.append(args)
+
+        runtime, _ = _runtime(binding, policy, sender)
+        with pytest.raises(ExtensionBrowserError, match="ORIGIN_BLOCKED"):
+            await runtime.call("open", "https://example.com/")
+        _allow(policy)
+        _allow(policy, "https://another.example")
+        with pytest.raises(ExtensionBrowserError, match="APPROVAL_REQUIRED"):
+            await runtime.call("navigate", "a0t1.load.tab", "https://another.example/")
+        with pytest.raises(ExtensionBrowserError, match="TAB_NOT_OWNED"):
+            await runtime.call("content", "foreign-tab", None)
+        mismatched, _ = _runtime(binding, policy, sender, binding_factory=lambda: replace(binding, context_id="other-context"))
+        with pytest.raises(ExtensionBrowserError, match="SCOPE_DENIED"):
+            await mismatched.call("list", include_content=False)
+        assert sent == []
+
+    asyncio.run(scenario())
+
+
+def test_revoked_policy_between_enqueue_and_send_blocks_the_effect():
+    async def scenario():
+        binding, policy = _fixture()
+        _allow(policy)
+        sent = []
+
+        async def sender(*args):
+            sent.append(args)
+
+        runtime, _ = _runtime(binding, policy, sender)
+        task = asyncio.create_task(runtime.call("open", "https://example.com/"))
+        await asyncio.sleep(0)
+        policy.revoke(server_instance_id="server-1", bridge_id="bridge-1", subject_id="single-user", origin="https://example.com")
+        with pytest.raises(ExtensionBrowserError, match="ORIGIN_BLOCKED"):
+            await task
+        assert sent == []
+
+    asyncio.run(scenario())

--- a/tests/test_browser_extension_selection_foundation.py
+++ b/tests/test_browser_extension_selection_foundation.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import re
+import shutil
+import subprocess
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from plugins._browser.helpers.config import (
+    ExtensionBrowserSelection,
+    normalize_host_browser_selection,
+    normalize_browser_config,
+    parse_extension_browser_selection,
+    validate_extension_browser_selection_change,
+)
+from plugins._browser.helpers import selector as browser_selector
+from plugins._a0_connector.helpers import browser_bridge_selection
+
+BRIDGE_ID = "b6ce74df-47e6-4a3d-b8dd-3f3fae0e79d2"
+
+
+def _agent(context_id: str = "ctx-extension-foundation"):
+    return SimpleNamespace(context=SimpleNamespace(id=context_id))
+
+
+@contextmanager
+def _load_browser_runtime_api(monkeypatch: pytest.MonkeyPatch):
+    class Response:
+        def __init__(self, *, response: str, status: int, mimetype: str) -> None:
+            self.response = response
+            self.status = status
+            self.mimetype = mimetype
+
+    api_stub = ModuleType("helpers.api")
+    api_stub.Request = object
+    api_stub.Response = Response
+    base_stub = ModuleType("plugins._a0_connector.api.v1.base")
+    base_stub.ProtectedConnectorApiHandler = object
+
+    module_name = "plugins._a0_connector.api.v1.browser_runtime"
+    previous = sys.modules.pop(module_name, None)
+    try:
+        with monkeypatch.context() as context:
+            context.setitem(sys.modules, "helpers.api", api_stub)
+            context.setitem(sys.modules, "plugins._a0_connector.api.v1.base", base_stub)
+            yield importlib.import_module(module_name)
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous is not None:
+            sys.modules[module_name] = previous
+
+
+def test_valid_extension_selection_is_typed_and_preserved_exactly():
+    value = f"extension:{BRIDGE_ID}"
+
+    assert (
+        normalize_browser_config({"host_browser_selection": f"  {value}  "})[
+            "host_browser_selection"
+        ]
+        == value
+    )
+    assert parse_extension_browser_selection(value) == ExtensionBrowserSelection(
+        value=value,
+        bridge_id=BRIDGE_ID,
+    )
+    assert parse_extension_browser_selection("chrome-cdp") is None
+    assert parse_extension_browser_selection("extenſion:123") is None
+    assert normalize_host_browser_selection(value) == value
+
+
+def test_bridge_selection_is_derived_from_exact_context_agent_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent import AgentContext
+    from plugins._browser.helpers import config as browser_config
+
+    context = SimpleNamespace(id="context-A")
+    agent = SimpleNamespace(context=context)
+    context.agent0 = agent
+    monkeypatch.setattr(
+        AgentContext,
+        "get",
+        staticmethod(lambda context_id: context if context_id == context.id else None),
+    )
+    current = {
+        "runtime_backend": "host_required",
+        "host_browser_selection": "extension:bridge-A",
+    }
+    monkeypatch.setattr(
+        browser_config,
+        "get_browser_config",
+        lambda *, agent: dict(current),
+    )
+
+    assert browser_bridge_selection.selected_bridge("context-A") == "bridge-A"
+    assert browser_bridge_selection.selection_current("context-A", "bridge-A")
+    assert not browser_bridge_selection.selection_current("context-A", "bridge-B")
+    assert browser_bridge_selection.selected_bridge("context-missing") is None
+    current["runtime_backend"] = "container"
+    assert browser_bridge_selection.selected_bridge("context-A") is None
+    current["runtime_backend"] = "host_required"
+    current["host_browser_selection"] = "chrome-cdp"
+    assert browser_bridge_selection.selected_bridge("context-A") is None
+
+
+def test_instance_rollout_gate_is_not_persisted_in_project_browser_config() -> None:
+    normalized = normalize_browser_config({"browser_bridge_rollout": "available"})
+
+    assert "browser_bridge_rollout" not in normalized
+
+
+def test_project_config_save_validation_blocks_new_extension_selection() -> None:
+    with pytest.raises(ValueError, match="pairing and activation"):
+        validate_extension_browser_selection_change(
+            proposed_value="extension:Bridge-Case-1",
+            current_value="chrome-cdp",
+            proposed_runtime_backend="container",
+            current_runtime_backend="container",
+        )
+    with pytest.raises(ValueError, match="reserved extension"):
+        validate_extension_browser_selection_change(
+            proposed_value="extension:",
+            current_value="",
+            proposed_runtime_backend="container",
+            current_runtime_backend="container",
+        )
+    with pytest.raises(ValueError, match="reserved extension"):
+        validate_extension_browser_selection_change(
+            proposed_value="Extension:bad/id",
+            current_value="extension:",
+            proposed_runtime_backend="container",
+            current_runtime_backend="container",
+        )
+
+
+def test_project_config_save_validation_allows_preservation_and_deactivation() -> None:
+    selection = "extension:Bridge-Case-1"
+
+    validate_extension_browser_selection_change(
+        proposed_value=selection,
+        current_value=selection,
+        proposed_runtime_backend="container",
+        current_runtime_backend="container",
+    )
+    validate_extension_browser_selection_change(
+        proposed_value="",
+        current_value=selection,
+        proposed_runtime_backend="host_required",
+        current_runtime_backend="host_required",
+    )
+
+
+def test_project_config_save_validation_blocks_backend_only_activation() -> None:
+    selection = "extension:Bridge-Case-1"
+
+    with pytest.raises(ValueError, match="pairing and activation"):
+        validate_extension_browser_selection_change(
+            proposed_value=selection,
+            current_value=selection,
+            proposed_runtime_backend="host_required",
+            current_runtime_backend="container",
+        )
+
+
+def test_connector_api_rejects_valid_extension_before_save(monkeypatch) -> None:
+    with _load_browser_runtime_api(monkeypatch) as runtime_api:
+        handler = runtime_api.BrowserRuntime.__new__(runtime_api.BrowserRuntime)
+        handler._project_name_for_context = lambda _context_id: ""
+        handler._load_browser_config = lambda _project: {
+            "runtime_backend": "container",
+            "host_browser_profile_mode": "existing",
+            "host_browser_selection": "",
+        }
+        handler._save_browser_config = lambda *_args: pytest.fail(
+            "unavailable extension selection was saved"
+        )
+        selection = "extension:Bridge-Case-1"
+
+        response = asyncio.run(
+            handler.process(
+                {
+                    "action": "set",
+                    "runtime_backend": "host_required",
+                    "host_browser_selection": selection,
+                },
+                request=None,
+            )
+        )
+
+    assert response.status == 400
+    assert "browser_extension_bridge_unavailable" in response.response
+
+
+def test_connector_api_rejects_malformed_extension_before_save(monkeypatch) -> None:
+    with _load_browser_runtime_api(monkeypatch) as runtime_api:
+        handler = runtime_api.BrowserRuntime.__new__(runtime_api.BrowserRuntime)
+        handler._project_name_for_context = lambda _context_id: ""
+        handler._load_browser_config = lambda _project: {
+            "runtime_backend": "container",
+            "host_browser_profile_mode": "existing",
+            "host_browser_selection": "",
+        }
+        handler._save_browser_config = lambda *_args: pytest.fail(
+            "malformed extension selection was saved"
+        )
+
+        response = asyncio.run(
+            handler.process(
+                {
+                    "action": "set",
+                    "runtime_backend": "host_required",
+                    "host_browser_selection": "extension:bad/id",
+                },
+                request=None,
+            )
+        )
+
+    assert response.status == 400
+    assert "invalid_extension_browser_selection" in response.response
+
+
+def test_connector_api_rejects_backend_only_activation_of_stored_extension(
+    monkeypatch,
+) -> None:
+    with _load_browser_runtime_api(monkeypatch) as runtime_api:
+        handler = runtime_api.BrowserRuntime.__new__(runtime_api.BrowserRuntime)
+        handler._project_name_for_context = lambda _context_id: ""
+        handler._load_browser_config = lambda _project: {
+            "runtime_backend": "container",
+            "host_browser_profile_mode": "existing",
+            "host_browser_selection": "extension:Bridge-Case-1",
+        }
+        handler._save_browser_config = lambda *_args: pytest.fail(
+            "backend-only extension activation was saved"
+        )
+
+        response = asyncio.run(
+            handler.process(
+                {"action": "set", "runtime_backend": "host_required"},
+                request=None,
+            )
+        )
+
+    assert response.status == 400
+    assert "browser_extension_bridge_unavailable" in response.response
+
+
+def test_connector_api_allows_extension_deactivation_with_echoed_selection(
+    monkeypatch,
+) -> None:
+    with _load_browser_runtime_api(monkeypatch) as runtime_api:
+        handler = runtime_api.BrowserRuntime.__new__(runtime_api.BrowserRuntime)
+        stored: dict[str, object] = {}
+        handler._project_name_for_context = lambda _context_id: ""
+        handler._load_browser_config = lambda _project: {
+            "runtime_backend": "host_required",
+            "host_browser_profile_mode": "existing",
+            "host_browser_selection": "extension:Bridge-Case-1",
+        }
+        handler._save_browser_config = lambda _project, settings: stored.update(settings)
+
+        response = asyncio.run(
+            handler.process(
+                {
+                    "action": "set",
+                    "runtime_backend": "container",
+                    "host_browser_selection": "extension:Bridge-Case-1",
+                },
+                request=None,
+            )
+        )
+
+    assert response["runtime_backend"] == "container"
+    assert stored["runtime_backend"] == "container"
+    assert stored["host_browser_selection"] == "extension:Bridge-Case-1"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "extension",
+        "extension:",
+        "Extension:b6ce74df-47e6-4a3d-b8dd-3f3fae0e79d2",
+        "extension: bridge-id",
+        "extension:bridge/id",
+        "extension:bridge:id",
+        "extension:bridge\x00id",
+        "extension\x00:bridge-id",
+    ],
+)
+def test_malformed_reserved_selection_stays_reserved_and_non_routable(value: str):
+    normalized = normalize_browser_config({"host_browser_selection": value})[
+        "host_browser_selection"
+    ]
+
+    assert normalized == "extension:"
+    with pytest.raises(ValueError):
+        parse_extension_browser_selection(normalized)
+
+
+@pytest.mark.parametrize(
+    ("selection", "message"),
+    [
+        (f"extension:{BRIDGE_ID}", "has not established a verified connection"),
+        ("extension:", "selection is invalid"),
+    ],
+)
+def test_extension_selection_fails_closed_before_any_runtime_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+    selection: str,
+    message: str,
+):
+    monkeypatch.setattr(
+        browser_selector,
+        "get_browser_config",
+        lambda agent=None: {
+            "runtime_backend": "host_required",
+            "host_browser_selection": selection,
+        },
+    )
+    monkeypatch.setattr(
+        browser_selector,
+        "_select_host_browser_candidate_sid",
+        lambda context_id: pytest.fail(
+            "extension selection consulted a legacy candidate"
+        ),
+    )
+
+    async def unexpected_container_runtime(context_id: str):
+        pytest.fail("extension selection fell back to the container runtime")
+
+    monkeypatch.setattr(
+        browser_selector,
+        "get_container_runtime",
+        unexpected_container_runtime,
+    )
+
+    with pytest.raises(browser_selector.RepairableException, match=message) as exc_info:
+        asyncio.run(browser_selector.get_tool_runtime(_agent()))
+
+    assert "did not fall back" in str(exc_info.value)
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="node is required")
+def test_browser_settings_preserve_valid_extension_identity_exactly() -> None:
+    source = (
+        PROJECT_ROOT / "plugins" / "_browser" / "webui" / "browser-config-store.js"
+    ).read_text(encoding="utf-8")
+    source = re.sub(r"^import .*;\n", "", source, flags=re.M)
+    source = source.replace("export const store = createStore", "const store = createStore")
+    selection = "extension:Bridge-Case-1"
+    numeric_selection = "extension:123"
+    unicode_lookalike = "extenſion:123"
+    script = (
+        "const createStore = (_name, value) => value;\n"
+        "const callJsonApi = async () => ({});\n"
+        "const showConfirmDialog = async () => false;\n"
+        + source
+        + f"\nconst config = ensureConfig({{ host_browser_selection: {selection!r} }});\n"
+        + f"if (config.host_browser_selection !== {selection!r}) "
+        + "throw new Error('extension ID changed');\n"
+        + f"if (normalizeHostBrowserSelection({numeric_selection!r}) "
+        + f"!== {numeric_selection!r}) throw new Error('numeric extension ID changed');\n"
+        + f"if (isCustomHostBrowserEndpoint({numeric_selection!r})) "
+        + "throw new Error('extension ID treated as endpoint');\n"
+        + f"if (normalizeHostBrowserSelection({unicode_lookalike!r}) "
+        + f"!== {unicode_lookalike!r}) throw new Error('prefix parity changed');\n"
+        + "if (normalizeHostBrowserSelection('Extension:Bridge-Case-1') "
+        + "!== 'extension:') throw new Error('invalid namespace did not fail closed');\n"
+    )
+
+    subprocess.run(["node", "--input-type=module", "-e", script], check=True, text=True)
+
+
+def test_container_backend_still_ignores_host_selection(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    expected_runtime = object()
+    monkeypatch.setattr(
+        browser_selector,
+        "get_browser_config",
+        lambda agent=None: {
+            "runtime_backend": "container",
+            "host_browser_selection": f"extension:{BRIDGE_ID}",
+        },
+    )
+
+    async def container_runtime(context_id: str):
+        assert context_id == "ctx-container"
+        return expected_runtime
+
+    monkeypatch.setattr(browser_selector, "get_container_runtime", container_runtime)
+
+    assert (
+        asyncio.run(browser_selector.get_tool_runtime(_agent("ctx-container")))
+        is expected_runtime
+    )
+
+
+@pytest.mark.parametrize("selection", ["", "chrome-cdp"])
+def test_empty_and_legacy_host_selection_keep_current_connector_path(
+    monkeypatch: pytest.MonkeyPatch,
+    selection: str,
+):
+    monkeypatch.setattr(
+        browser_selector,
+        "get_browser_config",
+        lambda agent=None: {
+            "runtime_backend": "host_required",
+            "host_browser_selection": selection,
+        },
+    )
+    monkeypatch.setattr(
+        browser_selector,
+        "_select_host_browser_candidate_sid",
+        lambda context_id: "sid-legacy",
+    )
+
+    connector_runtime_module = ModuleType("plugins._browser.helpers.connector_runtime")
+
+    class ConnectorBrowserRuntime:
+        def __init__(self, context_id, agent):
+            self.context_id = context_id
+            self.agent = agent
+
+    connector_runtime_module.ConnectorBrowserRuntime = ConnectorBrowserRuntime
+    monkeypatch.setitem(
+        sys.modules,
+        "plugins._browser.helpers.connector_runtime",
+        connector_runtime_module,
+    )
+
+    runtime = asyncio.run(browser_selector.get_tool_runtime(_agent("ctx-legacy")))
+
+    assert isinstance(runtime, ConnectorBrowserRuntime)
+    assert runtime.context_id == "ctx-legacy"

--- a/tests/test_browser_extension_services.py
+++ b/tests/test_browser_extension_services.py
@@ -1,0 +1,237 @@
+import asyncio
+import pytest
+from concurrent.futures import Future
+from types import SimpleNamespace
+from helpers.ws_principal import WsPrincipal
+from plugins._a0_connector.helpers.browser_bridge_operations import (
+    BridgeAuthorization,
+    BrowserBridgeOperationBroker,
+)
+from plugins._a0_connector.helpers.browser_bridge_policy import BrowserBridgePolicyRepository
+from plugins._browser.helpers.extension_runtime import configure_extension_runtime_factory
+from plugins._browser.helpers.extension_services import ExtensionBrowserServices, valid_finalization_result
+from plugins._browser.helpers.extension_sessions import (
+    ExtensionSessionLifecycle,
+    ExtensionSessionRegistry,
+    ExtensionSessionStateError,
+    ValidatedExtensionRoute,
+    TURN_FINALIZED,
+    TURN_OUTCOME_UNKNOWN,
+)
+from browser_bridge_test_support import MemoryPersistence
+from plugins._a0_connector.helpers import browser_bridge_application, browser_bridge_runtime_owner
+from plugins._browser.helpers import extension_sessions as sessions
+from test_browser_extension_runtime import _fixture, _authorize, _allow
+
+
+def test_finalization_rejects_malformed_duplicate_and_unbounded_lease_outcomes():
+    result = {"contract_version": 1, "control_id": "control", "closed": ["lease"],
+              "released": [], "retained": [], "already_finalized": [], "errors": []}
+    assert valid_finalization_result(result, "control")
+    assert not valid_finalization_result({**result, "contract_version": True}, "control")
+    assert not valid_finalization_result({**result, "released": ["lease"]}, "control")
+    assert not valid_finalization_result({**result, "closed": [12]}, "control")
+    assert not valid_finalization_result({**result, "closed": [f"lease-{i}" for i in range(257)]}, "control")
+    assert not valid_finalization_result({**result, "retained": [{"lease_id": "other", "tab_handle": "tab", "reason": "raw payload"}]}, "control")
+
+
+def test_service_install_preserves_preexisting_factory_and_lifecycle_owners():
+    lifecycle = ExtensionSessionLifecycle(
+        registry=ExtensionSessionRegistry(persistence=MemoryPersistence())
+    )
+    services = ExtensionBrowserServices(
+        lifecycle=lifecycle,
+        broker=object(),
+        route_resolver=lambda _context, _bridge: None,
+        policy_repository=BrowserBridgePolicyRepository(load=lambda: None),
+        server_instance_id="server-1",
+    )
+    configure_extension_runtime_factory(lambda _agent, _bridge: None)
+    try:
+        with pytest.raises(RuntimeError):
+            services.install()
+        assert not lifecycle.configured
+    finally:
+        configure_extension_runtime_factory(None)
+
+    lifecycle.configure(
+        route_resolver=lambda _context, _bridge: None,
+        sender=lambda _intent, _route: None,
+    )
+    with pytest.raises(ExtensionSessionStateError) as error:
+        services.install()
+    assert error.value.code == "ALREADY_CONFIGURED"
+    assert lifecycle.configured
+    # The failed service install rolled back only its own temporary factory.
+    configure_extension_runtime_factory(lambda _agent, _bridge: None)
+    configure_extension_runtime_factory(None)
+
+
+def test_services_compose_real_broker_synthetic_turn_and_acknowledged_cleanup(monkeypatch):
+    from plugins._browser.helpers import config as browser_config
+    watched_agents = []
+    follow = [True]
+    def settings(*, agent):
+        watched_agents.append(agent)
+        return {"autofocus_active_page": follow[0]}
+    monkeypatch.setattr(browser_config, "get_browser_config", settings)
+    async def scenario():
+        principal = WsPrincipal(
+            principal_type="browser_bridge", principal_id="bridge-1", subject_id="single-user",
+            scopes=frozenset({"browser.operate", "browser.control"}),
+            handler_path="plugins/_a0_connector/ws_connector", handler_id="ws_connector.WsConnector",
+            inbound_events=frozenset({"connector_browser_op_result", "connector_browser_control_result"}),
+            outbound_events=frozenset({"connector_browser_op", "connector_browser_control"}), key_generation=1,
+        )
+        route = ValidatedExtensionRoute("bridge-1", "extension:bridge-1", principal, "sid-1", "load-1")
+        registry = ExtensionSessionRegistry(persistence=MemoryPersistence())
+        lifecycle = ExtensionSessionLifecycle(
+            registry=registry, config_loader=lambda _agent: {"runtime_backend": "host_required", "host_browser_selection": "extension:bridge-1"},
+        )
+        sent = []
+        unknown = [False]
+
+        async def sender(sid, event, payload, _correlation, expected):
+            sent.append((event, payload))
+            keys = ["contract_version", "bridge_id", "load_generation_id", "context_id", "browser_session_id", "turn_id"]
+            if event == "connector_browser_op":
+                keys += ["op_id", "action_id"]
+                broker.settle_operation(
+                    principal=expected, connector_sid=sid, load_generation_id="load-1",
+                    payload={**{key: payload[key] for key in keys}, "ok": True, "result": {"tabs": []}, "receipts": [], "artifacts": []},
+                )
+            else:
+                keys += ["method", "control_id"]
+                broker.settle_control(
+                    principal=expected, connector_sid=sid, load_generation_id="load-1",
+                    payload={**{key: payload[key] for key in keys}, "ok": True, "result": {
+                        "contract_version": 1, "control_id": payload["control_id"],
+                        "closed": [], "released": [], "retained": [], "already_finalized": [],
+                        "errors": [{"code": "OUTCOME_UNKNOWN"}] if unknown[0] else [],
+                    }},
+                )
+
+        broker = BrowserBridgeOperationBroker(sender=sender, authorizer=lambda binding: BridgeAuthorization(
+            principal, "sid-1", "load-1", 1,
+            frozenset({"browser_extension_bridge_v1", "connector_browser_control"}), frozenset({"list"}), frozenset(),
+        ))
+        services = ExtensionBrowserServices(
+            lifecycle=lifecycle, broker=broker, route_resolver=lambda _context, _bridge: route,
+            target_origin_resolver=lambda _binding, _handle: None,
+            policy_repository=BrowserBridgePolicyRepository(load=lambda: None), server_instance_id="server-1",
+        )
+        tasks = []
+
+        def submit(coroutine):
+            task = asyncio.create_task(coroutine)
+            tasks.append(task)
+            # The production dispatcher uses a process-loop concurrent Future.
+            future = Future()
+            task.add_done_callback(lambda _task: future.set_result(None))
+            return future
+
+        services.install(submitter=submit)
+        try:
+            assert services.installed
+            # The legacy/test seam cannot withdraw this exact service owner.
+            configure_extension_runtime_factory(None)
+            assert services.installed
+            agent = SimpleNamespace(context=SimpleNamespace(id="context-1"))
+            runtime = services.runtime_for_agent(agent, "bridge-1")
+            assert runtime is not None
+            assert runtime._operation_display("open")["foreground"] is True
+            assert watched_agents == [agent]
+            follow[0] = False
+            assert runtime._operation_display("open")["foreground"] is False
+            assert await runtime.call("list", include_content=False) == {"tabs": []}
+            await asyncio.gather(*tasks)
+            assert [event for event, _ in sent] == ["connector_browser_op", "connector_browser_control"]
+            assert sent[0][1]["display"] == {"cursor": False, "foreground": False}
+            assert sent[1][1]["method"] == "browser.finalize_turn"
+            assert sent[0][1]["turn_id"] == sent[1][1]["turn_id"]
+            assert registry.session("context-1").turns[-1].state == TURN_FINALIZED
+            assert lifecycle.active_agent_turn(agent) is None
+            # A transport-level success with per-lease errors is still unknown.
+            unknown[0] = True
+            assert await runtime.call("list", include_content=False) == {"tabs": []}
+            await asyncio.gather(*tasks)
+            assert registry.session("context-1").turns[-1].state == TURN_OUTCOME_UNKNOWN
+            assert sent[0][1]["browser_session_id"] == sent[2][1]["browser_session_id"]
+            assert sent[0][1]["turn_id"] != sent[2][1]["turn_id"]
+        finally:
+            services.uninstall()
+            assert not services.installed
+            assert not lifecycle.configured
+
+    asyncio.run(scenario())
+
+
+def test_production_owner_hook_open_and_content_share_turn_until_monologue_end(monkeypatch):
+    async def scenario():
+        original_binding, policy = _fixture()
+        principal = original_binding.principal
+        _allow(policy)
+        lifecycle = sessions.ExtensionSessionLifecycle(
+            registry=sessions.ExtensionSessionRegistry(persistence=MemoryPersistence()),
+            config_loader=lambda _agent: {"runtime_backend": "host_required", "host_browser_selection": "extension:bridge-1"})
+        monkeypatch.setattr(sessions, "_lifecycle", lifecycle)
+        # Capture the real production constructor's dependency choice without
+        # installing a live socket/application or touching the default KVP.
+        monkeypatch.setattr(browser_bridge_application, "BrowserBridgeApplication",
+            lambda **kwargs: SimpleNamespace(browser=SimpleNamespace(lifecycle=kwargs["lifecycle"])))
+        owner = browser_bridge_runtime_owner.BrowserBridgeRuntimeOwner(
+            manager=SimpleNamespace(principal_for_sid=lambda *args: None), release_verifier=lambda *args: None)
+        assert owner.application.browser.lifecycle is sessions.get_extension_session_lifecycle()
+        route = sessions.ValidatedExtensionRoute("bridge-1", "extension:bridge-1", principal, "sid-1", "load-1")
+        sent, bindings, tasks = [], [], []
+        async def sender(sid, event, payload, correlation, expected):
+            sent.append((event, payload))
+            keys = ["contract_version", "bridge_id", "load_generation_id", "context_id", "browser_session_id", "turn_id"]
+            if event == "connector_browser_op":
+                keys += ["op_id", "action_id"]
+                if payload["action"] == "open":
+                    result = {"browser_id": "tab-1", "tab_handle": "tab-1", "lease_id": "lease-1",
+                              "origin": "https://example.com", "disposition": "ephemeral", "grouped": True}
+                else:
+                    result = {"browser_id": "tab-1", "tab_handle": "tab-1", "lease_id": "lease-1",
+                              "document_id": "doc-1", "document_epoch": "1", "title": "Synthetic",
+                              "text": "Synthetic page", "nodes": [], "truncated": False}
+                broker.settle_operation(principal=expected, connector_sid=sid, load_generation_id="load-1",
+                    payload={**{key: payload[key] for key in keys}, "ok": True, "result": result, "receipts": [], "artifacts": []})
+            else:
+                keys += ["method", "control_id"]
+                broker.settle_control(principal=expected, connector_sid=sid, load_generation_id="load-1",
+                    payload={**{key: payload[key] for key in keys}, "ok": True, "result": {
+                        "contract_version": 1, "control_id": payload["control_id"], "closed": ["lease-1"],
+                        "released": [], "retained": [], "already_finalized": [], "errors": []}})
+        def authorize(binding):
+            if hasattr(binding, "op_id"):
+                bindings.append(binding)
+            return _authorize(binding)
+        broker = BrowserBridgeOperationBroker(sender=sender, authorizer=authorize)
+        services = ExtensionBrowserServices(lifecycle=owner.application.browser.lifecycle, broker=broker,
+            route_resolver=lambda *args: route, policy_repository=policy, server_instance_id="server-1")
+        def submit(coroutine):
+            tasks.append(asyncio.create_task(coroutine))
+            return Future()
+        services.install(submitter=submit)
+        agent = SimpleNamespace(context=SimpleNamespace(id="context-1"))
+        try:
+            assert sessions.begin_extension_monologue(agent) is not None
+            first = services.runtime_for_agent(agent, "bridge-1")
+            result = await first.call("open", "https://example.com/")
+            second = services.runtime_for_agent(agent, "bridge-1")
+            assert (await second.call("content", result["browser_id"], None))["text"] == "Synthetic page"
+            operations = [payload for event, payload in sent if event == "connector_browser_op"]
+            assert len(operations) == 2 and operations[0]["turn_id"] == operations[1]["turn_id"]
+            assert operations[0]["browser_session_id"] == operations[1]["browser_session_id"]
+            assert not tasks and all(event == "connector_browser_op" for event, payload in sent)
+            assert services.leases.origin_for(bindings[-1], "tab-1") == "https://example.com"
+            sessions.finalize_extension_monologue(agent, reason="completed")
+            await asyncio.gather(*tasks)
+            assert services.leases.origin_for(bindings[-1], "tab-1") is None
+            assert len([event for event, payload in sent if event == "connector_browser_control"]) == 1
+        finally:
+            services.uninstall()
+            await asyncio.gather(*tasks)
+    asyncio.run(scenario())

--- a/tests/test_browser_extension_sessions_foundation.py
+++ b/tests/test_browser_extension_sessions_foundation.py
@@ -1,0 +1,615 @@
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import copy
+from dataclasses import replace
+import itertools
+import json
+from pathlib import Path
+from types import SimpleNamespace
+import threading
+
+import pytest
+
+from helpers.ws_principal import WsPrincipal
+from plugins._browser.helpers.extension_sessions import (
+    ExtensionSessionLifecycle,
+    ExtensionSessionRegistry,
+    ExtensionSessionStateError,
+    ProcessFinalizationDispatcher,
+    TURN_FINALIZATION_PENDING,
+    TURN_FINALIZED,
+    TURN_OUTCOME_UNKNOWN,
+    ValidatedExtensionRoute,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+BRIDGE_ID = "Bridge-Session-1"
+BROWSER_ID = f"extension:{BRIDGE_ID}"
+
+
+class MemoryPersistence:
+    def __init__(self, value=None):
+        self.value = copy.deepcopy(value)
+        self.writes = 0
+
+    def load(self):
+        return copy.deepcopy(self.value)
+
+    def save(self, value):
+        self.value = copy.deepcopy(value)
+        self.writes += 1
+
+
+def _registry(*, persistence=None, max_turns=64):
+    counter = itertools.count(1)
+    return ExtensionSessionRegistry(
+        persistence=persistence or MemoryPersistence(),
+        clock_ms=lambda: 1_700_000_000_000 + next(counter),
+        id_factory=lambda: f"id_{next(counter)}",
+        max_turns_per_session=max_turns,
+    )
+
+
+def _principal(bridge_id=BRIDGE_ID):
+    return WsPrincipal(
+        principal_type="browser_bridge",
+        principal_id=bridge_id,
+        subject_id="single_user",
+        scopes=frozenset({"bridge.connect", "browser.control"}),
+        handler_path="plugins/_a0_connector/ws_connector",
+        handler_id="ws_connector.WsConnector",
+        inbound_events=frozenset({"connector_browser_control_result"}),
+        outbound_events=frozenset({"connector_browser_control"}),
+        key_generation=4,
+    )
+
+
+def _route(bridge_id=BRIDGE_ID):
+    return ValidatedExtensionRoute(
+        bridge_id=bridge_id,
+        browser_id=f"extension:{bridge_id}",
+        principal=_principal(bridge_id),
+        connector_sid="sid-current",
+        load_generation_id="generation.current-1",
+    )
+
+
+def _agent(context_id="context-1"):
+    context = SimpleNamespace(id=context_id)
+    agent = SimpleNamespace(context=context)
+    context.agent0 = agent
+    context.streaming_agent = None
+    return agent
+
+
+def _extension_config(_agent):
+    return {
+        "runtime_backend": "host_required",
+        "host_browser_selection": BROWSER_ID,
+    }
+
+
+def test_registry_keeps_one_pinned_session_and_allocates_fresh_turns():
+    registry = _registry()
+
+    first_session, first_turn = registry.begin_turn(
+        context_id="context-1", browser_id=BROWSER_ID, bridge_id=BRIDGE_ID
+    )
+    second_session, second_turn = registry.begin_turn(
+        context_id="context-1", browser_id=BROWSER_ID, bridge_id=BRIDGE_ID
+    )
+
+    assert second_session.browser_session_id == first_session.browser_session_id
+    assert second_turn.turn_id != first_turn.turn_id
+    assert [turn.turn_id for turn in second_session.turns] == [
+        first_turn.turn_id,
+        second_turn.turn_id,
+    ]
+    with pytest.raises(ExtensionSessionStateError) as exc:
+        registry.begin_turn(
+            context_id="context-1",
+            browser_id="extension:another-bridge",
+            bridge_id="another-bridge",
+        )
+    assert exc.value.code == "BRIDGE_PIN_CONFLICT"
+
+
+def test_durable_projection_is_bounded_sanitized_and_contains_only_dispositions():
+    persistence = MemoryPersistence()
+    registry = _registry(persistence=persistence)
+    session, turn = registry.begin_turn(
+        context_id="context-safe", browser_id=BROWSER_ID, bridge_id=BRIDGE_ID
+    )
+    registry.record_disposition(
+        context_id=session.context_id,
+        browser_session_id=session.browser_session_id,
+        turn_id=turn.turn_id,
+        lease_id="lease_opaque_1",
+        disposition="ephemeral",
+    )
+    route = _route()
+
+    encoded = json.dumps(persistence.value, sort_keys=True)
+    assert persistence.value["contract"] == "a0.browser-bridge.extension-sessions.v1"
+    assert persistence.value["schema_version"] == 1
+    assert '"lease_opaque_1": "ephemeral"' in encoded
+    for forbidden in (
+        route.connector_sid,
+        route.load_generation_id,
+        route.principal.subject_id,
+        "principal",
+        "public_key",
+        "tab_id",
+        "group_id",
+        "tab_handle",
+        "https://",
+        "page_content",
+        "selector",
+        "script",
+    ):
+        assert forbidden not in encoded
+
+
+def test_finalization_is_idempotent_exact_and_first_terminal_wins():
+    registry = _registry()
+    _session, turn = registry.begin_turn(
+        context_id="context-1", browser_id=BROWSER_ID, bridge_id=BRIDGE_ID
+    )
+
+    first = registry.stage_finalize(
+        context_id="context-1", turn_id=turn.turn_id, reason="completed"
+    )
+    repeated = registry.stage_finalize(
+        context_id="context-1", turn_id=turn.turn_id, reason="different-repeat"
+    )
+
+    assert first == repeated
+    assert first[0].dispositions == ()
+    assert registry.settle_finalization(
+        replace(first[0], browser_session_id="wrong-session"), TURN_FINALIZED
+    ) == "mismatch"
+    assert registry.settle_finalization(first[0], TURN_FINALIZED) == "settled"
+    assert registry.settle_finalization(first[0], TURN_OUTCOME_UNKNOWN) == "duplicate"
+    settled = registry.session("context-1")
+    assert settled is not None
+    assert settled.turns[0].state == TURN_FINALIZED
+    assert "tabs_closed" not in repr(settled)
+
+
+def test_retirement_deletes_only_proven_finalized_state_and_retains_uncertainty():
+    finalized_registry = _registry()
+    _, turn = finalized_registry.begin_turn(
+        context_id="finalized-context", browser_id=BROWSER_ID, bridge_id=BRIDGE_ID
+    )
+    intent = finalized_registry.stage_finalize(
+        context_id="finalized-context",
+        turn_id=turn.turn_id,
+        reason="reset",
+        retire=True,
+    )[0]
+    assert finalized_registry.settle_finalization(intent, TURN_FINALIZED) == "settled"
+    assert finalized_registry.session("finalized-context") is None
+
+    unknown_registry = _registry()
+    _, turn = unknown_registry.begin_turn(
+        context_id="unknown-context", browser_id=BROWSER_ID, bridge_id=BRIDGE_ID
+    )
+    intent = unknown_registry.stage_finalize(
+        context_id="unknown-context",
+        turn_id=turn.turn_id,
+        reason="removed",
+        retire=True,
+        remove=True,
+    )[0]
+    assert unknown_registry.settle_finalization(intent, TURN_OUTCOME_UNKNOWN) == "settled"
+    retained = unknown_registry.session("unknown-context")
+    assert retained is not None
+    assert retained.remove_requested is True
+    assert retained.turns[0].state == TURN_OUTCOME_UNKNOWN
+
+
+def test_corrupt_or_over_capacity_state_fails_closed_without_rewrite():
+    corrupt = MemoryPersistence(
+        {
+            "contract": "a0.browser-bridge.extension-sessions.v1",
+            "schema_version": 1,
+            "sessions": [],
+            "page_content": "must-not-be-tolerated",
+        }
+    )
+    registry = _registry(persistence=corrupt)
+
+    with pytest.raises(ExtensionSessionStateError) as exc:
+        registry.begin_turn(
+            context_id="context-1", browser_id=BROWSER_ID, bridge_id=BRIDGE_ID
+        )
+    assert exc.value.code == "CORRUPT_STORE"
+    assert corrupt.writes == 0
+
+    bounded = _registry(max_turns=1)
+    bounded.begin_turn(
+        context_id="context-1", browser_id=BROWSER_ID, bridge_id=BRIDGE_ID
+    )
+    with pytest.raises(ExtensionSessionStateError) as exc:
+        bounded.begin_turn(
+            context_id="context-1", browser_id=BROWSER_ID, bridge_id=BRIDGE_ID
+        )
+    assert exc.value.code == "TURN_REGISTRY_FULL"
+
+
+def test_dispatcher_leaves_missing_route_pending_and_marks_send_uncertain():
+    registry = _registry()
+    _, turn = registry.begin_turn(
+        context_id="context-1", browser_id=BROWSER_ID, bridge_id=BRIDGE_ID
+    )
+    intent = registry.stage_finalize(
+        context_id="context-1", turn_id=turn.turn_id, reason="canceled"
+    )[0]
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        dispatcher = ProcessFinalizationDispatcher(
+            registry=registry,
+            route_resolver=lambda _context_id, _bridge_id: None,
+            sender=lambda _intent, _route: pytest.fail("sender must not run"),
+            submitter=lambda coroutine: executor.submit(asyncio.run, coroutine),
+        )
+        assert dispatcher.replay_pending() == ()
+        assert registry.session("context-1").turns[0].state == TURN_FINALIZATION_PENDING
+
+        async def uncertain_sender(_intent, _route):
+            raise ConnectionError("raw remote detail must not persist")
+
+        dispatcher = ProcessFinalizationDispatcher(
+            registry=registry,
+            route_resolver=lambda _context_id, _bridge_id: _route(),
+            sender=uncertain_sender,
+            submitter=lambda coroutine: executor.submit(asyncio.run, coroutine),
+        )
+        assert dispatcher.replay_pending() == (intent.control_id,)
+        for _ in range(100):
+            state = registry.session("context-1").turns[0].state
+            if state == TURN_OUTCOME_UNKNOWN:
+                break
+            threading.Event().wait(0.005)
+        assert state == TURN_OUTCOME_UNKNOWN
+
+    assert "raw remote detail" not in json.dumps(registry.sessions(), default=str)
+
+
+def test_process_owned_dispatch_survives_the_callers_scope():
+    registry = _registry()
+    _, turn = registry.begin_turn(
+        context_id="context-1", browser_id=BROWSER_ID, bridge_id=BRIDGE_ID
+    )
+    intent = registry.stage_finalize(
+        context_id="context-1", turn_id=turn.turn_id, reason="completed"
+    )[0]
+    release = threading.Event()
+    delivered = threading.Event()
+
+    async def sender(_intent, _route):
+        await asyncio.to_thread(release.wait)
+        delivered.set()
+        return TURN_FINALIZED
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        dispatcher = ProcessFinalizationDispatcher(
+            registry=registry,
+            route_resolver=lambda _context_id, _bridge_id: _route(),
+            sender=sender,
+            submitter=lambda coroutine: executor.submit(asyncio.run, coroutine),
+        )
+        assert dispatcher.schedule((intent,)) == (intent.control_id,)
+        assert dispatcher.inflight_count == 1
+        release.set()
+        assert delivered.wait(1)
+        for _ in range(100):
+            if registry.session("context-1").turns[0].state == TURN_FINALIZED:
+                break
+            threading.Event().wait(0.005)
+        assert registry.session("context-1").turns[0].state == TURN_FINALIZED
+
+
+def test_dispatch_re_resolves_route_after_background_handoff():
+    registry = _registry()
+    _, turn = registry.begin_turn(
+        context_id="context-1", browser_id=BROWSER_ID, bridge_id=BRIDGE_ID
+    )
+    intent = registry.stage_finalize(
+        context_id="context-1", turn_id=turn.turn_id, reason="completed"
+    )[0]
+    old_route = _route()
+    new_route = replace(old_route, connector_sid="sid-reconnected")
+    resolutions = iter((old_route, new_route))
+    used_routes = []
+
+    async def sender(_intent, route):
+        used_routes.append(route)
+        return TURN_FINALIZED
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        dispatcher = ProcessFinalizationDispatcher(
+            registry=registry,
+            route_resolver=lambda _context_id, _bridge_id: next(resolutions),
+            sender=sender,
+            submitter=lambda coroutine: executor.submit(asyncio.run, coroutine),
+        )
+        assert dispatcher.schedule((intent,)) == (intent.control_id,)
+        for _ in range(100):
+            if used_routes:
+                break
+            threading.Event().wait(0.005)
+
+    assert used_routes == [new_route]
+
+
+def test_lifecycle_creates_no_intent_without_exact_explicit_validated_route():
+    persistence = MemoryPersistence()
+    registry = _registry(persistence=persistence)
+    agent = _agent()
+    lifecycle = ExtensionSessionLifecycle(
+        registry=registry, config_loader=_extension_config
+    )
+
+    assert lifecycle.begin_agent_turn(agent) is None
+    assert persistence.writes == 0
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        lifecycle.configure(
+            route_resolver=lambda _context_id, _bridge_id: None,
+            sender=lambda _intent, _route: pytest.fail("sender must not run"),
+            submitter=lambda coroutine: executor.submit(asyncio.run, coroutine),
+        )
+        assert lifecycle.begin_agent_turn(agent) is None
+        assert persistence.writes == 0
+
+        container = ExtensionSessionLifecycle(
+            registry=registry,
+            config_loader=lambda _agent: {
+                "runtime_backend": "container",
+                "host_browser_selection": BROWSER_ID,
+            },
+        )
+        container.configure(
+            route_resolver=lambda _context_id, _bridge_id: _route(),
+            sender=lambda _intent, _route: TURN_FINALIZED,
+            submitter=lambda coroutine: executor.submit(asyncio.run, coroutine),
+        )
+        assert container.begin_agent_turn(agent) is None
+        assert persistence.writes == 0
+
+        lifecycle = ExtensionSessionLifecycle(
+            registry=registry, config_loader=_extension_config
+        )
+        lifecycle.configure(
+            route_resolver=lambda _context_id, _bridge_id: _route(),
+            sender=lambda _intent, _route: TURN_FINALIZED,
+            submitter=lambda coroutine: executor.submit(asyncio.run, coroutine),
+        )
+        turn = lifecycle.begin_agent_turn(agent)
+        assert turn is not None
+        session = registry.session("context-1")
+        assert session is not None
+        assert session.browser_id == BROWSER_ID
+        binding = lifecycle.active_agent_turn(agent)
+        assert binding is not None
+        assert lifecycle.is_current_turn(agent, binding) is True
+        assert (
+            binding.context_id,
+            binding.browser_session_id,
+            binding.browser_id,
+            binding.bridge_id,
+            binding.turn_id,
+        ) == (
+            "context-1",
+            session.browser_session_id,
+            BROWSER_ID,
+            BRIDGE_ID,
+            turn.turn_id,
+        )
+
+        with pytest.raises(ExtensionSessionStateError) as exc:
+            lifecycle.configure(
+                route_resolver=lambda _context_id, _bridge_id: _route(),
+                sender=lambda _intent, _route: TURN_FINALIZED,
+                submitter=lambda coroutine: executor.submit(asyncio.run, coroutine),
+            )
+        assert exc.value.code == "ALREADY_CONFIGURED"
+
+
+def test_exact_owner_unconfigure_is_reversible_and_preserves_offline_cleanup():
+    registry = _registry()
+    lifecycle = ExtensionSessionLifecycle(
+        registry=registry, config_loader=_extension_config
+    )
+    owner = object()
+    replacement_owner = object()
+    current_route = [_route()]
+    delivered = []
+
+    async def sender(intent, _route):
+        delivered.append(intent)
+        return TURN_FINALIZED
+
+    lifecycle.configure(
+        owner=owner,
+        route_resolver=lambda _context_id, _bridge_id: current_route[0],
+        sender=sender,
+    )
+    agent = _agent()
+    turn = lifecycle.begin_agent_turn(agent)
+    assert turn is not None
+    with pytest.raises(ExtensionSessionStateError) as exc:
+        lifecycle.unconfigure(owner=replacement_owner)
+    assert exc.value.code == "OWNER_MISMATCH"
+    assert lifecycle.configured_for(owner)
+
+    # Losing the route during owner retirement cannot turn a pending cleanup
+    # into a false not-applied or finalized result.
+    current_route[0] = None
+    assert lifecycle.unconfigure(owner=owner) == ()
+    pending = registry.session("context-1").turns[-1]
+    assert pending.state == TURN_FINALIZATION_PENDING
+    assert pending.reason == "restarted"
+    assert "runtime_owner_retired" not in repr(registry.sessions())
+    assert not lifecycle.configured
+
+    current_route[0] = _route()
+    replayed = lifecycle.configure(
+        owner=replacement_owner,
+        route_resolver=lambda _context_id, _bridge_id: current_route[0],
+        sender=sender,
+    )
+    assert replayed == (pending.control_id,)
+    for _ in range(100):
+        if registry.session("context-1").turns[-1].state == TURN_FINALIZED:
+            break
+        threading.Event().wait(0.005)
+    assert registry.session("context-1").turns[-1].state == TURN_FINALIZED
+    assert delivered[0].reason == "restarted"
+    assert lifecycle.unconfigure(owner=replacement_owner) == ()
+
+
+def test_offline_cleanup_stages_existing_intent_after_selection_changes():
+    persistence = MemoryPersistence()
+    registry = _registry(persistence=persistence)
+    agent = _agent("offline-context")
+    config = {
+        "runtime_backend": "host_required",
+        "host_browser_selection": BROWSER_ID,
+    }
+    current_route = [_route()]
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        lifecycle = ExtensionSessionLifecycle(
+            registry=registry, config_loader=lambda _agent: dict(config)
+        )
+        lifecycle.configure(
+            route_resolver=lambda _context_id, _bridge_id: current_route[0],
+            sender=lambda _intent, _route: pytest.fail("offline sender must not run"),
+            submitter=lambda coroutine: executor.submit(asyncio.run, coroutine),
+        )
+        turn = lifecycle.begin_agent_turn(agent)
+        assert turn is not None
+
+        config["runtime_backend"] = "container"
+        config["host_browser_selection"] = ""
+        current_route[0] = None
+        assert lifecycle.finalize_context(
+            agent.context, reason="reset", retire=True
+        ) == ()
+
+    session = registry.session("offline-context")
+    assert session is not None
+    assert session.retire_requested is True
+    assert session.turns[0].turn_id == turn.turn_id
+    assert session.turns[0].state == TURN_FINALIZATION_PENDING
+
+
+def test_task_done_fallback_stages_exact_tracked_turn_without_current_route():
+    callbacks = []
+
+    class FakeTask:
+        def add_done_callback(self, callback):
+            callbacks.append(callback)
+
+    registry = _registry()
+    agent = _agent("task-done-context")
+    agent.context.task = FakeTask()
+    current_route = [_route()]
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        lifecycle = ExtensionSessionLifecycle(
+            registry=registry, config_loader=_extension_config
+        )
+        lifecycle.configure(
+            route_resolver=lambda _context_id, _bridge_id: current_route[0],
+            sender=lambda _intent, _route: pytest.fail("offline sender must not run"),
+            submitter=lambda coroutine: executor.submit(asyncio.run, coroutine),
+        )
+        turn = lifecycle.begin_agent_turn(agent)
+        assert turn is not None
+        assert len(callbacks) == 1
+        current_route[0] = None
+        callbacks[0](object())
+
+    session = registry.session("task-done-context")
+    assert session is not None
+    assert session.turns[0].turn_id == turn.turn_id
+    assert session.turns[0].state == TURN_FINALIZATION_PENDING
+    assert session.turns[0].reason == "task_done"
+
+
+def test_synthetic_scope_is_exact_bounded_and_never_overwrites_monologue_turn():
+    registry = _registry()
+    agent = _agent("synthetic-context")
+    delivered = threading.Event()
+
+    async def sender(_intent, _route):
+        delivered.set()
+        return TURN_FINALIZED
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        lifecycle = ExtensionSessionLifecycle(
+            registry=registry, config_loader=_extension_config
+        )
+        lifecycle.configure(
+            route_resolver=lambda _context_id, _bridge_id: _route(),
+            sender=sender,
+            submitter=lambda coroutine: executor.submit(asyncio.run, coroutine),
+        )
+        synthetic = lifecycle.begin_synthetic_turn(agent)
+        assert synthetic is not None
+        assert lifecycle.active_agent_turn(agent) is None
+        assert lifecycle.is_current_turn(agent, synthetic) is True
+        assert lifecycle.begin_synthetic_turn(agent) is None
+        assert lifecycle.finalize_synthetic_turn(
+            agent, replace(synthetic, turn_id="wrong-turn")
+        ) == ()
+        scheduled = lifecycle.finalize_synthetic_turn(agent, synthetic)
+        assert len(scheduled) == 1
+        assert lifecycle.is_current_turn(agent, synthetic) is False
+        assert delivered.wait(1)
+
+        monologue_turn = lifecycle.begin_agent_turn(agent)
+        assert monologue_turn is not None
+        assert lifecycle.begin_synthetic_turn(agent) is None
+        active = lifecycle.active_agent_turn(agent)
+        assert active is not None
+        assert active.turn_id == monologue_turn.turn_id
+
+
+def test_lifecycle_hooks_are_wired_before_existing_reset_and_remove_cleanup():
+    browser_extensions = PROJECT_ROOT / "plugins" / "_browser" / "extensions" / "python"
+    expected = (
+        "monologue_start/_15_extension_session.py",
+        "monologue_end/_10_extension_session.py",
+        "_functions/agent/AgentContext/kill_process/start/_05_finalize_extension_session.py",
+        "_functions/agent/AgentContext/reset/start/_05_finalize_extension_session.py",
+        "_functions/agent/AgentContext/remove/start/_05_finalize_extension_session.py",
+        "_functions/agent/AgentContext/__init__/start/_05_finalize_replaced_extension_session.py",
+        "_functions/agent/Agent/monologue/end/_05_finalize_extension_session.py",
+    )
+    for relative in expected:
+        assert (browser_extensions / relative).is_file()
+
+    reset_names = sorted(
+        path.name
+        for path in (
+            browser_extensions / "_functions/agent/AgentContext/reset/start"
+        ).glob("*.py")
+    )
+    remove_names = sorted(
+        path.name
+        for path in (
+            browser_extensions / "_functions/agent/AgentContext/remove/start"
+        ).glob("*.py")
+    )
+    assert reset_names.index("_05_finalize_extension_session.py") < reset_names.index(
+        "_10_cleanup_browser_runtime.py"
+    )
+    assert remove_names.index("_05_finalize_extension_session.py") < remove_names.index(
+        "_10_cleanup_browser_runtime.py"
+    )

--- a/tests/test_browser_extension_uploads.py
+++ b/tests/test_browser_extension_uploads.py
@@ -1,0 +1,123 @@
+from types import SimpleNamespace
+import sys
+
+import pytest
+
+from plugins._browser.helpers.extension_uploads import (
+    STORE_KEY, UploadSourceDenied, record_user_attachments, prepare_upload,
+)
+
+
+class Context:
+    def __init__(self, identity):
+        self.id = identity
+        self.data = {}
+
+    def get_data(self, key, recursive=False):
+        return self.data.get(key)
+
+    def set_data(self, key, value, recursive=False):
+        self.data[key] = value
+
+
+@pytest.fixture
+def source(tmp_path, monkeypatch):
+    import helpers
+    files = SimpleNamespace(fix_dev_path=lambda value:value)
+    monkeypatch.setitem(sys.modules, "helpers.files", files)
+    monkeypatch.setattr(helpers, "files", files, raising=False)
+    path = tmp_path / "user-file.txt"
+    path.write_bytes(b"user-provided content")
+    path.chmod(0o600)
+    return tmp_path, path
+
+
+def test_only_frozen_current_chat_attachment_can_be_prepared_and_read(source):
+    root, path = source
+    context = Context("chat-1")
+    with pytest.raises(UploadSourceDenied):
+        prepare_upload(context, path=str(path), root=root)
+    record_user_attachments(context, [str(path)], root=root)
+    upload = prepare_upload(context, path=str(path), root=root)
+    assert upload.read() == b"user-provided content"
+    assert upload.mime_type == "text/plain"
+    assert str(path) not in repr(upload)
+    sibling = Context("chat-2")
+    sibling.data[STORE_KEY] = context.data[STORE_KEY]
+    with pytest.raises(UploadSourceDenied):
+        prepare_upload(sibling, path=str(path), root=root)
+    with pytest.raises(UploadSourceDenied):
+        prepare_upload(context, path=str(path), paths=[str(path)], root=root)
+
+
+def test_replacement_modification_links_and_foreign_paths_are_denied(source, tmp_path):
+    root, path = source
+    context = Context("chat-1")
+    record_user_attachments(context, [str(path)], root=root)
+    upload = prepare_upload(context, path=str(path), root=root)
+    path.write_bytes(b"different context changed file")
+    with pytest.raises(UploadSourceDenied):
+        upload.read()
+    link = root / "alias.txt"
+    link.symlink_to(path)
+    record_user_attachments(context, [str(link)], root=root)
+    with pytest.raises(UploadSourceDenied):
+        prepare_upload(context, path=str(link), root=root)
+    with pytest.raises(UploadSourceDenied):
+        prepare_upload(context, path="/etc/passwd", root=root)
+
+
+def test_corrupt_metadata_and_empty_or_multiple_sources_are_denied(source):
+    root, path = source
+    context = Context("chat-1")
+    record_user_attachments(context, [str(path)], root=root)
+    context.data[STORE_KEY][0]["byte_count"] = True
+    with pytest.raises(UploadSourceDenied):
+        prepare_upload(context, path=str(path), root=root)
+    for kwargs in ({}, {"paths":[]}, {"paths":[str(path),str(path)]}, {"paths":"not-a-list"}):
+        with pytest.raises(UploadSourceDenied):
+            prepare_upload(context, root=root, **kwargs)
+
+
+def test_runtime_upload_stages_only_recorded_bytes_after_operation_dispatch(source):
+    import asyncio
+    from dataclasses import replace
+    from test_browser_extension_runtime import _fixture, _allow, _authorize
+    from plugins._browser.helpers.extension_runtime import ExtensionBrowserRuntime
+    from plugins._a0_connector.helpers.browser_bridge_operations import BrowserBridgeOperationBroker
+
+    root, path = source
+    context = Context("context-1")
+    record_user_attachments(context, [str(path)], root=root)
+
+    async def scenario():
+        binding, policy = _fixture()
+        _allow(policy)
+        payloads, staged = [], []
+        def authorize(binding):
+            base = _authorize(binding)
+            return replace(base, actions=base.actions | {"upload_file"},
+                           features=base.features | {"trusted_input_v1", "artifacts_v1"})
+        async def sender(_sid, _event, payload, _correlation, _principal):
+            payloads.append(payload)
+        broker = BrowserBridgeOperationBroker(sender=sender, authorizer=authorize)
+        async def upload(operation, ticket, prepared):
+            await broker.wait_dispatched(ticket)
+            assert len(payloads) == 1
+            staged.append(prepared.read())
+            payload = payloads[0]
+            assert "path" not in payload["args"] and "paths" not in payload["args"]
+            assert str(path) not in str(payload)
+            keys = ("contract_version", "bridge_id", "load_generation_id", "context_id", "browser_session_id", "turn_id", "op_id", "action_id")
+            broker.settle_operation(principal=operation.principal, connector_sid=operation.connector_sid,
+                load_generation_id=operation.load_generation_id, payload={**{key:payload[key] for key in keys},
+                "ok":True,"result":{"lease_id":"lease-1","browser_id":"a0t1.load.tab","tab_handle":"a0t1.load.tab",
+                "document_epoch":"1","ref":"ref-1","action_class":"external_side_effect"},"receipts":[],"artifacts":[]})
+        runtime = ExtensionBrowserRuntime("context-1", "bridge-1", broker=broker, binding_factory=lambda:binding,
+            policy_repository=policy, server_instance_id="server-1", target_origin_resolver=lambda *_:"https://example.com",
+            action_challenge_ready=lambda _:True, prepare_upload=lambda **kwargs:prepare_upload(context,root=root,**kwargs),
+            upload_sender=upload)
+        result = await runtime.call("upload_file", "a0t1.load.tab", "ref-1", path=str(path), paths=[])
+        assert result["action_class"] == "external_side_effect"
+        assert staged == [b"user-provided content"]
+    asyncio.run(scenario())

--- a/tests/test_browser_extension_viewer_boundary.py
+++ b/tests/test_browser_extension_viewer_boundary.py
@@ -1,0 +1,81 @@
+"""Extension handles must never enter the incumbent container viewer lane."""
+import shutil
+import subprocess
+import ast
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace, MethodType
+
+import pytest
+
+
+def test_extension_log_projection_hides_input_without_mutating_tool_arguments():
+    root = Path(__file__).resolve().parents[1]
+    source = ast.parse((root / "plugins/_browser/tools/browser.py").read_text())
+    names = {"get_log_object", "_presentation_arguments", "get_display_args"}
+    methods = [node for node in ast.walk(source)
+               if isinstance(node, ast.FunctionDef) and node.name in names]
+    config = {"runtime_backend": "host_required", "host_browser_selection": "extension:bridge-1"}
+    namespace = {"get_browser_config": lambda **kwargs: config,
+                 "parse_extension_browser_selection": lambda value: value or None}
+    exec(compile(ast.Module(body=methods, type_ignores=[]), "browser-log-projection", "exec"), namespace)
+    args = {"action": "type", "text": "synthetic private text", "_browser_backend": "forged"}
+    agent = SimpleNamespace(agent_name="Agent Zero", context=SimpleNamespace(log=SimpleNamespace(log=lambda **kwargs: kwargs)))
+    owner = SimpleNamespace(args=args, agent=agent, name="browser")
+    for name in names:
+        setattr(owner, name, MethodType(namespace[name], owner))
+    projected = namespace["get_log_object"](owner)["kvps"]
+    assert projected["text"] == "[Input text withheld]" and projected["_browser_backend"] == "chrome_extension"
+    assert args["text"] == "synthetic private text" and args["_browser_backend"] == "forged"
+    # Exercise the actual base pre-execution console/extension-output path.
+    base = ast.parse((root / "helpers/tool.py").read_text())
+    before = next(node for node in ast.walk(base)
+                  if isinstance(node, ast.AsyncFunctionDef) and node.name == "before_execution")
+    output = []
+    async def observe(_hook, _agent, ctx):
+        output.append(ctx["content"])
+    namespace.update(PrintStyle=lambda **kwargs: SimpleNamespace(print=lambda *args: None, stream=lambda *args: None),
+                     call_extensions_async=observe)
+    exec(compile(ast.Module(body=[before], type_ignores=[]), "tool-display-projection", "exec"), namespace)
+    owner.nice_key = lambda key: key
+    asyncio.run(namespace["before_execution"](owner))
+    assert "synthetic private text" not in output and "[Input text withheld]" in output
+    config["runtime_backend"] = "container"
+    projected = namespace["get_log_object"](owner)["kvps"]
+    assert "_browser_backend" not in projected and projected["text"] == args["text"]
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="Node required")
+def test_extension_results_cannot_select_or_preview_container_tabs():
+    root = Path(__file__).resolve().parents[1]
+    script = r'''
+import fs from 'node:fs';
+import assert from 'node:assert/strict';
+const root=process.argv[2]+'/plugins/_browser/extensions/webui/';
+const source=fs.readFileSync(root+'get_tool_message_handler/browser-tool-handler.js','utf8');
+const extract=(text,name)=>text.match(new RegExp('function '+name+'\\([^]*?\\n}'))[0];
+const names=['browserIdFromResult','isExtensionBrowserTarget','buildBrowserCanvasPayload','shouldRenderBrowserScreenshotKvp','shouldSyncOpenBrowserCanvas'];
+const code=names.map(name=>extract(source,name)).join('\n');
+const probe=new Function('result','kvps', `
+const browserSnapshotMeta=()=>({}),currentBrowserContextId=()=> 'context-1';
+const normalizeBrowserAction=kvps=>kvps.action,NO_SCREENSHOT_ACTIONS=new Set();
+const isBrowserCanvasAlreadyOpen=()=>true,isFreshToolMessage=()=>true,FOCUS_ACTIONS=new Set(['navigate']);
+${code}
+return [buildBrowserCanvasPayload(result,kvps),shouldRenderBrowserScreenshotKvp(result,kvps),shouldSyncOpenBrowserCanvas({kvps},result)];`);
+for(const id of ['a0t1.generation.lease','extension:bridge-1']) {
+  assert.deepEqual(probe({browser_id:id},{action:'navigate'}),[null,false,false]);
+  assert.deepEqual(probe({},{browser_id:id,action:'navigate'}),[null,false,false]);
+}
+assert.deepEqual(probe({browser_id:7},{action:'navigate'}),[{browserId:7,contextId:'context-1',source:'tool-kvp'},true,true]);
+assert.deepEqual(probe({},{action:'ensure',_browser_backend:'chrome_extension'}),[null,false,false]);
+const auto=fs.readFileSync(root+'set_messages_after_loop/auto-open-browser-results.js','utf8');
+const sync=new Function('id', `const isBrowserCanvasAlreadyOpen=()=>true,isFresh=()=>true,FOCUS_ACTIONS=new Set(['navigate']);
+${extract(auto,'getBrowserId')}\n${extract(auto,'shouldSyncOpenBrowserCanvas')}
+return shouldSyncOpenBrowserCanvas({}, {action:'navigate'}, {browser_id:id});`);
+assert.equal(sync('a0t1.generation.lease'),false);assert.equal(sync(7),true);
+// Verified static screenshots remain visible despite suppressing live previews.
+assert.match(source,/if \(screenshotUri\) \{\s*displayKvps\[BROWSER_SCREENSHOT_KVP_KEY\] = screenshotUri;/);
+'''
+    result = subprocess.run(["node", "--input-type=module", "-", str(root)],
+                            input=script, text=True, capture_output=True, timeout=10)
+    assert result.returncode == 0, result.stderr

--- a/tests/test_browser_mv3_runtime_foundation.py
+++ b/tests/test_browser_mv3_runtime_foundation.py
@@ -1,0 +1,46 @@
+import pytest
+
+from plugins._browser.helpers.bridge_foundation import (
+    BrowserBridgeGate,
+    build_browser_bridge_status,
+)
+from plugins._browser.helpers.mv3_runtime_foundation import (
+    BRIDGE_CONTRACT_VERSION,
+    BRIDGE_PROTOCOL_CONTRACT,
+    CORE_ADAPTER_CONTRACT,
+    MV3_RUNTIME_CONTRACT,
+    build_mv3_runtime_foundation_status,
+)
+
+
+def test_mv3_status_projects_exact_contracts_but_remains_disabled() -> None:
+    assert build_mv3_runtime_foundation_status() == {
+        "contract": MV3_RUNTIME_CONTRACT,
+        "adapter_contract": CORE_ADAPTER_CONTRACT,
+        "protocol_contract": BRIDGE_PROTOCOL_CONTRACT,
+        "contract_version": BRIDGE_CONTRACT_VERSION,
+        "state": "disabled",
+        "reason_code": "mv3_runtime_foundation_only",
+        "runtime_ready": False,
+        "pairing_enabled": False,
+        "dispatch_enabled": False,
+        "browser_mutation_enabled": False,
+        "validation": {
+            "mode": "schema_only",
+            "task_lease_binding": False,
+            "turn_finalization": False,
+        },
+        "native_runtime_location": "user_browser_host",
+        "docker_browser_host_access": False,
+    }
+
+
+@pytest.mark.parametrize("gate_state", ["disabled", "preview", "available"])
+def test_rollout_gate_never_activates_mv3_foundation(gate_state: str) -> None:
+    bridge_status = build_browser_bridge_status(
+        None,
+        BrowserBridgeGate.from_value(gate_state),
+        checked_at="2026-09-04T12:00:00Z",
+    )
+    assert bridge_status["gate"]["state"] == gate_state
+    assert bridge_status["mv3_runtime"] == build_mv3_runtime_foundation_status()

--- a/tests/test_ws_restricted_principal.py
+++ b/tests/test_ws_restricted_principal.py
@@ -1,0 +1,342 @@
+"""Effect-free shared WebSocket security regressions (sync pytest entry points)."""
+
+import asyncio
+from dataclasses import FrozenInstanceError
+import threading
+from unittest.mock import AsyncMock
+
+import pytest
+from flask import Flask
+from werkzeug.test import EnvironBuilder
+
+from helpers import ws
+from helpers.ws import WsHandler
+from helpers.ws_manager import BufferedEvent, WsManager, WsResult
+from helpers.ws_principal import WsPrincipal, WsScopeDeniedError
+
+
+PATH = "plugins/_test/scoped"
+NS = "/ws"
+
+
+class Scoped(WsHandler):
+    active = True
+    calls = []
+    fail = False
+
+    @classmethod
+    def accepted_principal_types(cls):
+        return frozenset({"browser_bridge"})
+
+    @classmethod
+    def authenticate_principal(cls, auth):
+        envelope = auth.get("principal")
+        if envelope != {"type": "browser_bridge", "proof": {}, "signature": "valid"}:
+            return None
+        return principal()
+
+    @classmethod
+    def principal_is_active(cls, value):
+        return cls.active
+
+    async def on_connect(self, sid):
+        if self.fail:
+            raise ValueError("secret activation error")
+
+    async def process(self, event, data, sid):
+        self.calls.append((event, data, sid))
+        return {"safe": True}
+
+
+def principal(**overrides):
+    values = dict(
+        principal_type="browser_bridge", principal_id="bridge-1",
+        subject_id="single_user", scopes={"bridge.connect"},
+        handler_path=PATH, handler_id=f"{Scoped.__module__}.{Scoped.__name__}",
+        inbound_events={"connector_hello"}, outbound_events={"connector_bridge_credential_status"},
+        key_generation=1,
+    )
+    values.update(overrides)
+    return WsPrincipal(**values)
+
+
+class Socket:
+    def __init__(self):
+        self.handlers = {}
+        self.emit = AsyncMock()
+        self.disconnect = AsyncMock()
+
+    def on(self, event, *, namespace):
+        def decorate(fn):
+            self.handlers[event] = fn
+            return fn
+        return decorate
+
+
+@pytest.fixture
+def setup(monkeypatch):
+    server = Socket()
+    manager = WsManager(server, threading.RLock())
+    app = Flask(__name__)
+    app.secret_key = "synthetic-test-secret"
+    monkeypatch.setattr(ws.cache, "get", lambda area, path: Scoped if path == PATH else None)
+    monkeypatch.setattr(Scoped, "active", True)
+    monkeypatch.setattr(Scoped, "calls", [])
+    monkeypatch.setattr(Scoped, "fail", False)
+    monkeypatch.setattr(ws, "_ws_contexts", {})
+    monkeypatch.setattr(ws, "_active_handlers", {})
+    ws.register_ws_namespace(server, app, threading.RLock(), manager)
+    return server, manager, app
+
+
+def auth():
+    return {"handlers": [PATH], "principal": {"type": "browser_bridge", "proof": {}, "signature": "valid"}}
+
+
+def environ(origin="http://localhost:50080"):
+    return EnvironBuilder(base_url="http://localhost:50080", headers={"Origin": origin}).get_environ()
+
+
+async def connect(setup, sid="bridge"):
+    server, manager, app = setup
+    assert await server.handlers["connect"](sid, environ(), auth()) is True
+    return ws._active_handlers[sid][PATH]
+
+
+def test_principal_is_deeply_immutable():
+    events = {"connector_hello"}
+    value = principal(inbound_events=events)
+    events.add("code_execution")
+    assert value.inbound_events == frozenset({"connector_hello"})
+    with pytest.raises(FrozenInstanceError):
+        value.key_generation = 2
+
+
+@pytest.mark.parametrize("mutation", [
+    lambda a: a.update(principal=None),
+    lambda a: a.update(principal={}),
+    lambda a: a["principal"].update(signature="bad"),
+    lambda a: a["principal"].update(type="webui_session"),
+    lambda a: a["principal"].update(scopes=["everything"]),
+    lambda a: a.update(api_key="ambient", csrf_token="ambient"),
+    lambda a: a.update(handlers=[PATH, "ws_webui"]),
+    lambda a: a.update(handlers=["../ws_webui"]),
+    lambda a: a.update(handlers=[]),
+])
+def test_invalid_principal_never_falls_back_to_ambient_auth(setup, mutation, monkeypatch):
+    server, manager, app = setup
+    value = auth()
+    mutation(value)
+    # An open server would accept ordinary session auth. None of these may
+    # become an ordinary/open client instead.
+    assert asyncio.run(server.handlers["connect"]("bad", environ(), value)) is False
+    assert not manager.connections and not ws._ws_contexts
+    assert not server.emit.called
+
+
+@pytest.mark.parametrize("origin", ["https://evil.example", "null", "http://localhost:broken"])
+def test_origin_rejected_before_authenticator(setup, monkeypatch, origin):
+    server, manager, app = setup
+    called = []
+    monkeypatch.setattr(Scoped, "authenticate_principal", lambda a: called.append(a))
+    assert asyncio.run(server.handlers["connect"]("bad", environ(origin), auth())) is False
+    assert called == []
+
+
+def test_scoped_connect_isolated_from_ambient_and_global_lifecycle(setup):
+    async def scenario():
+        server, manager, app = setup
+        global_handler = Scoped(server, threading.RLock())
+        global_handler.on_connect = AsyncMock()
+        global_handler.on_disconnect = AsyncMock()
+        manager.register_handlers({NS: [global_handler]})
+        manager.set_server_restart_broadcast(True)
+        manager.buffers[(NS, "bridge")].append(BufferedEvent("state_push", {"secret": "canary"}))
+        instance = await connect(setup)
+        ctx = ws._ws_contexts["bridge"]
+        assert ctx.principal is manager.connections[(NS, "bridge")].principal
+        assert ctx.auth_hash is ctx.api_key is ctx.csrf_token is ctx.csrf_cookie is None
+        assert not manager.user_to_sids and not manager.sid_to_user
+        assert not manager.buffers and not server.emit.called
+        assert not manager.register_diagnostic_watcher(NS, "bridge")
+        global_handler.on_connect.assert_not_called()
+        with pytest.raises(WsScopeDeniedError):
+            instance.principal_for_sid("someone-else")
+        await server.handlers["disconnect"]("bridge")
+        await server.handlers["disconnect"]("bridge")
+        global_handler.on_disconnect.assert_not_called()
+        assert not manager.connections and not manager._known_sids
+        assert not manager._disconnect_times and not ws._ws_contexts
+    asyncio.run(scenario())
+
+
+def test_activation_failure_rolls_back_without_legacy_lifecycle(setup, monkeypatch):
+    server, manager, app = setup
+    monkeypatch.setattr(Scoped, "fail", True)
+    assert asyncio.run(server.handlers["connect"]("bridge", environ(), auth())) is False
+    assert not manager.connections and not manager._known_sids and not ws._ws_contexts
+
+
+@pytest.mark.parametrize("event", ["state_request", "connector_send_message", "connector_exec_op_result", "connector_file_op_result", "secret-arbitrary-event"])
+def test_denied_inbound_never_invokes_handler_or_diagnostic_payloads(setup, event):
+    async def scenario():
+        server, manager, app = setup
+        await connect(setup)
+        manager._diagnostics_enabled = True
+        result = await server.handlers["*"](event, "bridge", {"data": {"secret": "canary"}})
+        assert result["results"][0]["error"]["code"] == "SCOPE_DENIED"
+        assert not Scoped.calls and not server.emit.called
+        assert len(manager._scope_denials) == 1
+        assert "canary" not in str(manager._scope_denials)
+        assert event not in str(manager._scope_denials)
+    asyncio.run(scenario())
+
+
+def test_allowed_inbound_and_direct_manager_rechecks_active_identity(setup, monkeypatch):
+    async def scenario():
+        server, manager, app = setup
+        instance = await connect(setup)
+        result = await server.handlers["*"]("connector_hello", "bridge", {"data": {"secret": "canary"}, "correlationId": {"secret": "canary"}})
+        assert result["results"][0]["data"] == {"safe": True}
+        assert "canary" not in result["correlationId"]
+        assert len(Scoped.calls) == 1
+        monkeypatch.setattr(Scoped, "active", False)
+        result = await manager.process_client_event(NS, "connector_hello", {}, "bridge", handlers=[instance])
+        assert result["results"][0]["error"]["code"] == "SCOPE_DENIED"
+        await server.handlers["disconnect"]("bridge")
+        result = await manager.process_client_event(NS, "connector_hello", {}, "bridge", handlers=[instance])
+        assert result["results"][0]["error"]["code"] == "SCOPE_DENIED"
+        assert len(Scoped.calls) == 1
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("event,handler", [
+    ("server_restart", None), ("state_push", None),
+    ("ws_dev_console_event", None), ("connector_bridge_credential_status", "unrelated"),
+])
+def test_forbidden_outbound_is_typed_and_never_buffered(setup, event, handler):
+    async def scenario():
+        server, manager, app = setup
+        await connect(setup)
+        with pytest.raises(WsScopeDeniedError):
+            await manager.emit_to(NS, "bridge", event, {"secret": "canary"}, handler_id=handler, diagnostic=True)
+        assert not server.emit.called and not manager.buffers
+    asyncio.run(scenario())
+
+
+def test_outbound_revalidates_and_broadcast_never_targets_restricted_sids(setup, monkeypatch):
+    async def scenario():
+        server, manager, app = setup
+        instance = await connect(setup)
+        await manager.emit_to(NS, "bridge", "connector_bridge_credential_status", {}, handler_id=instance.identifier)
+        assert server.emit.await_count == 1
+        server.emit.reset_mock()
+        monkeypatch.setattr(Scoped, "active", False)
+        with pytest.raises(WsScopeDeniedError):
+            await manager.emit_to(NS, "bridge", "connector_bridge_credential_status", {}, handler_id=instance.identifier)
+        await manager.broadcast(NS, "connector_bridge_credential_status", {}, handler_id=instance.identifier)
+        assert not server.emit.called
+        assert await manager.route_event_all(NS, "connector_hello", {}) == []
+    asyncio.run(scenario())
+
+
+def test_new_proof_replaces_old_sid_and_old_handler_cannot_dispatch(setup):
+    async def scenario():
+        server, manager, app = setup
+        old = await connect(setup, "old")
+        await connect(setup, "new")
+        server.disconnect.assert_awaited_once_with("old", namespace=NS)
+        assert (NS, "old") not in manager.connections
+        result = await manager.process_client_event(NS, "connector_hello", {}, "old", handlers=[old])
+        assert result["results"][0]["error"]["code"] == "SCOPE_DENIED"
+        with pytest.raises(WsScopeDeniedError):
+            await old.emit_to("old", "connector_bridge_credential_status", {})
+        with pytest.raises(WsScopeDeniedError):
+            await old.broadcast("connector_bridge_credential_status", {})
+        with pytest.raises(WsScopeDeniedError):
+            await old.dispatch_to_all_sids("connector_hello", {})
+    asyncio.run(scenario())
+
+
+def test_queued_emit_cannot_cross_connection_generation(setup):
+    async def scenario():
+        server, manager, app = setup
+        await manager.handle_connect(NS, "reused")
+        old = manager.connections[(NS, "reused")]
+        # Capture work already authorized for a legacy generation.
+        queued = manager._emit_for_connection(old, "state_push", {"secret": "canary"})
+        await manager.handle_disconnect(NS, "reused")
+        await connect(setup, "reused")
+        server.emit.reset_mock()
+        await queued
+        assert not server.emit.called
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("raised", [True, False])
+def test_handler_failures_do_not_echo_raw_error_details(setup, raised, monkeypatch):
+    async def scenario():
+        server, manager, app = setup
+        instance = await connect(setup)
+        async def fail(*args):
+            if raised:
+                raise ValueError("secret-canary")
+            return WsResult.error(code="secret-canary", message="secret-canary", details="secret-canary")
+        monkeypatch.setattr(instance, "process", fail)
+        result = await manager.process_client_event(NS, "connector_hello", {}, "bridge", handlers=[instance])
+        assert "secret-canary" not in str(result)
+        assert result["results"][0]["ok"] is False
+    asyncio.run(scenario())
+
+
+def test_signed_proof_through_real_loaded_connector_and_namespace(setup, monkeypatch):
+    # Reuse the effect-free credential fixture, but exercise real Flask request
+    # context, module loading, WsHandler hooks, manager and connector together.
+    from test_browser_bridge_challenge_foundation import (
+        _credential, _challenge_store, _issue, _proof, _signature,
+        SERVER_ID, EXTENSION_ID, BRIDGE_CONNECTOR_HANDLER,
+    )
+    from helpers import runtime
+    from helpers.modules import load_classes_from_file
+    from plugins._a0_connector.helpers import browser_bridge_session as adapter
+    from plugins._a0_connector.helpers import ws_runtime
+
+    pairing, state, key = _credential()
+    challenges, clock = _challenge_store(pairing)
+    proof = _proof(_issue(challenges))
+    signature = _signature(key, proof)
+    envelope = {
+        "handlers": [BRIDGE_CONNECTOR_HANDLER],
+        "principal": {"type": "browser_bridge", "proof": proof, "signature": signature},
+    }
+    handler = load_classes_from_file("plugins/_a0_connector/api/ws_connector.py", WsHandler)[0]
+    monkeypatch.setattr(ws.cache, "get", lambda area, path: handler if path == BRIDGE_CONNECTOR_HANDLER else None)
+    monkeypatch.setattr(runtime, "get_persistent_id", lambda: SERVER_ID)
+    monkeypatch.setattr(adapter, "get_browser_bridge_challenge_store", lambda: challenges)
+    monkeypatch.setattr(adapter, "get_browser_bridge_pairing_store", lambda: pairing)
+    monkeypatch.setenv("A0_BROWSER_BRIDGE_ROLLOUT", "preview")
+    monkeypatch.setenv("A0_BROWSER_BRIDGE_EXTENSION_ID", EXTENSION_ID)
+    monkeypatch.delenv("A0_BROWSER_BRIDGE_SERVER_BASE_URL", raising=False)
+
+    async def scenario():
+        server, manager, app = setup
+        old_cli_sids = ws_runtime.connected_sids()
+        assert await server.handlers["connect"]("signed", environ(), envelope)
+        ctx = ws._ws_contexts["signed"]
+        assert ctx.principal.handler_id == "ws_connector.WsConnector"
+        assert signature not in repr(ctx) and proof["server_nonce"] not in repr(ctx)
+        assert ws_runtime.connected_sids() == old_cli_sids
+        response = await server.handlers["*"]("connector_hello", "signed", {"data": {"remote_exec": {"enabled": True}, "context_id": "victim"}})
+        assert response["results"][0]["data"] == adapter.hello({})
+        assert not server.emit.called
+        assert await server.handlers["connect"]("replay", environ(), envelope) is False
+        # Credential changes apply to the already connected namespace path.
+        record = state["document"]["bridges"][0]
+        record["state"] = "revoked"
+        record["revoked_at_ms"] = clock[0]
+        denied = await server.handlers["*"]("connector_hello", "signed", {})
+        assert denied["results"][0]["error"]["code"] == "SCOPE_DENIED"
+        await server.handlers["disconnect"]("signed")
+        assert not manager.connections and not manager.buffers
+        assert ws_runtime.connected_sids() == old_cli_sids
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary

Adds the Chrome extension bridge through the bundled `_browser` and `_a0_connector` plugins: protected pairing and default selection, signed restricted transport, exact runtime admission, site/action policy, chat and artifact relay, and owned-tab finalization. The native companion runs on the Chrome host, never inside Agent Zero's Docker container.

Coordinated changes: [extension setup PR #11](https://github.com/agent0ai/agent-zero-browser-extension/pull/11), [native companion and CLI PR #26](https://github.com/agent0ai/a0-connector/pull/26).

## Production-only scope and cleanup

- Removed 43 development-only files, including 16 DOX sidecars, development API/WebSocket handlers, limited runtime, WebUI stores and their dedicated tests/fixtures. Removed two obsolete foundation guides. No generated binaries or caches are included.
- Production transport only. Old development credentials/grants are neither promoted nor deleted; stale selectors reject without CLI/CDP/internal-browser fallback. Production users explicitly pair/select the production identity.
- Consolidated duplicate setup, approval, artifact and lifecycle tests into their owning suites; new test modules fell from 52 to 44 while retaining the 73 affected behavioral test functions. Shared synthetic fixtures replace duplicated setup. Subsequent review removed five tests for two unused discovery-only models; actual runtime/security tests remain. The latest regressions extend existing suites and shared fixtures, not new test modules.
- Full PR: **43,684 additions / 84 deletions across 196 files**, down from 52,828 additions (9,144 fewer). Production Python/JS/HTML/CSS source: **25,800 additions / 84 deletions / 25,716 net across 93 files**. Source figures exclude tests, DOX, prompts and configuration; comments and blank lines are included.
- One feature commit against `ready`: `9d23a49d75fd524316020e681b9436be59b2aa73`. Scoped backup refs retain earlier versions; no upstream history was rewritten. No Actions run requested.

## Why shared Core changes remain

Feature implementations remain plugin-owned. Shared changes total **439 added / 48 removed / 391 net lines across seven source files**, excluding tests and DOX.

| Shared file | Added / removed | Necessity |
| --- | ---: | --- |
| `helpers/ws.py` | 153 / 12 | Authenticates restricted companion principals after Origin validation and before handler activation, preventing ambient-cookie/API-key rescue and cross-handler dispatch. A plugin handler cannot secure the shared pre-dispatch path from inside itself. |
| `helpers/ws_manager.py` | 208 / 31 | Excludes restricted sockets from ordinary broadcasts, replay buffers and diagnostics; revalidates exact connection generation and credentials before queued delivery. Plugin checks cannot intercept shared fan-out after returning. |
| `helpers/ws_principal.py` | 45 / 0 | Shared immutable scope/handler/event identity and safe correlation IDs for both framework transport and plugin authorization. |
| `helpers/tool.py` | 7 / 2 | Default-compatible `get_display_args()` hook allows typed-input redaction before base-tool terminal logging. The existing browser log-object override protects a different output path. |
| `helpers/persist_chat.py` | 3 / 1 | Two extensibility decorators plus import let plugin hooks quarantine exact legacy state before serialization/deserialization, without embedding migration logic in Core. |
| `helpers/ui_server.py` | 13 / 2 | Existing `@extensible` construction hook plus a fresh local `AsyncExitStack` and `webui_server_start` dispatch inside each ASGI lifespan. Uvicorn retries reinstall services after prior cleanup; hook failure and shutdown await exact-owner retirement. No browser-specific imports remain in the shared server. |
| `extensions/python/_functions/helpers/ui_server/UiServerRuntime/create/end/_05_legacy_browser_guard.py` | 10 / 0 | Mandatory Core hook delegates the existing legacy HTTP retirement guard, even if the connector is disabled. It must not be an optional plugin hook that could revive retired routes. No retirement or runtime activation is initiated. |

No changes to `agent.py`, `initialize.py` or `models.py`. Matching helper DOX and owning contracts document the boundaries. Exact legacy fixture bytes remain because retirement tests verify their digests; they are inert fixtures, not an active development runtime.

## frdel review and simplification

Aligned in the reviewed boundaries, inferred from actual local diffs rather than a claim of maintainer approval: `89d4b891` consolidates helpers while preserving compatibility; `7eb6d5b1` preserves activated WebSocket handler identity; `b94d4b79` owns server construction/lifespan; `b6be345a` moves feature behavior into plugin hooks; `93d1131c` standardizes browser UI components.

- Removed singleton transport-registry searches, one-lifecycle fan-out, two unused discovery-only lease/finalization models and their private validators. Exact ownership and actual runtime binding tests remain. Static discovery keeps its IDs/keys but no longer claims live lease validation.
- Malformed non-string action/choice values in four protected APIs return no-store HTTP 400 before state access. Successful action notices expire after three seconds; uncertain decisions retain the no-retry warning.
- Resolved the lifetime 2,048-message/queue-receipt ceiling using one plugin-owned journal backed by existing atomic KVP storage. New hash-only receipts are individually indexed; original receipts remain a read-only fallback. Accepted replays, payload conflicts, uncertain reservations and the separate 32-live-item queue bound are preserved. Queue projection logic is shared and read failure after an effect reports unknown.
- Before the first indexed write, atomically mark the original journal schema v2 without changing its records. Older builds reject it, preventing downgrade from overlooking newer receipts and repeating work. Do not erase the marker or receipts to force rollback. Migration occurs on authorized writes, not startup. Disk usage grows with distinct IDs; this is not bounded disk retention or new cross-process transaction support.
- Browser installation and awaited cleanup now share each ASGI lifespan through the enabled connector's `webui_server_start` hook. Removed the stored server-lifetime shutdown stack: startup retries on the same server object install afresh after retirement. A later startup-hook failure also awaits cleanup. Plugin disablement does not suppress registered cleanup; exact manager checks and the mandatory legacy HTTP guard remain.
- Removed the alternate whole-document writer used only for injected journals. Tests now inject KVP-shaped reads/writes and execute the exact production indexed-storage and migration path. All tracked callbacks were updated; disk formats and browser wire contracts are unchanged.
- Replaced stale unwired/development-stage DOX with current unbound-versus-composed ownership. Construction, pairing and policy never substitute for production admission/reconciliation.

Across the initial review and approved follow-ups: **45 fewer total lines and 220 fewer production-source lines**. The lifetime-capacity fix deliberately retains replay receipts instead of deleting safety state to reduce size. Latest backup: `backup/core-before-frdel-second-review-20260906`.

## Verification

- **26 focused backend assertion scenarios passed** in an isolated framework source overlay: transport identity, 20 malformed raw-HTTP enum values, strict bodies, lifecycle ownership/turn cleanup, durable message replay/uncertainty, full original-journal migration, corruption/failing writes, queue limits, startup retry/failed-hook cleanup, disabled-plugin/exact-manager retirement, three application-composition cases and four context-controller cases.
- Changed Python syntax and scoped whitespace checks passed. Earlier review passed three Node UI and four MV3 discovery scenarios; unchanged UI/discovery code was not rerun for this backend follow-up.
- Pytest is unavailable in the framework environment. These were explicit assertion harnesses invoking test functions, **not a full pytest run**. No dependencies installed, live browser actions, credential changes or deployment performed. Whole-PR whitespace checking retains pre-existing EOF-blank warnings in digest-pinned legacy fixtures; those bytes were not rewritten.

## Release and deployment limits

- [Public extension repository](https://github.com/agent0ai/agent-zero-browser-extension); [documentation PR #12](https://github.com/agent0ai/agent-zero-browser-extension/pull/12) is merged. [Guided unpacked 0.1.1 ZIP and separate dashboard ZIP](https://github.com/agent0ai/agent-zero-browser-extension/releases/tag/extension-v0.1.1-prestore) are public. Pair once and choose the default across chats; update in the same folder/profile without resetting pairing.
- Production extension ID remains `nhliclifilepdkoolioacpjpijomfplj`. Published macOS 13+ Intel/Apple Silicon companion is signed/notarized 2.12.3. Core separately requires publisher-signed exact-version policy for 0.1.1 + 2.12.3; that operator policy is not committed here. This follow-up changes no wire protocol, native binary or extension package.
- Native/CLI PR #26 stays at `b0dd656a7888e27dd67ca2d091b6cb7955073daa`. Linux production packaging/catalog/provenance and desktop acceptance remain incomplete. Windows candidate verification/HKCU installation, genuine signing and native platform acceptance remain incomplete. Extension portability is not end-to-end OS support.
- Web Store publication, source licensing/icon provenance, live deployment and maintainer merge remain separate. This account has READ permission on upstream Core/CLI repositories; no maintainer approval, upstream merge, all-OS production completion or exhaustive security certification is claimed.
