### PR TITLE
fix: set a default LiteLLM request timeout

### DIFF
--- a/models.py
+++ b/models.py
@@ -49,6 +49,7 @@ from pydantic import ConfigDict
 
 DEFAULT_LITELLM_GLOBAL_KWARGS: dict[str, Any] = {
     "drop_params": True,
+    "timeout": 180,
 }
 
 # LiteLLM documents drop_params as both a module-level switch and per-call kwarg.

--- a/tests/test_stream_tool_early_stop.py
+++ b/tests/test_stream_tool_early_stop.py
@@ -166,9 +166,13 @@ def test_litellm_global_kwargs_merge_defaults_and_config(monkeypatch):
         lambda: {"litellm_global_kwargs": {}},
     )
 
-    assert models._merge_litellm_call_kwargs({})["drop_params"] is True
+    assert models._merge_litellm_call_kwargs({}) == {
+        "drop_params": True,
+        "timeout": 180,
+    }
     assert models._merge_litellm_call_kwargs({"temperature": 0}) == {
         "drop_params": True,
+        "timeout": 180,
         "temperature": 0,
     }
 
@@ -409,6 +413,7 @@ async def test_chat_completions_default_uses_acompletion(monkeypatch):
     async def fake_acompletion(*args, **kwargs):
         calls.append("chat")
         assert kwargs["stream"] is True
+        assert kwargs["timeout"] == 180
         assert "a0_api_mode" not in kwargs
         return stream
 


### PR DESCRIPTION
## Summary

- set a 180-second default timeout for all direct LiteLLM calls
- preserve existing global and per-model overrides
- verify the default is merged and reaches streaming chat completion requests

## Why

Without a timeout, an accepted request that stops producing data can await indefinitely, so Agent Zero never reaches its exception-driven retry path. The pinned LiteLLM direct completion API accepts timeout for both streaming and non-streaming calls. stream_timeout is primarily handled by LiteLLM Router, which Agent Zero does not use for these requests.

## Tests

- python -m pytest tests/test_stream_tool_early_stop.py (55 passed)
- focused post-assertion run for the default merge and streaming propagation tests (2 passed)
- git diff --check

Closes #1882