### PR TITLE
Warn when unparseable agent definitions are silently skipped

### DIFF
--- a/helpers/subagents.py
+++ b/helpers/subagents.py
@@ -4,6 +4,7 @@ from helpers import yaml as yaml_helper
 from typing import TypedDict, TYPE_CHECKING, Literal
 from pydantic import BaseModel, model_validator
 import json
+import logging
 import os
 
 GLOBAL_DIR = "."
@@ -11,6 +12,13 @@ USER_DIR = "usr"
 DEFAULT_AGENTS_DIR = "agents"
 USER_AGENTS_DIR = "usr/agents"
 PATHS_CACHE_AREA = "subagent_paths(plugins)"
+
+logger = logging.getLogger(__name__)
+
+# projects whose agents.json registrations were already cross-checked against
+# discovery in this process; keeps the check from spamming on every call
+# (get_available_agents_dict is a hot path)
+_UNDISCOVERED_CHECKED_PROJECTS: set[str] = set()
 
 cache.toggle_area(PATHS_CACHE_AREA, False)
 
@@ -107,7 +115,15 @@ def _get_agents_list_from_dir(dir: str, origin: Origin) -> dict[str, SubAgentLis
             agent_data.path = files.get_abs_path(dir, subdir)
             agent_data.origin = [origin]
             result[name] = agent_data
-        except Exception:
+        except Exception as e:
+            logger.warning(
+                "Skipping agent definition '%s' in '%s' (origin=%s): %s: %s",
+                subdir,
+                dir,
+                origin,
+                type(e).__name__,
+                e,
+            )
             continue
 
     return result
@@ -311,6 +327,52 @@ def get_default_promp_file_names() -> list[str]:
     return files.list_files("prompts", filter="*.md")
 
 
+def _warn_undiscovered_project_agents(
+    project_name: str, discovered: dict[str, SubAgentListItem]
+) -> None:
+    """Warn (once per project per process) when a slug is registered in the
+    project's agents.json but was not discovered by agent discovery — e.g. its
+    agent.yaml failed to parse and was skipped."""
+    if project_name in _UNDISCOVERED_CHECKED_PROJECTS:
+        return
+    _UNDISCOVERED_CHECKED_PROJECTS.add(project_name)
+
+    from helpers import projects
+
+    try:
+        abs_path = files.get_abs_path(
+            projects.get_project_meta(project_name), "agents.json"
+        )
+        data = json.loads(files.read_file(abs_path))
+    except Exception:
+        return
+
+    registered: list[str] = []
+    if isinstance(data, dict):
+        agents_field = data.get("agents")
+        if isinstance(agents_field, list):
+            # manifest format: {"agents": [{"slug": ...}, ...]}
+            for entry in agents_field:
+                if isinstance(entry, dict) and isinstance(entry.get("slug"), str):
+                    registered.append(entry["slug"])
+        else:
+            # flat availability format: {"<slug>": {"enabled": ...}}
+            registered = [
+                key for key, value in data.items() if isinstance(value, dict)
+            ]
+    if not registered:
+        return
+
+    undiscovered = [slug for slug in registered if slug not in discovered]
+    if undiscovered:
+        logger.warning(
+            "Project '%s': agents registered in agents.json but not discovered: %s "
+            "(check their agent.yaml for parse errors)",
+            project_name,
+            ", ".join(sorted(undiscovered)),
+        )
+
+
 def get_available_agents_dict(
     project_name: str | None,
 ) -> dict[str, SubAgentListItem]:
@@ -320,6 +382,9 @@ def get_available_agents_dict(
     project_settings = (
         projects.load_project_subagents(project_name) if project_name else {}
     )
+
+    if project_name:
+        _warn_undiscovered_project_agents(project_name, all_agents)
 
     filtered_agents: dict[str, SubAgentListItem] = {}
     for name, agent in all_agents.items():


### PR DESCRIPTION
## Problem

When an agent definition (`agent.yaml`) contains a YAML authoring error (e.g. an unquoted colon in a description, or a bad indent), `_get_agents_list_from_dir()` catches the exception and silently `continue`s. The agent simply vanishes from discovery — there is no log line at all. The only symptom surfaces much later, far from the cause: dispatching that profile fails with a distant "profile not found" error.

We hit this in production: four project agents were silently missing from the callable list for days before the root cause (a YAML typo) was found.

## Solution

Two purely additive warnings, no behavior change:

1. **Parse-failure warning** in `_get_agents_list_from_dir()`: when an agent definition fails to load/validate, log a warning naming the agent directory, its containing dir, its origin (`default`/`user`/`project`/`plugin`), and the exception. Skipping still happens exactly as before.

2. **Registered-but-undiscovered cross-check** (`_warn_undiscovered_project_agents()`): in `get_available_agents_dict()`, cross-check slugs registered in the project's `agents.json` against discovered agents and warn once (per project, per process) about any registered slug that was not discovered — pointing at likely `agent.yaml` parse errors. The cross-check reads both known `agents.json` shapes (manifest `{"agents": [{"slug": ...}]}` and flat `{"<slug>": {"enabled": ...}}`).

A warn-once dedupe set keeps the cross-check from spamming, since `get_available_agents_dict()` is a hot path.

## Testing

Scratch break-tests against a fresh worktree of `main`:

- Dir with one broken yaml (unquoted colon in `description`) + one good agent → warning fires naming the broken agent dir + error; good agent still discovered normally.
- Project with `agents.json` registering a ghost slug (no corresponding agent dir) + one real agent → exactly one warning naming the ghost slug; real agent unaffected; second call emits no additional warning (dedupe works).
- `import helpers.subagents` sanity check passes.
- Existing test files (`tests/test_subagent_metadata_merge.py`, `tests/test_subagent_profiles.py`): identical pass/fail set on patched vs. pristine `main` (the 6 pre-existing failures in `test_subagent_profiles.py` dispatch tests are unrelated and unchanged by this patch).

## Backwards compatibility

Purely additive warning logs. No API, signature, or behavior changes — agents are still skipped exactly as before, only now visibly.
