### PR TITLE
Fix stalled history compression when utility model fails

### DIFF
--- a/helpers/history.py
+++ b/helpers/history.py
@@ -23,6 +23,29 @@ LARGE_MESSAGE_TO_CURRENT_TOPIC_RATIO = 0.5
 LARGE_MESSAGE_TO_HISTORY_TOPIC_RATIO = 0.2
 RAW_MESSAGE_OUTPUT_TEXT_TRIM = 100
 COMPRESSION_TARGET_RATIO = 0.8
+EMERGENCY_SUMMARY_MAX_CHARS = 2000
+EMERGENCY_SUMMARY_MARKER = (
+    "\n[... content truncated by emergency fallback compression ...]\n"
+)
+
+
+def _truncate_summary(
+    text: str, max_chars: int = EMERGENCY_SUMMARY_MAX_CHARS
+) -> str:
+    text = (text or "").strip()
+    if not text:
+        return "(no content)"
+    if len(text) <= max_chars:
+        return text
+
+    content_chars = max_chars - len(EMERGENCY_SUMMARY_MARKER)
+    head_chars = int(content_chars * 0.6)
+    tail_chars = content_chars - head_chars
+    return (
+        text[:head_chars]
+        + EMERGENCY_SUMMARY_MARKER
+        + text[-tail_chars:]
+    )
 
 
 class RawMessage(TypedDict):
@@ -271,13 +294,18 @@ class Topic(Record):
 
     async def summarize_messages(self, messages: list[Message]):
         msg_txt = [m.output_text() for m in messages]
-        summary = await self.history.agent.call_utility_model(
-            system=self.history.agent.read_prompt("fw.topic_summary.sys.md"),
-            message=self.history.agent.read_prompt(
-                "fw.topic_summary.msg.md", content=msg_txt
-            ),
-        )
-        return summary
+        try:
+            summary = await self.history.agent.call_utility_model(
+                system=self.history.agent.read_prompt("fw.topic_summary.sys.md"),
+                message=self.history.agent.read_prompt(
+                    "fw.topic_summary.msg.md", content=msg_txt
+                ),
+            )
+            if summary and summary.strip():
+                return summary
+        except Exception:
+            pass
+        return _truncate_summary("\n\n".join(msg_txt))
 
     def to_dict(self):
         return {
@@ -321,11 +349,18 @@ class Bulk(Record):
         return False
 
     async def summarize(self):
-        self.summary = await self.history.agent.call_utility_model(
-            system=self.history.agent.read_prompt("fw.topic_summary.sys.md"),
-            message=self.history.agent.read_prompt(
-                "fw.topic_summary.msg.md", content=self.output_text()
-            ),
+        source = self.output_text()
+        try:
+            summary = await self.history.agent.call_utility_model(
+                system=self.history.agent.read_prompt("fw.topic_summary.sys.md"),
+                message=self.history.agent.read_prompt(
+                    "fw.topic_summary.msg.md", content=source
+                ),
+            )
+        except Exception:
+            summary = ""
+        self.summary = (
+            summary if summary and summary.strip() else _truncate_summary(source)
         )
         return self.summary
 
@@ -590,6 +625,8 @@ class History(Record):
         return False
 
     async def compress_bulks(self):
+        if not self.bulks:
+            return False
         # merge bulks if possible
         compressed = await self.merge_bulks_by(BULK_MERGE_COUNT)
         # remove oldest bulk if necessary

--- a/helpers/history.py.dox.md
+++ b/helpers/history.py.dox.md
@@ -57,6 +57,7 @@
   - `new_topic(self)`
   - `output(self) -> list[OutputMessage]`
 - Top-level functions:
+- `_truncate_summary(text: str, max_chars: int=...) -> str`
 - `deserialize_history(json_data: str, agent) -> History`
 - `_stringify_output(output: OutputMessage, ai_label=..., human_label=...)`
 - `_stringify_content(content: MessageContent) -> str`
@@ -72,6 +73,7 @@
 - `_json_dumps(obj)`
 - `_json_loads(obj)`
 - Notable constants/configuration names: `BULK_MERGE_COUNT`, `TOPICS_MERGE_COUNT`, `CURRENT_TOPIC_RATIO`, `HISTORY_TOPIC_RATIO`, `HISTORY_BULK_RATIO`, `CURRENT_TOPIC_ATTENTION_COMPRESSION`, `HISTORY_TOPIC_ATTENTION_COMPRESSION`, `LARGE_MESSAGE_TO_CURRENT_TOPIC_RATIO`, `LARGE_MESSAGE_TO_HISTORY_TOPIC_RATIO`, `RAW_MESSAGE_OUTPUT_TEXT_TRIM`, `COMPRESSION_TARGET_RATIO`.
+- Emergency history compression uses a bounded, deterministic head-and-tail summary when the utility model raises or returns empty content. Empty bulk collections are a no-op.
 
 ## Runtime Contracts
 

--- a/tests/test_history_compression_fallback.py
+++ b/tests/test_history_compression_fallback.py
@@ -1,0 +1,70 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from helpers.history import Bulk, History, Message, Topic
+
+
+class _FailingUtilityAgent:
+    async def call_utility_model(self, **_kwargs):
+        raise RuntimeError("utility model unavailable")
+
+    def read_prompt(self, name, **kwargs):
+        return f"{name}: {kwargs}"
+
+    def parse_prompt(self, name, **kwargs):
+        return f"{name}: {kwargs['summary']}"
+
+
+class _EmptyUtilityAgent(_FailingUtilityAgent):
+    async def call_utility_model(self, **_kwargs):
+        return ""
+
+
+@pytest.mark.parametrize("agent_cls", [_FailingUtilityAgent, _EmptyUtilityAgent])
+@pytest.mark.asyncio
+async def test_topic_compression_falls_back_when_utility_model_fails(agent_cls):
+    history = History(agent_cls())
+    topic = Topic(history)
+    topic.messages = [
+        Message(False, "opening"),
+        Message(False, "a" * 4_000),
+        Message(True, "b" * 4_000),
+        Message(True, "closing"),
+    ]
+    before_tokens = topic.get_tokens()
+
+    compressed = await topic.compress_attention(ratio=0)
+
+    assert compressed is True
+    assert topic.get_tokens() < before_tokens
+    assert "emergency fallback compression" in topic.messages[1].output_text()
+
+
+@pytest.mark.parametrize("agent_cls", [_FailingUtilityAgent, _EmptyUtilityAgent])
+@pytest.mark.asyncio
+async def test_bulk_summary_falls_back_when_utility_model_fails(agent_cls):
+    history = History(agent_cls())
+    bulk = Bulk(history)
+    topic = Topic(history)
+    topic.messages = [Message(False, "a" * 4_000), Message(True, "b" * 4_000)]
+    bulk.records = [topic]
+    original = bulk.output_text()
+
+    summary = await bulk.summarize()
+
+    assert summary == bulk.summary
+    assert "emergency fallback compression" in summary
+    assert len(summary) < len(original)
+
+
+@pytest.mark.asyncio
+async def test_compress_bulks_returns_false_when_no_bulks_exist():
+    history = History(_FailingUtilityAgent())
+
+    assert await history.compress_bulks() is False


### PR DESCRIPTION
## Summary

- fall back to deterministic, bounded head-and-tail compression when the utility model raises or returns empty content
- keep the healthy utility-model path unchanged
- treat an empty bulk collection as a no-op instead of raising `IndexError`
- add regression coverage for exception, empty-response, compression-progress, and empty-bulk paths

Unlike catch-and-stop handling, the fallback produces a non-empty bounded summary so saturated histories can continue shrinking.

## Tests

- `.venv/Scripts/python.exe -m pytest tests/test_history_compression_fallback.py tests/test_history_compression_wait.py tests/test_chat_compaction.py -q` — 9 passed
- `.venv/Scripts/python.exe -m py_compile helpers/history.py tests/test_history_compression_fallback.py`

Fixes #1881