### PR TITLE
fix(chat-naming): defer auto-naming for greeting-only first messages

### DIFF
--- a/plugins/_chat_naming/AGENTS.md
+++ b/plugins/_chat_naming/AGENTS.md
@@ -19,7 +19,7 @@
 - Automatic naming runs after the monologue completes, so it cannot delay the Main Model.
 - Utility Model input contains the current name and user messages only; assistant work and tool results are excluded.
 - The complete naming prompt must remain within 70% of the effective Utility Model context window, preserving the newest user context when trimming is required.
-- `once` names only unnamed user chats from their first user message; `always` considers the latest user message plus recent user context.
+- `once` names only unnamed user chats from their first substantive user message (bare greetings are deferred); `always` considers the latest user message plus recent user context.
 - Generated names are concise and normalized before persistence.
 - Renaming a parallel child updates both its context name and sidebar label.
 - Manual task renames update both scheduler metadata and the task context name.

--- a/plugins/_chat_naming/extensions/python/monologue_end/_60_rename_chat.py
+++ b/plugins/_chat_naming/extensions/python/monologue_end/_60_rename_chat.py
@@ -28,7 +28,15 @@ class RenameChat(Extension):
         if not messages:
             return
         if mode == naming.MODE_ONCE:
-            messages = messages[:1]
+            # Defer naming until the first substantive user message so chats
+            # that start with a bare greeting ("Hello!") are not named "Hello".
+            substantive = next(
+                (m for m in messages if naming.is_substantive_message(m)), None
+            )
+            selected = [substantive] if substantive else None
+            if not selected:
+                return
+            messages = selected
 
         asyncio.create_task(
             self.change_name(

--- a/plugins/_chat_naming/helpers/naming.py
+++ b/plugins/_chat_naming/helpers/naming.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 from agent import Agent
@@ -13,6 +14,19 @@ MODE_ONCE = "once"
 MODE_ALWAYS = "always"
 RECENT_USER_MESSAGES = 4
 GENERATED_NAME_LIMIT = 40
+_GREETING_TOKENS = (
+    "hi|hey|hello|yo|hiya|howdy|greetings|salutations|sup|"
+    "whats[ ]+up|what'?s[ ]+up|wassup|"
+    "good[ ]+(?:morning|afternoon|evening|day|night)"
+)
+GREETING_PATTERN = re.compile(
+    r"^(?:" + _GREETING_TOKENS + r")"
+    r"(?:[\s,;.!?(]*(?:" + _GREETING_TOKENS + r"))*"
+    r"[\s!.,?;:~'-]*$",
+    re.IGNORECASE,
+)
+
+MIN_SUBSTANTIVE_WORDS = 3
 UTILITY_CONTEXT_INPUT_RATIO = 0.7
 
 
@@ -25,6 +39,16 @@ def get_config(agent: Agent) -> dict[str, Any]:
         "automatic_naming": bool(config.get("automatic_naming", True)),
         "automatic_naming_mode": mode,
     }
+
+
+def is_substantive_message(text: str) -> bool:
+    """A message worth naming a chat from: not a bare greeting and not too short."""
+    stripped = str(text or "").strip()
+    if not stripped:
+        return False
+    if GREETING_PATTERN.match(stripped):
+        return False
+    return len(stripped.split()) >= MIN_SUBSTANTIVE_WORDS
 
 
 def get_user_messages(agent: Agent, *, limit: int | None = RECENT_USER_MESSAGES) -> list[str]:

--- a/plugins/_chat_naming/tests/test_chat_naming.py
+++ b/plugins/_chat_naming/tests/test_chat_naming.py
@@ -347,3 +347,16 @@ async def test_chat_naming_endpoints_keep_default_auth_and_csrf_protection():
 
     assert ChatName.requires_auth() is True
     assert ChatName.requires_csrf() is True
+
+
+def test_is_substantive_message():
+    assert not naming.is_substantive_message("Hello!")
+    assert not naming.is_substantive_message("hi")
+    assert not naming.is_substantive_message("")
+    assert not naming.is_substantive_message("hi there")
+    assert not naming.is_substantive_message("Hello, good morning!")
+    assert not naming.is_substantive_message("what's up??")
+    assert naming.is_substantive_message("Help me refactor my Python project")
+    assert naming.is_substantive_message("What is the capital of France?")
+    assert naming.is_substantive_message("Fix the failing database migration")
+    assert naming.is_substantive_message("Please summarize this document for me")


### PR DESCRIPTION
﻿Fixes #1895

## Problem

In `once` mode the chat title is generated from only the very first user message. Chats that start with a greeting ("Hello!") get permanently titled "Hello"/"Greeting" even after the real topic arrives, because `once` mode never renames.

## Fix (Option: defer, not rename-every-turn)

Keeps `once` mode and its single Utility Model call, but defers naming until the first **substantive** user message (not a bare greeting, at least 3 words):

- `plugins/_chat_naming/helpers/naming.py`: adds `is_substantive_message()` with a chained greeting-token pattern (handles compounds like "Hello, good morning!") and a minimum word count.
- `plugins/_chat_naming/extensions/python/monologue_end/_60_rename_chat.py`: in `once` mode, selects the first substantive user message as the naming source; if none exists yet, naming is deferred until one arrives.
- `plugins/_chat_naming/AGENTS.md`: DOX contract updated.
- `plugins/_chat_naming/tests/test_chat_naming.py`: unit tests for the new helper.

## Behavior after this change

| Chat start | Before | After |
|---|---|---|
| "Hello!" only | Named "Hello" forever | Stays unnamed (deferred) |
| "Hello!" then "Help me refactor my Python project" | "Hello" | Named from the substantive message |
| Substantive first message | Named from it | Same (no regression) |

`always` mode is unchanged.
