### PR TITLE
feat(scheduler): pin model preset per task

### DIFF
--- a/helpers/task_scheduler.py
+++ b/helpers/task_scheduler.py
@@ -162,6 +162,7 @@ class TaskPlan(BaseModel):
 class BaseTask(BaseModel):
     uuid: str = Field(default_factory=lambda: guids.generate_id())
     context_id: Optional[str] = Field(default=None)
+    pinned_preset: str | None = Field(default=None)
     state: TaskState = Field(default=TaskState.IDLE)
     name: str = Field()
     system_prompt: str
@@ -293,7 +294,8 @@ class AdHocTask(BaseTask):
         attachments: list[str] | None = None,
         context_id: str | None = None,
         project_name: str | None = None,
-        project_color: str | None = None
+        project_color: str | None = None,
+        pinned_preset: str | None = None
     ):
         return cls(name=name,
                    system_prompt=system_prompt,
@@ -302,7 +304,8 @@ class AdHocTask(BaseTask):
                    token=token,
                    context_id=context_id,
                    project_name=project_name,
-                   project_color=project_color)
+                   project_color=project_color,
+                   pinned_preset=pinned_preset)
 
     def update(self,
                name: str | None = None,
@@ -343,6 +346,7 @@ class ScheduledTask(BaseTask):
         timezone: str | None = None,
         project_name: str | None = None,
         project_color: str | None = None,
+        pinned_preset: str | None = None,
     ):
         # Set timezone in schedule if provided
         if timezone is not None:
@@ -357,7 +361,8 @@ class ScheduledTask(BaseTask):
                    schedule=schedule,
                    context_id=context_id,
                    project_name=project_name,
-                   project_color=project_color)
+                   project_color=project_color,
+                   pinned_preset=pinned_preset)
 
     def update(self,
                name: str | None = None,
@@ -431,7 +436,8 @@ class PlannedTask(BaseTask):
         attachments: list[str] | None = None,
         context_id: str | None = None,
         project_name: str | None = None,
-        project_color: str | None = None
+        project_color: str | None = None,
+        pinned_preset: str | None = None
     ):
         return cls(name=name,
                    system_prompt=system_prompt,
@@ -440,7 +446,8 @@ class PlannedTask(BaseTask):
                    attachments=list(attachments or []),
                    context_id=context_id,
                    project_name=project_name,
-                   project_color=project_color)
+                   project_color=project_color,
+                   pinned_preset=pinned_preset)
 
     def update(self,
                name: str | None = None,
@@ -837,7 +844,39 @@ class TaskScheduler:
         save_tmp_chat(context)
         return context
 
+    def _resolve_pinned_preset(self, task: Union[ScheduledTask, AdHocTask, PlannedTask]) -> dict | None:
+        """Resolve a pinned task's model preset, failing loudly if it no longer exists.
+
+        wOS D4: an unattended task must never silently fall back to ambient
+        model settings when its pinned preset is missing at fire time.
+        """
+        if not task.pinned_preset:
+            return None
+        try:
+            from plugins._model_config.helpers import model_config
+        except ImportError as exc:
+            message = (
+                f"Pinned preset '{task.pinned_preset}' for scheduler task '{task.name}' "
+                f"({task.uuid}) cannot be resolved: _model_config plugin unavailable"
+            )
+            PrintStyle.error(message)
+            raise ValueError(message) from exc
+        preset = model_config.get_preset_by_name(task.pinned_preset)
+        if not preset:
+            message = (
+                f"Pinned preset '{task.pinned_preset}' for scheduler task '{task.name}' "
+                f"({task.uuid}) no longer exists. Refusing to fall back to ambient model "
+                f"settings (wOS D4). Update or clear pinned_preset to resume this task."
+            )
+            PrintStyle.error(message)
+            raise ValueError(message)
+        return preset
+
     async def _get_chat_context(self, task: Union[ScheduledTask, AdHocTask, PlannedTask]) -> AgentContext:
+        # Resolve any pinned preset first: missing presets must fail loudly
+        # before any context is loaded or created (no silent ambient fallback).
+        pinned_preset = self._resolve_pinned_preset(task)
+
         context = AgentContext.get(task.context_id) if task.context_id else None
 
         if context:
@@ -846,7 +885,6 @@ class TaskScheduler:
                 f"Scheduler Task {task.name} loaded from task {task.uuid}, context ok"
             )
             save_tmp_chat(context)
-            return context
         else:
             message = (
                 f"Scheduler Task {task.name} loaded from task {task.uuid} but context not found"
@@ -855,7 +893,19 @@ class TaskScheduler:
                 PrintStyle.info(f"{message}; creating dedicated context")
             else:
                 PrintStyle.warning(message)
-            return await self.__new_context(task)
+            context = await self.__new_context(task)
+
+        # Enforce the pinned preset on every fire, for both freshly created
+        # and already existing contexts, so ambient drift never changes the
+        # task's model (wOS D4).
+        if pinned_preset is not None:
+            preset_name = str(pinned_preset.get("name") or task.pinned_preset)
+            context.set_data("chat_model_override", {"preset_name": preset_name})
+            save_tmp_chat(context)
+            PrintStyle.info(
+                f"Scheduler Task '{task.name}' pinned to model preset '{preset_name}'"
+            )
+        return context
 
     async def _persist_chat(self, task: Union[ScheduledTask, AdHocTask, PlannedTask], context: AgentContext):
         if context.id != task.context_id:
@@ -1191,6 +1241,7 @@ def serialize_task(task: Union[ScheduledTask, AdHocTask, PlannedTask]) -> Dict[s
         "next_run": serialize_datetime(task.get_next_run()),
         "last_result": task.last_result,
         "context_id": task.context_id,
+        "pinned_preset": task.pinned_preset,
         "dedicated_context": task.is_dedicated(),
         "project": {
             "name": task.project_name,
@@ -1262,6 +1313,7 @@ def deserialize_task(task_data: Dict[str, Any], task_class: Optional[Type[T]] = 
         "last_run": parse_datetime(task_data.get("last_run")),
         "last_result": task_data.get("last_result"),
         "context_id": task_data.get("context_id"),
+        "pinned_preset": task_data.get("pinned_preset"),
     }
 
     # Add type-specific fields

--- a/prompts/agent.system.tool.scheduler.md
+++ b/prompts/agent.system.tool.scheduler.md
@@ -3,7 +3,7 @@ Manage saved tasks and schedules. For complex task work, load skill `scheduled-t
 
 Actions: `list_tasks`, `find_task_by_name`, `show_task`, `run_task`, `update_task`, `delete_task`, `create_scheduled_task`, `create_adhoc_task`, `create_planned_task`, `wait_for_task`.
 
-Common args: `action`, `name`, `uuid`, `system_prompt`, `prompt`, `attachments`, `schedule`, `timezone`, `plan`, `dedicated_context`.
+Common args: `action`, `name`, `uuid`, `system_prompt`, `prompt`, `attachments`, `schedule`, `timezone`, `plan`, `dedicated_context`, `pinned_preset`.
 
 Rules:
 - Before `create_*`, `update_task`, `delete_task`, or `run_task`, inspect existing tasks with `find_task_by_name` or `list_tasks`.
@@ -14,3 +14,4 @@ Rules:
 - For one planned date/time, use `create_planned_task` with `plan: ["YYYY-MM-DDTHH:MM:SS"]`.
 - Use IANA timezones like `Europe/Rome`; include timezone when the user names a timezone.
 - For "tomorrow at 9:15 Rome time", scheduled shape is `schedule: {"minute":"15","hour":"9","day":"11","month":"5","weekday":"*","timezone":"Europe/Rome"}`.
+- `pinned_preset` (optional) pins a task's model preset for unattended runs (wOS D4). Accepted by all `create_*` actions and `update_task`. Use the exact preset name (see `Default`, `Coding (GLM-5.3 Max Reasoning)`, `Fallback & Vision Native (MiniMax-M3)`, ...). Pin existing tasks via `update_task` with `pinned_preset`; pass `""` to unpin. At fire time a missing preset fails loudly (task state=error) — never silently falls back to ambient settings.

--- a/tools/scheduler.py
+++ b/tools/scheduler.py
@@ -116,6 +116,25 @@ def _task_plan_from_input(plan: Any) -> tuple[TaskPlan | None, str]:
     return TaskPlan.create(todo=todo, in_progress=None, done=[]), ""
 
 
+def _validate_pinned_preset(value: Any) -> tuple[str | None, str]:
+    """Normalize and validate an optional pinned model preset name."""
+    if value is None:
+        return None, ""
+    name = str(value).strip()
+    if not name:
+        return None, ""
+    try:
+        from plugins._model_config.helpers import model_config
+    except ImportError:
+        return None, "Cannot validate pinned_preset: _model_config plugin unavailable."
+    if not model_config.get_preset_by_name(name):
+        presets = ", ".join(
+            str(p.get("name")) for p in model_config.get_presets() if p.get("name")
+        )
+        return None, f"Pinned preset not found: {name}. Available presets: {presets or 'none'}"
+    return name, ""
+
+
 class SchedulerTool(Tool):
 
     async def execute(self, **kwargs):
@@ -264,6 +283,13 @@ class SchedulerTool(Tool):
             if field in kwargs:
                 update_params[field] = kwargs[field]
 
+        if "pinned_preset" in kwargs:
+            pinned_preset, preset_err = _validate_pinned_preset(kwargs.get("pinned_preset"))
+            if preset_err:
+                return Response(message=preset_err, break_loop=False)
+            # empty string clears the pin (BaseTask.update skips None kwargs values)
+            update_params["pinned_preset"] = pinned_preset if pinned_preset is not None else ""
+
         if "state" in kwargs:
             update_params["state"] = TaskState(kwargs.get("state", TaskState.IDLE))
 
@@ -319,6 +345,9 @@ class SchedulerTool(Tool):
         attachments: list[str] = kwargs.get("attachments", [])
         schedule: dict[str, str] = kwargs.get("schedule", {})
         dedicated_context: bool = kwargs.get("dedicated_context", True)
+        pinned_preset, preset_err = _validate_pinned_preset(kwargs.get("pinned_preset"))
+        if preset_err:
+            return Response(message=preset_err, break_loop=False)
 
         try:
             task_schedule = _task_schedule_from_input(schedule, timezone=_schedule_timezone(kwargs))
@@ -340,6 +369,7 @@ class SchedulerTool(Tool):
             context_id=None if dedicated_context else self.agent.context.id,
             project_name=project_slug,
             project_color=project_color,
+            pinned_preset=pinned_preset,
         )
         await TaskScheduler.get().add_task(task)
         return Response(message=f"Scheduled task '{name}' created: {task.uuid}", break_loop=False)
@@ -351,6 +381,9 @@ class SchedulerTool(Tool):
         attachments: list[str] = kwargs.get("attachments", [])
         token: str = str(random.randint(1000000000000000000, 9999999999999999999))
         dedicated_context: bool = kwargs.get("dedicated_context", True)
+        pinned_preset, preset_err = _validate_pinned_preset(kwargs.get("pinned_preset"))
+        if preset_err:
+            return Response(message=preset_err, break_loop=False)
 
         project_slug, project_color = self._resolve_project_metadata()
 
@@ -363,6 +396,7 @@ class SchedulerTool(Tool):
             context_id=None if dedicated_context else self.agent.context.id,
             project_name=project_slug,
             project_color=project_color,
+            pinned_preset=pinned_preset,
         )
         await TaskScheduler.get().add_task(task)
         return Response(message=f"Adhoc task '{name}' created: {task.uuid}", break_loop=False)
@@ -374,6 +408,9 @@ class SchedulerTool(Tool):
         attachments: list[str] = kwargs.get("attachments", [])
         plan: list[str] = kwargs.get("plan", [])
         dedicated_context: bool = kwargs.get("dedicated_context", True)
+        pinned_preset, preset_err = _validate_pinned_preset(kwargs.get("pinned_preset"))
+        if preset_err:
+            return Response(message=preset_err, break_loop=False)
 
         # Convert plan to list of datetimes in UTC
         task_plan, err = _task_plan_from_input(plan)
@@ -391,7 +428,8 @@ class SchedulerTool(Tool):
             plan=task_plan,
             context_id=None if dedicated_context else self.agent.context.id,
             project_name=project_slug,
-            project_color=project_color
+            project_color=project_color,
+            pinned_preset=pinned_preset
         )
         await TaskScheduler.get().add_task(task)
         return Response(message=f"Planned task '{name}' created: {task.uuid}", break_loop=False)


### PR DESCRIPTION
## Problem

Scheduled tasks currently inherit the **ambient** model configuration: when a task fires, its context is (re)built from whatever the global settings happen to be at that moment. If the ambient preset's provider quota is exhausted at fire time, the unattended task dies with a `RateLimitError` and lands in error state — even though other presets in the instance are healthy. Unattended jobs should not inherit ambient config drift between dispatch and fire (the scheduler has no way to express "this task was created to run on model X").

Related prior discussion: #1058. A previous attempt (#1462) was closed by the stale bot without review; this PR is an independent, minimal implementation against current `main`.

## Solution

Opt-in `pinned_preset` on scheduler tasks:

- `BaseTask.pinned_preset: str | None = None` (pydantic; existing `tasks.json` round-trips unchanged, default `None`).
- `create_scheduled_task` / `create_adhoc_task` / `create_planned_task` accept an optional `pinned_preset`; invalid names are rejected up front with the list of available presets.
- `update_task` accepts `pinned_preset` too (empty string unpins), so existing tasks can be pinned without recreation.
- At fire time, `TaskScheduler._get_chat_context()` resolves the pin via the framework's own `_model_config` preset lookup and applies `chat_model_override` on the context — the same mechanism the `/model` command uses — to both freshly created and already-existing dedicated contexts, so pinning via `update_task` takes effect without a restart.
- If the pinned preset no longer exists at fire time, the task **fails loudly** (error naming task + uuid + preset, task set to error state). It never silently falls back to ambient settings.
- Tasks without a pin behave exactly as before (zero behavior change for unpinned tasks).

## Testing

Verified on a live instance (framework runtime) plus a clean worktree of `main`:

- Live `tasks.json` with 5 pre-existing tasks loads and re-validates unchanged (all `pinned_preset=None`).
- Scratch pinned task: `_get_chat_context` returns a real `AgentContext` whose `chat_model_override` equals the pinned preset, and the resolved chat model matches that preset.
- Missing-preset break-test (`pinned_preset='does-not-exist'`): loud `ValueError` naming task/uuid/preset, refusing ambient fallback; no context created.
- Unpinned control task: no override applied (ambient behavior unchanged).
- `tests/test_task_scheduler_timezone.py`: 4/4 pass.
- Real-context E2E through `_get_chat_context` (context creation + override consumption path) passes; `import helpers.task_scheduler, tools.scheduler` clean under the framework runtime.

## Compatibility notes

- Purely additive to the task schema and tool surface; `pinned_preset` defaults to `None` and is omitted from serialization when unset, so old `tasks.json` files load unchanged and old tool callers see no difference.
- The pin resolves through the existing bundled `_model_config` plugin (same `get_preset_by_name` + `chat_model_override` path used by `/model`), so pinned tasks automatically respect any future changes to preset resolution or override handling.
- Tool prompt (`prompts/agent.system.tool.scheduler.md`) documents the new parameter for the scheduler tool.
